### PR TITLE
fix(fe-server): do not print unexpected eof as error to log

### DIFF
--- a/src/utils/pgwire/src/pg_server.rs
+++ b/src/utils/pgwire/src/pg_server.rs
@@ -53,6 +53,7 @@ pub async fn pg_serve(addr: &str, session_mgr: Arc<dyn SessionManager>) -> io::R
                 tokio::spawn(async move {
                     // connection succeeded
                     pg_serve_conn(stream, session_mgr).await;
+                    tracing::info!("Connection {} closed", peer_addr);
                 });
             }
 
@@ -70,16 +71,16 @@ async fn pg_serve_conn(socket: TcpStream, session_mgr: Arc<dyn SessionManager>) 
         match terminate {
             Ok(is_ter) => {
                 if is_ter {
-                    tracing::info!("Connection closed by terminate cmd!");
                     break;
                 }
             }
             Err(e) => {
-                // Execution error should not break current connection.
-                tracing::error!("error {:?}!", e);
                 if matches!(e.kind(), ErrorKind::UnexpectedEof) {
                     break;
                 }
+                // Execution error should not break current connection.
+                // For unexpected eof, just break and not print to log.
+                tracing::error!("Error {:?}!", e);
             }
         }
     }


### PR DESCRIPTION
## What's changed and what's your intention?

1. Do not print unexpected eof as error to log.

Now when start fe, it will show (the wait TCP connection will always be the first open-and-closed connection):
```
2022-04-11T08:02:56.081101Z  INFO pgwire::pg_server: Server Listening at 127.0.0.1:4566
2022-04-11T08:02:56.107196Z  INFO pgwire::pg_server: New connection: 127.0.0.1:65275
2022-04-11T08:02:56.107395Z  INFO pgwire::pg_server: Connection 127.0.0.1:65275 closed
```
## Checklist

- [x] I have written necessary docs and comments
- [x] I have added necessary unit tests and integration tests

## Refer to a related PR or issue link (optional)
