### PR TITLE
feat(session-config): introduce entry-level pure in-memory set configuration

### DIFF
--- a/.github/workflow-template/jobs/e2e-risedev.yml
+++ b/.github/workflow-template/jobs/e2e-risedev.yml
@@ -98,7 +98,7 @@ jobs:
       - name: e2e test, batch, Rust frontend, 1 node
         timeout-minutes: 2
         run: |
-          RW_IMPLICIT_FLUSH=1 ~/cargo-make/makers ci-start ci-1cn-1fe
+          ~/cargo-make/makers ci-start ci-1cn-1fe
           sqllogictest -p 4566 './e2e_test/v2/ddl/**/*.slt'
           sqllogictest -p 4566 './e2e_test/v2/batch/**/*.slt'
 
@@ -108,7 +108,7 @@ jobs:
       - name: e2e test w/ Rust frontend ci-3node, batch, distributed
         timeout-minutes: 2
         run: |
-          RW_DIST_QUERY=1 RW_IMPLICIT_FLUSH=1 ~/cargo-make/makers ci-start ci-3cn-1fe
+          RW_DIST_QUERY=1 ~/cargo-make/makers ci-start ci-3cn-1fe
           sqllogictest -p 4566 './e2e_test/v2/batch_distributed/**/*.slt'
 
       - name: Kill cluster
@@ -135,7 +135,7 @@ jobs:
       - name: e2e test batch 3-node
         timeout-minutes: 2
         run: |
-          RW_IMPLICIT_FLUSH=1 ~/cargo-make/makers ci-start ci-3node
+          ~/cargo-make/makers ci-start ci-3node
           sqllogictest -p 4567 -d dev --engine risingwave './e2e_test/batch/**/*.slt'
 
       - name: Kill cluster

--- a/.github/workflow-template/jobs/e2e-risedev.yml
+++ b/.github/workflow-template/jobs/e2e-risedev.yml
@@ -135,7 +135,7 @@ jobs:
       - name: e2e test batch 3-node
         timeout-minutes: 2
         run: |
-          ~/cargo-make/makers ci-start ci-3node
+          RW_IMPLICIT_FLUSH=1 ~/cargo-make/makers ci-start ci-3node
           sqllogictest -p 4567 -d dev --engine risingwave './e2e_test/batch/**/*.slt'
 
       - name: Kill cluster

--- a/.github/workflow-template/jobs/e2e-source.yml
+++ b/.github/workflow-template/jobs/e2e-source.yml
@@ -109,7 +109,7 @@ jobs:
         timeout-minutes: 1
         run: |
           ~/cargo-make/makers clean-data
-          RW_IMPLICIT_FLUSH=1 ~/cargo-make/makers dev ci-3node
+          ~/cargo-make/makers dev ci-3node
           psql --version
           RUST_LOG=info target/debug/risingwave_regress_test -h 127.0.0.1 \
             -p ${{ env.RW_PORT }} \

--- a/.github/workflow-template/jobs/e2e-source.yml
+++ b/.github/workflow-template/jobs/e2e-source.yml
@@ -109,7 +109,7 @@ jobs:
         timeout-minutes: 1
         run: |
           ~/cargo-make/makers clean-data
-          ~/cargo-make/makers dev ci-3node
+          RW_IMPLICIT_FLUSH=1 ~/cargo-make/makers dev ci-3node
           psql --version
           RUST_LOG=info target/debug/risingwave_regress_test -h 127.0.0.1 \
             -p ${{ env.RW_PORT }} \

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -268,7 +268,7 @@ jobs:
       - name: e2e test, batch, Rust frontend, 1 node
         timeout-minutes: 2
         run: |
-          RW_IMPLICIT_FLUSH=1 ~/cargo-make/makers ci-start ci-1cn-1fe
+          ~/cargo-make/makers ci-start ci-1cn-1fe
           sqllogictest -p 4566 './e2e_test/v2/ddl/**/*.slt'
           sqllogictest -p 4566 './e2e_test/v2/batch/**/*.slt'
       - name: Kill cluster
@@ -276,7 +276,7 @@ jobs:
       - name: e2e test w/ Rust frontend ci-3node, batch, distributed
         timeout-minutes: 2
         run: |
