### PR TITLE
test(streaming): fix order assumption in `extreme_null`

### DIFF
--- a/e2e_test/streaming/extreme_null.slt
+++ b/e2e_test/streaming/extreme_null.slt
@@ -11,19 +11,10 @@ statement ok
 insert into t4 values (1,1,4), (NULL,1,4), (2,9,1), (NULL,8,1), (0,2,3);
 
 statement ok
-create materialized view mv1 as select * from t1;
-
-statement ok
 create materialized view mv2 as select round(avg(v1), 1) as avg_v1, sum(v2) as sum_v2, count(v3) as count_v3 from t1;
 
 statement ok
 create materialized view mv3 as select sum(v1) as sum_v1, min(v1) as min_v1, max(v1) as max_v1 from t4 group by v3;
-
-query III
-select v1, v2, v3 from mv1;
-----
-1 4 2
-2 3 3
 
 query RII
 select avg_v1, sum_v2, count_v3 from mv2;
@@ -36,14 +27,6 @@ insert into t1 values (3,4,4), (4,3,5);
 statement ok
 flush;
 
-query III
-select v1, v2, v3 from mv1;
-----
-1 4 2
-2 3 3
-3 4 4
-4 3 5
-
 query RII
 select avg_v1, sum_v2, count_v3 from mv2;
 ----
@@ -55,9 +38,6 @@ select sum_v1, min_v1, max_v1, v3 from mv3 order by sum_v1;
 0 0 0 3
 1 NULL 1 4
 2 NULL 2 1
-
-statement ok
-drop materialized view mv1
 
 statement ok
 drop materialized view mv2


### PR DESCRIPTION
Signed-off-by: Bugen Zhao <i@bugenzhao.com>

## What's changed and what's your intention?

We have no assumption about the order of inserted rows.

## Checklist

- [x] I have written necessary docs and comments
- [x] I have added necessary unit tests and integration tests

## Refer to a related PR or issue link (optional)
- https://github.com/singularity-data/risingwave/runs/5970211767?check_suite_focus=true