### PR TITLE
[WIP] chore(object-store): failed to remove async trait on object store

### DIFF
--- a/src/utils/pgwire/src/lib.rs
+++ b/src/utils/pgwire/src/lib.rs
@@ -1,5 +1,3 @@
-#![feature(io_error_other)]
-
 // Copyright 2022 Singularity Data
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
@@ -14,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#![feature(io_error_other)]
 pub mod error;
 pub mod pg_field_descriptor;
 pub mod pg_message;


### PR DESCRIPTION
## What's changed and what's your intention?

Part of #1132 . This PR now fails to compile seems due to compiler (yes again lifetime infer with GAT). 

Currently, the async trait refactor gives me some feelings
* makes the traits its self complicated (Luckily it do not expose to users). 
* some lifetime problem we have to hack. For example, expand some function.
* we do not have bench to show the performance gained from this, although in theory it indeed better. 



## Checklist

- [ ] I have written necessary docs and comments
- [ ] I have added necessary unit tests and integration tests

## Refer to a related PR or issue link (optional)