-          RW_DIST_QUERY=1 RW_IMPLICIT_FLUSH=1 ~/cargo-make/makers ci-start ci-3cn-1fe
+          RW_DIST_QUERY=1 ~/cargo-make/makers ci-start ci-3cn-1fe
           sqllogictest -p 4566 './e2e_test/v2/batch_distributed/**/*.slt'
       - name: Kill cluster
         run: ~/cargo-make/makers ci-kill
@@ -297,7 +297,7 @@ jobs:
       - name: e2e test batch 3-node
         timeout-minutes: 2
         run: |
-          RW_IMPLICIT_FLUSH=1 ~/cargo-make/makers ci-start ci-3node
+          ~/cargo-make/makers ci-start ci-3node
           sqllogictest -p 4567 -d dev --engine risingwave './e2e_test/batch/**/*.slt'
       - name: Kill cluster
         run: ~/cargo-make/makers ci-kill
@@ -388,7 +388,7 @@ jobs:
       - name: e2e test, batch, Rust frontend, 1 node
         timeout-minutes: 2
         run: |
-          RW_IMPLICIT_FLUSH=1 ~/cargo-make/makers ci-start ci-1cn-1fe
+          ~/cargo-make/makers ci-start ci-1cn-1fe
           sqllogictest -p 4566 './e2e_test/v2/ddl/**/*.slt'
           sqllogictest -p 4566 './e2e_test/v2/batch/**/*.slt'
       - name: Kill cluster
@@ -396,7 +396,7 @@ jobs:
       - name: e2e test w/ Rust frontend ci-3node, batch, distributed
         timeout-minutes: 2
         run: |
-          RW_DIST_QUERY=1 RW_IMPLICIT_FLUSH=1 ~/cargo-make/makers ci-start ci-3cn-1fe
+          RW_DIST_QUERY=1 ~/cargo-make/makers ci-start ci-3cn-1fe
           sqllogictest -p 4566 './e2e_test/v2/batch_distributed/**/*.slt'
       - name: Kill cluster
         run: ~/cargo-make/makers ci-kill
@@ -417,7 +417,7 @@ jobs:
       - name: e2e test batch 3-node
         timeout-minutes: 2
         run: |
-          RW_IMPLICIT_FLUSH=1 ~/cargo-make/makers ci-start ci-3node
+          ~/cargo-make/makers ci-start ci-3node
           sqllogictest -p 4567 -d dev --engine risingwave './e2e_test/batch/**/*.slt'
       - name: Kill cluster
         run: ~/cargo-make/makers ci-kill
@@ -516,7 +516,7 @@ jobs:
         timeout-minutes: 1
         run: |
           ~/cargo-make/makers clean-data
-          RW_IMPLICIT_FLUSH=1 ~/cargo-make/makers dev ci-3node
+          ~/cargo-make/makers dev ci-3node
           psql --version
           RUST_LOG=info target/debug/risingwave_regress_test -h 127.0.0.1 \
             -p ${{ env.RW_PORT }} \

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -297,7 +297,7 @@ jobs:
       - name: e2e test batch 3-node
         timeout-minutes: 2
         run: |
-          ~/cargo-make/makers ci-start ci-3node
+          RW_IMPLICIT_FLUSH=1 ~/cargo-make/makers ci-start ci-3node
           sqllogictest -p 4567 -d dev --engine risingwave './e2e_test/batch/**/*.slt'
       - name: Kill cluster
         run: ~/cargo-make/makers ci-kill
@@ -417,7 +417,7 @@ jobs:
       - name: e2e test batch 3-node
         timeout-minutes: 2
         run: |
-          ~/cargo-make/makers ci-start ci-3node
+          RW_IMPLICIT_FLUSH=1 ~/cargo-make/makers ci-start ci-3node
           sqllogictest -p 4567 -d dev --engine risingwave './e2e_test/batch/**/*.slt'
       - name: Kill cluster
         run: ~/cargo-make/makers ci-kill
@@ -516,7 +516,7 @@ jobs:
         timeout-minutes: 1
         run: |
           ~/cargo-make/makers clean-data
-          ~/cargo-make/makers dev ci-3node
+          RW_IMPLICIT_FLUSH=1 ~/cargo-make/makers dev ci-3node
           psql --version
           RUST_LOG=info target/debug/risingwave_regress_test -h 127.0.0.1 \
             -p ${{ env.RW_PORT }} \

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -252,7 +252,7 @@ jobs:
       - name: e2e test batch 3-node
         timeout-minutes: 2
         run: |
