### PR TITLE
fix: quick fix for create mv ut timeout

### DIFF
--- a/src/meta/src/stream/stream_manager.rs
+++ b/src/meta/src/stream/stream_manager.rs
@@ -520,14 +520,15 @@ mod tests {
                 global_stream_manager: stream_manager,
                 fragment_manager,
                 state,
-                join_handles: vec![join_handle, join_handle_2],
-                shutdown_txs: vec![shutdown_tx, shutdown_tx_2],
+                join_handles: vec![join_handle_2, join_handle],
+                shutdown_txs: vec![shutdown_tx_2, shutdown_tx],
             })
         }
 
         async fn stop(self) {
             for shutdown_tx in self.shutdown_txs {
                 shutdown_tx.send(()).unwrap();
+                tokio::time::sleep(Duration::from_millis(150)).await;
             }
             for join_handle in self.join_handles {
                 join_handle.await.unwrap();


### PR DESCRIPTION
## What's changed and what's your intention?

As title, this happens because of stopping the mock compute service during checkpoint. The barrier manager will enter recovery mode. This PR is a quick fix on this test, and `test_create_materialized_view` is outdated which need refactor.

## Checklist

- [x] I have written necessary docs and comments
- [x] I have added necessary unit tests and integration tests

## Refer to a related PR or issue link (optional)
Resolve https://github.com/singularity-data/risingwave/issues/1722