### PR TITLE
refactor: create source & create table

### DIFF
--- a/src/common/src/catalog/column.rs
+++ b/src/common/src/catalog/column.rs
@@ -111,7 +111,6 @@ impl ColumnDesc {
         descs
     }
 
-    #[cfg(test)]
     pub fn new_atomic(data_type: DataType, name: &str, column_id: i32) -> Self {
         Self {
             data_type,
@@ -122,7 +121,6 @@ impl ColumnDesc {
         }
     }
 
-    #[cfg(test)]
     pub fn new_struct(
         name: &str,
         column_id: i32,

--- a/src/frontend/src/handler/create_source.rs
+++ b/src/frontend/src/handler/create_source.rs
@@ -35,7 +35,7 @@ use crate::catalog::source_catalog::SourceCatalog;
 use crate::catalog::table_catalog::TableCatalog;
 use crate::session::{OptimizerContext, SessionImpl};
 
-/// The created object under a schema.
+/// The created object under a schema. This is a helper for creating tables and sources.
 pub struct CreateObject {
     pub database_id: u32,
     pub schema_id: u32,

--- a/src/frontend/src/handler/create_table.rs
+++ b/src/frontend/src/handler/create_table.rs
@@ -118,8 +118,10 @@ pub async fn handle_create_table(
 
     let (plan, source, table) = {
         let (plan, source, table) =
-            gen_create_table_plan(&*session, context.into(), table_name, columns)?;
-        (plan.to_stream_prost(), source, table)
+            gen_create_table_plan(&session, context.into(), table_name.clone(), columns)?;
+        let plan = plan.to_stream_prost();
+
+        (plan, source, table)
     };
 
     log::trace!(

--- a/src/frontend/src/handler/explain.rs
+++ b/src/frontend/src/handler/explain.rs
@@ -19,8 +19,7 @@ use risingwave_common::error::Result;
 use risingwave_sqlparser::ast::Statement;
 
 use super::create_mv::gen_create_mv_plan;
-use super::create_source::CreateObject;
-use super::create_table::{bind_sql_columns, gen_create_table_plan};
+use super::create_table::gen_create_table_plan;
 use crate::binder::Binder;
 use crate::planner::Planner;
 use crate::session::OptimizerContext;
@@ -44,9 +43,7 @@ pub(super) fn handle_explain(
         } => gen_create_mv_plan(&*session, planner.ctx(), query, name)?.0,
 
         Statement::CreateTable { name, columns, .. } => {
-            let object = CreateObject::new(&session, name)?;
-            let columns = bind_sql_columns(columns)?;
-            gen_create_table_plan(planner.ctx(), object, columns)?.0
+            gen_create_table_plan(&*session, planner.ctx(), name, columns)?.0
         }
 
         stmt => {

--- a/src/frontend/src/handler/explain.rs
+++ b/src/frontend/src/handler/explain.rs
@@ -19,7 +19,8 @@ use risingwave_common::error::Result;
 use risingwave_sqlparser::ast::Statement;
 
 use super::create_mv::gen_create_mv_plan;
-use super::create_table::gen_create_table_plan;
+use super::create_source::CreateObject;
+use super::create_table::{bind_sql_columns, gen_create_table_plan};
 use crate::binder::Binder;
 use crate::planner::Planner;
 use crate::session::OptimizerContext;
@@ -43,7 +44,9 @@ pub(super) fn handle_explain(
         } => gen_create_mv_plan(&*session, planner.ctx(), query, name)?.0,
 
         Statement::CreateTable { name, columns, .. } => {
-            gen_create_table_plan(&*session, planner.ctx(), name, columns)?.0
+            let object = CreateObject::new(&session, name)?;
+            let columns = bind_sql_columns(columns)?;
+            gen_create_table_plan(planner.ctx(), object, columns)?.0
         }
 
         stmt => {


### PR DESCRIPTION
## What's changed and what's your intention?

The principles of this refactoring are: 

1. Delay `to_protobuf` until necessary. For example, in `bind_sql_columns`, we created protobuf structs too early. And we heavily relied on `From<ProstXXX>` to construct an internally corresponding struct. This is an abuse of protobuf and will bring unnecessary conversions.

2. Construct catalog objects at the entry point of statement handling. Formerly the SourceCatalog and TableCatalog were constructed in StreamMaterialize, too deep in the code path. As catalog creation is a critical logic, it should be shed the light on and brought to the main logic.

4. Reduce duplication:

```rust
match format {
  Format::Protobuf(schema) => StreamSourceInfo { ... },
  Format::JSON(schema) => StreamSourceInfo { ... },
}
```

To 

```rust
let (xxx) = match format {
  Format::Protobuf(schema) => (xxx),
  Format::JSON(schema) => (xxx),
};
StreamSourceInfo {
  xxx
}
```

## Checklist

- [x] I have written necessary docs and comments
- [x] I have added necessary unit tests and integration tests

## Refer to a related PR or issue link (optional)