-          ~/cargo-make/makers ci-start ci-3node
+          RW_IMPLICIT_FLUSH=1 ~/cargo-make/makers ci-start ci-3node
           sqllogictest -p 4567 -d dev --engine risingwave './e2e_test/batch/**/*.slt'
       - name: Kill cluster
         run: ~/cargo-make/makers ci-kill
@@ -351,7 +351,7 @@ jobs:
         timeout-minutes: 1
         run: |
           ~/cargo-make/makers clean-data
-          ~/cargo-make/makers dev ci-3node
+          RW_IMPLICIT_FLUSH=1 ~/cargo-make/makers dev ci-3node
           psql --version
           RUST_LOG=info target/debug/risingwave_regress_test -h 127.0.0.1 \
             -p ${{ env.RW_PORT }} \

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -223,7 +223,7 @@ jobs:
       - name: e2e test, batch, Rust frontend, 1 node
         timeout-minutes: 2
         run: |
-          RW_IMPLICIT_FLUSH=1 ~/cargo-make/makers ci-start ci-1cn-1fe
+          ~/cargo-make/makers ci-start ci-1cn-1fe
           sqllogictest -p 4566 './e2e_test/v2/ddl/**/*.slt'
           sqllogictest -p 4566 './e2e_test/v2/batch/**/*.slt'
       - name: Kill cluster
@@ -231,7 +231,7 @@ jobs:
       - name: e2e test w/ Rust frontend ci-3node, batch, distributed
         timeout-minutes: 2
         run: |
-          RW_DIST_QUERY=1 RW_IMPLICIT_FLUSH=1 ~/cargo-make/makers ci-start ci-3cn-1fe
+          RW_DIST_QUERY=1 ~/cargo-make/makers ci-start ci-3cn-1fe
           sqllogictest -p 4566 './e2e_test/v2/batch_distributed/**/*.slt'
       - name: Kill cluster
         run: ~/cargo-make/makers ci-kill
@@ -252,7 +252,7 @@ jobs:
       - name: e2e test batch 3-node
         timeout-minutes: 2
         run: |
-          RW_IMPLICIT_FLUSH=1 ~/cargo-make/makers ci-start ci-3node
+          ~/cargo-make/makers ci-start ci-3node
           sqllogictest -p 4567 -d dev --engine risingwave './e2e_test/batch/**/*.slt'
       - name: Kill cluster
         run: ~/cargo-make/makers ci-kill
@@ -351,7 +351,7 @@ jobs:
         timeout-minutes: 1
         run: |
           ~/cargo-make/makers clean-data
-          RW_IMPLICIT_FLUSH=1 ~/cargo-make/makers dev ci-3node
+          ~/cargo-make/makers dev ci-3node
           psql --version
           RUST_LOG=info target/debug/risingwave_regress_test -h 127.0.0.1 \
             -p ${{ env.RW_PORT }} \

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -194,7 +194,7 @@ cargo install --git https://github.com/risinglightdb/sqllogictest-rs --features 
 To run end-to-end test, you will need to start a full cluster first:
 
 ```shell
-RW_IMPLICIT_FLUSH=1 ./risedev d
+./risedev d
 ```
 
 Then run some e2e tests:

--- a/e2e_test/v2/batch/aggregate/avg.slt
+++ b/e2e_test/v2/batch/aggregate/avg.slt
@@ -1,3 +1,7 @@
+
+statement ok
+SET RW_IMPLICIT_FLUSH TO true;
+
 statement ok
 create table t(v1 smallint, v2 int, v3 bigint, v4 numeric, v5 real, v6 double precision)
 

--- a/e2e_test/v2/batch/aggregate/count.slt
+++ b/e2e_test/v2/batch/aggregate/count.slt
@@ -1,3 +1,7 @@
+
+statement ok
+SET RW_IMPLICIT_FLUSH TO true;
+
 statement ok
 create table t (v1 int not null, v2 int not null, v3 int not null)
 

--- a/e2e_test/v2/batch/explain.slt
+++ b/e2e_test/v2/batch/explain.slt
@@ -1,3 +1,7 @@
+
+statement ok
+SET RW_IMPLICIT_FLUSH TO true;
+
 statement ok
 create table texplain (v1 int not null);
 

--- a/e2e_test/v2/batch/float_ord.slt
+++ b/e2e_test/v2/batch/float_ord.slt
@@ -1,3 +1,7 @@
+
+statement ok
+SET RW_IMPLICIT_FLUSH TO true;
+
 statement ok
 create table t (v1 real not null);
 

