### PR TITLE
feat: scheduling splits when creating a materialized view

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4968,7 +4968,6 @@ dependencies = [
  "parking_lot 0.12.0",
  "parking_lot_core 0.9.2",
  "petgraph",
- "prometheus",
  "prost 0.9.0",
  "rand 0.8.5",
  "regex",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1086,9 +1086,9 @@ dependencies = [
 
 [[package]]
 name = "darling"
-version = "0.13.3"
+version = "0.13.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dbcc37e3091b4dfd0af76cb0087b9c89b8e03072abc28ae2efc8fdd733bfc5f5"
+checksum = "a01d95850c592940db9b8194bc39f4bc0e89dee5c4265e4b1807c34a9aba453c"
 dependencies = [
  "darling_core",
  "darling_macro",
@@ -1096,9 +1096,9 @@ dependencies = [
 
 [[package]]
 name = "darling_core"
-version = "0.13.3"
+version = "0.13.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9569a966dba8cd57879b8efd2bf82b5c56bb466e19767a69c560bddee1a27f5c"
+checksum = "859d65a907b6852c9361e3185c862aae7fafd2887876799fa55f5f99dc40d610"
 dependencies = [
  "fnv",
  "ident_case",
@@ -1110,9 +1110,9 @@ dependencies = [
 
 [[package]]
 name = "darling_macro"
-version = "0.13.3"
+version = "0.13.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "efae147148c6380157050146a2040b65dbe91bef6e97aaaa39ef0d469d2eb4af"
+checksum = "9c972679f83bdf9c42bd905396b6c3588a843a17f0f16dfcfa3e2c5d57441835"
 dependencies = [
  "darling_core",
  "quote",
@@ -1822,9 +1822,9 @@ checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
 
 [[package]]
 name = "libc"
-version = "0.2.121"
+version = "0.2.122"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "efaa7b300f3b5fe8eb6bf21ce3895e1751d9665086af2d64b42f19701015ff4f"
+checksum = "ec647867e2bf0772e28c8bcde4f0d19a9216916e890543b5a03ed8ef27b8f259"
 
 [[package]]
 name = "libnghttp2-sys"
@@ -2378,18 +2378,18 @@ checksum = "0c520e05135d6e763148b6426a837e239041653ba7becd2e538c076c738025fc"
 
 [[package]]
 name = "path-absolutize"
-version = "3.0.12"
+version = "3.0.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0a2a79d7c1c4eab523515c4561459b10516d6e7014aa76edc3ea05680d5c5d2d"
+checksum = "d3de4b40bd9736640f14c438304c09538159802388febb02c8abaae0846c1f13"
 dependencies = [
  "path-dedot",
 ]
 
 [[package]]
 name = "path-dedot"
-version = "3.0.16"
+version = "3.0.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f326e2a3331685a5e3d4633bb9836bd92126e08037cb512252f3612f616a0b28"
+checksum = "d611d5291372b3738a34ebf0d1f849e58b1dcc1101032f76a346eaa1f8ddbb5b"
 dependencies = [
  "once_cell",
 ]
@@ -3457,6 +3457,7 @@ dependencies = [
  "prost 0.10.0",
  "rand 0.8.5",
  "risingwave_common",
+ "risingwave_connector",
  "risingwave_hummock_sdk",
  "risingwave_pb",
  "risingwave_rpc_client",
@@ -3907,9 +3908,9 @@ dependencies = [
 
 [[package]]
 name = "serde_with"
-version = "1.12.0"
+version = "1.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ec1e6ec4d8950e5b1e894eac0d360742f3b1407a6078a604a731c4b3f49cefbc"
+checksum = "946fa04a8ac43ff78a1f4b811990afb9ddbdf5890b46d6dda0ba1998230138b7"
 dependencies = [
  "rustversion",
  "serde",
@@ -3918,9 +3919,9 @@ dependencies = [
 
 [[package]]
 name = "serde_with_macros"
-version = "1.5.1"
+version = "1.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "12e47be9471c72889ebafb5e14d5ff930d89ae7a67bbdb5f8abb564f845a927e"
+checksum = "e182d6ec6f05393cc0e5ed1bf81ad6db3a8feedf8ee515ecdd369809bcce8082"
 dependencies = [
  "darling",
  "proc-macro2",

--- a/proto/data.proto
+++ b/proto/data.proto
@@ -152,8 +152,12 @@ message AddMutation {
   map<uint32, Actors> actors = 1;
 }
 
+message Splits {
+  repeated bytes splits = 1;
+}
+
 message SplitAssignMutation {
-  map<uint32, bytes> splits = 1;
+  map<uint32, Splits> splits = 1;
 }
 
 message Epoch {
@@ -168,8 +172,9 @@ message Barrier {
     StopMutation stop = 3;
     UpdateMutation update = 4;
     AddMutation add = 5;
+    SplitAssignMutation split_assign = 6;
   }
-  bytes span = 6;
+  bytes span = 7;
 }
 
 message Terminate {}

--- a/proto/data.proto
+++ b/proto/data.proto
@@ -152,6 +152,10 @@ message AddMutation {
   map<uint32, Actors> actors = 1;
 }
 
+message SplitAssignMutation {
+  map<uint32, bytes> splits = 1;
+}
+
 message Epoch {
   uint64 curr = 1;
   uint64 prev = 2;

--- a/proto/data.proto
+++ b/proto/data.proto
@@ -152,14 +152,6 @@ message AddMutation {
   map<uint32, Actors> actors = 1;
 }
 
-message Splits {
-  repeated bytes splits = 1;
-}
-
-message SplitAssignMutation {
-  map<uint32, Splits> splits = 1;
-}
-
 message Epoch {
   uint64 curr = 1;
   uint64 prev = 2;
@@ -172,9 +164,8 @@ message Barrier {
     StopMutation stop = 3;
     UpdateMutation update = 4;
     AddMutation add = 5;
-    SplitAssignMutation split_assign = 6;
   }
-  bytes span = 7;
+  bytes span = 6;
 }
 
 message Terminate {}

--- a/proto/stream_plan.proto
+++ b/proto/stream_plan.proto
@@ -14,6 +14,7 @@ message ActorMapping {
   repeated uint32 hash_mapping = 1;
 }
 
+// todo: StreamSourceNode or TableSourceNode
 message SourceNode {
   enum SourceType {
     TABLE = 0;
@@ -22,7 +23,12 @@ message SourceNode {
   plan.TableRefId table_ref_id = 1;
   repeated int32 column_ids = 2;
   SourceType source_type = 3;
-  repeated bytes stream_source_splits = 4;
+  StreamSourceSplits stream_source_splits = 4;
+}
+
+message StreamSourceSplits {
+  string split_type = 1;
+  repeated bytes stream_source_splits = 2;
 }
 
 message ProjectNode {

--- a/proto/stream_plan.proto
+++ b/proto/stream_plan.proto
@@ -23,10 +23,11 @@ message SourceNode {
   plan.TableRefId table_ref_id = 1;
   repeated int32 column_ids = 2;
   SourceType source_type = 3;
-  StreamSourceSplits stream_source_splits = 4;
+
+  StreamSourceState stream_source_state = 4;
 }
 
-message StreamSourceSplits {
+message StreamSourceState {
   string split_type = 1;
   repeated bytes stream_source_splits = 2;
 }

--- a/proto/stream_plan.proto
+++ b/proto/stream_plan.proto
@@ -22,6 +22,7 @@ message SourceNode {
   plan.TableRefId table_ref_id = 1;
   repeated int32 column_ids = 2;
   SourceType source_type = 3;
+  repeated bytes stream_source_splits = 4;
 }
 
 message ProjectNode {

--- a/proto/stream_plan.proto
+++ b/proto/stream_plan.proto
@@ -23,7 +23,9 @@ message SourceNode {
   plan.TableRefId table_ref_id = 1;
   repeated int32 column_ids = 2;
   SourceType source_type = 3;
-
+  // split allocation information,
+  // and in the future will distinguish between `StreamSource` and `TableSource`
+  // so that there is no need to put many fields that are not common into the same SourceNode structure
   StreamSourceState stream_source_state = 4;
 }
 

--- a/src/compute/src/rpc/service/stream_service.rs
+++ b/src/compute/src/rpc/service/stream_service.rs
@@ -219,7 +219,6 @@ impl StreamServiceImpl {
                     .create_source_v2(&id, info.to_owned())
                     .await?;
             }
-
             Info::TableSource(info) => {
                 let columns = info
                     .columns

--- a/src/compute/tests/table_v2_materialize.rs
+++ b/src/compute/tests/table_v2_materialize.rs
@@ -161,6 +161,7 @@ async fn test_table_v2_materialize() -> Result<()> {
         1,
         "SourceExecutor".to_string(),
         Arc::new(StreamingMetrics::unused()),
+        vec![],
     )?;
 
     // Create a `Materialize` to write the changes to storage

--- a/src/connector/src/base.rs
+++ b/src/connector/src/base.rs
@@ -29,7 +29,7 @@ pub enum SourceOffset {
     String(String),
 }
 
-use crate::pulsar::{PulsarSplitEnumerator};
+use crate::pulsar::PulsarSplitEnumerator;
 use crate::{kafka, kinesis, pulsar};
 
 const UPSTREAM_SOURCE_KEY: &str = "connector";
@@ -66,8 +66,8 @@ pub struct ConnectorState {
 pub trait SourceReader {
     async fn next(&mut self) -> Result<Option<Vec<InnerMessage>>>;
     async fn new(config: HashMap<String, String>, state: Option<ConnectorState>) -> Result<Self>
-        where
-            Self: Sized;
+    where
+        Self: Sized;
 }
 
 #[async_trait]
@@ -140,12 +140,8 @@ pub async fn new_connector(
 ) -> Result<Box<dyn SourceReader + Send + Sync>> {
     let upstream_type = config.get(UPSTREAM_SOURCE_KEY).unwrap();
     let connector: Box<dyn SourceReader + Send + Sync> = match upstream_type.as_str() {
-        KAFKA_SOURCE => {
-            Box::new(KafkaSplitReader::new(config, state).await?)
-        }
-        KINESIS_SOURCE => {
-            Box::new(KinesisSplitReader::new(config, state).await?)
-        }
+        KAFKA_SOURCE => Box::new(KafkaSplitReader::new(config, state).await?),
+        KINESIS_SOURCE => Box::new(KinesisSplitReader::new(config, state).await?),
         // PULSAR_SOURCE => {
         //     let pulsar = PulsarSplitReader::new(config, state).await?;
         //     Box::new(pulsar)

--- a/src/connector/src/base.rs
+++ b/src/connector/src/base.rs
@@ -29,10 +29,10 @@ pub enum SourceOffset {
     String(String),
 }
 
-use crate::pulsar::{PulsarSplit, PulsarSplitEnumerator};
-use crate::{kafka, kinesis, pulsar};
 use crate::kafka::KafkaSplit;
 use crate::kinesis::split::KinesisSplit;
+use crate::pulsar::{PulsarSplit, PulsarSplitEnumerator};
+use crate::{kafka, kinesis, pulsar};
 
 const UPSTREAM_SOURCE_KEY: &str = "connector";
 const KAFKA_SOURCE: &str = "kafka";
@@ -121,9 +121,13 @@ impl SplitImpl {
     pub fn restore_from_bytes(split_type: String, bytes: &[u8]) -> Result<Self> {
         match split_type.as_str() {
             kafka::KAFKA_SPLIT_TYPE => KafkaSplit::restore_from_bytes(bytes).map(SplitImpl::Kafka),
-            pulsar::PULSAR_SPLIT_TYPE => PulsarSplit::restore_from_bytes(bytes).map(SplitImpl::Pulsar),
-            kinesis::split::KINESIS_SPLIT_TYPE => KinesisSplit::restore_from_bytes(bytes).map(SplitImpl::Kinesis),
-            other => Err(anyhow!("split type {} not supported", other))
+            pulsar::PULSAR_SPLIT_TYPE => {
+                PulsarSplit::restore_from_bytes(bytes).map(SplitImpl::Pulsar)
+            }
+            kinesis::split::KINESIS_SPLIT_TYPE => {
+                KinesisSplit::restore_from_bytes(bytes).map(SplitImpl::Kinesis)
+            }
+            other => Err(anyhow!("split type {} not supported", other)),
         }
     }
 }

--- a/src/connector/src/base.rs
+++ b/src/connector/src/base.rs
@@ -29,7 +29,7 @@ pub enum SourceOffset {
     String(String),
 }
 
-use crate::pulsar::{PulsarSplit, PulsarSplitEnumerator};
+use crate::pulsar::{PulsarSplitEnumerator};
 use crate::{kafka, kinesis, pulsar};
 
 const UPSTREAM_SOURCE_KEY: &str = "connector";
@@ -141,12 +141,10 @@ pub async fn new_connector(
     let upstream_type = config.get(UPSTREAM_SOURCE_KEY).unwrap();
     let connector: Box<dyn SourceReader + Send + Sync> = match upstream_type.as_str() {
         KAFKA_SOURCE => {
-            let kafka = KafkaSplitReader::new(config, state).await?;
-            Box::new(kafka)
+            Box::new(KafkaSplitReader::new(config, state).await?)
         }
         KINESIS_SOURCE => {
-            let kinesis = KinesisSplitReader::new(config, state).await?;
-            Box::new(kinesis)
+            Box::new(KinesisSplitReader::new(config, state).await?)
         }
         // PULSAR_SOURCE => {
         //     let pulsar = PulsarSplitReader::new(config, state).await?;

--- a/src/connector/src/base.rs
+++ b/src/connector/src/base.rs
@@ -82,7 +82,7 @@ pub enum SplitEnumeratorImpl {
     Kinesis(kinesis::enumerator::client::KinesisSplitEnumerator),
 }
 
-#[derive(Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub enum SplitImpl {
     Kafka(kafka::KafkaSplit),
     Pulsar(pulsar::PulsarSplit),
@@ -95,6 +95,14 @@ impl SplitImpl {
             SplitImpl::Kafka(k) => k.id(),
             SplitImpl::Pulsar(p) => p.id(),
             SplitImpl::Kinesis(k) => k.id(),
+        }
+    }
+
+    pub fn to_string(&self) -> Result<String> {
+        match self {
+            SplitImpl::Kafka(k) => k.to_string(),
+            SplitImpl::Pulsar(p) => p.to_string(),
+            SplitImpl::Kinesis(k) => k.to_string(),
         }
     }
 }
@@ -121,8 +129,8 @@ impl SplitEnumeratorImpl {
 pub fn extract_split_enumerator(
     properties: &HashMap<String, String>,
 ) -> Result<SplitEnumeratorImpl> {
-    let source_type = match properties.get("upstream.source") {
-        None => return Err(anyhow!("upstream.source not found")),
+    let source_type = match properties.get("connector") {
+        None => return Err(anyhow!("connector not found")),
         Some(value) => value,
     };
 

--- a/src/connector/src/base.rs
+++ b/src/connector/src/base.rs
@@ -154,8 +154,8 @@ impl SplitEnumeratorImpl {
 pub fn extract_split_enumerator(
     properties: &HashMap<String, String>,
 ) -> Result<SplitEnumeratorImpl> {
-    let source_type = match properties.get("connector") {
-        None => return Err(anyhow!("connector not found")),
+    let source_type = match properties.get(UPSTREAM_SOURCE_KEY) {
+        None => return Err(anyhow!("{} not found", UPSTREAM_SOURCE_KEY)),
         Some(value) => value,
     };
 
@@ -175,10 +175,6 @@ pub async fn new_connector(
     let connector: Box<dyn SourceReader + Send + Sync> = match upstream_type.as_str() {
         KAFKA_SOURCE => Box::new(KafkaSplitReader::new(config, state).await?),
         KINESIS_SOURCE => Box::new(KinesisSplitReader::new(config, state).await?),
-        // PULSAR_SOURCE => {
-        //     let pulsar = PulsarSplitReader::new(config, state).await?;
-        //     Box::new(pulsar)
-        // }
         _other => {
             todo!()
         }

--- a/src/connector/src/base.rs
+++ b/src/connector/src/base.rs
@@ -80,9 +80,19 @@ pub enum SplitEnumeratorImpl {
     Pulsar(pulsar::enumerator::PulsarSplitEnumerator),
 }
 
+#[derive(Clone)]
 pub enum SplitImpl {
     Kafka(kafka::KafkaSplit),
     Pulsar(pulsar::PulsarSplit),
+}
+
+impl SplitImpl {
+    pub fn id(&self) -> String {
+        match self {
+            SplitImpl::Kafka(k) => k.id(),
+            SplitImpl::Pulsar(p) => p.id(),
+        }
+    }
 }
 
 impl SplitEnumeratorImpl {

--- a/src/connector/src/base.rs
+++ b/src/connector/src/base.rs
@@ -80,7 +80,7 @@ pub enum SplitEnumeratorImpl {
     Pulsar(pulsar::enumerator::PulsarSplitEnumerator),
 }
 
-#[derive(Clone)]
+#[derive(Clone, Serialize, Deserialize)]
 pub enum SplitImpl {
     Kafka(kafka::KafkaSplit),
     Pulsar(pulsar::PulsarSplit),

--- a/src/connector/src/filesystem/s3/source/s3_file_reader.rs
+++ b/src/connector/src/filesystem/s3/source/s3_file_reader.rs
@@ -69,7 +69,6 @@ impl Default for S3File {
     }
 }
 
-
 // todo(zhenzhou): better name
 const S3_SPLIT_TYPE: &str = "s3";
 

--- a/src/connector/src/filesystem/s3/source/s3_file_reader.rs
+++ b/src/connector/src/filesystem/s3/source/s3_file_reader.rs
@@ -15,7 +15,7 @@ use std::borrow::BorrowMut;
 use std::collections::HashMap;
 use std::sync::Arc;
 
-use anyhow::Result;
+use anyhow::{anyhow, Result};
 use async_trait::async_trait;
 use aws_sdk_s3::client as s3_client;
 use aws_smithy_http::byte_stream::ByteStream;
@@ -68,6 +68,10 @@ impl Default for S3File {
         }
     }
 }
+
+
+// todo(zhenzhou): better name
+const S3_SPLIT_TYPE: &str = "s3";
 
 #[derive(Debug, Clone, Eq, PartialEq, Serialize, Deserialize)]
 pub struct S3FileSplit {
@@ -126,6 +130,14 @@ impl SourceSplit for S3FileSplit {
         } else {
             Err(anyhow::Error::from(split_str.err().unwrap()))
         }
+    }
+
+    fn restore_from_bytes(bytes: &[u8]) -> Result<Self> {
+        serde_json::from_slice(bytes).map_err(|e| anyhow!(e))
+    }
+
+    fn get_type(&self) -> String {
+        S3_SPLIT_TYPE.to_string()
     }
 }
 

--- a/src/connector/src/filesystem/s3/source/s3_file_reader.rs
+++ b/src/connector/src/filesystem/s3/source/s3_file_reader.rs
@@ -69,7 +69,6 @@ impl Default for S3File {
     }
 }
 
-// todo(zhenzhou): better name
 const S3_SPLIT_TYPE: &str = "s3";
 
 #[derive(Debug, Clone, Eq, PartialEq, Serialize, Deserialize)]

--- a/src/connector/src/kafka/enumerator/client.rs
+++ b/src/connector/src/kafka/enumerator/client.rs
@@ -75,6 +75,7 @@ impl SplitEnumerator for KafkaSplitEnumerator {
         let ret = topic_partitions
             .into_iter()
             .map(|partition| KafkaSplit {
+                topic: self.topic.clone(),
                 partition,
                 start_offset: start_offsets.remove(&partition).unwrap(),
                 stop_offset: stop_offsets.remove(&partition).unwrap(),

--- a/src/connector/src/kafka/mod.rs
+++ b/src/connector/src/kafka/mod.rs
@@ -16,8 +16,7 @@ use std::time::Duration;
 
 pub(crate) mod enumerator;
 pub mod source;
-mod split;
-
+pub mod split;
 pub use enumerator::*;
 pub use source::*;
 pub use split::*;

--- a/src/connector/src/kafka/mod.rs
+++ b/src/connector/src/kafka/mod.rs
@@ -23,5 +23,9 @@ pub use source::*;
 pub use split::*;
 
 const KAFKA_SYNC_CALL_TIMEOUT: Duration = Duration::from_secs(1);
+
 const KAFKA_CONFIG_BROKER_KEY: &str = "kafka.broker";
 const KAFKA_CONFIG_TOPIC_KEY: &str = "kafka.topic";
+const KAFKA_CONFIG_SCAN_STARTUP_MODE: &str = "kafka.scan.startup.mode";
+const KAFKA_CONFIG_TIME_OFFSET: &str = "kafka.time.offset";
+const KAFKA_CONFIG_CONSUME_GROUP: &str = "kafka.consumer.group";

--- a/src/connector/src/kafka/source/reader.rs
+++ b/src/connector/src/kafka/source/reader.rs
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use std::collections::HashMap;
 use std::sync::Arc;
 use std::time::{SystemTime, UNIX_EPOCH};
 
@@ -21,25 +22,32 @@ use futures::StreamExt;
 use rdkafka::config::RDKafkaLogLevel;
 use rdkafka::consumer::stream_consumer::StreamPartitionQueue;
 use rdkafka::consumer::{Consumer, DefaultConsumerContext, StreamConsumer};
-use rdkafka::{ClientConfig, Message, TopicPartitionList};
+use rdkafka::{ClientConfig, Message, Offset, TopicPartitionList};
+use risingwave_common::error::ErrorCode::{InternalError, ProtocolError};
+use risingwave_common::error::RwError;
 
 use crate::base::{InnerMessage, SourceReader};
 use crate::kafka::split::{KafkaOffset, KafkaSplit};
+use crate::ConnectorState;
 
 const KAFKA_MAX_FETCH_MESSAGES: usize = 1024;
 
+const KAFKA_CONFIG_TOPIC_KEY: &str = "kafka.topic";
+const KAFKA_CONFIG_BOOTSTRAP_SERVER_KEY: &str = "kafka.bootstrap.servers";
+
 pub struct KafkaSplitReader {
     consumer: Arc<StreamConsumer<DefaultConsumerContext>>,
-    partition_queue: StreamPartitionQueue<DefaultConsumerContext>,
-    topic: String,
-    assigned_split: KafkaSplit,
+    assigned_splits: HashMap<String, Vec<KafkaSplit>>,
+    // partition_queue: StreamPartitionQueue<DefaultConsumerContext>,
+    // topic: String,
+    // assigned_split: KafkaSplit,
 }
 
 #[async_trait]
 impl SourceReader for KafkaSplitReader {
     async fn next(&mut self) -> Result<Option<Vec<InnerMessage>>> {
         let mut stream = self
-            .partition_queue
+            .consumer
             .stream()
             .ready_chunks(KAFKA_MAX_FETCH_MESSAGES);
 
@@ -53,19 +61,21 @@ impl SourceReader for KafkaSplitReader {
         for msg in chunk {
             let msg = msg.map_err(|e| anyhow!(e))?;
 
-            let offset = msg.offset();
-
-            if let KafkaOffset::Offset(stopping_offset) = self.assigned_split.stop_offset {
-                if offset >= stopping_offset {
-                    // `self.partition_queue` will expire when it's done
-                    // FIXME(chen): error handling
-                    self.consumer
-                        .assign(&TopicPartitionList::new())
-                        .map_err(|e| anyhow!(e))?;
-
-                    break;
-                }
-            }
+            // let offset = msg.offset();
+            //
+            // let topic =
+            //
+            // if let KafkaOffset::Offset(stopping_offset) = self.assigned_split.stop_offset {
+            //     if offset >= stopping_offset {
+            //         // `self.partition_queue` will expire when it's done
+            //         // FIXME(chen): error handling
+            //         self.consumer
+            //             .assign(&TopicPartitionList::new())
+            //             .map_err(|e| anyhow!(e))?;
+            //
+            //         break;
+            //     }
+            // }
 
             ret.push(InnerMessage::from(msg));
         }
@@ -73,51 +83,28 @@ impl SourceReader for KafkaSplitReader {
         Ok(Some(ret))
     }
 
-    // async fn assign_split<'a>(&'a mut self, split: &'a [u8]) -> Result<()> {
-    //     let kafka_split: KafkaSplit = serde_json::from_str(from_utf8(split)?)?;
-    //     let mut tpl = TopicPartitionList::new();
-
-    //     let offset = match kafka_split.start_offset {
-    //         KafkaOffset::None | KafkaOffset::Earliest => Offset::Beginning,
-    //         KafkaOffset::Latest => Offset::End,
-    //         KafkaOffset::Offset(offset) => Offset::Offset(offset),
-    //         KafkaOffset::Timestamp(_) => unimplemented!(),
-    //     };
-
-    //     tpl.add_partition_offset(self.topic.as_str(), kafka_split.partition, offset)
-    //         .map_err(|e| anyhow!(e))?;
-
-    //     self.consumer.assign(&tpl).map_err(|e| anyhow!(e))?;
-
-    //     let partition_queue = self
-    //         .consumer
-    //         .split_partition_queue(self.topic.as_str(), kafka_split.partition)
-    //         .ok_or_else(|| anyhow!("Failed to split partition queue"))?;
-
-    //     self.partition_queue = partition_queue;
-    //     self.assigned_split = kafka_split;
-
-    //     Ok(())
-    // }
-
     async fn new(
-        _config: std::collections::HashMap<String, String>,
-        _state: Option<crate::ConnectorState>,
+        properties: HashMap<String, String>,
+        state: Option<crate::ConnectorState>,
     ) -> Result<Self>
     where
         Self: Sized,
     {
-        todo!()
-    }
-}
+        let bootstrap_servers =
+            properties
+                .get(KAFKA_CONFIG_BOOTSTRAP_SERVER_KEY)
+                .ok_or(RwError::from(ProtocolError(format!(
+                    "could not found config {}",
+                    KAFKA_CONFIG_BOOTSTRAP_SERVER_KEY
+                ))))?;
 
-impl KafkaSplitReader {
-    fn create_consumer(&self) -> Result<StreamConsumer<DefaultConsumerContext>> {
         let mut config = ClientConfig::new();
 
-        config.set("topic.metadata.refresh.interval.ms", "30000");
-        config.set("fetch.message.max.bytes", "134217728");
-        config.set("auto.offset.reset", "earliest");
+        // disable partition eof
+        config.set("enable.partition.eof", "false");
+        config.set("enable.auto.commit", "false");
+        config.set("auto.offset.reset", "smallest");
+        config.set("bootstrap.servers", bootstrap_servers);
 
         if config.get("group.id").is_none() {
             config.set(
@@ -132,14 +119,52 @@ impl KafkaSplitReader {
             );
         }
 
-        // disable partition eof
-        config.set("enable.partition.eof", "false");
-        config.set("enable.auto.commit", "false");
-        // config.set("bootstrap.servers", self.bootstrap_servers.join(","));
-
-        config
-            .set_log_level(RDKafkaLogLevel::Debug)
+        let consumer = config
+            .set_log_level(RDKafkaLogLevel::Info)
             .create_with_context(DefaultConsumerContext)
-            .map_err(|e| anyhow!(e))
+            .map_err(|e| RwError::from(InternalError(format!("consumer creation failed {}", e))))?;
+
+        // if let Some(state) = state {
+        //     let identifier = state.identifier;
+        //     serde_json::from_str()
+        // }
+
+        Ok(Self {
+            consumer: Arc::new(consumer),
+            assigned_splits: HashMap::new(),
+        })
     }
 }
+
+// impl KafkaSplitReader {
+//     fn create_consumer(&self) -> Result<StreamConsumer<DefaultConsumerContext>> {
+//         let mut config = ClientConfig::new();
+//
+//         config.set("topic.metadata.refresh.interval.ms", "30000");
+//         config.set("fetch.message.max.bytes", "134217728");
+//         config.set("auto.offset.reset", "earliest");
+//
+//         if config.get("group.id").is_none() {
+//             config.set(
+//                 "group.id",
+//                 format!(
+//                     "consumer-{}",
+//                     SystemTime::now()
+//                         .duration_since(UNIX_EPOCH)
+//                         .unwrap()
+//                         .as_micros()
+//                 ),
+//             );
+//         }
+//
+//         // disable partition eof
+//         config.set("enable.partition.eof", "false");
+//         config.set("enable.auto.commit", "false");
+//         // config.set("bootstrap.servers", self.bootstrap_servers.join(","));
+//
+//         config
+//             .set_log_level(RDKafkaLogLevel::Debug)
+//             .create_with_context(DefaultConsumerContext)
+//             .map_err(|e| anyhow!(e))
+//     }
+// }

--- a/src/connector/src/kafka/source/reader.rs
+++ b/src/connector/src/kafka/source/reader.rs
@@ -20,15 +20,13 @@ use anyhow::{anyhow, Result};
 use async_trait::async_trait;
 use futures::StreamExt;
 use rdkafka::config::RDKafkaLogLevel;
-use rdkafka::consumer::stream_consumer::StreamPartitionQueue;
-use rdkafka::consumer::{Consumer, DefaultConsumerContext, StreamConsumer};
-use rdkafka::{ClientConfig, Message, Offset, TopicPartitionList};
+use rdkafka::consumer::{DefaultConsumerContext, StreamConsumer};
+use rdkafka::ClientConfig;
 use risingwave_common::error::ErrorCode::{InternalError, ProtocolError};
 use risingwave_common::error::RwError;
 
 use crate::base::{InnerMessage, SourceReader};
-use crate::kafka::split::{KafkaOffset, KafkaSplit};
-use crate::ConnectorState;
+use crate::kafka::split::KafkaSplit;
 
 const KAFKA_MAX_FETCH_MESSAGES: usize = 1024;
 
@@ -85,15 +83,15 @@ impl SourceReader for KafkaSplitReader {
 
     async fn new(
         properties: HashMap<String, String>,
-        state: Option<crate::ConnectorState>,
+        _state: Option<crate::ConnectorState>,
     ) -> Result<Self>
-    where
-        Self: Sized,
+        where
+            Self: Sized,
     {
         let bootstrap_servers =
             properties
                 .get(KAFKA_CONFIG_BOOTSTRAP_SERVER_KEY)
-                .ok_or(RwError::from(ProtocolError(format!(
+                .ok_or_else(|| RwError::from(ProtocolError(format!(
                     "could not found config {}",
                     KAFKA_CONFIG_BOOTSTRAP_SERVER_KEY
                 ))))?;

--- a/src/connector/src/kafka/source/reader.rs
+++ b/src/connector/src/kafka/source/reader.rs
@@ -96,11 +96,6 @@ impl SourceReader for KafkaSplitReader {
             .create_with_context(DefaultConsumerContext)
             .map_err(|e| RwError::from(InternalError(format!("consumer creation failed {}", e))))?;
 
-        // if let Some(state) = state {
-        //     let identifier = state.identifier;
-        //     serde_json::from_str()
-        // }
-
         Ok(Self {
             consumer: Arc::new(consumer),
             assigned_splits: HashMap::new(),

--- a/src/connector/src/kafka/split.rs
+++ b/src/connector/src/kafka/split.rs
@@ -27,8 +27,9 @@ pub enum KafkaOffset {
     None,
 }
 
-#[derive(Copy, Clone, Serialize, Deserialize)]
+#[derive(Clone, Serialize, Deserialize)]
 pub struct KafkaSplit {
+    pub(crate) topic: String,
     pub(crate) partition: i32,
     pub(crate) start_offset: KafkaOffset,
     pub(crate) stop_offset: KafkaOffset,
@@ -45,8 +46,9 @@ impl SourceSplit for KafkaSplit {
 }
 
 impl KafkaSplit {
-    pub fn new(partition: i32, start_offset: KafkaOffset, stop_offset: KafkaOffset) -> KafkaSplit {
+    pub fn new(partition: i32, start_offset: KafkaOffset, stop_offset: KafkaOffset, topic: String) -> KafkaSplit {
         KafkaSplit {
+            topic,
             partition,
             start_offset,
             stop_offset,

--- a/src/connector/src/kafka/split.rs
+++ b/src/connector/src/kafka/split.rs
@@ -25,6 +25,8 @@ pub struct KafkaSplit {
     pub(crate) stop_offset: Option<i64>,
 }
 
+pub const KAFKA_SPLIT_TYPE: &str = "kafka";
+
 impl SourceSplit for KafkaSplit {
     fn id(&self) -> String {
         format!("{}", self.partition)
@@ -32,6 +34,14 @@ impl SourceSplit for KafkaSplit {
 
     fn to_string(&self) -> anyhow::Result<String> {
         serde_json::to_string(self).map_err(|e| anyhow!(e))
+    }
+
+    fn restore_from_bytes(bytes: &[u8]) -> anyhow::Result<Self> {
+        serde_json::from_slice(bytes).map_err(|e| anyhow!(e))
+    }
+
+    fn get_type(&self) -> String {
+        KAFKA_SPLIT_TYPE.to_string()
     }
 }
 

--- a/src/connector/src/kafka/split.rs
+++ b/src/connector/src/kafka/split.rs
@@ -17,22 +17,12 @@ use serde::{Deserialize, Serialize};
 
 use crate::base::SourceSplit;
 
-#[derive(Debug, Copy, Clone, Eq, PartialEq, Serialize, Deserialize)]
-#[serde(tag = "type")]
-pub enum KafkaOffset {
-    Earliest,
-    Latest,
-    Offset(i64),
-    Timestamp(i64),
-    None,
-}
-
 #[derive(Clone, Serialize, Deserialize, Debug)]
 pub struct KafkaSplit {
     pub(crate) topic: String,
     pub(crate) partition: i32,
-    pub(crate) start_offset: KafkaOffset,
-    pub(crate) stop_offset: KafkaOffset,
+    pub(crate) start_offset: Option<i64>,
+    pub(crate) stop_offset: Option<i64>,
 }
 
 impl SourceSplit for KafkaSplit {
@@ -48,8 +38,8 @@ impl SourceSplit for KafkaSplit {
 impl KafkaSplit {
     pub fn new(
         partition: i32,
-        start_offset: KafkaOffset,
-        stop_offset: KafkaOffset,
+        start_offset: Option<i64>,
+        stop_offset: Option<i64>,
         topic: String,
     ) -> KafkaSplit {
         KafkaSplit {
@@ -59,4 +49,16 @@ impl KafkaSplit {
             stop_offset,
         }
     }
+}
+
+#[cfg(test)]
+mod test {
+
+    // #[test]
+    // fn test_serialize() {
+    //     let split = KafkaSplit::new(3, None, Some(123), "test_topic".to_string());
+    //     let bytes = split.to_string().unwrap();
+    //
+    //     println!("bytes {}", bytes);
+    // }
 }

--- a/src/connector/src/kafka/split.rs
+++ b/src/connector/src/kafka/split.rs
@@ -27,7 +27,7 @@ pub enum KafkaOffset {
     None,
 }
 
-#[derive(Clone, Serialize, Deserialize)]
+#[derive(Clone, Serialize, Deserialize, Debug)]
 pub struct KafkaSplit {
     pub(crate) topic: String,
     pub(crate) partition: i32,
@@ -46,7 +46,12 @@ impl SourceSplit for KafkaSplit {
 }
 
 impl KafkaSplit {
-    pub fn new(partition: i32, start_offset: KafkaOffset, stop_offset: KafkaOffset, topic: String) -> KafkaSplit {
+    pub fn new(
+        partition: i32,
+        start_offset: KafkaOffset,
+        stop_offset: KafkaOffset,
+        topic: String,
+    ) -> KafkaSplit {
         KafkaSplit {
             topic,
             partition,

--- a/src/connector/src/kafka/split.rs
+++ b/src/connector/src/kafka/split.rs
@@ -60,15 +60,3 @@ impl KafkaSplit {
         }
     }
 }
-
-#[cfg(test)]
-mod test {
-
-    // #[test]
-    // fn test_serialize() {
-    //     let split = KafkaSplit::new(3, None, Some(123), "test_topic".to_string());
-    //     let bytes = split.to_string().unwrap();
-    //
-    //     println!("bytes {}", bytes);
-    // }
-}

--- a/src/connector/src/kinesis/enumerator/mod.rs
+++ b/src/connector/src/kinesis/enumerator/mod.rs
@@ -12,4 +12,4 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-mod client;
+pub mod client;

--- a/src/connector/src/kinesis/mod.rs
+++ b/src/connector/src/kinesis/mod.rs
@@ -13,6 +13,6 @@
 // limitations under the License.
 
 pub mod config;
-mod enumerator;
+pub mod enumerator;
 pub mod source;
-mod split;
+pub mod split;

--- a/src/connector/src/kinesis/split.rs
+++ b/src/connector/src/kinesis/split.rs
@@ -26,6 +26,8 @@ pub enum KinesisOffset {
     None,
 }
 
+pub const KINESIS_SPLIT_TYPE: &str= "kinesis";
+
 #[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct KinesisSplit {
     pub(crate) shard_id: String,
@@ -40,6 +42,14 @@ impl SourceSplit for KinesisSplit {
 
     fn to_string(&self) -> anyhow::Result<String> {
         serde_json::to_string(self).map_err(|e| anyhow!(e))
+    }
+
+    fn restore_from_bytes(bytes: &[u8]) -> anyhow::Result<Self> {
+        serde_json::from_slice(bytes).map_err(|e| anyhow!(e))
+    }
+
+    fn get_type(&self) -> String {
+        KINESIS_SPLIT_TYPE.to_string()
     }
 }
 

--- a/src/connector/src/kinesis/split.rs
+++ b/src/connector/src/kinesis/split.rs
@@ -26,7 +26,7 @@ pub enum KinesisOffset {
     None,
 }
 
-pub const KINESIS_SPLIT_TYPE: &str= "kinesis";
+pub const KINESIS_SPLIT_TYPE: &str = "kinesis";
 
 #[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct KinesisSplit {

--- a/src/connector/src/pulsar/mod.rs
+++ b/src/connector/src/pulsar/mod.rs
@@ -14,7 +14,7 @@
 
 mod admin;
 pub(crate) mod enumerator;
-mod source;
+pub mod source;
 mod split;
 mod topic;
 

--- a/src/connector/src/pulsar/mod.rs
+++ b/src/connector/src/pulsar/mod.rs
@@ -15,7 +15,7 @@
 mod admin;
 pub(crate) mod enumerator;
 pub mod source;
-mod split;
+pub mod split;
 mod topic;
 
 pub use enumerator::*;

--- a/src/connector/src/pulsar/source/mod.rs
+++ b/src/connector/src/pulsar/source/mod.rs
@@ -13,4 +13,4 @@
 // limitations under the License.
 
 mod message;
-mod reader;
+pub mod reader;

--- a/src/connector/src/pulsar/split.rs
+++ b/src/connector/src/pulsar/split.rs
@@ -24,6 +24,8 @@ pub enum PulsarOffset {
     None,
 }
 
+pub const PULSAR_SPLIT_TYPE: &str = "pulsar";
+
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct PulsarSplit {
     pub(crate) sub_topic: String,
@@ -48,5 +50,13 @@ impl SourceSplit for PulsarSplit {
 
     fn to_string(&self) -> anyhow::Result<String> {
         serde_json::to_string(self).map_err(|e| anyhow!(e))
+    }
+
+    fn restore_from_bytes(bytes: &[u8]) -> anyhow::Result<Self> {
+        serde_json::from_slice(bytes).map_err(|e| anyhow!(e))
+    }
+
+    fn get_type(&self) -> String {
+        PULSAR_SPLIT_TYPE.to_string()
     }
 }

--- a/src/frontend/src/optimizer/plan_node/stream_source.rs
+++ b/src/frontend/src/optimizer/plan_node/stream_source.rs
@@ -79,7 +79,7 @@ impl ToStreamProst for StreamSource {
                 .map(|c| c.column_id().into())
                 .collect(),
             source_type: self.logical.source_catalog.source_type as i32,
-            stream_source_splits: vec![],
+            stream_source_splits: None,
         })
     }
 }

--- a/src/frontend/src/optimizer/plan_node/stream_source.rs
+++ b/src/frontend/src/optimizer/plan_node/stream_source.rs
@@ -79,7 +79,7 @@ impl ToStreamProst for StreamSource {
                 .map(|c| c.column_id().into())
                 .collect(),
             source_type: self.logical.source_catalog.source_type as i32,
-            stream_source_splits: None,
+            stream_source_state: None,
         })
     }
 }

--- a/src/frontend/src/optimizer/plan_node/stream_source.rs
+++ b/src/frontend/src/optimizer/plan_node/stream_source.rs
@@ -79,6 +79,7 @@ impl ToStreamProst for StreamSource {
                 .map(|c| c.column_id().into())
                 .collect(),
             source_type: self.logical.source_catalog.source_type as i32,
+            stream_source_splits: vec![],
         })
     }
 }

--- a/src/meta/Cargo.toml
+++ b/src/meta/Cargo.toml
@@ -32,6 +32,7 @@ prometheus = "0.13"
 prost = "0.10"
 rand = "0.8"
 risingwave_common = { path = "../common" }
+risingwave_connector = { path = "../connector" }
 risingwave_hummock_sdk = { path = "../storage/hummock_sdk" }
 risingwave_pb = { path = "../prost" }
 risingwave_rpc_client = { path = "../rpc_client" }

--- a/src/meta/src/manager/catalog_v2.rs
+++ b/src/meta/src/manager/catalog_v2.rs
@@ -723,6 +723,10 @@ where
             .remove(&(source.database_id, source.schema_id, source.name.clone()))
     }
 
+    pub async fn get_source(&self, id: SourceId) -> Result<Option<Source>> {
+        Source::select(self.env.meta_store(), &id).await
+    }
+
     fn get_ref_count(&self, relation_id: RelationId) -> Option<usize> {
         self.relation_ref_count.get(&relation_id).cloned()
     }

--- a/src/meta/src/model/stream.rs
+++ b/src/meta/src/model/stream.rs
@@ -20,11 +20,13 @@ use risingwave_common::error::Result;
 use risingwave_pb::meta::table_fragments::fragment::FragmentType;
 use risingwave_pb::meta::table_fragments::{ActorState, ActorStatus, Fragment};
 use risingwave_pb::meta::TableFragments as ProstTableFragments;
+use risingwave_pb::stream_plan::source_node::SourceType;
 use risingwave_pb::stream_plan::stream_node::Node;
 use risingwave_pb::stream_plan::{StreamActor, StreamNode};
 
 use super::{ActorId, FragmentId};
 use crate::cluster::WorkerId;
+use crate::manager::SourceId;
 use crate::model::MetadataModel;
 
 /// Column family name for table fragments.
@@ -150,6 +152,22 @@ impl TableFragments {
         }
 
         false
+    }
+
+    pub fn fetch_stream_source_id(stream_node: &StreamNode) -> Option<SourceId> {
+        if let Some(Node::SourceNode(s)) = stream_node.node.as_ref() {
+            if s.source_type == SourceType::Source as i32 {
+                return Some(s.table_ref_id.as_ref().unwrap().table_id as SourceId);
+            }
+        }
+
+        for child in &stream_node.input {
+            if let Some(source_id) = Self::fetch_stream_source_id(child) {
+                return Some(source_id);
+            }
+        }
+
+        None
     }
 
     /// Returns actors that contains Chain node.

--- a/src/meta/src/rpc/server.rs
+++ b/src/meta/src/rpc/server.rs
@@ -182,6 +182,7 @@ pub async fn rpc_serve_with_store<S: MetaStore>(
             env.clone(),
             cluster_manager.clone(),
             barrier_manager.clone(),
+            catalog_manager_v2.clone(),
         )
         .await
         .unwrap(),

--- a/src/meta/src/rpc/service/ddl_service.rs
+++ b/src/meta/src/rpc/service/ddl_service.rs
@@ -31,7 +31,7 @@ use crate::manager::{CatalogManagerRef, IdCategory, MetaSrvEnv, SourceId, TableI
 use crate::model::TableFragments;
 use crate::storage::MetaStore;
 use crate::stream::{
-    FragmentManagerRef, GlobalSourceManagerRef, GlobalStreamManagerRef, StreamFragmenter,
+    FragmentManagerRef, GlobalStreamManagerRef, SourceManagerRef, StreamFragmenter,
 };
 
 #[derive(Clone)]
@@ -40,7 +40,7 @@ pub struct DdlServiceImpl<S: MetaStore> {
 
     catalog_manager: CatalogManagerRef<S>,
     stream_manager: GlobalStreamManagerRef<S>,
-    source_manager: GlobalSourceManagerRef<S>,
+    source_manager: SourceManagerRef<S>,
     cluster_manager: ClusterManagerRef<S>,
     fragment_manager: FragmentManagerRef<S>,
 }
@@ -53,7 +53,7 @@ where
         env: MetaSrvEnv<S>,
         catalog_manager: CatalogManagerRef<S>,
         stream_manager: GlobalStreamManagerRef<S>,
-        source_manager: GlobalSourceManagerRef<S>,
+        source_manager: SourceManagerRef<S>,
         cluster_manager: ClusterManagerRef<S>,
         fragment_manager: FragmentManagerRef<S>,
     ) -> Self {

--- a/src/meta/src/stream/source_manager.rs
+++ b/src/meta/src/stream/source_manager.rs
@@ -12,13 +12,24 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use std::borrow::{Borrow, BorrowMut};
+use std::collections::HashMap;
 use std::sync::Arc;
+use std::time::Duration;
+use anyhow::anyhow;
 
 use futures::future::try_join_all;
-use risingwave_common::error::{Result, ToRwResult};
-use risingwave_pb::catalog::Source;
+use tokio::io::AsyncReadExt;
+use tokio::sync::{Mutex, oneshot};
+use tokio::time;
+use risingwave_common::error::{Result, RwError, ToRwResult};
+use risingwave_common::error::ErrorCode::InternalError;
+use risingwave_connector::{extract_split_enumerator, SplitEnumeratorImpl, SplitImpl};
+use risingwave_pb::catalog::{Source, StreamSourceInfo};
+use risingwave_pb::catalog::source::Info;
 use risingwave_pb::common::worker_node::State::Running;
 use risingwave_pb::common::WorkerType;
+use risingwave_pb::meta::table_fragments::Fragment;
 use risingwave_pb::stream_service::{
     CreateSourceRequest as ComputeNodeCreateSourceRequest,
     DropSourceRequest as ComputeNodeDropSourceRequest,
@@ -26,7 +37,8 @@ use risingwave_pb::stream_service::{
 
 use crate::barrier::BarrierManagerRef;
 use crate::cluster::ClusterManagerRef;
-use crate::manager::{MetaSrvEnv, SourceId, StreamClient};
+use crate::manager::{CatalogManagerRef, MetaSrvEnv, SourceId, StreamClient, TableId};
+use crate::model::{ActorId, FragmentId};
 use crate::storage::MetaStore;
 
 pub type GlobalSourceManagerRef<S> = Arc<GlobalSourceManager<S>>;
@@ -37,25 +49,152 @@ pub struct GlobalSourceManager<S: MetaStore> {
 
     cluster_manager: ClusterManagerRef<S>,
     barrier_manager: BarrierManagerRef<S>,
+
+    catalog_manager: CatalogManagerRef<S>,
+
+    core: Arc<Mutex<SourceManagerCore<S>>>,
 }
 
+pub struct SourceDiscovery {
+    id: SourceId,
+    current_splits: Arc<Mutex<Option<Vec<SplitImpl>>>>,
+    stop_tx: oneshot::Sender<()>,
+}
+
+impl SourceDiscovery {
+    async fn create(source_id: SourceId, info: &StreamSourceInfo) -> Result<Self> {
+        let mut enumerator = extract_split_enumerator(&info.properties).to_rw_result()?;
+        let (stop_tx, mut stop_rx) = oneshot::channel::<()>();
+        let mut splits = Arc::new(Mutex::new(None));
+        let mut splits_clone = splits.clone();
+
+        tokio::spawn(async move {
+            let mut interval = time::interval(Duration::from_secs(10));
+            loop {
+                tokio::select! {
+                    _ = interval.tick() => {
+                        let new_splits = enumerator.list_splits().await.unwrap();
+
+                        {
+                            let mut splits = splits_clone.lock().await;
+                            *splits = Some(new_splits);
+                        }
+                    }
+                    _ = stop_rx.borrow_mut() => {
+                        log::info!("source {} discovery loop stopped", source_id );
+                        break
+                    }
+                }
+            }
+        });
+
+        Ok(Self {
+            id: source_id,
+            current_splits: splits,
+            stop_tx,
+        })
+    }
+}
+
+pub struct RegisterSourceContext {
+    pub materialized_view_id: TableId,
+    pub fragments: HashMap<SourceId, Vec<Fragment>>,
+}
+
+pub struct SourceManagerCore<S: MetaStore> {
+    pub managed_sources: HashMap<SourceId, SourceDiscovery>,
+    associated_sources: HashMap<TableId, HashMap<SourceId, Vec<Fragment>>>,
+    meta_srv_env: MetaSrvEnv<S>,
+}
+
+impl<S> SourceManagerCore<S> where S: MetaStore {
+    fn new() -> Result<Self> {
+        todo!()
+    }
+
+
+    async fn tick(&mut self) -> Result<()> {
+        for (mv_id, map) in self.associated_sources {
+            for (source_id, frags) in map {
+                let discovery = self.managed_sources.get(&source_id).unwrap();
+                let current_splits = discovery.current_splits.lock().await.as_ref();
+                match current_splits{
+                    None => continue,
+                    Some(splits) => {
+                        
+                    }
+                }
+
+
+            }
+        }
+
+        todo!()
+    }
+
+
+    fn diff_splits() -> Result<()> {
+        todo!()
+    }
+}
+
+
 impl<S> GlobalSourceManager<S>
-where
-    S: MetaStore,
+    where
+        S: MetaStore,
 {
     pub async fn new(
         env: MetaSrvEnv<S>,
         cluster_manager: ClusterManagerRef<S>,
         barrier_manager: BarrierManagerRef<S>,
+        catalog_manager: CatalogManagerRef<S>,
     ) -> Result<Self> {
         Ok(Self {
             env,
             cluster_manager,
             barrier_manager,
+            catalog_manager,
+            core: Arc::new(Mutex::new(SourceManagerCore::new().unwrap())),
         })
     }
 
-    async fn all_stream_clients(&self) -> Result<impl Iterator<Item = StreamClient>> {
+    async fn register_source_discovery(&mut self, ctx: RegisterSourceContext) -> Result<()> {
+        let mut core = self.core.lock().await;
+
+        if core.associated_sources.contains_key(&ctx.materialized_view_id) {
+            return Err(anyhow!("mv {} already registered in source manager",ctx.materialized_view_id)).to_rw_result();
+        }
+
+        for source_id in ctx.fragments.keys() {
+            if !core.managed_sources.contains_key(source_id) {
+                let catalog_core = self.catalog_manager.get_catalog_core_guard().await;
+                let source = catalog_core.get_source(source_id.clone()).await?
+                    .ok_or(RwError::from(InternalError(format!(
+                        "source {} does not exists",
+                        source_id,
+                    ))))?;
+
+                let source_info = match source.get_info()?.clone() {
+                    Info::StreamSource(s) => s,
+                    _ => {
+                        return Err(RwError::from(InternalError(
+                            "only stream source is support".to_string(),
+                        )));
+                    }
+                };
+
+                core.managed_sources.insert(source_id.clone(), SourceDiscovery::create(source_id.clone(), &source_info).await?);
+            }
+        }
+
+        let mut ctx = ctx;
+
+        core.associated_sources.insert(ctx.materialized_view_id, std::mem::take(&mut ctx.fragments));
+
+        Ok(())
+    }
+
+    async fn all_stream_clients(&self) -> Result<impl Iterator<Item=StreamClient>> {
         // FIXME: there is gap between the compute node activate itself and source ddl operation,
         // create/drop source(non-stateful source like TableSource) before the compute node
         // activate itself will cause an inconsistent state. This situation will happen when some
@@ -70,8 +209,8 @@ where
                 .iter()
                 .map(|worker| self.env.stream_clients().get(worker)),
         )
-        .await?
-        .into_iter();
+            .await?
+            .into_iter();
 
         Ok(all_stream_clients)
     }

--- a/src/meta/src/stream/source_manager.rs
+++ b/src/meta/src/stream/source_manager.rs
@@ -267,6 +267,7 @@ where
         let mut result = HashMap::new();
 
         for (splits, fragments) in source_splits.into_iter().zip_eq(actors.into_values()) {
+            log::debug!("found {} splits", splits.len());
             for actors in fragments {
                 let actor_count = actors.len();
                 let mut chunks = vec![vec![]; actor_count];
@@ -402,7 +403,6 @@ where
             tokio::select! {
             _ = interval.tick() => {
                     let mut core = self.core.lock().await;
-                    log::debug!("Source manager tick! total {} sources", core.managed_sources.len());
                     if let Err(e) = core.tick().await {
                         log::error!("source manager tick failed! {}", e);
                     }

--- a/src/meta/src/stream/source_manager.rs
+++ b/src/meta/src/stream/source_manager.rs
@@ -342,6 +342,7 @@ where
             tokio::select! {
             _ = interval.tick() => {
                     let mut core = self.core.lock().await;
+                    log::debug!("Source manager tick! total {} sources", core.managed_sources.len());
                     if let Err(e) = core.tick().await {
                         log::error!("source manager tick failed! {}", e);
                     }

--- a/src/meta/src/stream/source_manager.rs
+++ b/src/meta/src/stream/source_manager.rs
@@ -13,20 +13,19 @@
 // limitations under the License.
 
 use std::borrow::{Borrow, BorrowMut};
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
+use std::hash::Hash;
 use std::sync::Arc;
 use std::time::Duration;
-use anyhow::anyhow;
 
+use anyhow::anyhow;
 use futures::future::try_join_all;
-use tokio::io::AsyncReadExt;
-use tokio::sync::{Mutex, oneshot};
-use tokio::time;
-use risingwave_common::error::{Result, RwError, ToRwResult};
+use itertools::Itertools;
 use risingwave_common::error::ErrorCode::InternalError;
+use risingwave_common::error::{Result, RwError, ToRwResult};
 use risingwave_connector::{extract_split_enumerator, SplitEnumeratorImpl, SplitImpl};
-use risingwave_pb::catalog::{Source, StreamSourceInfo};
 use risingwave_pb::catalog::source::Info;
+use risingwave_pb::catalog::{Source, StreamSourceInfo};
 use risingwave_pb::common::worker_node::State::Running;
 use risingwave_pb::common::WorkerType;
 use risingwave_pb::meta::table_fragments::Fragment;
@@ -34,8 +33,12 @@ use risingwave_pb::stream_service::{
     CreateSourceRequest as ComputeNodeCreateSourceRequest,
     DropSourceRequest as ComputeNodeDropSourceRequest,
 };
+use tokio::io::AsyncReadExt;
+use tokio::sync::{oneshot, Mutex};
+use tokio::time;
+use risingwave_pb::data::barrier::Mutation;
 
-use crate::barrier::BarrierManagerRef;
+use crate::barrier::{BarrierManagerRef, Command};
 use crate::cluster::ClusterManagerRef;
 use crate::manager::{CatalogManagerRef, MetaSrvEnv, SourceId, StreamClient, TableId};
 use crate::model::{ActorId, FragmentId};
@@ -58,6 +61,7 @@ pub struct GlobalSourceManager<S: MetaStore> {
 pub struct SourceDiscovery {
     id: SourceId,
     current_splits: Arc<Mutex<Option<Vec<SplitImpl>>>>,
+    last_assigned_splits: Vec<Vec<(ActorId, Vec<SplitImpl>)>>,
     stop_tx: oneshot::Sender<()>,
 }
 
@@ -65,8 +69,8 @@ impl SourceDiscovery {
     async fn create(source_id: SourceId, info: &StreamSourceInfo) -> Result<Self> {
         let mut enumerator = extract_split_enumerator(&info.properties).to_rw_result()?;
         let (stop_tx, mut stop_rx) = oneshot::channel::<()>();
-        let mut splits = Arc::new(Mutex::new(None));
-        let mut splits_clone = splits.clone();
+        let splits = Arc::new(Mutex::new(None));
+        let splits_clone = splits.clone();
 
         tokio::spawn(async move {
             let mut interval = time::interval(Duration::from_secs(10));
@@ -74,7 +78,6 @@ impl SourceDiscovery {
                 tokio::select! {
                     _ = interval.tick() => {
                         let new_splits = enumerator.list_splits().await.unwrap();
-
                         {
                             let mut splits = splits_clone.lock().await;
                             *splits = Some(new_splits);
@@ -91,53 +94,91 @@ impl SourceDiscovery {
         Ok(Self {
             id: source_id,
             current_splits: splits,
+            last_assigned_splits: vec![],
             stop_tx,
         })
     }
 }
 
-pub struct RegisterSourceContext {
-    pub materialized_view_id: TableId,
-    pub fragments: HashMap<SourceId, Vec<Fragment>>,
-}
-
 pub struct SourceManagerCore<S: MetaStore> {
     pub managed_sources: HashMap<SourceId, SourceDiscovery>,
-    associated_sources: HashMap<TableId, HashMap<SourceId, Vec<Fragment>>>,
-    meta_srv_env: MetaSrvEnv<S>,
+    pub barrier_manager: BarrierManagerRef<S>,
+    pub catalog_manager: CatalogManagerRef<S>,
 }
 
-impl<S> SourceManagerCore<S> where S: MetaStore {
-    fn new() -> Result<Self> {
+
+impl<S> SourceManagerCore<S>
+    where
+        S: MetaStore,
+{
+    fn new(meta_srv_env: MetaSrvEnv<S>) -> Result<Self> {
+        // Ok(Self {
+        //     managed_sources: HashMap::new(),
+        //     source_actors: HashMap::new(),
+        //     meta_srv_env,
+        // })
+
         todo!()
     }
 
-
     async fn tick(&mut self) -> Result<()> {
-        for (mv_id, map) in self.associated_sources {
-            for (source_id, frags) in map {
-                let discovery = self.managed_sources.get(&source_id).unwrap();
-                let current_splits = discovery.current_splits.lock().await.as_ref();
-                match current_splits{
-                    None => continue,
-                    Some(splits) => {
-                        
-                    }
+        for (_, source) in self.managed_sources.iter() {
+            let last_assign_splits = &source.last_assigned_splits;
+
+            let current_splits = match {
+                let guard = source.current_splits.lock().await;
+                guard.clone()
+            } {
+                None => {
+                    // source discovery is not ready
+                    continue;
                 }
+                Some(splits) => splits,
+            };
 
+            let new_ids = current_splits
+                .iter()
+                .map(|split| (split.id(), split))
+                .collect::<HashMap<_, _>>();
 
+            let mut assign = HashMap::new();
+
+            // TODO(peng): use metastore instead
+            for last_splits in last_assign_splits {
+                // for now we only check new splits
+                let assigned_ids = last_splits
+                    .iter()
+                    .map(|(_, splits)| splits.iter().map(|s| s.id()))
+                    .flatten()
+                    .collect::<HashSet<_>>();
+
+                let new_created_ids = new_ids
+                    .iter()
+                    .filter(|(id, _)| !assigned_ids.contains(*id))
+                    .collect_vec();
+
+                let actor_ids = last_splits
+                    .iter()
+                    .map(|(actor_id, _)| actor_id)
+                    .collect_vec();
+
+                for (i, (_, split)) in new_created_ids.iter().cloned().enumerate() {
+                    let actor_id = actor_ids[i % actor_ids.len()];
+                    assign
+                        .entry(actor_id.clone())
+                        .or_insert_with(Vec::new)
+                        .push((**split).clone());
+                }
+            }
+
+            if assign.len() > 0 {
+                self.barrier_manager.run_command(Command::Plain(Mutation::Add()))
             }
         }
 
-        todo!()
-    }
-
-
-    fn diff_splits() -> Result<()> {
-        todo!()
+        Ok(())
     }
 }
-
 
 impl<S> GlobalSourceManager<S>
     where
@@ -150,29 +191,31 @@ impl<S> GlobalSourceManager<S>
         catalog_manager: CatalogManagerRef<S>,
     ) -> Result<Self> {
         Ok(Self {
-            env,
+            env: env.clone(),
             cluster_manager,
             barrier_manager,
             catalog_manager,
-            core: Arc::new(Mutex::new(SourceManagerCore::new().unwrap())),
+            core: Arc::new(Mutex::new(SourceManagerCore::new(env).unwrap())),
         })
     }
 
-    async fn register_source_discovery(&mut self, ctx: RegisterSourceContext) -> Result<()> {
+    async fn register_source_discovery(
+        &mut self,
+        actors: HashMap<SourceId, Vec<Vec<ActorId>>>,
+    ) -> Result<()> {
         let mut core = self.core.lock().await;
 
-        if core.associated_sources.contains_key(&ctx.materialized_view_id) {
-            return Err(anyhow!("mv {} already registered in source manager",ctx.materialized_view_id)).to_rw_result();
-        }
-
-        for source_id in ctx.fragments.keys() {
+        for (source_id, actors) in actors.iter() {
             if !core.managed_sources.contains_key(source_id) {
                 let catalog_core = self.catalog_manager.get_catalog_core_guard().await;
-                let source = catalog_core.get_source(source_id.clone()).await?
-                    .ok_or(RwError::from(InternalError(format!(
-                        "source {} does not exists",
-                        source_id,
-                    ))))?;
+                let source =
+                    catalog_core
+                        .get_source(source_id.clone())
+                        .await?
+                        .ok_or(RwError::from(InternalError(format!(
+                            "source {} does not exists",
+                            source_id,
+                        ))))?;
 
                 let source_info = match source.get_info()?.clone() {
                     Info::StreamSource(s) => s,
@@ -183,13 +226,23 @@ impl<S> GlobalSourceManager<S>
                     }
                 };
 
-                core.managed_sources.insert(source_id.clone(), SourceDiscovery::create(source_id.clone(), &source_info).await?);
+                let source_discovery =
+                    SourceDiscovery::create(source_id.clone(), &source_info).await?;
+                core.managed_sources
+                    .insert(source_id.clone(), source_discovery);
             }
+
+            let mut new_assign_splits = actors
+                .iter()
+                .map(|actor_ids| actor_ids.iter().map(|x| (x.clone(), vec![])).collect())
+                .collect_vec();
+
+            core.managed_sources
+                .get_mut(source_id)
+                .unwrap()
+                .last_assigned_splits
+                .append(&mut new_assign_splits);
         }
-
-        let mut ctx = ctx;
-
-        core.associated_sources.insert(ctx.materialized_view_id, std::mem::take(&mut ctx.fragments));
 
         Ok(())
     }
@@ -246,7 +299,36 @@ impl<S> GlobalSourceManager<S>
     }
 
     pub async fn run(&self) -> Result<()> {
-        // todo: fill me
-        Ok(())
+        let mut interval = time::interval(Duration::from_secs(10));
+
+        let mut core = self.core.lock().await;
+        let x = match core.tick().await {
+            Ok(o) => o,
+            Err(e) => {
+                log::error!("source manager tick failed: {:?}", e);
+                todo!()
+                //   continue
+            }
+        };
+
+        let x = self.barrier_manager.run_command(Command::Plain(Mutation::Nothing()));
+
+
+        loop {
+            tokio::select! {
+                _ = interval.tick() => {
+                        {
+
+
+
+                        }
+                    // let new_splits = enumerator.list_splits().await.unwrap();
+                    // {
+                    //     let mut splits = splits_clone.lock().await;
+                    //     *splits = Some(new_splits);
+                    // }
+                }
+            }
+        }
     }
 }

--- a/src/meta/src/stream/source_manager.rs
+++ b/src/meta/src/stream/source_manager.rs
@@ -12,10 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use std::borrow::BorrowMut;
-use std::collections::{HashMap, HashSet};
+use std::collections::HashMap;
 use std::sync::Arc;
-use std::time::Duration;
 
 use futures::future::try_join_all;
 use itertools::Itertools;
@@ -23,19 +21,15 @@ use risingwave_common::error::ErrorCode::InternalError;
 use risingwave_common::error::{Result, RwError, ToRwResult};
 use risingwave_connector::{extract_split_enumerator, SplitImpl};
 use risingwave_pb::catalog::source::Info;
-use risingwave_pb::catalog::{Source, StreamSourceInfo};
+use risingwave_pb::catalog::Source;
 use risingwave_pb::common::worker_node::State::Running;
 use risingwave_pb::common::WorkerType;
-use risingwave_pb::data::barrier::Mutation;
-use risingwave_pb::data::{SplitAssignMutation, Splits};
 use risingwave_pb::stream_service::{
     CreateSourceRequest as ComputeNodeCreateSourceRequest,
     DropSourceRequest as ComputeNodeDropSourceRequest,
 };
-use tokio::sync::{oneshot, Mutex};
-use tokio::time;
 
-use crate::barrier::{BarrierManagerRef, Command};
+use crate::barrier::BarrierManagerRef;
 use crate::cluster::ClusterManagerRef;
 use crate::manager::{CatalogManagerRef, MetaSrvEnv, SourceId, StreamClient};
 use crate::model::ActorId;
@@ -48,165 +42,6 @@ pub struct SourceManager<S: MetaStore> {
     env: MetaSrvEnv<S>,
     cluster_manager: ClusterManagerRef<S>,
     catalog_manager: CatalogManagerRef<S>,
-    core: Arc<Mutex<SourceManagerCore<S>>>,
-}
-
-pub struct SourceDiscovery {
-    current_splits: Arc<Mutex<Option<Vec<SplitImpl>>>>,
-    last_assigned_splits: Vec<HashMap<ActorId, Vec<SplitImpl>>>,
-    stop_tx: oneshot::Sender<()>,
-}
-
-impl SourceDiscovery {
-    pub async fn create(source_id: SourceId, info: &StreamSourceInfo) -> Result<Self> {
-        let mut enumerator = extract_split_enumerator(&info.properties).to_rw_result()?;
-        let (stop_tx, mut stop_rx) = oneshot::channel::<()>();
-        let splits = Arc::new(Mutex::new(None));
-        let splits_clone = splits.clone();
-
-        tokio::spawn(async move {
-            let mut interval = time::interval(Duration::from_secs(10));
-            loop {
-                tokio::select! {
-                    _ = interval.tick() => {
-                        let new_splits = enumerator.list_splits().await.unwrap();
-                        {
-                            let mut splits = splits_clone.lock().await;
-                            *splits = Some(new_splits);
-                        }
-                    }
-                    _ = stop_rx.borrow_mut() => {
-                        log::info!("source {} discovery loop stopped", source_id );
-                        break
-                    }
-                }
-            }
-        });
-
-        Ok(Self {
-            current_splits: splits,
-            last_assigned_splits: vec![],
-            stop_tx,
-        })
-    }
-
-    pub async fn stop(self) {
-        self.stop_tx.send(()).unwrap();
-    }
-}
-
-pub struct SourceManagerCore<S: MetaStore> {
-    pub managed_sources: HashMap<SourceId, SourceDiscovery>,
-    pub barrier_manager: BarrierManagerRef<S>,
-    pub catalog_manager: CatalogManagerRef<S>,
-    pub meta_srv_env: MetaSrvEnv<S>,
-}
-
-impl<S> SourceManagerCore<S>
-where
-    S: MetaStore,
-{
-    fn new(
-        meta_srv_env: MetaSrvEnv<S>,
-        barrier_manager: BarrierManagerRef<S>,
-        catalog_manager: CatalogManagerRef<S>,
-    ) -> Result<Self> {
-        // todo: restore managed source from meta
-        Ok(Self {
-            managed_sources: HashMap::new(),
-            barrier_manager,
-            catalog_manager,
-            meta_srv_env,
-        })
-    }
-
-    async fn tick(&mut self) -> Result<()> {
-        for mut source in self.managed_sources.values_mut() {
-            let last_assign_splits = &source.last_assigned_splits;
-
-            let current_splits = match {
-                let guard = source.current_splits.lock().await;
-                guard.clone()
-            } {
-                None => {
-                    // source discovery is not ready
-                    continue;
-                }
-                Some(splits) => splits,
-            };
-
-            let current_split_with_ids = current_splits
-                .iter()
-                .map(|split| (split.id(), split))
-                .collect::<HashMap<_, _>>();
-
-            let mut assign = HashMap::new();
-            let mut current_assigned_splits = vec![];
-
-            // TODO(peng): use metastore instead
-            for last_splits in last_assign_splits {
-                let mut grouped_splits = last_splits.clone();
-
-                // for now we only check new splits
-                let assigned_ids = last_splits
-                    .iter()
-                    .flat_map(|(_, splits)| splits.iter().map(|s| s.id()))
-                    .collect::<HashSet<_>>();
-
-                let new_created_ids = current_split_with_ids
-                    .iter()
-                    .filter(|(id, _)| !assigned_ids.contains(*id))
-                    .collect_vec();
-
-                let actor_ids = last_splits
-                    .iter()
-                    .map(|(actor_id, _)| actor_id)
-                    .collect_vec();
-
-                // todo: use heap
-                for (i, (_, split)) in new_created_ids.iter().cloned().enumerate() {
-                    let actor_id = actor_ids[i % actor_ids.len()];
-                    assign
-                        .entry(*actor_id)
-                        .or_insert_with(Vec::new)
-                        .push((**split).clone());
-
-                    grouped_splits
-                        .entry(*actor_id)
-                        .or_insert_with(Vec::new)
-                        .push((**split).clone());
-                }
-
-                current_assigned_splits.push(grouped_splits);
-            }
-
-            // todo: error handling
-            if !assign.is_empty() {
-                self.barrier_manager
-                    .run_command(Command::Plain(Mutation::SplitAssign(SplitAssignMutation {
-                        splits: assign
-                            .into_iter()
-                            .map(|(actor_id, assigned_splits)| {
-                                (
-                                    actor_id,
-                                    Splits {
-                                        splits: assigned_splits
-                                            .into_iter()
-                                            .map(|split| serde_json::to_vec(&split).unwrap())
-                                            .collect(),
-                                    },
-                                )
-                            })
-                            .collect(),
-                    })))
-                    .await?;
-
-                source.last_assigned_splits = current_assigned_splits;
-            }
-        }
-
-        Ok(())
-    }
 }
 
 impl<S> SourceManager<S>
@@ -216,16 +51,13 @@ where
     pub async fn new(
         env: MetaSrvEnv<S>,
         cluster_manager: ClusterManagerRef<S>,
-        barrier_manager: BarrierManagerRef<S>,
+        _barrier_manager: BarrierManagerRef<S>,
         catalog_manager: CatalogManagerRef<S>,
     ) -> Result<Self> {
         Ok(Self {
-            catalog_manager: catalog_manager.clone(),
-            env: env.clone(),
+            env,
             cluster_manager,
-            core: Arc::new(Mutex::new(
-                SourceManagerCore::new(env, barrier_manager, catalog_manager).unwrap(),
-            )),
+            catalog_manager,
         })
     }
 
@@ -288,63 +120,6 @@ where
         Ok(result)
     }
 
-    pub async fn unregister_source_discovery(&self, source_id: SourceId) -> Result<()> {
-        let mut core = self.core.lock().await;
-
-        if let Some(source) = core.managed_sources.remove(&source_id) {
-            source.stop().await;
-        }
-
-        Ok(())
-    }
-
-    pub async fn register_source_discovery(
-        &self,
-        actors: HashMap<SourceId, Vec<Vec<ActorId>>>,
-    ) -> Result<()> {
-        let mut core = self.core.lock().await;
-
-        for (source_id, actors) in &actors {
-            if !core.managed_sources.contains_key(source_id) {
-                let source = {
-                    let catalog_core = core.catalog_manager.get_catalog_core_guard().await;
-                    catalog_core.get_source(*source_id).await?.ok_or_else(|| {
-                        RwError::from(InternalError(format!(
-                            "source {} does not exists",
-                            source_id,
-                        )))
-                    })?
-                };
-
-                let source_info = match source.get_info()?.clone() {
-                    Info::StreamSource(s) => s,
-                    _ => {
-                        return Err(RwError::from(InternalError(
-                            "only stream source is support".to_string(),
-                        )));
-                    }
-                };
-
-                let source_discovery = SourceDiscovery::create(*source_id, &source_info).await?;
-
-                core.managed_sources.insert(*source_id, source_discovery);
-            }
-
-            let mut new_assign_splits = actors
-                .iter()
-                .map(|actor_ids| actor_ids.iter().map(|x| (*x, vec![])).collect())
-                .collect_vec();
-
-            core.managed_sources
-                .get_mut(source_id)
-                .unwrap()
-                .last_assigned_splits
-                .append(&mut new_assign_splits);
-        }
-
-        Ok(())
-    }
-
     async fn all_stream_clients(&self) -> Result<impl Iterator<Item = StreamClient>> {
         // FIXME: there is gap between the compute node activate itself and source ddl operation,
         // create/drop source(non-stateful source like TableSource) before the compute node
@@ -397,17 +172,7 @@ where
     }
 
     pub async fn run(&self) -> Result<()> {
-        let mut interval = time::interval(Duration::from_secs(10));
-
-        loop {
-            tokio::select! {
-            _ = interval.tick() => {
-                    let mut core = self.core.lock().await;
-                    if let Err(e) = core.tick().await {
-                        log::error!("source manager tick failed! {}", e);
-                    }
-                }
-            }
-        }
+        // todo: in the future, split change will be pushed as a long running service
+        Ok(())
     }
 }

--- a/src/meta/src/stream/source_manager.rs
+++ b/src/meta/src/stream/source_manager.rs
@@ -86,6 +86,10 @@ where
             .to_rw_result()
     }
 
+    /// Perform one-time split scheduling, using the round-robin method to assign splits to the
+    /// source actor under the same fragment Note that the same Materialized View will have
+    /// multiple identical Sources to join, so there will be multiple groups of Actors under same
+    /// `SourceId`
     pub async fn schedule_split_for_actors(
         &self,
         actors: HashMap<SourceId, Vec<Vec<ActorId>>>,

--- a/src/meta/src/stream/stream_manager.rs
+++ b/src/meta/src/stream/stream_manager.rs
@@ -24,11 +24,11 @@ use risingwave_common::error::{Result, ToRwResult};
 use risingwave_pb::common::{ActorInfo, WorkerType};
 use risingwave_pb::meta::table_fragments::{ActorState, ActorStatus};
 use risingwave_pb::stream_plan::stream_node::Node;
+use risingwave_pb::stream_plan::StreamSourceState;
 use risingwave_pb::stream_service::{
     BroadcastActorInfoTableRequest, BuildActorsRequest, HangingChannel, UpdateActorsRequest,
 };
 use uuid::Uuid;
-use risingwave_pb::stream_plan::StreamSourceSplits;
 
 use super::ScheduledLocations;
 use crate::barrier::{BarrierManagerRef, Command};
@@ -73,8 +73,8 @@ pub struct GlobalStreamManager<S: MetaStore> {
 }
 
 impl<S> GlobalStreamManager<S>
-    where
-        S: MetaStore,
+where
+    S: MetaStore,
 {
     pub async fn new(
         env: MetaSrvEnv<S>,
@@ -145,7 +145,7 @@ impl<S> GlobalStreamManager<S>
             let mut source_actors = HashMap::new();
             for actor in &fragment.actors {
                 if let Some(source_id) =
-                TableFragments::fetch_stream_source_id(actor.nodes.as_ref().unwrap())
+                    TableFragments::fetch_stream_source_id(actor.nodes.as_ref().unwrap())
                 {
                     source_actors
                         .entry(source_id)
@@ -183,7 +183,7 @@ impl<S> GlobalStreamManager<S>
                     );
 
                     if !splits.is_empty() {
-                        s.stream_source_splits = Some(StreamSourceSplits {
+                        s.stream_source_state = Some(StreamSourceState {
                             split_type: splits.first().unwrap().get_type(),
                             stream_source_splits: splits
                                 .iter()
@@ -606,7 +606,7 @@ mod tests {
                     barrier_manager.clone(),
                     catalog_manager.clone(),
                 )
-                    .await?,
+                .await?,
             );
 
             let stream_manager = GlobalStreamManager::new(
@@ -616,7 +616,7 @@ mod tests {
                 cluster_manager.clone(),
                 source_manager.clone(),
             )
-                .await?;
+            .await?;
 
             let (join_handle_2, shutdown_tx_2) = GlobalBarrierManager::start(barrier_manager).await;
 

--- a/src/meta/src/stream/stream_manager.rs
+++ b/src/meta/src/stream/stream_manager.rs
@@ -175,6 +175,11 @@ where
                 }
 
                 if let Some(Node::SourceNode(s)) = node.node.as_mut() {
+                    log::debug!(
+                        "patching source node #{} with splits {:?}",
+                        actor_id,
+                        splits
+                    );
                     s.stream_source_splits = splits
                         .iter()
                         .map(|split| split.to_string().unwrap().as_bytes().to_vec())

--- a/src/meta/src/stream/stream_manager.rs
+++ b/src/meta/src/stream/stream_manager.rs
@@ -96,7 +96,8 @@ where
     /// Create materialized view, it works as follows:
     /// 1. schedule the actors to nodes in the cluster.
     /// 2. broadcast the actor info table.
-    /// 3. notify related nodes to update and build the actors.
+    /// (optional) get the split information of the `StreamSource` via source manager and patch
+    /// actors 3. notify related nodes to update and build the actors.
     /// 4. store related meta data.
     pub async fn create_materialized_view(
         &self,

--- a/src/meta/src/stream/stream_manager.rs
+++ b/src/meta/src/stream/stream_manager.rs
@@ -339,37 +339,6 @@ where
                 dispatches,
             })
             .await?;
-        // let mut source_actors_group_by_frag = HashMap::new();
-        //
-        // for (_actor_id, actor) in actor_map {
-        //     let mut node = actor.get_nodes().unwrap();
-        //     while !node.get_input().is_empty() {
-        //         node = node.get_input().get(0).unwrap();
-        //     }
-        //     if let Node::SourceNode(n) = node.get_node().unwrap() {
-        //         let source_type = n.get_source_type().unwrap();
-        //         if matches!(source_type, source_node::SourceType::Source) {
-        //             let source_id = n.table_ref_id.as_ref().unwrap().table_id as u32;
-        //             let frag_id = actor.fragment_id;
-        //             let actor_id = actor.actor_id;
-        //             source_actors_group_by_frag
-        //                 .entry(source_id)
-        //                 .or_insert_with(HashMap::new)
-        //                 .entry(frag_id)
-        //                 .or_insert(vec![])
-        //                 .push(actor_id);
-        //         }
-        //     }
-        // }
-        //
-        // self.source_manager
-        //     .register_source_discovery(
-        //         source_actors_group_by_frag
-        //             .into_iter()
-        //             .map(|(actor_id, frag)| (actor_id, frag.into_values().collect_vec()))
-        //             .collect(),
-        //     )
-        //     .await
 
         Ok(())
     }

--- a/src/meta/src/stream/test_fragmenter.rs
+++ b/src/meta/src/stream/test_fragmenter.rs
@@ -123,7 +123,7 @@ fn make_stream_node() -> StreamNode {
             table_ref_id: Some(table_ref_id),
             column_ids: vec![1, 2, 0],
             source_type: SourceType::Table as i32,
-            stream_source_splits: vec![]
+            stream_source_splits: vec![],
         })),
         pk_indices: vec![2],
         ..Default::default()

--- a/src/meta/src/stream/test_fragmenter.rs
+++ b/src/meta/src/stream/test_fragmenter.rs
@@ -123,6 +123,7 @@ fn make_stream_node() -> StreamNode {
             table_ref_id: Some(table_ref_id),
             column_ids: vec![1, 2, 0],
             source_type: SourceType::Table as i32,
+            stream_source_splits: vec![]
         })),
         pk_indices: vec![2],
         ..Default::default()

--- a/src/meta/src/stream/test_fragmenter.rs
+++ b/src/meta/src/stream/test_fragmenter.rs
@@ -123,7 +123,7 @@ fn make_stream_node() -> StreamNode {
             table_ref_id: Some(table_ref_id),
             column_ids: vec![1, 2, 0],
             source_type: SourceType::Table as i32,
-            stream_source_splits: vec![],
+            stream_source_state: None,
         })),
         pk_indices: vec![2],
         ..Default::default()

--- a/src/source/src/manager.rs
+++ b/src/source/src/manager.rs
@@ -40,6 +40,7 @@ pub type SourceRef = Arc<SourceImpl>;
 // necessary
 const UPSTREAM_SOURCE_KEY: &str = "connector";
 const KINESIS_SOURCE: &str = "kinesis";
+const KAFKA_SOURCE: &str = "kafka";
 
 const PROTOBUF_MESSAGE_KEY: &str = "proto.message";
 const PROTOBUF_TEMP_LOCAL_FILENAME: &str = "rw.proto";
@@ -206,6 +207,7 @@ impl SourceManager for MemSourceManager {
         let config = match get_properties(&info.properties, UPSTREAM_SOURCE_KEY)? {
             // TODO support more connector here
             KINESIS_SOURCE => Ok(SourceConfig::Connector(info.properties.clone())),
+            KAFKA_SOURCE => Ok(SourceConfig::Connector(info.properties.clone())),
             other => Err(RwError::from(ProtocolError(format!(
                 "source type {} not supported",
                 other

--- a/src/stream/src/executor/mod.rs
+++ b/src/stream/src/executor/mod.rs
@@ -279,6 +279,7 @@ impl Barrier {
                 )
                 .into(),
             ),
+            ProstMutation::SplitAssign(_) => todo!("split assign is not support!"),
         };
         let epoch = prost.get_epoch().unwrap();
         Ok(Barrier {

--- a/src/stream/src/executor/mod.rs
+++ b/src/stream/src/executor/mod.rs
@@ -279,7 +279,6 @@ impl Barrier {
                 )
                 .into(),
             ),
-            ProstMutation::SplitAssign(_) => todo!("split assign is not support!"),
         };
         let epoch = prost.get_epoch().unwrap();
         Ok(Barrier {

--- a/src/stream/src/executor/source.rs
+++ b/src/stream/src/executor/source.rs
@@ -106,6 +106,8 @@ impl ExecutorBuilder for SourceExecutorBuilder {
         let source_id = TableId::from(&node.table_ref_id);
         let source_desc = params.env.source_manager().get_source(&source_id)?;
 
+        println!("source node {:#?}", node);
+
         let column_ids: Vec<_> = node
             .get_column_ids()
             .iter()

--- a/src/workspace-hack/Cargo.toml
+++ b/src/workspace-hack/Cargo.toml
@@ -40,7 +40,6 @@ num-traits = { version = "0.2", features = ["i128", "std"] }
 parking_lot = { version = "0.12", features = ["arc_lock", "deadlock_detection"] }
 parking_lot_core = { version = "0.9", default-features = false, features = ["backtrace", "deadlock_detection", "petgraph", "thread-id"] }
 petgraph = { version = "0.6", features = ["graphmap", "matrix_graph", "stable_graph"] }
-prometheus = { version = "0.13", features = ["libc", "process", "procfs", "protobuf"] }
 prost = { version = "0.9", features = ["prost-derive", "std"] }
 rand = { version = "0.8", features = ["alloc", "getrandom", "libc", "rand_chacha", "small_rng", "std", "std_rng"] }
 regex = { version = "1", features = ["aho-corasick", "memchr", "perf", "perf-cache", "perf-dfa", "perf-inline", "perf-literal", "std", "unicode", "unicode-age", "unicode-bool", "unicode-case", "unicode-gencat", "unicode-perl", "unicode-script", "unicode-segment"] }
@@ -88,7 +87,6 @@ num-traits = { version = "0.2", features = ["i128", "std"] }
 parking_lot = { version = "0.12", features = ["arc_lock", "deadlock_detection"] }
 parking_lot_core = { version = "0.9", default-features = false, features = ["backtrace", "deadlock_detection", "petgraph", "thread-id"] }
 petgraph = { version = "0.6", features = ["graphmap", "matrix_graph", "stable_graph"] }
-prometheus = { version = "0.13", features = ["libc", "process", "procfs", "protobuf"] }
 prost = { version = "0.9", features = ["prost-derive", "std"] }
 rand = { version = "0.8", features = ["alloc", "getrandom", "libc", "rand_chacha", "small_rng", "std", "std_rng"] }
 regex = { version = "1", features = ["aho-corasick", "memchr", "perf", "perf-cache", "perf-dfa", "perf-inline", "perf-literal", "std", "unicode", "unicode-age", "unicode-bool", "unicode-case", "unicode-gencat", "unicode-perl", "unicode-script", "unicode-segment"] }


### PR DESCRIPTION
## What's changed and what's your intention?

***PLEASE DO NOT LEAVE THIS EMPTY !!!***

This PR initially provides the ability to `create materialized view from source`

When creating the materialized view, the fragmenter generates the corresponding fragment by slicing the graph, and each fragement generates the corresponding actor group by setting the parallelism, during which the stream source actor is found by `SourceNode` matching and a one-time split scheduling is performed, `Split` is the abstraction of the external partition in the `Source,` and when the actor is created later, it will start the subscription and consume according to the split information.

The subsequent design will asynchronize the split assign and push the split assignment/addition asynchronously through config change barrier after the overall startup, so as to obtain the ability to add dynamic splits and shorten the time to create mv


## Checklist

- [x] I have written necessary docs and comments
- [x] I have added necessary unit tests and integration tests

## Refer to a related PR or issue link (optional)
