### PR TITLE
refactor(stream): refine AggExecutor and Executor

### DIFF
--- a/src/stream/src/executor_v2/agg.rs
+++ b/src/stream/src/executor_v2/agg.rs
@@ -37,6 +37,20 @@ pub trait AggExecutor: Send + 'static {
     /// Flush the buffered chunk to the storage backend, and get the edits of the states. If there's
     /// no dirty states to flush, return `Ok(None)`.
     async fn flush_data(&mut self, epoch: u64) -> StreamExecutorResult<Option<StreamChunk>>;
+
+    /// See [`Executor::schema`].
+    fn schema(&self) -> &Schema;
+
+    /// See [`Executor::pk_indices`].
+    fn pk_indices(&self) -> PkIndicesRef;
+
+    /// See [`Executor::identity`].
+    fn identity(&self) -> &str;
+
+    /// See [`Executor::clear_cache`].
+    fn clear_cache(&mut self) -> super::Result<()> {
+        Ok(())
+    }
 }
 
 /// The struct wraps a [`AggExecutor`]
@@ -47,7 +61,7 @@ pub struct AggExecutorWrapper<E> {
 
 impl<E> Executor for AggExecutorWrapper<E>
 where
-    E: AggExecutor + Executor,
+    E: AggExecutor,
 {
     fn execute(self: Box<Self>) -> BoxedMessageStream {
         self.agg_executor_execute().boxed()
@@ -64,19 +78,9 @@ where
     fn identity(&self) -> &str {
         self.inner.identity()
     }
-}
 
-#[async_trait]
-impl<E> AggExecutor for AggExecutorWrapper<E>
-where
-    E: AggExecutor,
-{
-    async fn apply_chunk(&mut self, chunk: StreamChunk, epoch: u64) -> StreamExecutorResult<()> {
-        self.inner.apply_chunk(chunk, epoch).await
-    }
-
-    async fn flush_data(&mut self, epoch: u64) -> StreamExecutorResult<Option<StreamChunk>> {
-        self.inner.flush_data(epoch).await
+    fn clear_cache(&mut self) -> super::Result<()> {
+        self.inner.clear_cache()
     }
 }
 

--- a/src/stream/src/executor_v2/global_simple_agg.rs
+++ b/src/stream/src/executor_v2/global_simple_agg.rs
@@ -28,7 +28,7 @@ use crate::executor_v2::agg::{
     generate_agg_schema, generate_agg_state, AggExecutor, AggExecutorWrapper,
 };
 use crate::executor_v2::error::StreamExecutorError;
-use crate::executor_v2::{BoxedMessageStream, PkIndices};
+use crate::executor_v2::PkIndices;
 
 /// `SimpleAggExecutor` is the aggregation operator for streaming system.
 /// To create an aggregation operator, states and expressions should be passed along the
@@ -124,33 +124,6 @@ impl<S: StateStore> AggSimpleAggExecutor<S> {
 
     fn is_dirty(&self) -> bool {
         self.states.as_ref().map(|s| s.is_dirty()).unwrap_or(false)
-    }
-}
-
-impl<S: StateStore> Executor for AggSimpleAggExecutor<S> {
-    fn execute(self: Box<Self>) -> BoxedMessageStream {
-        panic!("Should execute by wrapper")
-    }
-
-    fn schema(&self) -> &Schema {
-        &self.schema
-    }
-
-    fn pk_indices(&self) -> PkIndicesRef {
-        &self.pk_indices
-    }
-
-    fn identity(&self) -> &str {
-        self.info.identity.as_str()
-    }
-
-    fn clear_cache(&mut self) -> Result<()> {
-        assert!(
-            !self.is_dirty(),
-            "cannot clear cache while states of simple agg are dirty"
-        );
-        self.states.take();
-        Ok(())
     }
 }
 
@@ -255,6 +228,27 @@ impl<S: StateStore> AggExecutor for AggSimpleAggExecutor<S> {
         let chunk = StreamChunk::new(new_ops, columns, None);
 
         Ok(Some(chunk))
+    }
+
+    fn schema(&self) -> &Schema {
+        &self.schema
+    }
+
+    fn pk_indices(&self) -> PkIndicesRef {
+        &self.pk_indices
+    }
+
+    fn identity(&self) -> &str {
+        self.info.identity.as_str()
+    }
+
+    fn clear_cache(&mut self) -> Result<()> {
+        assert!(
+            !self.is_dirty(),
+            "cannot clear cache while states of simple agg are dirty"
+        );
+        self.states.take();
+        Ok(())
     }
 }
 

--- a/src/stream/src/executor_v2/hash_agg.rs
+++ b/src/stream/src/executor_v2/hash_agg.rs
@@ -35,7 +35,7 @@ use crate::executor_v2::agg::{
     generate_agg_schema, generate_agg_state, AggExecutor, AggExecutorWrapper,
 };
 use crate::executor_v2::error::StreamExecutorError;
-use crate::executor_v2::{BoxedMessageStream, PkIndices};
+use crate::executor_v2::PkIndices;
 
 /// [`HashAggExecutor`] could process large amounts of data using a state backend. It works as
 /// follows:
@@ -177,33 +177,6 @@ impl<K: HashKey, S: StateStore> AggHashAggExecutor<K, S> {
         self.state_map
             .values()
             .any(|state| state.as_ref().unwrap().is_dirty())
-    }
-}
-
-impl<K: HashKey, S: StateStore> Executor for AggHashAggExecutor<K, S> {
-    fn execute(self: Box<Self>) -> BoxedMessageStream {
-        panic!("Should execute by wrapper")
-    }
-
-    fn schema(&self) -> &Schema {
-        &self.schema
-    }
-
-    fn pk_indices(&self) -> PkIndicesRef {
-        &self.pk_indices
-    }
-
-    fn identity(&self) -> &str {
-        self.info.identity.as_str()
-    }
-
-    fn clear_cache(&mut self) -> Result<()> {
-        assert!(
-            !self.is_dirty(),
-            "cannot clear cache while states of hash agg are dirty"
-        );
-        self.state_map.clear();
-        Ok(())
     }
 }
 
@@ -380,6 +353,27 @@ impl<K: HashKey, S: StateStore> AggExecutor for AggHashAggExecutor<K, S> {
 
         trace!("output_chunk: {:?}", &chunk);
         Ok(Some(chunk))
+    }
+
+    fn schema(&self) -> &Schema {
+        &self.schema
+    }
+
+    fn pk_indices(&self) -> PkIndicesRef {
+        &self.pk_indices
+    }
+
+    fn identity(&self) -> &str {
+        self.info.identity.as_str()
+    }
+
+    fn clear_cache(&mut self) -> Result<()> {
+        assert!(
+            !self.is_dirty(),
+            "cannot clear cache while states of hash agg are dirty"
+        );
+        self.state_map.clear();
+        Ok(())
     }
 }
 