--- a/e2e_test/v2/batch/insert_expr.slt
+++ b/e2e_test/v2/batch/insert_expr.slt
@@ -1,4 +1,7 @@
 statement ok
+SET RW_IMPLICIT_FLUSH TO true;
+
+statement ok
 create table t (v1 int not null);
 
 statement ok

--- a/e2e_test/v2/batch/join.slt
+++ b/e2e_test/v2/batch/join.slt
@@ -1,4 +1,7 @@
 statement ok
+SET RW_IMPLICIT_FLUSH TO true;
+
+statement ok
 create table t1 (v1 int not null, v2 int not null);
 
 statement ok

--- a/e2e_test/v2/batch/modify.slt
+++ b/e2e_test/v2/batch/modify.slt
@@ -1,4 +1,7 @@
 statement ok
+SET RW_IMPLICIT_FLUSH TO true;
+
+statement ok
 create table t (v1 real not null, v2 int not null);
 
 # Insert

--- a/e2e_test/v2/batch/query.slt
+++ b/e2e_test/v2/batch/query.slt
@@ -1,4 +1,7 @@
 statement ok
+SET RW_IMPLICIT_FLUSH TO true;
+
+statement ok
 create table t3 (v1 int, v2 int, v3 int);
 
 statement ok

--- a/e2e_test/v2/batch/tpch.slt
+++ b/e2e_test/v2/batch/tpch.slt
@@ -1,3 +1,6 @@
+statement ok
+SET RW_IMPLICIT_FLUSH TO true;
+
 include ../../tpch/create_tables.slt.part
 
 include ../../tpch/insert_customer.slt.part

--- a/e2e_test/v2/batch/types/decimal.slt
+++ b/e2e_test/v2/batch/types/decimal.slt
@@ -1,4 +1,7 @@
 statement ok
+SET RW_IMPLICIT_FLUSH TO true;
+
+statement ok
 create table t (v1 numeric, v2 numeric)
 
 statement ok

--- a/e2e_test/v2/batch_distributed/aggregate/avg.slt
+++ b/e2e_test/v2/batch_distributed/aggregate/avg.slt
@@ -1,4 +1,7 @@
 statement ok
+SET RW_IMPLICIT_FLUSH TO true;
+
+statement ok
 create table t(v1 smallint, v2 int, v3 bigint, v4 numeric, v5 real, v6 double precision)
 
 statement ok

--- a/e2e_test/v2/batch_distributed/aggregate/count.slt
+++ b/e2e_test/v2/batch_distributed/aggregate/count.slt
@@ -1,4 +1,7 @@
 statement ok
+SET RW_IMPLICIT_FLUSH TO true;
+
+statement ok
 create table t (v1 int not null, v2 int not null, v3 int not null)
 
 statement ok

--- a/e2e_test/v2/batch_distributed/float_ord.slt
+++ b/e2e_test/v2/batch_distributed/float_ord.slt
@@ -1,4 +1,7 @@
 statement ok
+SET RW_IMPLICIT_FLUSH TO true;
+
+statement ok
 create table t (v1 real not null);
 
 statement ok

--- a/e2e_test/v2/batch_distributed/insert_expr.slt
+++ b/e2e_test/v2/batch_distributed/insert_expr.slt
@@ -2,6 +2,9 @@ statement ok
 create table t (v1 int not null);
 
 statement ok
+SET RW_IMPLICIT_FLUSH TO true;
+
+statement ok
 insert into t values (3);
 
 query I rowsort

--- a/e2e_test/v2/batch_distributed/insert_expr.slt
+++ b/e2e_test/v2/batch_distributed/insert_expr.slt
@@ -1,8 +1,8 @@
 statement ok
-create table t (v1 int not null);
+SET RW_IMPLICIT_FLUSH TO true;
 
 statement ok
-SET RW_IMPLICIT_FLUSH TO true;
+create table t (v1 int not null);
 
 statement ok
 insert into t values (3);

--- a/e2e_test/v2/batch_distributed/modify.slt
+++ b/e2e_test/v2/batch_distributed/modify.slt
@@ -1,4 +1,7 @@
 statement ok
+SET RW_IMPLICIT_FLUSH TO true;
+
+statement ok
 create table t (v1 real not null, v2 int not null);
 
 # Insert

