### PR TITLE
style: enable rustfmt reorder_impl_items

### DIFF
--- a/rustfmt.toml
+++ b/rustfmt.toml
@@ -6,6 +6,7 @@ normalize_comments = true
 normalize_doc_attributes = true
 imports_granularity = "Module"
 group_imports = "StdExternalCrate"
+reorder_impl_items = true
 reorder_imports = true
 tab_spaces = 4
 wrap_comments = true

--- a/src/batch/src/executor/join/hash_join.rs
+++ b/src/batch/src/executor/join/hash_join.rs
@@ -541,6 +541,7 @@ mod tests {
                 join_type,
             }
         }
+
         fn create_left_executor(&self) -> BoxedExecutor {
             let schema = Schema {
                 fields: vec![

--- a/src/batch/src/executor/join/nested_loop_join.rs
+++ b/src/batch/src/executor/join/nested_loop_join.rs
@@ -150,6 +150,7 @@ impl Executor for NestedLoopJoinExecutor {
             }
         }
     }
+
     async fn close(&mut self) -> Result<()> {
         Ok(())
     }

--- a/src/batch/src/executor/join/sort_merge_join.rs
+++ b/src/batch/src/executor/join/sort_merge_join.rs
@@ -222,6 +222,7 @@ impl SortMergeJoinExecutor {
             identity,
         }
     }
+
     fn compare_with_last_row(&self, cur_row: Option<RowRef>) -> bool {
         self.last_probe_key
             .clone()

--- a/src/batch/src/executor/monitor/stats.rs
+++ b/src/batch/src/executor/monitor/stats.rs
@@ -34,6 +34,7 @@ impl BatchMetrics {
             row_seq_scan_next_duration,
         }
     }
+
     /// Create a new `BatchMetrics` instance used in tests or other places.
     pub fn unused() -> Self {
         Self::new(prometheus::Registry::new())

--- a/src/batch/src/executor/order_by.rs
+++ b/src/batch/src/executor/order_by.rs
@@ -114,6 +114,7 @@ impl OrderByExecutor {
             self.vis_indices[idx] += 1;
         }
     }
