### PR TITLE
chore(ci): use bors try for contributors

### DIFF
--- a/.github/workflow-template/pr-override.yml
+++ b/.github/workflow-template/pr-override.yml
@@ -8,6 +8,8 @@ on:
   push:
     branches:
       - "forks/*"
+      - staging
+      - trying
 
 concurrency:
   group: environment-${{ github.ref }}

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -12,6 +12,8 @@ on:
   push:
     branches:
       - "forks/*"
+      - staging
+      - trying
 env:
   RUST_TOOLCHAIN: nightly-2022-04-09
   CACHE_KEY_SUFFIX: v20220412

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -373,11 +373,10 @@ We use [cargo-sort](https://crates.io/crates/cargo-sort) to ensure all deps are 
 
 ## To check-in PRs from forks...
 
+Use
+
 ```
-gh pr checkout <PR id>
-git checkout -b forks/<PR id>
-git push origin HEAD -u
+bors try
 ```
 
-After that, CI checks will begin on branches of RisingWave's main repo,
-and the status will be automatically updated to PRs from forks.
+in PR to run tests in forks. Note that we don't use bors to merge PRs.

--- a/bors.toml
+++ b/bors.toml
@@ -1,0 +1,8 @@
+status = [
+  "frontend-check",
+  "misc-check",
+  "compute-node-build-dev",
+  "e2e-test-risedev-dev",
+  "e2e-test-source",
+  "license-header-check"
+]


### PR DESCRIPTION
Signed-off-by: Alex Chi <iskyzh@gmail.com>

## What's changed and what's your intention?

TL;DR: use `bors try` on contributors' PR to run tests.

## Checklist

- [x] I have written necessary docs and comments
- [x] I have added necessary unit tests and integration tests

## Refer to a related PR or issue link (optional)

close https://github.com/singularity-data/risingwave/issues/1727