--- a/e2e_test/v2/batch_distributed/tpch.slt
+++ b/e2e_test/v2/batch_distributed/tpch.slt
@@ -1,3 +1,6 @@
+statement ok
+SET RW_IMPLICIT_FLUSH TO true;
+
 include ../../tpch/create_tables.slt.part
 
 include ../../tpch/insert_customer.slt.part

--- a/e2e_test/v2/batch_distributed/types/decimal.slt
+++ b/e2e_test/v2/batch_distributed/types/decimal.slt
@@ -1,4 +1,7 @@
 statement ok
+SET RW_IMPLICIT_FLUSH TO true;
+
+statement ok
 create table t (v1 numeric, v2 numeric)
 
 statement ok

--- a/src/frontend/src/handler/mod.rs
+++ b/src/frontend/src/handler/mod.rs
@@ -29,8 +29,9 @@ pub mod drop_table;
 mod explain;
 mod flush;
 #[allow(dead_code)]
-mod query;
-mod query_single;
+pub mod query;
+pub mod query_single;
+mod set;
 mod show;
 pub mod util;
 
@@ -91,6 +92,11 @@ pub(super) async fn handle(session: Arc<SessionImpl>, stmt: Statement) -> Result
             ..
         } => create_mv::handle_create_mv(context, name, query).await,
         Statement::Flush => flush::handle_flush(context).await,
+        Statement::SetVariable {
+            local: _,
+            variable,
+            value,
+        } => set::handle_set(context, variable, value),
         _ => {
             Err(ErrorCode::NotImplemented(format!("Unhandled ast: {:?}", stmt), None.into()).into())
         }

--- a/src/frontend/src/handler/query.rs
+++ b/src/frontend/src/handler/query.rs
@@ -26,13 +26,11 @@ use crate::scheduler::plan_fragmenter::BatchPlanFragmenter;
 use crate::scheduler::{DataChunkStream, ExecutionContext, ExecutionContextRef};
 use crate::session::{OptimizerContext, SessionImpl};
 
-lazy_static::lazy_static! {
-    /// If `RW_IMPLICIT_FLUSH` is on, then every INSERT/UPDATE/DELETE statement will block
-    /// until the entire dataflow is refreshed. In other words, every related table & MV will
-    /// be able to see the write.
-    /// TODO: Use session config to set this.
-    pub static ref IMPLICIT_FLUSH: &'static str = "RW_IMPLICIT_FLUSH";
-}
+/// If `RW_IMPLICIT_FLUSH` is on, then every INSERT/UPDATE/DELETE statement will block
+/// until the entire dataflow is refreshed. In other words, every related table & MV will
+/// be able to see the write.
+/// TODO: Use session config to set this.
+pub static IMPLICIT_FLUSH: &str = "RW_IMPLICIT_FLUSH";
 
 pub async fn handle_query(context: OptimizerContext, stmt: Statement) -> Result<PgResponse> {
     let stmt_type = to_statement_type(&stmt);
@@ -69,8 +67,8 @@ pub async fn handle_query(context: OptimizerContext, stmt: Statement) -> Result<
         _ => unreachable!(),
     };
 
