### PR TITLE
docs: fix typo in streaming-overview

### DIFF
--- a/docs/streaming-overview.md
+++ b/docs/streaming-overview.md
@@ -29,7 +29,7 @@ In this document we give an overview of RisingWave streaming engine.
 
 ![streaming-architecture](./images/streaming-overview/streaming-architecture.svg)
 
-The overall architecture of RisingWave is depicted in the figure above. In brief, RisingWave streaming engine consists of three sets of nodes: frontend, compute nodes, and meta service. The frontend node consists the serving layer, handling users’ SQL requests concurrently. Underlying is the processing layer. Each compute node hosts a collection of long-running actors for stream processing. All actors access a shared persistence layer of storage (currently AWS S3) as its state storage. The meta service maintains all meta-information and coordinates the whole cluster. 
+The overall architecture of RisingWave is depicted in the figure above. In brief, RisingWave streaming engine consists of three sets of nodes: frontend, compute nodes, and meta service. The frontend node consists the serving layer, handling user’s SQL requests concurrently. Underlying is the processing layer. Each compute node hosts a collection of long-running actors for stream processing. All actors access a shared persistence layer of storage (currently AWS S3) as its state storage. The meta service maintains all meta-information and coordinates the whole cluster. 
 
 When receiving a create materialized view statement at the front end, a materialized view and the corresponding streaming pipeline are built in following steps.  
 


### PR DESCRIPTION
Signed-off-by: Fedomn <fedomn.ma@gmail.com>

## What's changed and what's your intention?

fix a typo: `users’` to `user’s`

## Checklist

- [x] I have written necessary docs and comments
- [x] I have added necessary unit tests and integration tests

## Refer to a related PR or issue link (optional)
