### PR TITLE
fix(streaming): avoid violating the assumption of U+ after U- in hash join & add checker

### DIFF
--- a/src/stream/src/executor/debug/mod.rs
+++ b/src/stream/src/executor/debug/mod.rs
@@ -16,6 +16,7 @@ mod cache_clear;
 mod epoch_check;
 mod schema_check;
 mod trace;
+mod update_check;
 use std::fmt::Debug;
 
 use async_trait::async_trait;
@@ -26,6 +27,8 @@ pub use self::cache_clear::*;
 pub use self::epoch_check::*;
 pub use self::schema_check::*;
 pub use self::trace::*;
+pub use self::update_check::*;
+
 use super::{Executor, Message};
 
 /// [`DebugExecutor`] is an abstraction of wrapper executors, generally used for debug purpose. Data

--- a/src/stream/src/executor/debug/mod.rs
+++ b/src/stream/src/executor/debug/mod.rs
@@ -28,7 +28,6 @@ pub use self::epoch_check::*;
 pub use self::schema_check::*;
 pub use self::trace::*;
 pub use self::update_check::*;
-
 use super::{Executor, Message};
 
 /// [`DebugExecutor`] is an abstraction of wrapper executors, generally used for debug purpose. Data

--- a/src/stream/src/executor/debug/update_check.rs
+++ b/src/stream/src/executor/debug/update_check.rs
@@ -47,7 +47,8 @@ impl super::DebugExecutor for UpdateCheckExecutor {
                             assert_eq!(
                                 row2.as_ref().map(|r| r.op()),
                                 Some(Op::UpdateInsert),
-                                "expect an `UpdateInsert` after the `UpdateDelete`:\n first: {:?}\nsecond: {:?}",
+                                "update check failed on `{}`: expect an `UpdateInsert` after the `UpdateDelete`:\n first: {:?}\nsecond: {:?}",
+                                self.input.logical_operator_info(),
                                 row1,
                                 row2
                             );

--- a/src/stream/src/executor/debug/update_check.rs
+++ b/src/stream/src/executor/debug/update_check.rs
@@ -1,0 +1,119 @@
+// Copyright 2022 Singularity Data
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::fmt::Debug;
+
+use async_trait::async_trait;
+use itertools::Itertools;
+use risingwave_common::array::Op;
+use risingwave_common::error::Result;
+
+use crate::executor::{Executor, Message};
+
+/// [`UpdateCheckExecutor`] checks whether the two rows of updates are next to each other.
+#[derive(Debug)]
+pub struct UpdateCheckExecutor {
+    /// The input of the current executor.
+    input: Box<dyn Executor>,
+}
+
+impl UpdateCheckExecutor {
+    pub fn new(input: Box<dyn Executor>) -> Self {
+        Self { input }
+    }
+}
+
+#[async_trait]
+impl super::DebugExecutor for UpdateCheckExecutor {
+    async fn next(&mut self) -> Result<Message> {
+        let message = self.input.next().await?;
+
+        if let Message::Chunk(chunk) = &message {
+            for (row1, row2) in chunk.rows().map(Some).chain(None).tuple_windows() {
+                match (row1, row2) {
+                    (Some(row1), row2) => {
+                        if row1.op() == Op::UpdateDelete {
+                            assert_eq!(
+                                row2.as_ref().map(|r| r.op()),
+                                Some(Op::UpdateInsert),
+                                "expect an `UpdateInsert` after the `UpdateDelete`:\n{:?}\n{:?}",
+                                row1,
+                                row2
+                            );
+                        }
+                    }
+                    _ => unreachable!(),
+                }
+            }
+        }
+
+        Ok(message)
+    }
+
+    fn input(&self) -> &dyn Executor {
+        self.input.as_ref()
+    }
+
+    fn input_mut(&mut self) -> &mut dyn Executor {
+        self.input.as_mut()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::iter::once;
+
+    use risingwave_common::array::{I64Array, StreamChunk};
+    use risingwave_common::column_nonnull;
+
+    use super::*;
+    use crate::executor::test_utils::MockSource;
+
+    #[should_panic]
+    #[tokio::test]
+    async fn test_not_next_to_each_other() {
+        let chunk = StreamChunk::new(
+            vec![
+                Op::UpdateDelete,
+                Op::UpdateDelete,
+                Op::UpdateInsert,
+                Op::UpdateInsert,
+            ],
+            vec![column_nonnull! { I64Array, [114, 514, 1919, 810] }],
+            None,
+        );
+
+        let mut source = MockSource::new(Default::default(), vec![]);
+        source.push_chunks(once(chunk));
+
+        let mut checked = UpdateCheckExecutor::new(Box::new(source));
+        checked.next().await.unwrap(); // should panic
+    }
+
+    #[should_panic]
+    #[tokio::test]
+    async fn test_last_one_update_delete() {
+        let chunk = StreamChunk::new(
+            vec![Op::UpdateDelete, Op::UpdateInsert, Op::UpdateDelete],
+            vec![column_nonnull! { I64Array, [114, 514, 1919810] }],
+            None,
+        );
+
+        let mut source = MockSource::new(Default::default(), vec![]);
+        source.push_chunks(once(chunk));
+
+        let mut checked = UpdateCheckExecutor::new(Box::new(source));
+        checked.next().await.unwrap(); // should panic
+    }
+}

--- a/src/stream/src/executor/debug/update_check.rs
+++ b/src/stream/src/executor/debug/update_check.rs
@@ -47,7 +47,7 @@ impl super::DebugExecutor for UpdateCheckExecutor {
                             assert_eq!(
                                 row2.as_ref().map(|r| r.op()),
                                 Some(Op::UpdateInsert),
-                                "expect an `UpdateInsert` after the `UpdateDelete`:\n{:?}\n{:?}",
+                                "expect an `UpdateInsert` after the `UpdateDelete`:\n first: {:?}\nsecond: {:?}",
                                 row1,
                                 row2
                             );

--- a/src/stream/src/executor/debug/update_check.rs
+++ b/src/stream/src/executor/debug/update_check.rs
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 use std::fmt::Debug;
+use std::iter::once;
 
 use async_trait::async_trait;
 use itertools::Itertools;
@@ -40,14 +41,14 @@ impl super::DebugExecutor for UpdateCheckExecutor {
         let message = self.input.next().await?;
 
         if let Message::Chunk(chunk) = &message {
-            for (row1, row2) in chunk.rows().map(Some).chain(None).tuple_windows() {
+            for (row1, row2) in chunk.rows().map(Some).chain(once(None)).tuple_windows() {
                 match (row1, row2) {
                     (Some(row1), row2) => {
                         if row1.op() == Op::UpdateDelete {
                             assert_eq!(
                                 row2.as_ref().map(|r| r.op()),
                                 Some(Op::UpdateInsert),
-                                "update check failed on `{}`: expect an `UpdateInsert` after the `UpdateDelete`:\n first: {:?}\nsecond: {:?}",
+                                "update check failed on `{}`: expect an `UpdateInsert` after the `UpdateDelete`:\n first row: {:?}\nsecond row: {:?}",
                                 self.input.logical_operator_info(),
                                 row1,
                                 row2

--- a/src/stream/src/executor/hash_join.rs
+++ b/src/stream/src/executor/hash_join.rs
@@ -486,7 +486,7 @@ impl<S: StateStore, const T: JoinTypePrimitive> HashJoinExecutor<S, T> {
                                 } else {
                                     // concat with the matched_row and append the new row
                                     // FIXME: we always use `Op::Delete` here to avoid violating
-                                    // the assumption for update rows.
+                                    // the assumption for U+ after U-.
                                     stream_chunk_builder.append_row(
                                         Op::Insert,
                                         &row,
@@ -538,7 +538,7 @@ impl<S: StateStore, const T: JoinTypePrimitive> HashJoinExecutor<S, T> {
                                     } else {
                                         // concat with the matched_row and append the new row
                                         // FIXME: we always use `Op::Delete` here to avoid violating
-                                        // the assumption for update rows.
+                                        // the assumption for U+ after U-.
                                         stream_chunk_builder.append_row(
                                             Op::Delete,
                                             &row,

--- a/src/stream/src/executor/hash_join.rs
+++ b/src/stream/src/executor/hash_join.rs
@@ -485,7 +485,13 @@ impl<S: StateStore, const T: JoinTypePrimitive> HashJoinExecutor<S, T> {
                                     )?;
                                 } else {
                                     // concat with the matched_row and append the new row
-                                    stream_chunk_builder.append_row(*op, &row, &matched_row.row)?;
+                                    // FIXME: we always use `Op::Delete` here to avoid violating
+                                    // the assumption for update rows.
+                                    stream_chunk_builder.append_row(
+                                        Op::Insert,
+                                        &row,
+                                        &matched_row.row,
+                                    )?;
                                 }
                                 matched_row.inc_degree();
                             } else {
@@ -531,8 +537,10 @@ impl<S: StateStore, const T: JoinTypePrimitive> HashJoinExecutor<S, T> {
                                         )?;
                                     } else {
                                         // concat with the matched_row and append the new row
+                                        // FIXME: we always use `Op::Delete` here to avoid violating
+                                        // the assumption for update rows.
                                         stream_chunk_builder.append_row(
-                                            *op,
+                                            Op::Delete,
                                             &row,
                                             &matched_row.row,
                                         )?;

--- a/src/stream/src/task/stream_manager.rs
+++ b/src/stream/src/task/stream_manager.rs
@@ -556,6 +556,8 @@ impl LocalStreamManagerCore {
         if env_var_is_true(CACHE_CLEAR_ENABLED_ENV_VAR_KEY) {
             executor = Box::new(CacheClearExecutor::new(executor));
         }
+        // Update check
+        executor = Box::new(UpdateCheckExecutor::new(executor));
 
         Ok(executor)
     }


### PR DESCRIPTION
## What's changed and what's your intention?

When there're multiple rows matched with a single `UpdateDelete`, the hash join executor will yield multiple continuous `UpdateDelete`s, which violates the assumption of U+ after U- used by `Merge`, `Filter` and so on. One can simply reproduce this in tpch q17, q18 with rearranged chain in #1556 since it introduces more barriers than before.

## Checklist

- [x] I have written necessary docs and comments
- [x] I have added necessary unit tests and integration tests

## Refer to a related PR or issue link (optional)
- Close #1801