### PR TITLE
feat(frontend): WIP implicit cast operands during FunctionCall::new

### DIFF
--- a/src/common/src/types/mod.rs
+++ b/src/common/src/types/mod.rs
@@ -187,7 +187,7 @@ impl DataType {
         }
     }
 
-    pub fn is_numeric(&self) -> bool {
+    pub fn is_number(&self) -> bool {
         matches!(
             self,
             DataType::Int16
@@ -203,8 +203,11 @@ impl DataType {
         matches!(self, DataType::Varchar)
     }
 
-    pub fn is_date_or_timestamp(&self) -> bool {
-        matches!(self, DataType::Date | DataType::Timestamp)
+    pub fn is_instant(&self) -> bool {
+        matches!(
+            self,
+            DataType::Date | DataType::Timestamp | DataType::Timestampz
+        )
     }
 
     /// Type index is used to find the least restrictive type that is of the larger index.

--- a/src/common/src/types/mod.rs
+++ b/src/common/src/types/mod.rs
@@ -187,6 +187,13 @@ impl DataType {
         }
     }
 
+    pub fn is_exact(&self) -> bool {
+        matches!(
+            self,
+            DataType::Int16 | DataType::Int32 | DataType::Int64 | DataType::Decimal
+        )
+    }
+
     pub fn is_number(&self) -> bool {
         matches!(
             self,

--- a/src/frontend/src/binder/expr/mod.rs
+++ b/src/frontend/src/binder/expr/mod.rs
@@ -155,7 +155,7 @@ impl Binder {
     fn rewrite_positive(&mut self, expr: Expr) -> Result<ExprImpl> {
         let expr = self.bind_expr(expr)?;
         let return_type = expr.return_type();
-        if return_type.is_numeric() {
+        if return_type.is_number() {
             return Ok(expr);
         }
         return Err(ErrorCode::InvalidInputSyntax(format!("+ {:?}", return_type)).into());

--- a/src/frontend/src/binder/values.rs
+++ b/src/frontend/src/binder/values.rs
@@ -92,22 +92,12 @@ impl Binder {
 
     /// Find compatible type for `left` and `right`.
     pub fn find_compat(left: DataType, right: DataType) -> Result<DataType> {
-        if (left == right || left.is_numeric() && right.is_numeric())
-            || (left.is_string() && right.is_string()
-                || (left.is_date_or_timestamp() && right.is_date_or_timestamp()))
-        {
-            if left.type_index() > right.type_index() {
-                Ok(left)
-            } else {
-                Ok(right)
-            }
-        } else {
-            Err(ErrorCode::InternalError(format!(
-                "Can not find compatible type for {:?} and {:?}",
-                left, right
-            ))
-            .into())
-        }
+        let s = format!(
+            "Can not find compatible type for {:?} and {:?}",
+            left, right
+        );
+        crate::expr::least_restrictive(left, right)
+            .ok_or_else(|| ErrorCode::InternalError(s).into())
     }
 }
 

--- a/src/frontend/src/expr/function_call.rs
+++ b/src/frontend/src/expr/function_call.rs
@@ -15,7 +15,7 @@
 use risingwave_common::error::{Result, RwError};
 use risingwave_common::types::DataType;
 
-use super::{infer_type, Expr, ExprImpl};
+use super::{Expr, ExprImpl};
 use crate::expr::ExprType;
 
 #[derive(Clone, Eq, PartialEq, Hash)]
@@ -90,20 +90,12 @@ impl FunctionCall {
     where
         F: FnOnce(&Vec<ExprImpl>) -> RwError,
     {
-        infer_type(
-            func_type,
-            inputs.iter().map(|expr| expr.return_type()).collect(),
-        )
-        .ok_or_else(|| err_f(&inputs))
-        .map(|return_type| Self::new_with_return_type(func_type, inputs, return_type))
+        let e = err_f(&inputs);
+        Self::new(func_type, inputs).ok_or(e)
     }
 
     pub fn new(func_type: ExprType, inputs: Vec<ExprImpl>) -> Option<Self> {
-        let return_type = infer_type(
-            func_type,
-            inputs.iter().map(|expr| expr.return_type()).collect(),
-        )?; // should be derived from inputs
-        Some(Self::new_with_return_type(func_type, inputs, return_type))
+        super::new_func(func_type, inputs)
     }
 
     /// used for expressions like cast

--- a/src/frontend/src/expr/mod.rs
+++ b/src/frontend/src/expr/mod.rs
@@ -43,7 +43,7 @@ pub type ExprType = risingwave_pb::expr::expr_node::Type;
 
 mod t2;
 use paste::paste;
-pub use t2::new_func;
+pub use t2::{least_restrictive, new_func};
 
 /// the trait of bound exprssions
 pub trait Expr: Into<ExprImpl> {

--- a/src/frontend/src/expr/mod.rs
+++ b/src/frontend/src/expr/mod.rs
@@ -41,7 +41,9 @@ mod expr_visitor;
 pub use expr_visitor::*;
 pub type ExprType = risingwave_pb::expr::expr_node::Type;
 
+mod t2;
 use paste::paste;
+pub use t2::new_func;
 
 /// the trait of bound exprssions
 pub trait Expr: Into<ExprImpl> {

--- a/src/frontend/src/expr/t2.rs
+++ b/src/frontend/src/expr/t2.rs
@@ -1,0 +1,60 @@
+use std::collections::HashMap;
+
+use itertools::Itertools as _;
+use risingwave_common::types::DataType;
+
+use crate::expr::{ExprImpl, ExprType, FunctionCall};
+
+lazy_static::lazy_static! {
+    static ref FUNC_SIG_MAP: HashMap<ExprType, (DataType, Vec<DataType>)> = {
+        build_type_derive_map()
+    };
+}
+
+fn build_type_derive_map() -> HashMap<ExprType, (DataType, Vec<DataType>)> {
+    use {DataType as T, ExprType as E};
+    let mut m = HashMap::new();
+    // logical expressions
+    m.insert(E::And, (T::Boolean, vec![T::Boolean, T::Boolean]));
+    m.insert(E::Or, (T::Boolean, vec![T::Boolean, T::Boolean]));
+    m.insert(E::Not, (T::Boolean, vec![T::Boolean]));
+    m.insert(E::IsTrue, (T::Boolean, vec![T::Boolean]));
+    m.insert(E::IsNotTrue, (T::Boolean, vec![T::Boolean]));
+    m.insert(E::IsFalse, (T::Boolean, vec![T::Boolean]));
+    m.insert(E::IsNotFalse, (T::Boolean, vec![T::Boolean]));
+    // string expressions
+    m.insert(
+        E::Replace,
+        (T::Varchar, vec![T::Varchar, T::Varchar, T::Varchar]),
+    );
+    m.insert(
+        E::Translate,
+        (T::Varchar, vec![T::Varchar, T::Varchar, T::Varchar]),
+    );
+    m.insert(E::Upper, (T::Varchar, vec![T::Varchar]));
+    m.insert(E::Lower, (T::Varchar, vec![T::Varchar]));
+    m.insert(E::Trim, (T::Varchar, vec![T::Varchar]));
+    m.insert(E::Ltrim, (T::Varchar, vec![T::Varchar]));
+    m.insert(E::Rtrim, (T::Varchar, vec![T::Varchar]));
+    m.insert(E::Position, (T::Int32, vec![T::Varchar, T::Varchar]));
+    m.insert(E::Length, (T::Int32, vec![T::Varchar]));
+    m.insert(E::Ascii, (T::Int32, vec![T::Varchar]));
+    m.insert(E::Like, (T::Boolean, vec![T::Varchar, T::Varchar]));
+    m
+}
+
+pub fn new_func(func_type: ExprType, inputs: Vec<ExprImpl>) -> Option<FunctionCall> {
+    if let Some((return_type, operand_types)) = FUNC_SIG_MAP.get(&func_type) {
+        let args = inputs
+            .into_iter()
+            .zip_eq(operand_types)
+            .map(|(e, t)| e.ensure_type(t.clone()))
+            .collect();
+        return Some(FunctionCall::new_with_return_type(
+            func_type,
+            args,
+            return_type.clone(),
+        ));
+    }
+    None
+}

--- a/src/frontend/src/expr/t2.rs
+++ b/src/frontend/src/expr/t2.rs
@@ -227,8 +227,11 @@ fn new_num_atm(func_type: ExprType, lhs: ExprImpl, rhs: ExprImpl) -> Option<Func
 }
 
 fn as_unary(inputs: Vec<ExprImpl>) -> Option<ExprImpl> {
-    let mut iter = inputs.into_iter();
+    let mut iter = inputs.into_iter().fuse();
     let arg = iter.next()?;
+    if iter.next().is_some() {
+        return None;
+    }
     Some(arg)
 }
 
@@ -236,5 +239,8 @@ fn as_binary(inputs: Vec<ExprImpl>) -> Option<(ExprImpl, ExprImpl)> {
     let mut iter = inputs.into_iter().fuse();
     let lhs = iter.next()?;
     let rhs = iter.next()?;
+    if iter.next().is_some() {
+        return None;
+    }
     Some((lhs, rhs))
 }

--- a/src/frontend/src/expr/t2.rs
+++ b/src/frontend/src/expr/t2.rs
@@ -144,6 +144,13 @@ fn new_add(func_type: ExprType, inputs: Vec<ExprImpl>) -> Option<FunctionCall> {
             DataType::Timestamp,
         ));
     }
+    if rt.is_date_or_timestamp() && lt == DataType::Interval {
+        return Some(FunctionCall::new_with_return_type(
+            func_type,
+            vec![lhs, rhs],
+            DataType::Timestamp,
+        ));
+    }
     None
 }
 


### PR DESCRIPTION
## What's changed and what's your intention?

Still prototyping and looking for the best style ... Just pushing to run tests on ci.

More description on the design will be provided once it is in good shape.

For now, replace `type_inference::FUNC_SIG_MAP: HashMap<FuncSign, DataTypeName>` with `t2::FUNC_H_MAP: HashMap<ExprType, H>` and `t2::FUNC_SIG_MAP: HashMap<ExprType, (DataType, Vec<DataType>)>`.

***PLEASE DO NOT LEAVE THIS EMPTY !!!***

Please explain **IN DETAIL** what the changes are in this PR and why they are needed:

- Summarize your change (**mandatory**)
- How does this PR work? Need a brief introduction for the changed logic (optional)
- Describe clearly one logical change and avoid lazy messages (optional)
- Describe any limitations of the current code (optional)

## Checklist

- [ ] I have written necessary docs and comments
- [ ] I have added necessary unit tests and integration tests

## Refer to a related PR or issue link (optional)
