### PR TITLE
feat: add sub_fields in field to support create mv conclude struct column

### DIFF
--- a/src/batch/src/executor/stream_scan.rs
+++ b/src/batch/src/executor/stream_scan.rs
@@ -65,6 +65,7 @@ impl BoxedExecutorBuilder for StreamScanExecutor {
                     .map(|col| Field {
                         data_type: col.data_type.clone(),
                         name: col.name.clone(),
+                        sub_fields: vec![],
                     })
                     .ok_or_else(|| {
                         RwError::from(InternalError(format!(

--- a/src/batch/src/executor/stream_scan.rs
+++ b/src/batch/src/executor/stream_scan.rs
@@ -62,11 +62,7 @@ impl BoxedExecutorBuilder for StreamScanExecutor {
                     .columns
                     .iter()
                     .find(|c| c.column_id == *id)
-                    .map(|col| Field {
-                        data_type: col.data_type.clone(),
-                        name: col.name.clone(),
-                        sub_fields: vec![],
-                    })
+                    .map(|col| Field::with_name(col.data_type.clone(), col.name.clone()))
                     .ok_or_else(|| {
                         RwError::from(InternalError(format!(
                             "Failed to find column id: {} in source: {:?}",

--- a/src/common/src/catalog/column.rs
+++ b/src/common/src/catalog/column.rs
@@ -145,6 +145,15 @@ impl ColumnDesc {
             type_name: type_name.to_string(),
         }
     }
+
+    /// Generate incremental `column_id` for `column_desc` and `field_descs`
+    pub fn generate_increment_id(&mut self, index: &mut i32) {
+        self.column_id = ColumnId::new(*index);
+        *index += 1;
+        for field in &mut self.field_descs {
+            field.generate_increment_id(index);
+        }
+    }
 }
 
 impl From<&Field> for ColumnDesc {

--- a/src/common/src/catalog/column.rs
+++ b/src/common/src/catalog/column.rs
@@ -18,6 +18,7 @@ use risingwave_pb::plan::{
     OrderedColumnDesc as ProstOrderedColumnDesc,
 };
 
+use crate::catalog::Field;
 use crate::types::DataType;
 use crate::util::sort_util::OrderType;
 
@@ -142,6 +143,18 @@ impl ColumnDesc {
             name: name.to_string(),
             field_descs: fields,
             type_name: type_name.to_string(),
+        }
+    }
+}
+
+impl From<&Field> for ColumnDesc {
+    fn from(field: &Field) -> Self {
+        Self {
+            data_type: field.data_type.clone(),
+            column_id: ColumnId::new(0),
+            name: field.name.clone(),
+            field_descs: field.sub_fields.iter().map(|d| d.into()).collect_vec(),
+            type_name: "".to_string(),
         }
     }
 }

--- a/src/common/src/catalog/column.rs
+++ b/src/common/src/catalog/column.rs
@@ -154,7 +154,7 @@ impl From<&Field> for ColumnDesc {
             column_id: ColumnId::new(0),
             name: field.name.clone(),
             field_descs: field.sub_fields.iter().map(|d| d.into()).collect_vec(),
-            type_name: "".to_string(),
+            type_name: field.type_name.clone(),
         }
     }
 }

--- a/src/common/src/catalog/schema.rs
+++ b/src/common/src/catalog/schema.rs
@@ -14,6 +14,7 @@
 
 use std::ops::Index;
 
+use itertools::Itertools;
 use risingwave_pb::plan::Field as ProstField;
 
 use super::ColumnDesc;
@@ -26,11 +27,16 @@ use crate::types::DataType;
 pub struct Field {
     pub data_type: DataType,
     pub name: String,
+    pub sub_fields: Vec<Field>,
 }
 
 impl std::fmt::Debug for Field {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        write!(f, "{}:{:?}", self.name, self.data_type)
+        write!(
+            f,
+            "{}:{:?}",
+            self.name, self.data_type
+        )
     }
 }
 
@@ -110,6 +116,7 @@ impl Field {
         Self {
             data_type,
             name: name.into(),
+            sub_fields: vec![],
         }
     }
 
@@ -117,6 +124,7 @@ impl Field {
         Self {
             data_type,
             name: String::new(),
+            sub_fields: vec![],
         }
     }
 
@@ -130,6 +138,7 @@ impl From<&ProstField> for Field {
         Self {
             data_type: DataType::from(prost_field.get_data_type().expect("data type not found")),
             name: prost_field.get_name().clone(),
+            sub_fields: vec![],
         }
     }
 }
@@ -139,6 +148,7 @@ impl From<&ColumnDesc> for Field {
         Self {
             data_type: desc.data_type.clone(),
             name: desc.name.clone(),
+            sub_fields: desc.field_descs.iter().map(|d| d.into()).collect_vec(),
         }
     }
 }

--- a/src/common/src/catalog/schema.rs
+++ b/src/common/src/catalog/schema.rs
@@ -27,7 +27,10 @@ use crate::types::DataType;
 pub struct Field {
     pub data_type: DataType,
     pub name: String,
+    /// For STRUCT type.
     pub sub_fields: Vec<Field>,
+    /// The user-defined type's name, when the type is created from a protobuf schema file,
+    /// this field will store the message name.
     pub type_name: String,
 }
 

--- a/src/common/src/catalog/schema.rs
+++ b/src/common/src/catalog/schema.rs
@@ -32,15 +32,23 @@ pub struct Field {
 
 impl std::fmt::Debug for Field {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        write!(
-            f,
-            "{}:{:?}",
-            self.name, self.data_type
-        )
+        write!(f, "{}:{:?}", self.name, self.data_type)
     }
 }
 
 impl Field {
+    pub fn new(data_type: DataType, name: impl Into<String>) -> Field {
+        Field::new_with_sub_fields(data_type, name.into(), vec![])
+    }
+
+    pub fn new_with_sub_fields(data_type: DataType, name: String, sub_fields: Vec<Field>) -> Field {
+        Self {
+            data_type,
+            name,
+            sub_fields,
+        }
+    }
+
     pub fn to_prost(&self) -> ProstField {
         ProstField {
             data_type: Some(self.data_type.to_protobuf()),

--- a/src/common/src/catalog/schema.rs
+++ b/src/common/src/catalog/schema.rs
@@ -28,6 +28,7 @@ pub struct Field {
     pub data_type: DataType,
     pub name: String,
     pub sub_fields: Vec<Field>,
+    pub type_name: String,
 }
 
 impl std::fmt::Debug for Field {
@@ -37,18 +38,6 @@ impl std::fmt::Debug for Field {
 }
 
 impl Field {
-    pub fn new(data_type: DataType, name: impl Into<String>) -> Field {
-        Field::new_with_sub_fields(data_type, name.into(), vec![])
-    }
-
-    pub fn new_with_sub_fields(data_type: DataType, name: String, sub_fields: Vec<Field>) -> Field {
-        Self {
-            data_type,
-            name,
-            sub_fields,
-        }
-    }
-
     pub fn to_prost(&self) -> ProstField {
         ProstField {
             data_type: Some(self.data_type.to_protobuf()),
@@ -125,6 +114,24 @@ impl Field {
             data_type,
             name: name.into(),
             sub_fields: vec![],
+            type_name: String::new(),
+        }
+    }
+
+    pub fn with_struct<S>(
+        data_type: DataType,
+        name: S,
+        sub_fields: Vec<Field>,
+        type_name: S,
+    ) -> Self
+    where
+        S: Into<String>,
+    {
+        Self {
+            data_type,
+            name: name.into(),
+            sub_fields,
+            type_name: type_name.into(),
         }
     }
 
@@ -133,6 +140,7 @@ impl Field {
             data_type,
             name: String::new(),
             sub_fields: vec![],
+            type_name: String::new(),
         }
     }
 
@@ -147,6 +155,7 @@ impl From<&ProstField> for Field {
             data_type: DataType::from(prost_field.get_data_type().expect("data type not found")),
             name: prost_field.get_name().clone(),
             sub_fields: vec![],
+            type_name: String::new(),
         }
     }
 }
@@ -157,6 +166,7 @@ impl From<&ColumnDesc> for Field {
             data_type: desc.data_type.clone(),
             name: desc.name.clone(),
             sub_fields: desc.field_descs.iter().map(|d| d.into()).collect_vec(),
+            type_name: desc.type_name.clone(),
         }
     }
 }

--- a/src/frontend/Cargo.toml
+++ b/src/frontend/Cargo.toml
@@ -35,6 +35,7 @@ risingwave_source = { path = "../source" }
 risingwave_sqlparser = { path = "../sqlparser" }
 serde_json = "1"
 smallvec = { version = "1.6.1", features = ["serde"] }
+tempfile = "3"
 thiserror = "1"
 tokio = { version = "1", features = [
     "rt",

--- a/src/frontend/src/binder/relation.rs
+++ b/src/frontend/src/binder/relation.rs
@@ -235,8 +235,7 @@ impl Binder {
                     catalog
                         .get_source_by_name(&self.db_name, schema_name, table_name)
                         .map(|s| {
-                            let mut source = s.clone();
-                            source.rewrite_columns();
+                            let source = s.clone().flatten();
                             (Relation::Source(Box::new((&source).into())), source.columns)
                         })
                 })

--- a/src/frontend/src/binder/relation.rs
+++ b/src/frontend/src/binder/relation.rs
@@ -234,7 +234,11 @@ impl Binder {
                 .or_else(|_| {
                     catalog
                         .get_source_by_name(&self.db_name, schema_name, table_name)
-                        .map(|s| (Relation::Source(Box::new(s.into())), s.columns.clone()))
+                        .map(|s| {
+                            let mut source = s.clone();
+                            source.rewrite_columns();
+                            (Relation::Source(Box::new((&source).into())), source.columns)
+                        })
                 })
                 .map_err(|_| {
                     RwError::from(CatalogError::NotFound(

--- a/src/frontend/src/catalog/column_catalog.rs
+++ b/src/frontend/src/catalog/column_catalog.rs
@@ -62,6 +62,14 @@ impl ColumnCatalog {
             is_hidden: true,
         }
     }
+
+    /// Generate incremental `column_id` for every `column_desc` and `column_desc.field_descs`
+    pub fn generate_increment_id(catalogs: &mut Vec<ColumnCatalog>) {
+        let mut index = 0;
+        for catalog in catalogs {
+            catalog.column_desc.generate_increment_id(&mut index);
+        }
+    }
 }
 
 impl From<ProstColumnCatalog> for ColumnCatalog {

--- a/src/frontend/src/catalog/source_catalog.rs
+++ b/src/frontend/src/catalog/source_catalog.rs
@@ -1,3 +1,4 @@
+use itertools::Itertools;
 // Copyright 2022 Singularity Data
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
@@ -26,6 +27,27 @@ pub struct SourceCatalog {
     pub columns: Vec<ColumnCatalog>,
     pub pk_col_ids: Vec<ColumnId>,
     pub source_type: SourceType,
+}
+
+impl SourceCatalog {
+    pub fn rewrite_columns(&mut self) {
+        let mut catalogs = vec![];
+        for col in &self.columns {
+            // Extract `field_descs` and return `column_catalogs`.
+            catalogs.append(
+                &mut col
+                    .column_desc
+                    .get_column_descs()
+                    .into_iter()
+                    .map(|c| ColumnCatalog {
+                        column_desc: c,
+                        is_hidden: col.is_hidden,
+                    })
+                    .collect_vec(),
+            )
+        }
+        self.columns = catalogs.clone();
+    }
 }
 
 impl From<&ProstSource> for SourceCatalog {

--- a/src/frontend/src/catalog/source_catalog.rs
+++ b/src/frontend/src/catalog/source_catalog.rs
@@ -30,6 +30,7 @@ pub struct SourceCatalog {
 }
 
 impl SourceCatalog {
+    /// Extract `field_descs` from `column_desc` and add in source catalog.
     pub fn rewrite_columns(&mut self) {
         let mut catalogs = vec![];
         for col in &self.columns {

--- a/src/frontend/src/catalog/source_catalog.rs
+++ b/src/frontend/src/catalog/source_catalog.rs
@@ -1,4 +1,3 @@
-use itertools::Itertools;
 // Copyright 2022 Singularity Data
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
@@ -12,6 +11,7 @@ use itertools::Itertools;
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
+use itertools::Itertools;
 use risingwave_pb::catalog::source::Info;
 use risingwave_pb::catalog::Source as ProstSource;
 use risingwave_pb::stream_plan::source_node::SourceType;
@@ -31,7 +31,7 @@ pub struct SourceCatalog {
 
 impl SourceCatalog {
     /// Extract `field_descs` from `column_desc` and add in source catalog.
-    pub fn rewrite_columns(&mut self) {
+    pub fn flatten(mut self) -> Self {
         let mut catalogs = vec![];
         for col in &self.columns {
             // Extract `field_descs` and return `column_catalogs`.
@@ -48,6 +48,7 @@ impl SourceCatalog {
             )
         }
         self.columns = catalogs.clone();
+        self
     }
 }
 

--- a/src/frontend/src/handler/create_source.rs
+++ b/src/frontend/src/handler/create_source.rs
@@ -128,50 +128,16 @@ pub(super) async fn handle_create_source(
 #[cfg(test)]
 pub mod tests {
     use std::collections::HashMap;
-    use std::io::Write;
 
     use risingwave_common::catalog::{DEFAULT_DATABASE_NAME, DEFAULT_SCHEMA_NAME};
     use risingwave_common::types::DataType;
-    use tempfile::NamedTempFile;
 
     use crate::catalog::gen_row_id_column_name;
-    use crate::test_utils::LocalFrontend;
-
-    /// Returns the file.
-    /// (`NamedTempFile` will automatically delete the file when it goes out of scope.)
-    pub fn create_proto_file() -> NamedTempFile {
-        static PROTO_FILE_DATA: &str = r#"
-    syntax = "proto3";
-    package test;
-    message TestRecord {
-      int32 id = 1;
-      Country country = 3;
-      int64 zipcode = 4;
-      float rate = 5;
-    }
-    message Country {
-      string address = 1;
-      City city = 2;
-      string zipcode = 3;
-    }
-    message City {
-      string address = 1;
-      string zipcode = 2;
-    }"#;
-        let temp_file = tempfile::Builder::new()
-            .prefix("temp")
-            .suffix(".proto")
-            .rand_bytes(5)
-            .tempfile()
-            .unwrap();
-        let mut file = temp_file.as_file();
-        file.write_all(PROTO_FILE_DATA.as_ref()).unwrap();
-        temp_file
-    }
+    use crate::test_utils::{create_proto_file, LocalFrontend, PROTO_FILE_DATA};
 
     #[tokio::test]
     async fn test_create_source_handler() {
-        let proto_file = create_proto_file();
+        let proto_file = create_proto_file(PROTO_FILE_DATA);
         let sql = format!(
             r#"CREATE SOURCE t
     WITH ('kafka.topic' = 'abc', 'kafka.servers' = 'localhost:1001')

--- a/src/frontend/src/handler/describe.rs
+++ b/src/frontend/src/handler/describe.rs
@@ -97,12 +97,11 @@ mod tests {
     use std::collections::HashMap;
     use std::ops::Index;
 
-    use crate::handler::create_source::tests::create_proto_file;
-    use crate::test_utils::LocalFrontend;
+    use crate::test_utils::{create_proto_file, LocalFrontend, PROTO_FILE_DATA};
 
     #[tokio::test]
     async fn test_describe_handler() {
-        let proto_file = create_proto_file();
+        let proto_file = create_proto_file(PROTO_FILE_DATA);
         let sql = format!(
             r#"CREATE SOURCE t
     WITH ('kafka.topic' = 'abc', 'kafka.servers' = 'localhost:1001')

--- a/src/frontend/src/optimizer/plan_node/logical_agg.rs
+++ b/src/frontend/src/optimizer/plan_node/logical_agg.rs
@@ -300,11 +300,7 @@ impl LogicalAgg {
                     .enumerate()
                     .map(|(id, (data_type, alias))| {
                         let name = alias.clone().unwrap_or(format!("agg#{}", id));
-                        Field {
-                            data_type,
-                            name,
-                            sub_fields: vec![],
-                        }
+                        Field::new(data_type, name)
                     }),
             )
             .collect();
@@ -580,21 +576,9 @@ mod tests {
         let ty = DataType::Int32;
         let ctx = OptimizerContext::mock().await;
         let fields: Vec<Field> = vec![
-            Field {
-                data_type: ty.clone(),
-                name: "v1".to_string(),
-                sub_fields: vec![],
-            },
-            Field {
-                data_type: ty.clone(),
-                name: "v2".to_string(),
-                sub_fields: vec![],
-            },
-            Field {
-                data_type: ty.clone(),
-                name: "v3".to_string(),
-                sub_fields: vec![],
-            },
+            Field::new(ty.clone(), "v1"),
+            Field::new(ty.clone(), "v2"),
+            Field::new(ty.clone(), "v3"),
         ];
         let values = LogicalValues::new(vec![], Schema { fields }, ctx);
         let input = Rc::new(values);
@@ -717,21 +701,9 @@ mod tests {
         let ty = DataType::Int32;
         let ctx = OptimizerContext::mock().await;
         let fields: Vec<Field> = vec![
-            Field {
-                data_type: ty.clone(),
-                name: "v1".to_string(),
-                sub_fields: vec![],
-            },
-            Field {
-                data_type: ty.clone(),
-                name: "v2".to_string(),
-                sub_fields: vec![],
-            },
-            Field {
-                data_type: ty.clone(),
-                name: "v3".to_string(),
-                sub_fields: vec![],
-            },
+            Field::new(ty.clone(), "v1"),
+            Field::new(ty.clone(), "v2"),
+            Field::new(ty.clone(), "v3"),
         ];
         let values = LogicalValues::new(
             vec![],
@@ -788,21 +760,9 @@ mod tests {
         let ctx = OptimizerContext::mock().await;
         let ty = DataType::Int32;
         let fields: Vec<Field> = vec![
-            Field {
-                data_type: ty.clone(),
-                name: "v1".to_string(),
-                sub_fields: vec![],
-            },
-            Field {
-                data_type: ty.clone(),
-                name: "v2".to_string(),
-                sub_fields: vec![],
-            },
-            Field {
-                data_type: ty.clone(),
-                name: "v3".to_string(),
-                sub_fields: vec![],
-            },
+            Field::new(ty.clone(), "v1"),
+            Field::new(ty.clone(), "v2"),
+            Field::new(ty.clone(), "v3"),
         ];
         let values = LogicalValues::new(
             vec![],
@@ -866,21 +826,9 @@ mod tests {
         let ty = DataType::Int32;
         let ctx = OptimizerContext::mock().await;
         let fields: Vec<Field> = vec![
-            Field {
-                data_type: ty.clone(),
-                name: "v1".to_string(),
-                sub_fields: vec![],
-            },
-            Field {
-                data_type: ty.clone(),
-                name: "v2".to_string(),
-                sub_fields: vec![],
-            },
-            Field {
-                data_type: ty.clone(),
-                name: "v3".to_string(),
-                sub_fields: vec![],
-            },
+            Field::new(ty.clone(), "v1"),
+            Field::new(ty.clone(), "v2"),
+            Field::new(ty.clone(), "v3"),
         ];
         let values = LogicalValues::new(
             vec![],

--- a/src/frontend/src/optimizer/plan_node/logical_agg.rs
+++ b/src/frontend/src/optimizer/plan_node/logical_agg.rs
@@ -300,7 +300,7 @@ impl LogicalAgg {
                     .enumerate()
                     .map(|(id, (data_type, alias))| {
                         let name = alias.clone().unwrap_or(format!("agg#{}", id));
-                        Field::new(data_type, name)
+                        Field::with_name(data_type, name)
                     }),
             )
             .collect();
@@ -576,9 +576,9 @@ mod tests {
         let ty = DataType::Int32;
         let ctx = OptimizerContext::mock().await;
         let fields: Vec<Field> = vec![
-            Field::new(ty.clone(), "v1"),
-            Field::new(ty.clone(), "v2"),
-            Field::new(ty.clone(), "v3"),
+            Field::with_name(ty.clone(), "v1"),
+            Field::with_name(ty.clone(), "v2"),
+            Field::with_name(ty.clone(), "v3"),
         ];
         let values = LogicalValues::new(vec![], Schema { fields }, ctx);
         let input = Rc::new(values);
@@ -701,9 +701,9 @@ mod tests {
         let ty = DataType::Int32;
         let ctx = OptimizerContext::mock().await;
         let fields: Vec<Field> = vec![
-            Field::new(ty.clone(), "v1"),
-            Field::new(ty.clone(), "v2"),
-            Field::new(ty.clone(), "v3"),
+            Field::with_name(ty.clone(), "v1"),
+            Field::with_name(ty.clone(), "v2"),
+            Field::with_name(ty.clone(), "v3"),
         ];
         let values = LogicalValues::new(
             vec![],
@@ -760,9 +760,9 @@ mod tests {
         let ctx = OptimizerContext::mock().await;
         let ty = DataType::Int32;
         let fields: Vec<Field> = vec![
-            Field::new(ty.clone(), "v1"),
-            Field::new(ty.clone(), "v2"),
-            Field::new(ty.clone(), "v3"),
+            Field::with_name(ty.clone(), "v1"),
+            Field::with_name(ty.clone(), "v2"),
+            Field::with_name(ty.clone(), "v3"),
         ];
         let values = LogicalValues::new(
             vec![],
@@ -826,9 +826,9 @@ mod tests {
         let ty = DataType::Int32;
         let ctx = OptimizerContext::mock().await;
         let fields: Vec<Field> = vec![
-            Field::new(ty.clone(), "v1"),
-            Field::new(ty.clone(), "v2"),
-            Field::new(ty.clone(), "v3"),
+            Field::with_name(ty.clone(), "v1"),
+            Field::with_name(ty.clone(), "v2"),
+            Field::with_name(ty.clone(), "v3"),
         ];
         let values = LogicalValues::new(
             vec![],

--- a/src/frontend/src/optimizer/plan_node/logical_agg.rs
+++ b/src/frontend/src/optimizer/plan_node/logical_agg.rs
@@ -300,7 +300,11 @@ impl LogicalAgg {
                     .enumerate()
                     .map(|(id, (data_type, alias))| {
                         let name = alias.clone().unwrap_or(format!("agg#{}", id));
-                        Field { data_type, name }
+                        Field {
+                            data_type,
+                            name,
+                            sub_fields: vec![],
+                        }
                     }),
             )
             .collect();
@@ -579,14 +583,17 @@ mod tests {
             Field {
                 data_type: ty.clone(),
                 name: "v1".to_string(),
+                sub_fields: vec![],
             },
             Field {
                 data_type: ty.clone(),
                 name: "v2".to_string(),
+                sub_fields: vec![],
             },
             Field {
                 data_type: ty.clone(),
                 name: "v3".to_string(),
+                sub_fields: vec![],
             },
         ];
         let values = LogicalValues::new(vec![], Schema { fields }, ctx);
@@ -713,14 +720,17 @@ mod tests {
             Field {
                 data_type: ty.clone(),
                 name: "v1".to_string(),
+                sub_fields: vec![],
             },
             Field {
                 data_type: ty.clone(),
                 name: "v2".to_string(),
+                sub_fields: vec![],
             },
             Field {
                 data_type: ty.clone(),
                 name: "v3".to_string(),
+                sub_fields: vec![],
             },
         ];
         let values = LogicalValues::new(
@@ -781,14 +791,17 @@ mod tests {
             Field {
                 data_type: ty.clone(),
                 name: "v1".to_string(),
+                sub_fields: vec![],
             },
             Field {
                 data_type: ty.clone(),
                 name: "v2".to_string(),
+                sub_fields: vec![],
             },
             Field {
                 data_type: ty.clone(),
                 name: "v3".to_string(),
+                sub_fields: vec![],
             },
         ];
         let values = LogicalValues::new(
@@ -856,14 +869,17 @@ mod tests {
             Field {
                 data_type: ty.clone(),
                 name: "v1".to_string(),
+                sub_fields: vec![],
             },
             Field {
                 data_type: ty.clone(),
                 name: "v2".to_string(),
+                sub_fields: vec![],
             },
             Field {
                 data_type: ty.clone(),
                 name: "v3".to_string(),
+                sub_fields: vec![],
             },
         ];
         let values = LogicalValues::new(

--- a/src/frontend/src/optimizer/plan_node/logical_filter.rs
+++ b/src/frontend/src/optimizer/plan_node/logical_filter.rs
@@ -242,14 +242,17 @@ mod tests {
             Field {
                 data_type: ty.clone(),
                 name: "v1".to_string(),
+                sub_fields: vec![],
             },
             Field {
                 data_type: ty.clone(),
                 name: "v2".to_string(),
+                sub_fields: vec![],
             },
             Field {
                 data_type: ty.clone(),
                 name: "v3".to_string(),
+                sub_fields: vec![],
             },
         ];
         let values = LogicalValues::new(

--- a/src/frontend/src/optimizer/plan_node/logical_filter.rs
+++ b/src/frontend/src/optimizer/plan_node/logical_filter.rs
@@ -239,9 +239,9 @@ mod tests {
         let ctx = OptimizerContext::mock().await;
         let ty = DataType::Int32;
         let fields: Vec<Field> = vec![
-            Field::new(ty.clone(), "v1"),
-            Field::new(ty.clone(), "v2"),
-            Field::new(ty.clone(), "v3"),
+            Field::with_name(ty.clone(), "v1"),
+            Field::with_name(ty.clone(), "v2"),
+            Field::with_name(ty.clone(), "v3"),
         ];
         let values = LogicalValues::new(
             vec![],

--- a/src/frontend/src/optimizer/plan_node/logical_filter.rs
+++ b/src/frontend/src/optimizer/plan_node/logical_filter.rs
@@ -239,21 +239,9 @@ mod tests {
         let ctx = OptimizerContext::mock().await;
         let ty = DataType::Int32;
         let fields: Vec<Field> = vec![
-            Field {
-                data_type: ty.clone(),
-                name: "v1".to_string(),
-                sub_fields: vec![],
-            },
-            Field {
-                data_type: ty.clone(),
-                name: "v2".to_string(),
-                sub_fields: vec![],
-            },
-            Field {
-                data_type: ty.clone(),
-                name: "v3".to_string(),
-                sub_fields: vec![],
-            },
+            Field::new(ty.clone(), "v1"),
+            Field::new(ty.clone(), "v2"),
+            Field::new(ty.clone(), "v3"),
         ];
         let values = LogicalValues::new(
             vec![],

--- a/src/frontend/src/optimizer/plan_node/logical_join.rs
+++ b/src/frontend/src/optimizer/plan_node/logical_join.rs
@@ -436,6 +436,7 @@ mod tests {
             .map(|i| Field {
                 data_type: ty.clone(),
                 name: format!("v{}", i),
+                sub_fields: vec![],
             })
             .collect();
         let left = LogicalValues::new(
@@ -519,6 +520,7 @@ mod tests {
             .map(|i| Field {
                 data_type: ty.clone(),
                 name: format!("v{}", i),
+                sub_fields: vec![],
             })
             .collect();
         let left = LogicalValues::new(
@@ -597,6 +599,7 @@ mod tests {
             .map(|i| Field {
                 data_type: DataType::Int32,
                 name: format!("v{}", i),
+                sub_fields: vec![],
             })
             .collect();
         let left = LogicalValues::new(

--- a/src/frontend/src/optimizer/plan_node/logical_join.rs
+++ b/src/frontend/src/optimizer/plan_node/logical_join.rs
@@ -433,11 +433,7 @@ mod tests {
         let ty = DataType::Int32;
         let ctx = OptimizerContext::mock().await;
         let fields: Vec<Field> = (1..7)
-            .map(|i| Field {
-                data_type: ty.clone(),
-                name: format!("v{}", i),
-                sub_fields: vec![],
-            })
+            .map(|i| Field::new(ty.clone(), format!("v{}", i)))
             .collect();
         let left = LogicalValues::new(
             vec![],
@@ -517,11 +513,7 @@ mod tests {
         let ty = DataType::Int32;
         let ctx = OptimizerContext::mock().await;
         let fields: Vec<Field> = (1..7)
-            .map(|i| Field {
-                data_type: ty.clone(),
-                name: format!("v{}", i),
-                sub_fields: vec![],
-            })
+            .map(|i| Field::new(ty.clone(), format!("v{}", i)))
             .collect();
         let left = LogicalValues::new(
             vec![],
@@ -596,11 +588,7 @@ mod tests {
     async fn test_join_to_batch() {
         let ctx = OptimizerContext::mock().await;
         let fields: Vec<Field> = (1..7)
-            .map(|i| Field {
-                data_type: DataType::Int32,
-                name: format!("v{}", i),
-                sub_fields: vec![],
-            })
+            .map(|i| Field::new(DataType::Int32, format!("v{}", i)))
             .collect();
         let left = LogicalValues::new(
             vec![],

--- a/src/frontend/src/optimizer/plan_node/logical_join.rs
+++ b/src/frontend/src/optimizer/plan_node/logical_join.rs
@@ -433,7 +433,7 @@ mod tests {
         let ty = DataType::Int32;
         let ctx = OptimizerContext::mock().await;
         let fields: Vec<Field> = (1..7)
-            .map(|i| Field::new(ty.clone(), format!("v{}", i)))
+            .map(|i| Field::with_name(ty.clone(), format!("v{}", i)))
             .collect();
         let left = LogicalValues::new(
             vec![],
@@ -513,7 +513,7 @@ mod tests {
         let ty = DataType::Int32;
         let ctx = OptimizerContext::mock().await;
         let fields: Vec<Field> = (1..7)
-            .map(|i| Field::new(ty.clone(), format!("v{}", i)))
+            .map(|i| Field::with_name(ty.clone(), format!("v{}", i)))
             .collect();
         let left = LogicalValues::new(
             vec![],
@@ -588,7 +588,7 @@ mod tests {
     async fn test_join_to_batch() {
         let ctx = OptimizerContext::mock().await;
         let fields: Vec<Field> = (1..7)
-            .map(|i| Field::new(DataType::Int32, format!("v{}", i)))
+            .map(|i| Field::with_name(DataType::Int32, format!("v{}", i)))
             .collect();
         let left = LogicalValues::new(
             vec![],

--- a/src/frontend/src/optimizer/plan_node/logical_project.rs
+++ b/src/frontend/src/optimizer/plan_node/logical_project.rs
@@ -145,11 +145,7 @@ impl LogicalProject {
                     Some(input_idx) => input_schema.fields()[input_idx].name.clone(),
                     None => format!("expr#{}", id),
                 });
-                Field {
-                    name,
-                    data_type: expr.return_type(),
-                    sub_fields,
-                }
+                Field::new_with_sub_fields(expr.return_type(), name, sub_fields)
             })
             .collect();
         Schema { fields }
@@ -352,21 +348,9 @@ mod tests {
         let ty = DataType::Int32;
         let ctx = OptimizerContext::mock().await;
         let fields: Vec<Field> = vec![
-            Field {
-                data_type: ty.clone(),
-                name: "v1".to_string(),
-                sub_fields: vec![],
-            },
-            Field {
-                data_type: ty.clone(),
-                name: "v2".to_string(),
-                sub_fields: vec![],
-            },
-            Field {
-                data_type: ty.clone(),
-                name: "v3".to_string(),
-                sub_fields: vec![],
-            },
+            Field::new(ty.clone(), "v1"),
+            Field::new(ty.clone(), "v2"),
+            Field::new(ty.clone(), "v3"),
         ];
         let values = LogicalValues::new(
             vec![],

--- a/src/frontend/src/optimizer/plan_node/logical_project.rs
+++ b/src/frontend/src/optimizer/plan_node/logical_project.rs
@@ -138,6 +138,7 @@ impl LogicalProject {
             .zip_eq(expr_alias.iter())
             .enumerate()
             .map(|(id, (expr, alias))| {
+                // Get field info from o2i.
                 let (default_name, sub_fields, type_name) = match o2i.try_map(id) {
                     Some(input_idx) => {
                         let field = input_schema.fields()[input_idx].clone();

--- a/src/frontend/src/optimizer/plan_node/logical_project.rs
+++ b/src/frontend/src/optimizer/plan_node/logical_project.rs
@@ -137,6 +137,10 @@ impl LogicalProject {
             .zip_eq(expr_alias.iter())
             .enumerate()
             .map(|(id, (expr, alias))| {
+                let sub_fields = match o2i.try_map(id) {
+                    Some(input_idx) => input_schema.fields()[input_idx].sub_fields.clone(),
+                    None => vec![],
+                };
                 let name = alias.clone().unwrap_or(match o2i.try_map(id) {
                     Some(input_idx) => input_schema.fields()[input_idx].name.clone(),
                     None => format!("expr#{}", id),
@@ -144,6 +148,7 @@ impl LogicalProject {
                 Field {
                     name,
                     data_type: expr.return_type(),
+                    sub_fields,
                 }
             })
             .collect();
@@ -350,14 +355,17 @@ mod tests {
             Field {
                 data_type: ty.clone(),
                 name: "v1".to_string(),
+                sub_fields: vec![],
             },
             Field {
                 data_type: ty.clone(),
                 name: "v2".to_string(),
+                sub_fields: vec![],
             },
             Field {
                 data_type: ty.clone(),
                 name: "v3".to_string(),
+                sub_fields: vec![],
             },
         ];
         let values = LogicalValues::new(

--- a/src/frontend/src/optimizer/plan_node/stream_materialize.rs
+++ b/src/frontend/src/optimizer/plan_node/stream_materialize.rs
@@ -17,7 +17,7 @@ use std::fmt;
 
 use fixedbitset::FixedBitSet;
 use itertools::Itertools;
-use risingwave_common::catalog::{ColumnDesc, Field, OrderedColumnDesc, Schema, TableId};
+use risingwave_common::catalog::{Field, OrderedColumnDesc, Schema, TableId};
 use risingwave_common::error::ErrorCode::InternalError;
 use risingwave_common::error::Result;
 use risingwave_common::util::sort_util::OrderType;
@@ -110,20 +110,19 @@ impl StreamMaterialize {
         let pk_indices = &base.pk_indices;
         // Materialize executor won't change the append-only behavior of the stream, so it depends
         // on input's `append_only`.
-        println!("{:?}", schema.fields);
-        let columns = schema
+        let mut columns = schema
             .fields()
             .iter()
             .enumerate()
-            .map(|(i, field)| {
-                let mut column_desc: ColumnDesc = field.into();
-                column_desc.column_id = ColumnId::new(i as i32);
-                ColumnCatalog {
-                    column_desc,
-                    is_hidden: !user_cols.contains(i),
-                }
+            .map(|(i, field)| ColumnCatalog {
+                column_desc: field.into(),
+                is_hidden: !user_cols.contains(i),
             })
             .collect_vec();
+
+        // Since the `field.into()` only generate same ColumnId,
+        // so rewrite ColumnId for each `column_desc` and `column_desc.field_desc`.
+        ColumnCatalog::generate_increment_id(&mut columns);
 
         let mut in_pk = FixedBitSet::with_capacity(schema.len());
         let mut pk_desc = vec![];

--- a/src/frontend/src/optimizer/plan_node/stream_materialize.rs
+++ b/src/frontend/src/optimizer/plan_node/stream_materialize.rs
@@ -77,11 +77,11 @@ impl StreamMaterialize {
             .iter()
             .map(|field| match is_row_id_column_name(&field.name) {
                 true => {
-                    let field = Field {
-                        data_type: field.data_type.clone(),
-                        name: gen_row_id_column_name(row_id_count),
-                        sub_fields: field.sub_fields.clone(),
-                    };
+                    let field = Field::new_with_sub_fields(
+                        field.data_type.clone(),
+                        gen_row_id_column_name(row_id_count),
+                        field.sub_fields.clone(),
+                    );
                     row_id_count += 1;
                     field
                 }

--- a/src/frontend/src/optimizer/plan_node/stream_materialize.rs
+++ b/src/frontend/src/optimizer/plan_node/stream_materialize.rs
@@ -80,6 +80,7 @@ impl StreamMaterialize {
                     let field = Field {
                         data_type: field.data_type.clone(),
                         name: gen_row_id_column_name(row_id_count),
+                        sub_fields: field.sub_fields.clone(),
                     };
                     row_id_count += 1;
                     field
@@ -108,19 +109,18 @@ impl StreamMaterialize {
         let pk_indices = &base.pk_indices;
         // Materialize executor won't change the append-only behavior of the stream, so it depends
         // on input's `append_only`.
+        println!("{:?}", schema.fields);
         let columns = schema
             .fields()
             .iter()
             .enumerate()
-            .map(|(i, field)| ColumnCatalog {
-                column_desc: ColumnDesc {
-                    data_type: field.data_type.clone(),
-                    column_id: (i as i32).into(),
-                    name: field.name.clone(),
-                    field_descs: vec![],
-                    type_name: "".to_string(),
-                },
-                is_hidden: !user_cols.contains(i),
+            .map(|(i, field)| {
+                let mut column_desc: ColumnDesc = field.into();
+                column_desc.column_id = ColumnId::new(i as i32);
+                ColumnCatalog {
+                    column_desc,
+                    is_hidden: !user_cols.contains(i),
+                }
             })
             .collect_vec();
 

--- a/src/frontend/src/optimizer/plan_node/stream_materialize.rs
+++ b/src/frontend/src/optimizer/plan_node/stream_materialize.rs
@@ -77,10 +77,11 @@ impl StreamMaterialize {
             .iter()
             .map(|field| match is_row_id_column_name(&field.name) {
                 true => {
-                    let field = Field::new_with_sub_fields(
+                    let field = Field::with_struct(
                         field.data_type.clone(),
                         gen_row_id_column_name(row_id_count),
                         field.sub_fields.clone(),
+                        field.type_name.clone(),
                     );
                     row_id_count += 1;
                     field

--- a/src/frontend/src/test_utils.rs
+++ b/src/frontend/src/test_utils.rs
@@ -14,6 +14,7 @@
 
 use std::collections::HashMap;
 use std::error::Error;
+use std::io::Write;
 use std::sync::atomic::{AtomicU32, Ordering};
 use std::sync::Arc;
 
@@ -29,6 +30,7 @@ use risingwave_pb::catalog::{
 use risingwave_pb::stream_plan::StreamNode;
 use risingwave_sqlparser::ast::Statement;
 use risingwave_sqlparser::parser::Parser;
+use tempfile::{Builder, NamedTempFile};
 
 use crate::binder::Binder;
 use crate::catalog::catalog_service::CatalogWriter;
@@ -247,4 +249,38 @@ impl FrontendMetaClient for MockFrontendMetaClient {
     async fn unpin_snapshot(&self, _epoch: u64) -> Result<()> {
         Ok(())
     }
+}
+pub static PROTO_FILE_DATA: &str = r#"
+    syntax = "proto3";
+    package test;
+    message TestRecord {
+      int32 id = 1;
+      Country country = 3;
+      int64 zipcode = 4;
+      float rate = 5;
+    }
+    message Country {
+      string address = 1;
+      City city = 2;
+      string zipcode = 3;
+    }
+    message City {
+      string address = 1;
+      string zipcode = 2;
+    }"#;
+
+/// Returns the file.
+/// (`NamedTempFile` will automatically delete the file when it goes out of scope.)
+pub fn create_proto_file(proto_data: &str) -> NamedTempFile {
+    let temp_file = Builder::new()
+        .prefix("temp")
+        .suffix(".proto")
+        .rand_bytes(5)
+        .tempfile()
+        .unwrap();
+
+    let mut file = temp_file.as_file();
+    file.write_all(proto_data.as_ref())
+        .expect("writing binary to test file");
+    temp_file
 }


### PR DESCRIPTION
## What's changed and what's your intention?

***PLEASE DO NOT LEAVE THIS EMPTY !!!***
Since we cannot make query on source and need to create mv from source first, this pr support to create mv conclude struct column.
```
create materialized view mv1 as select t1.country as c from t1
```

Two main changes:
1. bind field_descs in ColumnDesc from SourceCatalog.
2. add sub_fields and type_name in Field used to into field_descs and type_name in ColumnDesc.

## Checklist

- [x] I have written necessary docs and comments
- [x] I have added necessary unit tests and integration tests

## Refer to a related PR or issue link (optional)