--- a/src/stream/src/executor_v2/local_simple_agg.rs
+++ b/src/stream/src/executor_v2/local_simple_agg.rs
@@ -25,7 +25,7 @@ use super::{Executor, ExecutorInfo, StreamExecutorResult};
 use crate::executor::{create_streaming_agg_state, AggCall, PkIndicesRef, StreamingAggStateImpl};
 use crate::executor_v2::agg::{generate_agg_schema, AggExecutor, AggExecutorWrapper};
 use crate::executor_v2::error::StreamExecutorError;
-use crate::executor_v2::{BoxedMessageStream, PkIndices};
+use crate::executor_v2::PkIndices;
 
 pub type LocalSimpleAggExecutor = AggExecutorWrapper<AggLocalSimpleAggExecutor>;
 
@@ -106,24 +106,6 @@ impl AggLocalSimpleAggExecutor {
     }
 }
 
-impl Executor for AggLocalSimpleAggExecutor {
-    fn execute(self: Box<Self>) -> BoxedMessageStream {
-        panic!("Should execute by wrapper")
-    }
-
-    fn schema(&self) -> &Schema {
-        &self.schema
-    }
-
-    fn pk_indices(&self) -> PkIndicesRef {
-        &self.pk_indices
-    }
-
-    fn identity(&self) -> &str {
-        self.info.identity.as_str()
-    }
-}
-
 #[async_trait]
 impl AggExecutor for AggLocalSimpleAggExecutor {
     async fn apply_chunk(&mut self, chunk: StreamChunk, _epoch: u64) -> StreamExecutorResult<()> {
@@ -172,6 +154,18 @@ impl AggExecutor for AggLocalSimpleAggExecutor {
         let ops = vec![Op::Insert; 1];
         self.is_dirty = false;
         Ok(Some(StreamChunk::new(ops, columns, None)))
+    }
+
+    fn schema(&self) -> &Schema {
+        &self.schema
+    }
+
+    fn pk_indices(&self) -> PkIndicesRef {
+        &self.pk_indices
+    }
+
+    fn identity(&self) -> &str {
+        self.info.identity.as_str()
     }
 }
 


### PR DESCRIPTION
Signed-off-by: TennyZhuang <zty0826@gmail.com>

## What's changed and what's your intention?

***PLEASE DO NOT LEAVE THIS EMPTY !!!***

The relation between `Executor` and `AggExecutor` are combinations, not inheritance, so no structure should implement them both.

## Checklist

- [x] I have written necessary docs and comments
- [x] I have added necessary unit tests and integration tests

## Refer to a related PR or issue link (optional)