+
     fn get_order_index_from(&self, idx: usize) -> Vec<usize> {
         let mut index: Vec<usize> = (0..self.chunks[idx].cardinality()).collect();
         index.sort_by(|ia, ib| {
@@ -134,6 +135,7 @@ impl OrderByExecutor {
         });
         index
     }
+
     async fn collect_child_data(&mut self) -> Result<()> {
         while let Some(chunk) = self.child.next().await? {
             if !self.disable_encoding && self.encodable {

--- a/src/batch/src/task/broadcast_channel.rs
+++ b/src/batch/src/task/broadcast_channel.rs
@@ -31,6 +31,7 @@ pub struct BroadcastSender {
 
 impl ChanSender for BroadcastSender {
     type SendFuture<'a> = impl Future<Output = Result<()>>;
+
     fn send(&mut self, chunk: Option<DataChunk>) -> Self::SendFuture<'_> {
         async move {
             self.senders.iter().try_for_each(|sender| {
@@ -49,6 +50,7 @@ pub struct BroadcastReceiver {
 
 impl ChanReceiver for BroadcastReceiver {
     type RecvFuture<'a> = impl Future<Output = Result<Option<DataChunk>>>;
+
     fn recv(&mut self) -> Self::RecvFuture<'_> {
         async move {
             match self.receiver.recv().await {

--- a/src/batch/src/task/fifo_channel.rs
+++ b/src/batch/src/task/fifo_channel.rs
@@ -31,6 +31,7 @@ pub struct FifoReceiver {
 
 impl ChanSender for FifoSender {
     type SendFuture<'a> = impl Future<Output = Result<()>>;
+
     fn send(&mut self, chunk: Option<DataChunk>) -> Self::SendFuture<'_> {
         async move {
             self.sender
@@ -42,6 +43,7 @@ impl ChanSender for FifoSender {
 
 impl ChanReceiver for FifoReceiver {
     type RecvFuture<'a> = impl Future<Output = Result<Option<DataChunk>>>;
+
     fn recv(&mut self) -> Self::RecvFuture<'_> {
         async move {
             match self.receiver.recv().await {

--- a/src/batch/src/task/hash_shuffle_channel.rs
+++ b/src/batch/src/task/hash_shuffle_channel.rs
@@ -88,6 +88,7 @@ fn generate_new_data_chunks(
 
 impl ChanSender for HashShuffleSender {
     type SendFuture<'a> = impl Future<Output = Result<()>>;
+
     fn send(&mut self, chunk: Option<DataChunk>) -> Self::SendFuture<'_> {
         async move {
             match chunk {
@@ -130,6 +131,7 @@ impl HashShuffleSender {
 
 impl ChanReceiver for HashShuffleReceiver {
     type RecvFuture<'a> = impl Future<Output = Result<Option<DataChunk>>>;
+
     fn recv(&mut self) -> Self::RecvFuture<'_> {
         async move {
             match self.receiver.recv().await {

--- a/src/batch/src/task/task_.rs
+++ b/src/batch/src/task/task_.rs
@@ -81,6 +81,7 @@ impl TaskId {
 
 impl TryFrom<&ProstOutputId> for TaskOutputId {
     type Error = RwError;
+
     fn try_from(prost: &ProstOutputId) -> Result<Self> {
         Ok(TaskOutputId {
             task_id: TaskId::from(prost.get_task_id()?),

--- a/src/common/src/array/bool_array.rs
+++ b/src/common/src/array/bool_array.rs
@@ -41,9 +41,9 @@ impl BoolArray {
 
 impl Array for BoolArray {
     type Builder = BoolArrayBuilder;
-    type RefItem<'a> = bool;
-    type OwnedItem = bool;
     type Iter<'a> = ArrayIterator<'a, Self>;
+    type OwnedItem = bool;
+    type RefItem<'a> = bool;
 
     fn value_at(&self, idx: usize) -> Option<bool> {
         if !self.is_null(idx) {

--- a/src/common/src/array/data_chunk_iter.rs
+++ b/src/common/src/array/data_chunk_iter.rs
@@ -100,6 +100,7 @@ impl<'a> From<&'a Row> for RowRef<'a> {
 
 impl<'a> ops::Index<usize> for RowRef<'a> {
     type Output = DatumRef<'a>;
+
     fn index(&self, index: usize) -> &Self::Output {
         &self.0[index]
     }
@@ -110,6 +111,7 @@ pub struct Row(pub Vec<Datum>);
 
 impl ops::Index<usize> for Row {
     type Output = Datum;
+
     fn index(&self, index: usize) -> &Self::Output {
         &self.0[index]
     }

--- a/src/common/src/array/decimal_array.rs
+++ b/src/common/src/array/decimal_array.rs
@@ -43,9 +43,9 @@ impl DecimalArray {
 
 impl Array for DecimalArray {
     type Builder = DecimalArrayBuilder;
-    type RefItem<'a> = Decimal;
-    type OwnedItem = Decimal;
     type Iter<'a> = ArrayIterator<'a, Self>;
+    type OwnedItem = Decimal;
+    type RefItem<'a> = Decimal;
 
     fn value_at(&self, idx: usize) -> Option<Decimal> {
         if !self.is_null(idx) {

--- a/src/common/src/array/interval_array.rs
+++ b/src/common/src/array/interval_array.rs
@@ -48,9 +48,9 @@ impl IntervalArray {
 
 impl Array for IntervalArray {
     type Builder = IntervalArrayBuilder;
-    type RefItem<'a> = IntervalUnit;
-    type OwnedItem = IntervalUnit;
     type Iter<'a> = ArrayIterator<'a, Self>;
+    type OwnedItem = IntervalUnit;
+    type RefItem<'a> = IntervalUnit;
 
     fn value_at(&self, idx: usize) -> Option<Self::RefItem<'_>> {
         if !self.is_null(idx) {

--- a/src/common/src/array/iterator.rs
+++ b/src/common/src/array/iterator.rs
@@ -29,6 +29,7 @@ impl<'a, A: Array> ArrayIterator<'a, A> {
 
 impl<'a, A: Array> Iterator for ArrayIterator<'a, A> {
     type Item = Option<A::RefItem<'a>>;
+
     fn next(&mut self) -> Option<Self::Item> {
         if self.pos >= self.data.len() {
             None
@@ -53,6 +54,7 @@ impl<'a> ArrayImplIterator<'a> {
 
 impl<'a> Iterator for ArrayImplIterator<'a> {
     type Item = DatumRef<'a>;
+
     fn next(&mut self) -> Option<Self::Item> {
         if self.pos >= self.data.len() {
             None

--- a/src/common/src/array/list_array.rs
+++ b/src/common/src/array/list_array.rs
@@ -126,13 +126,10 @@ pub struct ListArray {
 }
 
 impl Array for ListArray {
-    type RefItem<'a> = ListRef<'a>;
-
-    type OwnedItem = ListValue;
-
     type Builder = ListArrayBuilder;
-
     type Iter<'a> = ArrayIterator<'a, Self>;
+    type OwnedItem = ListValue;
+    type RefItem<'a> = ListRef<'a>;
 
     fn value_at(&self, idx: usize) -> Option<ListRef<'_>> {
         if !self.is_null(idx) {

--- a/src/common/src/array/primitive_array.rs
+++ b/src/common/src/array/primitive_array.rs
@@ -104,9 +104,9 @@ impl<T: PrimitiveArrayItemType> PrimitiveArray<T> {
 
 impl<T: PrimitiveArrayItemType> Array for PrimitiveArray<T> {
     type Builder = PrimitiveArrayBuilder<T>;
-    type RefItem<'a> = T;
-    type OwnedItem = T;
     type Iter<'a> = ArrayIterator<'a, Self>;
+    type OwnedItem = T;
+    type RefItem<'a> = T;
 
     fn value_at(&self, idx: usize) -> Option<T> {
         if !self.is_null(idx) {

--- a/src/common/src/array/struct_array.rs
+++ b/src/common/src/array/struct_array.rs
@@ -128,13 +128,10 @@ pub struct StructArray {
 }
 
 impl Array for StructArray {
-    type RefItem<'a> = StructRef<'a>;
-
-    type OwnedItem = StructValue;
-
     type Builder = StructArrayBuilder;
-
     type Iter<'a> = ArrayIterator<'a, Self>;
+    type OwnedItem = StructValue;
+    type RefItem<'a> = StructRef<'a>;
 
     fn value_at(&self, idx: usize) -> Option<StructRef<'_>> {
         if !self.is_null(idx) {

--- a/src/common/src/array/utf8_array.rs
+++ b/src/common/src/array/utf8_array.rs
@@ -34,10 +34,10 @@ pub struct Utf8Array {
 }
 
 impl Array for Utf8Array {
-    type RefItem<'a> = &'a str;
-    type OwnedItem = String;
     type Builder = Utf8ArrayBuilder;
     type Iter<'a> = ArrayIterator<'a, Self>;
+    type OwnedItem = String;
+    type RefItem<'a> = &'a str;
 
     fn value_at(&self, idx: usize) -> Option<&str> {
         if !self.is_null(idx) {

--- a/src/common/src/buffer/bitmap.rs
+++ b/src/common/src/buffer/bitmap.rs
@@ -261,6 +261,7 @@ impl From<Buffer> for Bitmap {
 
 impl TryFrom<&BoolArray> for Bitmap {
     type Error = RwError;
+
     fn try_from(bools: &BoolArray) -> Result<Bitmap> {
         let mut builder = BitmapBuilder::default();
         bools.iter().for_each(|e| {

--- a/src/common/src/hash/key.rs
+++ b/src/common/src/hash/key.rs
@@ -202,6 +202,7 @@ pub type KeySerialized = SerializedKey;
 
 impl HashKeySerDe<'_> for bool {
     type S = [u8; 1];
+
     fn serialize(self) -> Self::S {
         if self {
             [1u8; 1]

--- a/src/common/src/types/decimal.rs
+++ b/src/common/src/types/decimal.rs
@@ -89,6 +89,7 @@ macro_rules! impl_try_from_decimal {
     ($from_ty:ty, $to_ty:ty, $convert:path, $err:expr) => {
         impl core::convert::TryFrom<$from_ty> for $to_ty {
             type Error = Error;
+
             fn try_from(value: $from_ty) -> Result<Self, Self::Error> {
                 $convert(&value).ok_or_else(|| Error::from($err))
             }
@@ -100,6 +101,7 @@ macro_rules! impl_try_from_float {
     ($from_ty:ty, $to_ty:ty, $convert:path, $err:expr) => {
         impl core::convert::TryFrom<$from_ty> for $to_ty {
             type Error = Error;
+
             fn try_from(value: $from_ty) -> Result<Self, Self::Error> {
                 $convert(value).ok_or_else(|| Error::from($err))
             }
@@ -148,6 +150,7 @@ impl FromPrimitive for Decimal {
         (i32, from_i32),
         (i64, from_i64)
     ]);
+
     impl_from_float!([(f32, from_f32), (f64, from_f64)]);
 }
 
@@ -188,6 +191,7 @@ impl Add for Decimal {
 
 impl Neg for Decimal {
     type Output = Self;
+
     fn neg(self) -> Self {
         match self {
             Self::Normalized(d) => Self::Normalized(-d),
@@ -401,6 +405,7 @@ impl Decimal {
     pub fn new(num: i64, scale: u32) -> Self {
         Self::Normalized(RustDecimal::new(num, scale))
     }
+
     pub fn zero() -> Self {
         Self::from(0)
     }
@@ -487,6 +492,7 @@ impl ToPrimitive for Decimal {
         (u16, to_u16),
         (u8, to_u8)
     ]);
+
     impl_to_float!([(f64, to_f64), (f32, to_f32)]);
 }
 

--- a/src/common/src/types/ordered_float.rs
+++ b/src/common/src/types/ordered_float.rs
@@ -475,10 +475,12 @@ impl<T: Float + Signed> Signed for OrderedFloat<T> {
     fn signum(&self) -> Self {
         OrderedFloat(self.0.signum())
     }
+
     #[inline]
     fn is_positive(&self) -> bool {
         self.0.is_positive()
     }
+
     #[inline]
     fn is_negative(&self) -> bool {
         self.0.is_negative()
@@ -565,36 +567,47 @@ impl<T: FromPrimitive> FromPrimitive for OrderedFloat<T> {
     fn from_i64(n: i64) -> Option<Self> {
         T::from_i64(n).map(OrderedFloat)
     }
+
     fn from_u64(n: u64) -> Option<Self> {
         T::from_u64(n).map(OrderedFloat)
     }
+
     fn from_isize(n: isize) -> Option<Self> {
         T::from_isize(n).map(OrderedFloat)
     }
+
     fn from_i8(n: i8) -> Option<Self> {
         T::from_i8(n).map(OrderedFloat)
     }
+
     fn from_i16(n: i16) -> Option<Self> {
         T::from_i16(n).map(OrderedFloat)
     }
+
     fn from_i32(n: i32) -> Option<Self> {
         T::from_i32(n).map(OrderedFloat)
     }
+
     fn from_usize(n: usize) -> Option<Self> {
         T::from_usize(n).map(OrderedFloat)
     }
+
     fn from_u8(n: u8) -> Option<Self> {
         T::from_u8(n).map(OrderedFloat)
     }
+
     fn from_u16(n: u16) -> Option<Self> {
         T::from_u16(n).map(OrderedFloat)
     }
+
     fn from_u32(n: u32) -> Option<Self> {
         T::from_u32(n).map(OrderedFloat)
     }
+
     fn from_f32(n: f32) -> Option<Self> {
         T::from_f32(n).map(OrderedFloat)
     }
+
     fn from_f64(n: f64) -> Option<Self> {
         T::from_f64(n).map(OrderedFloat)
     }
@@ -604,36 +617,47 @@ impl<T: ToPrimitive> ToPrimitive for OrderedFloat<T> {
     fn to_i64(&self) -> Option<i64> {
         self.0.to_i64()
     }
+
     fn to_u64(&self) -> Option<u64> {
         self.0.to_u64()
     }
+
     fn to_isize(&self) -> Option<isize> {
         self.0.to_isize()
     }
+
     fn to_i8(&self) -> Option<i8> {
         self.0.to_i8()
     }
+
     fn to_i16(&self) -> Option<i16> {
         self.0.to_i16()
     }
+
     fn to_i32(&self) -> Option<i32> {
         self.0.to_i32()
     }
+
     fn to_usize(&self) -> Option<usize> {
         self.0.to_usize()
     }
+
     fn to_u8(&self) -> Option<u8> {
         self.0.to_u8()
     }
+
     fn to_u16(&self) -> Option<u16> {
         self.0.to_u16()
     }
+
     fn to_u32(&self) -> Option<u32> {
         self.0.to_u32()
     }
+
     fn to_f32(&self) -> Option<f32> {
         self.0.to_f32()
     }
+
     fn to_f64(&self) -> Option<f64> {
         self.0.to_f64()
     }
@@ -643,172 +667,228 @@ impl<T: Float> Float for OrderedFloat<T> {
     fn nan() -> Self {
         OrderedFloat(T::nan())
     }
+
     fn infinity() -> Self {
         OrderedFloat(T::infinity())
     }
+
     fn neg_infinity() -> Self {
         OrderedFloat(T::neg_infinity())
     }
+
     fn neg_zero() -> Self {
         OrderedFloat(T::neg_zero())
     }
+
     fn min_value() -> Self {
         OrderedFloat(T::min_value())
     }
+
     fn min_positive_value() -> Self {
         OrderedFloat(T::min_positive_value())
     }
+
     fn max_value() -> Self {
         OrderedFloat(T::max_value())
     }
+
     fn is_nan(self) -> bool {
         self.0.is_nan()
     }
+
     fn is_infinite(self) -> bool {
         self.0.is_infinite()
     }
+
     fn is_finite(self) -> bool {
         self.0.is_finite()
     }
+
     fn is_normal(self) -> bool {
         self.0.is_normal()
     }
+
     fn classify(self) -> FpCategory {
         self.0.classify()
     }
+
     fn floor(self) -> Self {
         OrderedFloat(self.0.floor())
     }
+
     fn ceil(self) -> Self {
         OrderedFloat(self.0.ceil())
     }
+
     fn round(self) -> Self {
         OrderedFloat(self.0.round())
     }
+
     fn trunc(self) -> Self {
         OrderedFloat(self.0.trunc())
     }
+
     fn fract(self) -> Self {
         OrderedFloat(self.0.fract())
     }
+
     fn abs(self) -> Self {
         OrderedFloat(self.0.abs())
     }
+
     fn signum(self) -> Self {
         OrderedFloat(self.0.signum())
     }
+
     fn is_sign_positive(self) -> bool {
         self.0.is_sign_positive()
     }
+
     fn is_sign_negative(self) -> bool {
         self.0.is_sign_negative()
     }
+
     fn mul_add(self, a: Self, b: Self) -> Self {
         OrderedFloat(self.0.mul_add(a.0, b.0))
     }
+
     fn recip(self) -> Self {
         OrderedFloat(self.0.recip())
     }
+
     fn powi(self, n: i32) -> Self {
         OrderedFloat(self.0.powi(n))
     }
+
     fn powf(self, n: Self) -> Self {
         OrderedFloat(self.0.powf(n.0))
     }
+
     fn sqrt(self) -> Self {
         OrderedFloat(self.0.sqrt())
     }
+
     fn exp(self) -> Self {
         OrderedFloat(self.0.exp())
     }
+
     fn exp2(self) -> Self {
         OrderedFloat(self.0.exp2())
     }
+
     fn ln(self) -> Self {
         OrderedFloat(self.0.ln())
     }
+
     fn log(self, base: Self) -> Self {
         OrderedFloat(self.0.log(base.0))
     }
+
     fn log2(self) -> Self {
         OrderedFloat(self.0.log2())
     }
+
     fn log10(self) -> Self {
         OrderedFloat(self.0.log10())
     }
+
     fn max(self, other: Self) -> Self {
         OrderedFloat(self.0.max(other.0))
     }
+
     fn min(self, other: Self) -> Self {
         OrderedFloat(self.0.min(other.0))
     }
+
     fn abs_sub(self, other: Self) -> Self {
         OrderedFloat(self.0.abs_sub(other.0))
     }
+
     fn cbrt(self) -> Self {
         OrderedFloat(self.0.cbrt())
     }
+
     fn hypot(self, other: Self) -> Self {
         OrderedFloat(self.0.hypot(other.0))
     }
+
     fn sin(self) -> Self {
         OrderedFloat(self.0.sin())
     }
+
     fn cos(self) -> Self {
         OrderedFloat(self.0.cos())
     }
+
     fn tan(self) -> Self {
         OrderedFloat(self.0.tan())
     }
+
     fn asin(self) -> Self {
         OrderedFloat(self.0.asin())
     }
+
     fn acos(self) -> Self {
         OrderedFloat(self.0.acos())
     }
+
     fn atan(self) -> Self {
         OrderedFloat(self.0.atan())
     }
+
     fn atan2(self, other: Self) -> Self {
         OrderedFloat(self.0.atan2(other.0))
     }
+
     fn sin_cos(self) -> (Self, Self) {
         let (a, b) = self.0.sin_cos();
         (OrderedFloat(a), OrderedFloat(b))
     }
+
     fn exp_m1(self) -> Self {
         OrderedFloat(self.0.exp_m1())
     }
+
     fn ln_1p(self) -> Self {
         OrderedFloat(self.0.ln_1p())
     }
+
     fn sinh(self) -> Self {
         OrderedFloat(self.0.sinh())
     }
+
     fn cosh(self) -> Self {
         OrderedFloat(self.0.cosh())
     }
+
     fn tanh(self) -> Self {
         OrderedFloat(self.0.tanh())
     }
+
     fn asinh(self) -> Self {
         OrderedFloat(self.0.asinh())
     }
+
     fn acosh(self) -> Self {
         OrderedFloat(self.0.acosh())
     }
+
     fn atanh(self) -> Self {
         OrderedFloat(self.0.atanh())
     }
+
     fn integer_decode(self) -> (u64, i16, i8) {
         self.0.integer_decode()
     }
+
     fn epsilon() -> Self {
         OrderedFloat(T::epsilon())
     }
+
     fn to_degrees(self) -> Self {
         OrderedFloat(self.0.to_degrees())
     }
+
     fn to_radians(self) -> Self {
         OrderedFloat(self.0.to_radians())
     }
@@ -816,6 +896,7 @@ impl<T: Float> Float for OrderedFloat<T> {
 
 impl<T: Float + Num> Num for OrderedFloat<T> {
     type FromStrRadixErr = T::FromStrRadixErr;
+
     fn from_str_radix(str: &str, radix: u32) -> Result<Self, Self::FromStrRadixErr> {
         T::from_str_radix(str, radix).map(OrderedFloat)
     }
@@ -894,6 +975,7 @@ mod impl_rand {
         ($f:ty) => {
             impl UniformSampler for UniformOrdered<$f> {
                 type X = OrderedFloat<$f>;
+
                 fn new<B1, B2>(low: B1, high: B2) -> Self
                 where
                     B1: SampleBorrow<Self::X> + Sized,
@@ -901,6 +983,7 @@ mod impl_rand {
                 {
                     UniformOrdered(UniformFloat::<$f>::new(low.borrow().0, high.borrow().0))
                 }
+
                 fn new_inclusive<B1, B2>(low: B1, high: B2) -> Self
                 where
                     B1: SampleBorrow<Self::X> + Sized,
@@ -908,6 +991,7 @@ mod impl_rand {
                 {
                     UniformSampler::new(low, high)
                 }
+
                 fn sample<R: Rng + ?Sized>(&self, rng: &mut R) -> Self::X {
                     OrderedFloat(self.0.sample(rng))
                 }

--- a/src/connector/src/pulsar/enumerator/client.rs
+++ b/src/connector/src/pulsar/enumerator/client.rs
@@ -57,6 +57,7 @@ impl PulsarSplitEnumerator {
 #[async_trait]
 impl SplitEnumerator for PulsarSplitEnumerator {
     type Split = PulsarSplit;
+
     async fn list_splits(&mut self) -> anyhow::Result<Vec<PulsarSplit>> {
         let meta = self.admin_client.get_topic_metadata(&self.topic).await?;
 

--- a/src/expr/src/vector_op/agg/count_star.rs
+++ b/src/expr/src/vector_op/agg/count_star.rs
@@ -37,16 +37,19 @@ impl Aggregator for CountStar {
     fn return_type(&self) -> DataType {
         self.return_type.clone()
     }
+
     fn update(&mut self, input: &DataChunk) -> Result<()> {
         self.result += input.cardinality();
         Ok(())
     }
+
     fn output(&self, builder: &mut ArrayBuilderImpl) -> Result<()> {
         match builder {
             ArrayBuilderImpl::Int64(b) => b.append(Some(self.result as i64)),
             _ => Err(ErrorCode::InternalError("Unexpected builder for count(*).".into()).into()),
         }
     }
+
     fn update_and_output_with_sorted_groups(
         &mut self,
         input: &DataChunk,

--- a/src/expr/src/vector_op/agg/general_agg.rs
+++ b/src/expr/src/vector_op/agg/general_agg.rs
@@ -49,6 +49,7 @@ where
             _phantom: PhantomData,
         }
     }
+
     pub(super) fn update_with_scalar_concrete(&mut self, input: &T, row_id: usize) -> Result<()> {
         let datum = self
             .f
@@ -60,6 +61,7 @@ where
         self.result = datum;
         Ok(())
     }
+
     pub(super) fn update_concrete(&mut self, input: &T) -> Result<()> {
         let mut cur = self.result.as_ref().map(|x| x.as_scalar_ref());
         for datum in input.iter() {
@@ -69,9 +71,11 @@ where
         self.result = r;
         Ok(())
     }
+
     pub(super) fn output_concrete(&self, builder: &mut R::Builder) -> Result<()> {
         builder.append(self.result.as_ref().map(|x| x.as_scalar_ref()))
     }
+
     pub(super) fn update_and_output_with_sorted_groups_concrete(
         &mut self,
         input: &T,
@@ -102,6 +106,7 @@ macro_rules! impl_aggregator {
             fn return_type(&self) -> DataType {
                 self.return_type.clone()
             }
+
             fn update_with_row(&mut self, input: &DataChunk, row_id: usize) -> Result<()> {
                 if let ArrayImpl::$input_variant(i) =
                     input.column_at(self.input_col_idx).array_ref()
@@ -129,6 +134,7 @@ macro_rules! impl_aggregator {
                     .into())
                 }
             }
+
             fn output(&self, builder: &mut ArrayBuilderImpl) -> Result<()> {
                 if let ArrayBuilderImpl::$result_variant(b) = builder {
                     self.output_concrete(b)
@@ -140,6 +146,7 @@ macro_rules! impl_aggregator {
                     .into())
                 }
             }
+
             fn update_and_output_with_sorted_groups(
                 &mut self,
                 input: &DataChunk,

--- a/src/expr/src/vector_op/agg/general_distinct_agg.rs
+++ b/src/expr/src/vector_op/agg/general_distinct_agg.rs
@@ -89,9 +89,11 @@ where
         self.result = r;
         Ok(())
     }
+
     fn output_concrete(&self, builder: &mut R::Builder) -> Result<()> {
         builder.append(self.result.as_ref().map(|x| x.as_scalar_ref()))
     }
+
     fn update_and_output_with_sorted_groups_concrete(
         &mut self,
         input: &T,
@@ -125,6 +127,7 @@ macro_rules! impl_aggregator {
             fn return_type(&self) -> DataType {
                 self.return_type.clone()
             }
+
             fn update_with_row(&mut self, input: &DataChunk, row_id: usize) -> Result<()> {
                 if let ArrayImpl::$input_variant(i) =
                     input.column_at(self.input_col_idx).array_ref()
@@ -152,6 +155,7 @@ macro_rules! impl_aggregator {
                     .into())
                 }
             }
+
             fn output(&self, builder: &mut ArrayBuilderImpl) -> Result<()> {
                 if let ArrayBuilderImpl::$result_variant(b) = builder {
                     self.output_concrete(b)
@@ -163,6 +167,7 @@ macro_rules! impl_aggregator {
                     .into())
                 }
             }
+
             fn update_and_output_with_sorted_groups(
                 &mut self,
                 input: &DataChunk,

--- a/src/expr/src/vector_op/agg/general_sorted_grouper.rs
+++ b/src/expr/src/vector_op/agg/general_sorted_grouper.rs
@@ -151,6 +151,7 @@ where
         }
         Ok(EqGroups(ret))
     }
+
     pub fn update_and_output_with_sorted_groups_concrete(
         &mut self,
         input: &T,
@@ -171,6 +172,7 @@ where
         self.group_value = cur.map(|x| x.to_owned_scalar());
         Ok(())
     }
+
     pub fn output_concrete(&self, builder: &mut T::Builder) -> Result<()> {
         builder.append(self.group_value.as_ref().map(|x| x.as_scalar_ref()))
     }
@@ -190,6 +192,7 @@ macro_rules! impl_sorted_grouper {
                     .into())
                 }
             }
+
             fn output(&self, builder: &mut ArrayBuilderImpl) -> Result<()> {
                 if let ArrayBuilderImpl::$input_variant(b) = builder {
                     self.output_concrete(b)
@@ -201,6 +204,7 @@ macro_rules! impl_sorted_grouper {
                     .into())
                 }
             }
+
             fn update_and_output_with_sorted_groups(
                 &mut self,
                 input: &ArrayImpl,

--- a/src/frontend/src/catalog/catalog_service.rs
+++ b/src/frontend/src/catalog/catalog_service.rs
@@ -38,6 +38,7 @@ impl CatalogReader {
     pub fn new(inner: Arc<RwLock<Catalog>>) -> Self {
         CatalogReader(inner)
     }
+
     pub fn read_guard(&self) -> CatalogReadGuard {
         self.0.read_arc()
     }

--- a/src/frontend/src/catalog/root_catalog.rs
+++ b/src/frontend/src/catalog/root_catalog.rs
@@ -89,6 +89,7 @@ impl Catalog {
             .unwrap()
             .create_table(proto);
     }
+
     pub fn create_source(&mut self, proto: ProstSource) {
         self.get_database_mut(proto.database_id)
             .unwrap()

--- a/src/frontend/src/catalog/schema_catalog.rs
+++ b/src/frontend/src/catalog/schema_catalog.rs
@@ -43,6 +43,7 @@ impl SchemaCatalog {
         self.table_by_name.try_insert(name.clone(), table).unwrap();
         self.table_name_by_id.try_insert(id, name).unwrap();
     }
+
     pub fn drop_table(&mut self, id: TableId) {
         let name = self.table_name_by_id.remove(&id).unwrap();
         self.table_by_name.remove(&name).unwrap();
@@ -57,6 +58,7 @@ impl SchemaCatalog {
             .unwrap();
         self.source_name_by_id.try_insert(id, name).unwrap();
     }
+
     pub fn drop_source(&mut self, id: SourceId) {
         let name = self.source_name_by_id.remove(&id).unwrap();
         self.source_by_name.remove(&name).unwrap();
@@ -83,6 +85,7 @@ impl SchemaCatalog {
     pub fn get_table_by_name(&self, table_name: &str) -> Option<&TableCatalog> {
         self.table_by_name.get(table_name)
     }
+
     pub fn get_source_by_name(&self, source_name: &str) -> Option<&SourceCatalog> {
         self.source_by_name.get(source_name)
     }

--- a/src/frontend/src/expr/agg_call.rs
+++ b/src/frontend/src/expr/agg_call.rs
@@ -99,9 +99,11 @@ impl AggCall {
             inputs,
         })
     }
+
     pub fn decompose(self) -> (AggKind, Vec<ExprImpl>) {
         (self.agg_kind, self.inputs)
     }
+
     pub fn agg_kind(&self) -> AggKind {
         self.agg_kind.clone()
     }

--- a/src/frontend/src/expr/function_call.rs
+++ b/src/frontend/src/expr/function_call.rs
@@ -122,6 +122,7 @@ impl FunctionCall {
     pub fn decompose(self) -> (ExprType, Vec<ExprImpl>, DataType) {
         (self.func_type, self.inputs, self.return_type)
     }
+
     pub fn decompose_as_binary(self) -> (ExprType, ExprImpl, ExprImpl) {
         assert_eq!(self.inputs.len(), 2);
         let mut iter = self.inputs.into_iter();
@@ -129,6 +130,7 @@ impl FunctionCall {
         let right = iter.next().unwrap();
         (self.func_type, left, right)
     }
+
     pub fn decompose_as_unary(self) -> (ExprType, ExprImpl) {
         assert_eq!(self.inputs.len(), 1);
         let mut iter = self.inputs.into_iter();

--- a/src/frontend/src/expr/literal.rs
+++ b/src/frontend/src/expr/literal.rs
@@ -47,9 +47,11 @@ impl Literal {
     pub fn new(data: Datum, data_type: DataType) -> Self {
         Literal { data, data_type }
     }
+
     pub fn get_expr_type(&self) -> ExprType {
         ExprType::ConstantValue
     }
+
     pub fn get_data(&self) -> &Datum {
         &self.data
     }

--- a/src/frontend/src/expr/type_inference.rs
+++ b/src/frontend/src/expr/type_inference.rs
@@ -116,24 +116,28 @@ impl FuncSign {
     pub fn new(func: ExprType, inputs_type: Vec<DataTypeName>) -> Self {
         FuncSign { func, inputs_type }
     }
+
     pub fn new_no_input(func: ExprType) -> Self {
         FuncSign {
             func,
             inputs_type: vec![],
         }
     }
+
     pub fn new_unary(func: ExprType, p1: DataTypeName) -> Self {
         FuncSign {
             func,
             inputs_type: vec![p1],
         }
     }
+
     pub fn new_binary(func: ExprType, p1: DataTypeName, p2: DataTypeName) -> Self {
         FuncSign {
             func,
             inputs_type: vec![p1, p2],
         }
     }
+
     pub fn new_ternary(
         func: ExprType,
         p1: DataTypeName,

--- a/src/frontend/src/optimizer/plan_node/batch_exchange.rs
+++ b/src/frontend/src/optimizer/plan_node/batch_exchange.rs
@@ -52,6 +52,7 @@ impl PlanTreeNodeUnary for BatchExchange {
     fn input(&self) -> PlanRef {
         self.input.clone()
     }
+
     fn clone_with_input(&self, input: PlanRef) -> Self {
         Self::new(input, self.order().clone(), self.distribution().clone())
     }

--- a/src/frontend/src/optimizer/plan_node/batch_hash_agg.rs
+++ b/src/frontend/src/optimizer/plan_node/batch_hash_agg.rs
@@ -46,9 +46,11 @@ impl BatchHashAgg {
         let base = PlanBase::new_batch(ctx, logical.schema().clone(), dist, Order::any().clone());
         BatchHashAgg { base, logical }
     }
+
     pub fn agg_calls(&self) -> &[PlanAggCall] {
         self.logical.agg_calls()
     }
+
     pub fn group_keys(&self) -> &[usize] {
         self.logical.group_keys()
     }

--- a/src/frontend/src/optimizer/plan_node/batch_hash_join.rs
+++ b/src/frontend/src/optimizer/plan_node/batch_hash_join.rs
@@ -94,9 +94,11 @@ impl PlanTreeNodeBinary for BatchHashJoin {
     fn left(&self) -> PlanRef {
         self.logical.left()
     }
+
     fn right(&self) -> PlanRef {
         self.logical.right()
     }
+
     fn clone_with_left_right(&self, left: PlanRef, right: PlanRef) -> Self {
         Self::new(
             self.logical.clone_with_left_right(left, right),

--- a/src/frontend/src/optimizer/plan_node/batch_limit.rs
+++ b/src/frontend/src/optimizer/plan_node/batch_limit.rs
@@ -54,6 +54,7 @@ impl PlanTreeNodeUnary for BatchLimit {
     fn input(&self) -> PlanRef {
         self.logical.input()
     }
+
     fn clone_with_input(&self, input: PlanRef) -> Self {
         Self::new(self.logical.clone_with_input(input))
     }

--- a/src/frontend/src/optimizer/plan_node/batch_project.rs
+++ b/src/frontend/src/optimizer/plan_node/batch_project.rs
@@ -59,6 +59,7 @@ impl PlanTreeNodeUnary for BatchProject {
     fn input(&self) -> PlanRef {
         self.logical.input()
     }
+
     fn clone_with_input(&self, input: PlanRef) -> Self {
         Self::new(self.logical.clone_with_input(input))
     }
@@ -71,6 +72,7 @@ impl ToDistributedBatch for BatchProject {
         let new_input = self.input().to_distributed();
         self.clone_with_input(new_input).into()
     }
+
     fn to_distributed_with_required(
         &self,
         required_order: &Order,

--- a/src/frontend/src/optimizer/plan_node/batch_simple_agg.rs
+++ b/src/frontend/src/optimizer/plan_node/batch_simple_agg.rs
@@ -40,6 +40,7 @@ impl BatchSimpleAgg {
         let base = PlanBase::new_batch(ctx, logical.schema().clone(), dist, Order::any().clone());
         BatchSimpleAgg { base, logical }
     }
+
     pub fn agg_calls(&self) -> &[PlanAggCall] {
         self.logical.agg_calls()
     }

--- a/src/frontend/src/optimizer/plan_node/batch_sort.rs
+++ b/src/frontend/src/optimizer/plan_node/batch_sort.rs
@@ -49,6 +49,7 @@ impl PlanTreeNodeUnary for BatchSort {
     fn input(&self) -> PlanRef {
         self.input.clone()
     }
+
     fn clone_with_input(&self, input: PlanRef) -> Self {
         Self::new(input, self.base.order.clone())
     }

--- a/src/frontend/src/optimizer/plan_node/logical_agg.rs
+++ b/src/frontend/src/optimizer/plan_node/logical_agg.rs
@@ -215,6 +215,7 @@ impl ExprRewriter for ExprHandler {
             ))
         }
     }
+
     // When there is an InputRef (outside of agg call), it must refers to a group column.
     fn rewrite_input_ref(&mut self, input_ref: InputRef) -> ExprImpl {
         let expr = input_ref.into();
@@ -381,6 +382,7 @@ impl PlanTreeNodeUnary for LogicalAgg {
     fn input(&self) -> PlanRef {
         self.input.clone()
     }
+
     fn clone_with_input(&self, input: PlanRef) -> Self {
         Self::new(
             self.agg_calls().to_vec(),
@@ -389,6 +391,7 @@ impl PlanTreeNodeUnary for LogicalAgg {
             input,
         )
     }
+
     #[must_use]
     fn rewrite_with_input(
         &self,

--- a/src/frontend/src/optimizer/plan_node/logical_filter.rs
+++ b/src/frontend/src/optimizer/plan_node/logical_filter.rs
@@ -76,9 +76,11 @@ impl PlanTreeNodeUnary for LogicalFilter {
     fn input(&self) -> PlanRef {
         self.input.clone()
     }
+
     fn clone_with_input(&self, input: PlanRef) -> Self {
         Self::new(input, self.predicate.clone())
     }
+
     #[must_use]
     fn rewrite_with_input(
         &self,

--- a/src/frontend/src/optimizer/plan_node/logical_insert.rs
+++ b/src/frontend/src/optimizer/plan_node/logical_insert.rs
@@ -103,6 +103,7 @@ impl ToStream for LogicalInsert {
     fn to_stream(&self) -> PlanRef {
         unreachable!("insert should always be converted to batch plan");
     }
+
     fn logical_rewrite_for_stream(&self) -> (PlanRef, crate::utils::ColIndexMapping) {
         unreachable!("delete should always be converted to batch plan");
     }

--- a/src/frontend/src/optimizer/plan_node/logical_join.rs
+++ b/src/frontend/src/optimizer/plan_node/logical_join.rs
@@ -148,6 +148,7 @@ impl LogicalJoin {
             self.join_type(),
         )
     }
+
     pub fn o2r_col_mapping(&self) -> ColIndexMapping {
         Self::o2r_col_mapping_inner(
             self.left().schema().len(),
@@ -155,6 +156,7 @@ impl LogicalJoin {
             self.join_type(),
         )
     }
+
     pub fn l2o_col_mapping(&self) -> ColIndexMapping {
         Self::l2o_col_mapping_inner(
             self.left().schema().len(),
@@ -162,6 +164,7 @@ impl LogicalJoin {
             self.join_type(),
         )
     }
+
     pub fn r2o_col_mapping(&self) -> ColIndexMapping {
         Self::r2o_col_mapping_inner(
             self.left().schema().len(),
@@ -207,6 +210,7 @@ impl LogicalJoin {
             .flatten()
             .collect()
     }
+
     /// Get a reference to the logical join's on.
     pub fn on(&self) -> &Condition {
         &self.on

--- a/src/frontend/src/optimizer/plan_node/logical_limit.rs
+++ b/src/frontend/src/optimizer/plan_node/logical_limit.rs
@@ -62,9 +62,11 @@ impl PlanTreeNodeUnary for LogicalLimit {
     fn input(&self) -> PlanRef {
         self.input.clone()
     }
+
     fn clone_with_input(&self, input: PlanRef) -> Self {
         Self::new(input, self.limit, self.offset)
     }
+
     #[must_use]
     fn rewrite_with_input(
         &self,
@@ -106,6 +108,7 @@ impl ToStream for LogicalLimit {
     fn to_stream(&self) -> PlanRef {
         panic!("there is no limit stream operator");
     }
+
     fn logical_rewrite_for_stream(&self) -> (PlanRef, ColIndexMapping) {
         let (input, input_col_change) = self.input.logical_rewrite_for_stream();
         let (filter, out_col_change) = self.rewrite_with_input(input, input_col_change);

--- a/src/frontend/src/optimizer/plan_node/logical_project.rs
+++ b/src/frontend/src/optimizer/plan_node/logical_project.rs
@@ -158,6 +158,7 @@ impl LogicalProject {
             .collect::<Option<Vec<_>>>()
             .unwrap_or_default()
     }
+
     pub fn exprs(&self) -> &Vec<ExprImpl> {
         &self.exprs
     }
@@ -200,9 +201,11 @@ impl PlanTreeNodeUnary for LogicalProject {
     fn input(&self) -> PlanRef {
         self.input.clone()
     }
+
     fn clone_with_input(&self, input: PlanRef) -> Self {
         Self::new(input, self.exprs.clone(), self.expr_alias().to_vec())
     }
+
     fn rewrite_with_input(
         &self,
         input: PlanRef,

--- a/src/frontend/src/optimizer/plan_node/logical_topn.rs
+++ b/src/frontend/src/optimizer/plan_node/logical_topn.rs
@@ -56,9 +56,11 @@ impl PlanTreeNodeUnary for LogicalTopN {
     fn input(&self) -> PlanRef {
         self.input.clone()
     }
+
     fn clone_with_input(&self, input: PlanRef) -> Self {
         Self::new(input, self.limit, self.offset, self.order.clone())
     }
+
     #[must_use]
     fn rewrite_with_input(
         &self,
@@ -133,6 +135,7 @@ impl ToStream for LogicalTopN {
     fn to_stream(&self) -> PlanRef {
         todo!()
     }
+
     fn logical_rewrite_for_stream(&self) -> (PlanRef, ColIndexMapping) {
         let (input, input_col_change) = self.input.logical_rewrite_for_stream();
         let (top_n, out_col_change) = self.rewrite_with_input(input, input_col_change);

--- a/src/frontend/src/optimizer/plan_node/mod.rs
+++ b/src/frontend/src/optimizer/plan_node/mod.rs
@@ -108,21 +108,27 @@ impl dyn PlanNode {
     pub fn id(&self) -> PlanNodeId {
         self.plan_base().id
     }
+
     pub fn ctx(&self) -> OptimizerContextRef {
         self.plan_base().ctx.clone()
     }
+
     pub fn schema(&self) -> &Schema {
         &self.plan_base().schema
     }
+
     pub fn pk_indices(&self) -> &[usize] {
         &self.plan_base().pk_indices
     }
+
     pub fn order(&self) -> &Order {
         &self.plan_base().order
     }
+
     pub fn distribution(&self) -> &Distribution {
         &self.plan_base().dist
     }
+
     pub fn append_only(&self) -> bool {
         self.plan_base().append_only
     }

--- a/src/frontend/src/optimizer/plan_node/plan_base.rs
+++ b/src/frontend/src/optimizer/plan_node/plan_base.rs
@@ -53,6 +53,7 @@ impl PlanBase {
             append_only: true,
         }
     }
+
     pub fn new_stream(
         ctx: OptimizerContextRef,
         schema: Schema,
@@ -72,6 +73,7 @@ impl PlanBase {
             append_only,
         }
     }
+
     pub fn new_batch(
         ctx: OptimizerContextRef,
         schema: Schema,

--- a/src/frontend/src/optimizer/plan_node/plan_tree_node.rs
+++ b/src/frontend/src/optimizer/plan_node/plan_tree_node.rs
@@ -126,6 +126,7 @@ macro_rules! impl_plan_tree_node_for_binary {
             fn inputs(&self) -> smallvec::SmallVec<[crate::optimizer::PlanRef; 2]> {
                 smallvec::smallvec![self.left(), self.right()]
             }
+
             fn clone_with_inputs(
                 &self,
                 inputs: &[crate::optimizer::PlanRef],

--- a/src/frontend/src/optimizer/plan_node/stream_exchange.rs
+++ b/src/frontend/src/optimizer/plan_node/stream_exchange.rs
@@ -54,6 +54,7 @@ impl PlanTreeNodeUnary for StreamExchange {
     fn input(&self) -> PlanRef {
         self.input.clone()
     }
+
     fn clone_with_input(&self, input: PlanRef) -> Self {
         Self::new(input, self.distribution().clone())
     }

--- a/src/frontend/src/optimizer/plan_node/stream_hash_agg.rs
+++ b/src/frontend/src/optimizer/plan_node/stream_hash_agg.rs
@@ -52,9 +52,11 @@ impl StreamHashAgg {
         let base = PlanBase::new_stream(ctx, logical.schema().clone(), pk_indices, dist, false);
         StreamHashAgg { base, logical }
     }
+
     pub fn agg_calls(&self) -> &[PlanAggCall] {
         self.logical.agg_calls()
     }
+
     pub fn distribution_keys(&self) -> &[usize] {
         self.logical.group_keys()
     }

--- a/src/frontend/src/optimizer/plan_node/stream_hash_join.rs
+++ b/src/frontend/src/optimizer/plan_node/stream_hash_join.rs
@@ -106,9 +106,11 @@ impl PlanTreeNodeBinary for StreamHashJoin {
     fn left(&self) -> PlanRef {
         self.logical.left()
     }
+
     fn right(&self) -> PlanRef {
         self.logical.right()
     }
+
     fn clone_with_left_right(&self, left: PlanRef, right: PlanRef) -> Self {
         Self::new(
             self.logical.clone_with_left_right(left, right),

--- a/src/frontend/src/optimizer/plan_node/stream_materialize.rs
+++ b/src/frontend/src/optimizer/plan_node/stream_materialize.rs
@@ -89,6 +89,7 @@ impl StreamMaterialize {
             .collect();
         Ok(Schema { fields })
     }
+
     #[must_use]
     pub fn new(input: PlanRef, table: TableCatalog) -> Self {
         let base = Self::derive_plan_base(&input).unwrap();

--- a/src/frontend/src/optimizer/plan_node/stream_project.rs
+++ b/src/frontend/src/optimizer/plan_node/stream_project.rs
@@ -59,6 +59,7 @@ impl PlanTreeNodeUnary for StreamProject {
     fn input(&self) -> PlanRef {
         self.logical.input()
     }
+
     fn clone_with_input(&self, input: PlanRef) -> Self {
         Self::new(self.logical.clone_with_input(input))
     }

--- a/src/frontend/src/optimizer/plan_node/stream_simple_agg.rs
+++ b/src/frontend/src/optimizer/plan_node/stream_simple_agg.rs
@@ -43,6 +43,7 @@ impl StreamSimpleAgg {
         let base = PlanBase::new_stream(ctx, logical.schema().clone(), pk_indices, dist, false);
         StreamSimpleAgg { base, logical }
     }
+
     pub fn agg_calls(&self) -> &[PlanAggCall] {
         self.logical.agg_calls()
     }

--- a/src/frontend/src/optimizer/plan_node/stream_source.rs
+++ b/src/frontend/src/optimizer/plan_node/stream_source.rs
@@ -39,6 +39,7 @@ impl StreamSource {
         );
         Self { base, logical }
     }
+
     pub fn column_names(&self) -> Vec<String> {
         self.schema()
             .fields()

--- a/src/frontend/src/optimizer/property/distribution.rs
+++ b/src/frontend/src/optimizer/property/distribution.rs
@@ -74,6 +74,7 @@ impl Distribution {
             _ => unreachable!(),
         }
     }
+
     // "A -> B" represent A satisfies B
     //                   +---+
     //                   |Any|
@@ -108,9 +109,11 @@ impl Distribution {
             },
         }
     }
+
     pub fn any() -> &'static Self {
         &ANY_DISTRIBUTION
     }
+
     pub fn is_any(&self) -> bool {
         matches!(self, Distribution::Any)
     }

--- a/src/frontend/src/optimizer/property/order.rs
+++ b/src/frontend/src/optimizer/property/order.rs
@@ -168,10 +168,12 @@ impl Order {
             plan
         }
     }
+
     pub fn enforce(&self, plan: PlanRef) -> PlanRef {
         assert_eq!(plan.convention(), Convention::Batch);
         BatchSort::new(plan, self.clone()).into()
     }
+
     pub fn satisfies(&self, other: &Order) -> bool {
         if self.field_order.len() < other.field_order.len() {
             return false;
@@ -184,9 +186,11 @@ impl Order {
         }
         true
     }
+
     pub fn any() -> &'static Self {
         &ANY_ORDER
     }
+
     pub fn is_any(&self) -> bool {
         self.field_order.is_empty()
     }

--- a/src/frontend/src/utils/condition.rs
+++ b/src/frontend/src/utils/condition.rs
@@ -30,8 +30,8 @@ pub struct Condition {
 }
 
 impl IntoIterator for Condition {
-    type Item = ExprImpl;
     type IntoIter = std::vec::IntoIter<ExprImpl>;
+    type Item = ExprImpl;
 
     fn into_iter(self) -> Self::IntoIter {
         self.conjunctions.into_iter()

--- a/src/meta/src/hummock/compaction.rs
+++ b/src/meta/src/hummock/compaction.rs
@@ -472,6 +472,7 @@ impl Transactional for CompactStatus {
         );
         Ok(())
     }
+
     fn delete_in_transaction(&self, trx: &mut Transaction) -> Result<()> {
         trx.delete(
             CompactStatus::cf_name().to_string(),

--- a/src/meta/src/hummock/model/compact_task_assignment.rs
+++ b/src/meta/src/hummock/model/compact_task_assignment.rs
@@ -22,8 +22,8 @@ const HUMMOCK_COMPACT_TASK_ASSIGNMENT: &str = "cf/compact_task_assignment";
 
 /// `AssignedCompactTasks` tracks compact tasks assigned to context id.
 impl MetadataModel for CompactTaskAssignment {
-    type ProstType = CompactTaskAssignment;
     type KeyType = CompactTaskRefId;
+    type ProstType = CompactTaskAssignment;
 
     fn cf_name() -> String {
         HUMMOCK_COMPACT_TASK_ASSIGNMENT.to_string()

--- a/src/meta/src/hummock/model/current_version_id.rs
+++ b/src/meta/src/hummock/model/current_version_id.rs
@@ -31,8 +31,8 @@ pub struct CurrentHummockVersionId {
 }
 
 impl MetadataModel for CurrentHummockVersionId {
-    type ProstType = HummockVersionRefId;
     type KeyType = String;
+    type ProstType = HummockVersionRefId;
 
     fn cf_name() -> String {
         HUMMOCK_DEFAULT_CF_NAME.to_string()

--- a/src/meta/src/hummock/model/pinned_snapshot.rs
+++ b/src/meta/src/hummock/model/pinned_snapshot.rs
@@ -24,8 +24,8 @@ const HUMMOCK_PINNED_SNAPSHOT_CF_NAME: &str = "cf/hummock_pinned_snapshot";
 
 /// `HummockPinnedSnapshot` tracks pinned snapshots by given context id.
 impl MetadataModel for HummockPinnedSnapshot {
-    type ProstType = HummockPinnedSnapshot;
     type KeyType = HummockContextRefId;
+    type ProstType = HummockPinnedSnapshot;
 
     fn cf_name() -> String {
         String::from(HUMMOCK_PINNED_SNAPSHOT_CF_NAME)

--- a/src/meta/src/hummock/model/pinned_version.rs
+++ b/src/meta/src/hummock/model/pinned_version.rs
@@ -24,8 +24,8 @@ const HUMMOCK_PINNED_VERSION_CF_NAME: &str = "cf/hummock_pinned_version";
 
 /// `HummockPinnedVersion` tracks pinned versions by given context id.
 impl MetadataModel for HummockPinnedVersion {
-    type ProstType = HummockPinnedVersion;
     type KeyType = HummockContextRefId;
+    type ProstType = HummockPinnedVersion;
 
     fn cf_name() -> String {
         String::from(HUMMOCK_PINNED_VERSION_CF_NAME)

--- a/src/meta/src/hummock/model/sstable_id_info.rs
+++ b/src/meta/src/hummock/model/sstable_id_info.rs
@@ -28,8 +28,8 @@ pub const INVALID_TIMESTAMP: u64 = 0;
 /// `SstableIdInfo` tracks when the sstable id is acquired from meta node and when the corresponding
 /// sstable is tracked in meta node.
 impl MetadataModel for SstableIdInfo {
-    type ProstType = SstableIdInfo;
     type KeyType = SstableRefId;
+    type ProstType = SstableIdInfo;
 
     fn cf_name() -> String {
         String::from(HUMMOCK_SSTABLE_ID_CF_NAME)

--- a/src/meta/src/hummock/model/stale_sstables.rs
+++ b/src/meta/src/hummock/model/stale_sstables.rs
@@ -23,8 +23,8 @@ const HUMMOCK_STALE_SSTABLES_CF_NAME: &str = "cf/hummock_stale_sstables";
 
 /// `HummockStaleSstables` tracks `SSTables` no longer needed after the given version.
 impl MetadataModel for HummockStaleSstables {
-    type ProstType = HummockStaleSstables;
     type KeyType = HummockVersionRefId;
+    type ProstType = HummockStaleSstables;
 
     fn cf_name() -> String {
         String::from(HUMMOCK_STALE_SSTABLES_CF_NAME)

--- a/src/meta/src/hummock/model/version.rs
+++ b/src/meta/src/hummock/model/version.rs
@@ -23,8 +23,8 @@ const HUMMOCK_VERSION_CF_NAME: &str = "cf/hummock_version";
 
 /// `HummockVersion` tracks `SSTables` in given version.
 impl MetadataModel for HummockVersion {
-    type ProstType = HummockVersion;
     type KeyType = HummockVersionRefId;
+    type ProstType = HummockVersion;
 
     fn cf_name() -> String {
         String::from(HUMMOCK_VERSION_CF_NAME)

--- a/src/meta/src/model/catalog.rs
+++ b/src/meta/src/model/catalog.rs
@@ -37,8 +37,8 @@ const FIRST_VERSION_ID: CatalogVersion = 1;
 macro_rules! impl_model_for_catalog {
     ($name:ident, $cf:ident, $key_ty:ty, $key_fn:ident) => {
         impl MetadataModel for $name {
-            type ProstType = Self;
             type KeyType = $key_ty;
+            type ProstType = Self;
 
             fn cf_name() -> String {
                 $cf.to_string()
@@ -93,8 +93,8 @@ impl CatalogVersionGenerator {
 }
 
 impl MetadataModel for CatalogVersionGenerator {
-    type ProstType = CatalogVersion;
     type KeyType = String;
+    type ProstType = CatalogVersion;
 
     fn cf_name() -> String {
         CATALOG_VERSION_CF_NAME.to_string()

--- a/src/meta/src/model/catalog_v2.rs
+++ b/src/meta/src/model/catalog_v2.rs
@@ -29,8 +29,8 @@ const CATALOG_DATABASE_CF_NAME: &str = "cf/catalog_database";
 macro_rules! impl_model_for_catalog {
     ($name:ident, $cf:ident, $key_ty:ty, $key_fn:ident) => {
         impl MetadataModel for $name {
-            type ProstType = Self;
             type KeyType = $key_ty;
+            type ProstType = Self;
 
             fn cf_name() -> String {
                 $cf.to_string()

--- a/src/meta/src/model/cluster.rs
+++ b/src/meta/src/model/cluster.rs
@@ -29,8 +29,8 @@ pub struct Worker {
 }
 
 impl MetadataModel for Worker {
-    type ProstType = WorkerNode;
     type KeyType = HostAddress;
+    type ProstType = WorkerNode;
 
     fn cf_name() -> String {
         WORKER_CF_NAME.to_string()

--- a/src/meta/src/model/hash_mapping.rs
+++ b/src/meta/src/model/hash_mapping.rs
@@ -38,8 +38,8 @@ const HASH_MAPPING_KEY: &str = "consistent_hash_mapping";
 pub struct ConsistentHashMapping(ParallelUnitMapping);
 
 impl MetadataModel for ConsistentHashMapping {
-    type ProstType = ParallelUnitMapping;
     type KeyType = String;
+    type ProstType = ParallelUnitMapping;
 
     fn cf_name() -> String {
         HASH_MAPPING_CF_NAME.to_string()

--- a/src/meta/src/model/mod.rs
+++ b/src/meta/src/model/mod.rs
@@ -138,6 +138,7 @@ where
         );
         Ok(())
     }
+
     fn delete_in_transaction(&self, trx: &mut Transaction) -> Result<()> {
         trx.delete(Self::cf_name(), self.key()?.encode_to_vec());
         Ok(())

--- a/src/meta/src/model/stream.rs
+++ b/src/meta/src/model/stream.rs
@@ -45,8 +45,8 @@ pub struct TableFragments {
 }
 
 impl MetadataModel for TableFragments {
-    type ProstType = ProstTableFragments;
     type KeyType = u32;
+    type ProstType = ProstTableFragments;
 
     fn cf_name() -> String {
         TABLE_FRAGMENTS_CF_NAME.to_string()

--- a/src/meta/src/rpc/intercept.rs
+++ b/src/meta/src/rpc/intercept.rs
@@ -53,9 +53,9 @@ where
     S: Service<hyper::Request<Body>> + Clone + Send + 'static,
     S::Future: Send + 'static,
 {
-    type Response = S::Response;
     type Error = S::Error;
     type Future = futures::future::BoxFuture<'static, Result<Self::Response, Self::Error>>;
+    type Response = S::Response;
 
     fn poll_ready(&mut self, cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
         self.inner.poll_ready(cx)

--- a/src/meta/src/rpc/service/hummock_service.rs
+++ b/src/meta/src/rpc/service/hummock_service.rs
@@ -53,6 +53,8 @@ impl<S> HummockManagerService for HummockServiceImpl<S>
 where
     S: MetaStore,
 {
+    type SubscribeCompactTasksStream = RwReceiverStream<SubscribeCompactTasksResponse>;
+
     async fn pin_version(
         &self,
         request: Request<PinVersionRequest>,
@@ -195,8 +197,6 @@ where
             Err(e) => Err(e.to_grpc_status()),
         }
     }
-
-    type SubscribeCompactTasksStream = RwReceiverStream<SubscribeCompactTasksResponse>;
 
     async fn subscribe_compact_tasks(
         &self,

--- a/src/meta/src/storage/etcd_meta_store.rs
+++ b/src/meta/src/storage/etcd_meta_store.rs
@@ -90,6 +90,7 @@ struct GetViewer {
 
 impl SnapshotViewer for GetViewer {
     type Output = Vec<u8>;
+
     type OutputFuture<'a> = impl Future<Output = Result<(i64, Self::Output)>> + 'a;
 
     fn view(&self, mut client: KvClient, revision: i64) -> Self::OutputFuture<'_> {
@@ -123,6 +124,7 @@ struct ListViewer {
 
 impl SnapshotViewer for ListViewer {
     type Output = Vec<Vec<u8>>;
+
     type OutputFuture<'a> = impl Future<Output = Result<(i64, Self::Output)>> + 'a;
 
     fn view(&self, mut client: KvClient, revision: i64) -> Self::OutputFuture<'_> {

--- a/src/source/src/high_level_kafka.rs
+++ b/src/source/src/high_level_kafka.rs
@@ -237,8 +237,8 @@ impl HighLevelKafkaSource {
 
 #[async_trait]
 impl Source for HighLevelKafkaSource {
-    type ReaderContext = HighLevelKafkaSourceReaderContext;
     type BatchReader = HighLevelKafkaSourceBatchReader;
+    type ReaderContext = HighLevelKafkaSourceReaderContext;
     type StreamReader = HighLevelKafkaSourceStreamReader;
 
     fn batch_reader(

--- a/src/source/src/table_v2.rs
+++ b/src/source/src/table_v2.rs
@@ -173,8 +173,8 @@ impl StreamSourceReader for TableV2StreamReader {
 
 #[async_trait]
 impl Source for TableSourceV2 {
-    type ReaderContext = TableV2ReaderContext;
     type BatchReader = TableV2BatchReader;
+    type ReaderContext = TableV2ReaderContext;
     type StreamReader = TableV2StreamReader;
 
     fn batch_reader(

--- a/src/sqlparser/src/parser.rs
+++ b/src/sqlparser/src/parser.rs
@@ -116,6 +116,10 @@ pub struct Parser {
 }
 
 impl Parser {
+    const BETWEEN_PREC: u8 = 20;
+    const PLUS_MINUS_PREC: u8 = 30;
+    const UNARY_NOT_PREC: u8 = 15;
+
     /// Parse the specified tokens
     pub fn new(tokens: Vec<Token>) -> Self {
         Parser { tokens, index: 0 }
@@ -1106,10 +1110,6 @@ impl Parser {
             data_type: self.parse_data_type()?,
         })
     }
-
-    const UNARY_NOT_PREC: u8 = 15;
-    const BETWEEN_PREC: u8 = 20;
-    const PLUS_MINUS_PREC: u8 = 30;
 
     /// Get the precedence of the next token
     pub fn get_next_precedence(&self) -> Result<u8, ParserError> {

--- a/src/storage/src/cell_based_row_serializer.rs
+++ b/src/storage/src/cell_based_row_serializer.rs
@@ -30,6 +30,7 @@ impl CellBasedRowSerializer {
     pub fn new() -> Self {
         Self {}
     }
+
     pub fn serialize(
         &mut self,
         pk: &[u8],

--- a/src/storage/src/hummock/mod.rs
+++ b/src/storage/src/hummock/mod.rs
@@ -211,6 +211,7 @@ impl fmt::Debug for HummockStorage {
 
 impl StateStore for HummockStorage {
     type Iter<'a> = HummockStateStoreIter<'a>;
+
     define_state_store_associated_type!();
 
     /// Gets the value of a specified `key`.
@@ -613,7 +614,9 @@ impl<'a> HummockStateStoreIter<'a> {
 impl<'a> StateStoreIter for HummockStateStoreIter<'a> {
     // TODO: directly return `&[u8]` to user instead of `Bytes`.
     type Item = (Bytes, Bytes);
+
     type NextFuture<'b> = impl Future<Output = crate::error::StorageResult<Option<Self::Item>>> where Self:'b;
+
     fn next(&mut self) -> Self::NextFuture<'_> {
         async move {
             let iter = &mut self.inner;

--- a/src/storage/src/hummock/sstable/reverse_sstable_iterator.rs
+++ b/src/storage/src/hummock/sstable/reverse_sstable_iterator.rs
@@ -138,6 +138,7 @@ impl SSTableIteratorBase for ReverseSSTableIterator {}
 
 impl SSTableIteratorType for ReverseSSTableIterator {
     type SSTableIterator = ReverseSSTableIterator;
+
     const DIRECTION: usize = BACKWARD;
 
     fn new(table: Arc<Sstable>, sstable_store: SstableStoreRef) -> Self::SSTableIterator {

--- a/src/storage/src/hummock/sstable/sstable_iterator.rs
+++ b/src/storage/src/hummock/sstable/sstable_iterator.rs
@@ -147,6 +147,7 @@ impl SSTableIteratorBase for SSTableIterator {}
 
 impl SSTableIteratorType for SSTableIterator {
     type SSTableIterator = SSTableIterator;
+
     const DIRECTION: usize = FORWARD;
 
     fn new(table: Arc<Sstable>, sstable_store: SstableStoreRef) -> Self::SSTableIterator {

--- a/src/storage/src/hummock/sstable/utils.rs
+++ b/src/storage/src/hummock/sstable/utils.rs
@@ -196,6 +196,7 @@ impl From<CompressionAlgorithm> for u64 {
 
 impl TryFrom<u8> for CompressionAlgorithm {
     type Error = HummockError;
+
     fn try_from(v: u8) -> core::result::Result<Self, Self::Error> {
         match v {
             0 => Ok(Self::None),

--- a/src/storage/src/memory.rs
+++ b/src/storage/src/memory.rs
@@ -82,6 +82,7 @@ impl MemoryStateStore {
 
 impl StateStore for MemoryStateStore {
     type Iter<'a> = MemoryStateStoreIter;
+
     define_state_store_associated_type!();
 
     fn get<'a>(&'a self, key: &'a [u8], epoch: u64) -> Self::GetFuture<'_> {
@@ -215,7 +216,9 @@ impl MemoryStateStoreIter {
 
 impl StateStoreIter for MemoryStateStoreIter {
     type Item = (Bytes, Bytes);
+
     type NextFuture<'a> = impl Future<Output = crate::error::StorageResult<Option<Self::Item>>>;
+
     fn next(&mut self) -> Self::NextFuture<'_> {
         async move { Ok(self.inner.next()) }
     }

--- a/src/storage/src/monitor/monitored_store.rs
+++ b/src/storage/src/monitor/monitored_store.rs
@@ -36,6 +36,7 @@ impl<S> MonitoredStateStore<S> {
     pub fn new(inner: S, stats: Arc<StateStoreMetrics>) -> Self {
         Self { inner, stats }
     }
+
     pub fn inner(&self) -> &S {
         &self.inner
     }
@@ -68,6 +69,7 @@ where
     S: StateStore,
 {
     type Iter<'a> = MonitoredStateStoreIter<S::Iter<'a>> where Self: 'a;
+
     define_state_store_associated_type!();
 
     fn get<'a>(&'a self, key: &'a [u8], epoch: u64) -> Self::GetFuture<'_> {
@@ -215,7 +217,9 @@ where
     I: StateStoreIter<Item = (Bytes, Bytes)>,
 {
     type Item = (Bytes, Bytes);
+
     type NextFuture<'a> = impl Future<Output = crate::error::StorageResult<Option<Self::Item>>> where Self: 'a;
+
     fn next(&mut self) -> Self::NextFuture<'_> {
         async move {
             let pair = self.inner.next().await?;

--- a/src/storage/src/panic_store.rs
+++ b/src/storage/src/panic_store.rs
@@ -28,6 +28,7 @@ pub struct PanicStateStore;
 
 impl StateStore for PanicStateStore {
     type Iter<'a> = PanicStateStoreIter;
+
     define_state_store_associated_type!();
 
     fn get<'a>(&'a self, _key: &'a [u8], _epoch: u64) -> Self::GetFuture<'_> {
@@ -123,7 +124,9 @@ pub struct PanicStateStoreIter {}
 
 impl StateStoreIter for PanicStateStoreIter {
     type Item = (Bytes, Bytes);
+
     type NextFuture<'a> = impl Future<Output = crate::error::StorageResult<Option<Self::Item>>>;
+
     fn next(&'_ mut self) -> Self::NextFuture<'_> {
         async move { unreachable!() }
     }

--- a/src/storage/src/rocksdb_local.rs
+++ b/src/storage/src/rocksdb_local.rs
@@ -50,6 +50,7 @@ impl RocksDBStateStore {
 
 impl StateStore for RocksDBStateStore {
     type Iter<'a> = RocksDBStateStoreIter;
+
     define_state_store_associated_type!();
 
     fn get<'a>(&'a self, key: &'a [u8], _epoch: u64) -> Self::GetFuture<'_> {
@@ -194,6 +195,7 @@ impl RocksDBStateStoreIter {
 
 impl StateStoreIter for RocksDBStateStoreIter {
     type Item = (Bytes, Bytes);
+
     type NextFuture<'a> = impl Future<Output = crate::error::StorageResult<Option<Self::Item>>>;
 
     fn next(&mut self) -> Self::NextFuture<'_> {

--- a/src/storage/src/rocksdb_local_mock.rs
+++ b/src/storage/src/rocksdb_local_mock.rs
@@ -36,6 +36,7 @@ impl RocksDBStateStore {
 
 impl StateStore for RocksDBStateStore {
     type Iter<'a> = RocksDBStateStoreIter;
+
     define_state_store_associated_type!();
 
     fn get<'a>(&'a self, _key: &'a [u8], _epoch: u64) -> Self::GetFuture<'_> {
@@ -119,7 +120,9 @@ impl RocksDBStateStoreIter {
 
 impl StateStoreIter for RocksDBStateStoreIter {
     type Item = (Bytes, Bytes);
+
     type NextFuture<'a> = impl Future<Output = crate::error::StorageResult<Option<Self::Item>>>;
+
     fn next(&mut self) -> Self::NextFuture<'_> {
         async move { unimplemented!() }
     }

--- a/src/storage/src/table/cell_based_table.rs
+++ b/src/storage/src/table/cell_based_table.rs
@@ -289,6 +289,7 @@ impl<S: StateStore> CellBasedTableRowIter<S> {
         };
         Ok(iter)
     }
+
     async fn consume_more(&mut self) -> StorageResult<()> {
         assert_eq!(self.next_idx, self.buf.len());
 

--- a/src/storage/src/tikv.rs
+++ b/src/storage/src/tikv.rs
@@ -42,6 +42,7 @@ impl TikvStateStore {
             pd: pd_endpoints,
         }
     }
+
     pub async fn client(&self) -> &tikv_client::transaction::Client {
         self.client
             .get_or_init(|| async {
@@ -54,6 +55,7 @@ impl TikvStateStore {
 
 impl StateStore for TikvStateStore {
     type Iter<'a> = TikvStateStoreIter;
+
     define_state_store_associated_type!();
 
     fn get<'a>(&'a self, key: &'a [u8], _epoch: u64) -> Self::GetFuture<'_> {
@@ -215,6 +217,7 @@ impl TikvStateStoreIter {
 
 impl StateStoreIter for TikvStateStoreIter {
     type Item = (Bytes, Bytes);
+
     type NextFuture<'a> = impl Future<Output = crate::error::StorageResult<Option<Self::Item>>>;
 
     fn next(&mut self) -> Self::NextFuture<'_> {

--- a/src/storage/src/tikv_mock.rs
+++ b/src/storage/src/tikv_mock.rs
@@ -33,6 +33,7 @@ impl TikvStateStore {
 
 impl StateStore for TikvStateStore {
     type Iter<'a> = TikvStateStoreIter;
+
     define_state_store_associated_type!();
 
     fn get<'a>(&'a self, _key: &'a [u8], _epoch: u64) -> Self::GetFuture<'_> {
@@ -116,6 +117,7 @@ impl TikvStateStoreIter {
 
 impl StateStoreIter for TikvStateStoreIter {
     type Item = (Bytes, Bytes);
+
     type NextFuture<'a> = impl Future<Output = crate::error::StorageResult<Option<Self::Item>>>;
 
     fn next(&mut self) -> Self::NextFuture<'_> {

--- a/src/stream/src/executor/aggregation/foldable.rs
+++ b/src/stream/src/executor/aggregation/foldable.rs
@@ -292,6 +292,7 @@ where
     pub fn new() -> Self {
         Self::default()
     }
+
     /// Get current state without using an array builder
     pub fn get_state(&self) -> &Option<R::OwnedItem> {
         &self.result

--- a/src/stream/src/executor/monitor/streaming_stats.rs
+++ b/src/stream/src/executor/monitor/streaming_stats.rs
@@ -46,6 +46,7 @@ impl StreamingMetrics {
             source_output_row_count,
         }
     }
+
     /// Create a new `StreamingMetrics` instance used in tests or other places.
     pub fn unused() -> Self {
         Self::new(prometheus::Registry::new())

--- a/src/utils/logging/src/trace_runtime.rs
+++ b/src/utils/logging/src/trace_runtime.rs
@@ -44,8 +44,8 @@ impl TraceRuntime for RwTokio {
 }
 
 impl Runtime for RwTokio {
-    type Interval = tokio_stream::wrappers::IntervalStream;
     type Delay = tokio::time::Sleep;
+    type Interval = tokio_stream::wrappers::IntervalStream;
 
     fn interval(&self, duration: Duration) -> Self::Interval {
         opentelemetry::util::tokio_interval_stream(duration)

--- a/src/utils/memcomparable/src/de.rs
+++ b/src/utils/memcomparable/src/de.rs
@@ -78,10 +78,15 @@ macro_rules! def_method {
 
 impl<B: Buf> MaybeFlip<B> {
     def_method!(get_u8, u8);
+
     def_method!(get_u16, u16);
+
     def_method!(get_u32, u32);
+
     def_method!(get_u64, u64);
+
     def_method!(get_i32, i32);
+
     def_method!(get_i64, i64);
 
     fn copy_to_slice(&mut self, dst: &mut [u8]) {

--- a/src/utils/memcomparable/src/ser.rs
+++ b/src/utils/memcomparable/src/ser.rs
@@ -67,10 +67,15 @@ macro_rules! def_method {
 
 impl<B: BufMut> MaybeFlip<B> {
     def_method!(put_u8, u8);
+
     def_method!(put_u16, u16);
+
     def_method!(put_u32, u32);
+
     def_method!(put_u64, u64);
+
     def_method!(put_i32, i32);
+
     def_method!(put_i64, i64);
 
     fn put_slice(&mut self, src: &[u8]) {
@@ -90,16 +95,15 @@ impl<B: BufMut> MaybeFlip<B> {
 // https://github.com/facebook/mysql-5.6/wiki/MyRocks-record-format#memcomparable-format
 // https://haxisnake.github.io/2020/11/06/TIDB源码学习笔记-基本类型编解码方案/
 impl<'a, B: BufMut> ser::Serializer for &'a mut Serializer<B> {
-    type Ok = ();
     type Error = Error;
-
+    type Ok = ();
+    type SerializeMap = Self;
     type SerializeSeq = Self;
+    type SerializeStruct = Self;
+    type SerializeStructVariant = Self;
     type SerializeTuple = Self;
     type SerializeTupleStruct = Self;
     type SerializeTupleVariant = Self;
-    type SerializeMap = Self;
-    type SerializeStruct = Self;
-    type SerializeStructVariant = Self;
 
     fn serialize_bool(self, v: bool) -> Result<()> {
         self.serialize_u8(v as u8)
@@ -310,8 +314,8 @@ impl<'a, B: BufMut> ser::Serializer for &'a mut Serializer<B> {
 }
 
 impl<'a, B: BufMut> ser::SerializeSeq for &'a mut Serializer<B> {
-    type Ok = ();
     type Error = Error;
+    type Ok = ();
 
     fn serialize_element<T>(&mut self, value: &T) -> Result<()>
     where
@@ -330,8 +334,8 @@ impl<'a, B: BufMut> ser::SerializeSeq for &'a mut Serializer<B> {
 }
 
 impl<'a, B: BufMut> ser::SerializeTuple for &'a mut Serializer<B> {
-    type Ok = ();
     type Error = Error;
+    type Ok = ();
 
     fn serialize_element<T>(&mut self, value: &T) -> Result<()>
     where
@@ -346,8 +350,8 @@ impl<'a, B: BufMut> ser::SerializeTuple for &'a mut Serializer<B> {
 }
 
 impl<'a, B: BufMut> ser::SerializeTupleStruct for &'a mut Serializer<B> {
-    type Ok = ();
     type Error = Error;
+    type Ok = ();
 
     fn serialize_field<T>(&mut self, value: &T) -> Result<()>
     where
@@ -362,8 +366,8 @@ impl<'a, B: BufMut> ser::SerializeTupleStruct for &'a mut Serializer<B> {
 }
 
 impl<'a, B: BufMut> ser::SerializeTupleVariant for &'a mut Serializer<B> {
-    type Ok = ();
     type Error = Error;
+    type Ok = ();
 
     fn serialize_field<T>(&mut self, value: &T) -> Result<()>
     where
@@ -378,8 +382,8 @@ impl<'a, B: BufMut> ser::SerializeTupleVariant for &'a mut Serializer<B> {
 }
 
 impl<'a, B: BufMut> ser::SerializeMap for &'a mut Serializer<B> {
-    type Ok = ();
     type Error = Error;
+    type Ok = ();
 
     fn serialize_key<T>(&mut self, key: &T) -> Result<()>
     where
@@ -401,8 +405,8 @@ impl<'a, B: BufMut> ser::SerializeMap for &'a mut Serializer<B> {
 }
 
 impl<'a, B: BufMut> ser::SerializeStruct for &'a mut Serializer<B> {
-    type Ok = ();
     type Error = Error;
+    type Ok = ();
 
     fn serialize_field<T>(&mut self, _key: &'static str, value: &T) -> Result<()>
     where
@@ -417,8 +421,8 @@ impl<'a, B: BufMut> ser::SerializeStruct for &'a mut Serializer<B> {
 }
 
 impl<'a, B: BufMut> ser::SerializeStructVariant for &'a mut Serializer<B> {
-    type Ok = ();
     type Error = Error;
+    type Ok = ();
 
     fn serialize_field<T>(&mut self, _key: &'static str, value: &T) -> Result<()>
     where

--- a/src/utils/pgwire/src/pg_field_descriptor.rs
+++ b/src/utils/pgwire/src/pg_field_descriptor.rs
@@ -57,6 +57,7 @@ impl PgFieldDescriptor {
             type_oid,
         }
     }
+
     pub fn get_name(&self) -> &str {
         &self.name
     }


### PR DESCRIPTION
Signed-off-by: TennyZhuang <zty0826@gmail.com>

## What's changed and what's your intention?

***PLEASE DO NOT LEAVE THIS EMPTY !!!***

Enable rustfmt `reorder_impl_items`.

The rule has an interesting side effect, it will automatically insert a blank line between methods, we need it!

## Checklist

- [x] I have written necessary docs and comments
- [x] I have added necessary unit tests and integration tests

## Refer to a related PR or issue link (optional)