-    if let Some(flag) = session.get(&IMPLICIT_FLUSH) {
-        if flag.is_true() {
+    if let Some(flag) = session.get_config(IMPLICIT_FLUSH) {
+        if flag.is_set(false) {
             flush_for_write(&session, stmt_type).await?;
         }
     }

--- a/src/frontend/src/handler/query_single.rs
+++ b/src/frontend/src/handler/query_single.rs
@@ -75,8 +75,10 @@ pub async fn handle_query_single(context: OptimizerContext, stmt: Statement) -> 
     };
 
     // Implicitly flush the writes.
-    if *IMPLICIT_FLUSH {
-        flush_for_write(&session, stmt_type).await?;
+    if let Some(flag) = session.get(&IMPLICIT_FLUSH) {
+        if flag.is_true() {
+            flush_for_write(&session, stmt_type).await?;
+        }
     }
 
     Ok(PgResponse::new(stmt_type, rows_count, rows, pg_descs))

--- a/src/frontend/src/handler/query_single.rs
+++ b/src/frontend/src/handler/query_single.rs
@@ -75,8 +75,8 @@ pub async fn handle_query_single(context: OptimizerContext, stmt: Statement) -> 
     };
 
     // Implicitly flush the writes.
-    if let Some(flag) = session.get(&IMPLICIT_FLUSH) {
-        if flag.is_true() {
+    if let Some(flag) = session.get_config(IMPLICIT_FLUSH) {
+        if flag.is_set(false) {
             flush_for_write(&session, stmt_type).await?;
         }
     }

--- a/src/frontend/src/handler/set.rs
+++ b/src/frontend/src/handler/set.rs
@@ -1,0 +1,24 @@
+use pgwire::pg_response::{PgResponse, StatementType};
+use risingwave_common::error::Result;
+use risingwave_sqlparser::ast::{Ident, SetVariableValue};
+
+use crate::session::OptimizerContext;
+
+pub(super) fn handle_set(
+    context: OptimizerContext,
+    name: Ident,
+    value: Vec<SetVariableValue>,
+) -> Result<PgResponse> {
+    let string_val = to_string(&value[0]);
+    // Currently store the config variable simply as String -> ConfigEntry(String).
+    // In future we can add converter/parser to make the API more robust.
+    context.session_ctx.set(&name.value, &string_val);
+
+    Ok(PgResponse::empty_result(StatementType::SET_OPTION))
+}
+
+/// Convert any set variable to String.
+/// For example, TRUE -> "TRUE", 1 -> "1".
+fn to_string(value: &SetVariableValue) -> String {
+    format!("{}", value)
+}

--- a/src/frontend/src/handler/set.rs
+++ b/src/frontend/src/handler/set.rs
@@ -12,7 +12,7 @@ pub(super) fn handle_set(
     let string_val = to_string(&value[0]);
     // Currently store the config variable simply as String -> ConfigEntry(String).
     // In future we can add converter/parser to make the API more robust.
-    context.session_ctx.set(&name.value, &string_val);
+    context.session_ctx.set_config(&name.value, &string_val);
 
     Ok(PgResponse::empty_result(StatementType::SET_OPTION))
 }

--- a/src/frontend/src/session.rs
+++ b/src/frontend/src/session.rs
@@ -265,8 +265,9 @@ impl ConfigEntry {
         ConfigEntry { str_val }
     }
 
-    pub fn is_true(&self) -> bool {
-        self.str_val.parse().unwrap_or(false)
+    /// Only used for boolean configurations.
+    pub fn is_set(&self, default: bool) -> bool {
+        self.str_val.parse().unwrap_or(default)
     }
 }
 
@@ -296,13 +297,16 @@ impl SessionImpl {
         &self.database
     }
 
-    pub fn set(&self, key: &str, val: &str) {
+    /// Set configuration values in this session.
+    /// For example, `set_config("RW_IMPLICIT_FLUSH", true)` will implicit flush for every inserts.
+    pub fn set_config(&self, key: &str, val: &str) {
         self.config_map
             .write()
             .insert(key.to_string(), ConfigEntry::new(val.to_string()));
     }
 
-    pub fn get(&self, key: &str) -> Option<ConfigEntry> {
+    /// Get configuration values in this session.
+    pub fn get_config(&self, key: &str) -> Option<ConfigEntry> {
         let reader = self.config_map.read();
         reader.get(key).cloned()
     }


### PR DESCRIPTION
## What's changed and what's your intention?

Note this is just a simple beginning of [support set comand](https://github.com/singularity-data/risingwave/issues/1219). There are still a lot of todos: better config init policy, how to handle system level config/consistency of change config, how to persist config, better API design (Builder code patterns or possible generic to make the code pretty). I'd like to distribute the tasks to anyone who are interested in the project. Java's design looks good:

https://github.com/singularity-data/risingwave/blob/8a7c9718dc97eaaede84c1be5a107944a69835e1/legacy/common/src/main/java/com/risingwave/common/config/ConfigEntry.java#L11-L27

But I do not found properly crates to help me and a little overdesign (This part of java code is hard to translate to Rust), so I leave it simple.

The main goal is to remove annoying RW_IMPLICIT_FLUSH in start risedev. Design a `RwLock<HashMap<String, ConfigEntry>>` (RwLook from parking_lot, not sure whether it is good, needs investigate) to store config flags, now all type of config values are stored as Stirng (e.g. "1", "true", "on"). For init, we will constructthe map manually in `build_config_map()`. 

## Checklist

- [x] I have written necessary docs and comments
- [x] I have added necessary unit tests and integration tests

## Refer to a related PR or issue link (optional)
