### PR TITLE
refactor(storage): remove unnecessary ref to local_version_manager

### DIFF
--- a/src/bench/ss_bench/main.rs
+++ b/src/bench/ss_bench/main.rs
@@ -155,7 +155,6 @@ async fn main() {
     if let StateStoreImpl::HummockStateStore(hummock) = state_store.clone() {
         context = Some(Arc::new(CompactorContext {
             options: config.clone(),
-            local_version_manager: hummock.inner().local_version_manager().clone(),
             hummock_meta_client: mock_hummock_meta_client.clone(),
             sstable_store: hummock.inner().sstable_store(),
             stats: state_store_stats.clone(),

--- a/src/bench/ss_bench/operations/write_batch.rs
+++ b/src/bench/ss_bench/operations/write_batch.rs
@@ -98,13 +98,6 @@ impl Operations {
             if let Some(context) = context {
                 if let Some(task) = self.meta_client.get_compact_task().await {
                     Compactor::compact(context.clone(), task).await;
-                    let last_pinned = context.local_version_manager.get_version().unwrap();
-                    let version = self
-                        .meta_client
-                        .pin_version(last_pinned.id())
-                        .await
-                        .unwrap();
-                    context.local_version_manager.try_set_version(version);
                 }
             }
         }

--- a/src/compute/src/server.rs
+++ b/src/compute/src/server.rs
@@ -118,7 +118,6 @@ pub async fn compute_node_serve(
     if let Some(hummock) = state_store.as_hummock_state_store() {
         sub_tasks.push(Compactor::start_compactor(
             hummock.inner().options().clone(),
-            hummock.inner().local_version_manager().clone(),
             hummock.inner().hummock_meta_client().clone(),
             hummock.inner().sstable_store(),
             state_store_metrics,

--- a/src/storage/src/hummock/compactor_tests.rs
+++ b/src/storage/src/hummock/compactor_tests.rs
@@ -53,7 +53,7 @@ mod tests {
             block_cache_capacity,
             meta_cache_capacity,
         ));
-        let local_version_manager = Arc::new(LocalVersionManager::new(sstable_store.clone()));
+        let local_version_manager = Arc::new(LocalVersionManager::new());
         let storage = HummockStorage::with_default_stats(
             options.clone(),
             sstable_store,
@@ -84,7 +84,6 @@ mod tests {
         let storage = get_hummock_storage(hummock_meta_client.clone()).await;
         let compact_ctx = CompactorContext {
             options: storage.options().clone(),
-            local_version_manager: storage.local_version_manager().clone(),
             sstable_store: storage.sstable_store(),
             hummock_meta_client: hummock_meta_client.clone(),
             stats: Arc::new(StateStoreMetrics::unused()),
@@ -144,8 +143,8 @@ mod tests {
             .unwrap()
             .id;
         let table = storage
-            .local_version_manager()
-            .pick_few_tables(&[output_table_id])
+            .sstable_store()
+            .sstables(&[output_table_id])
             .await
             .unwrap()
             .first()

--- a/src/storage/src/hummock/mod.rs
+++ b/src/storage/src/hummock/mod.rs
@@ -257,10 +257,7 @@ impl StateStore for HummockStorage {
                             })
                             .map(|info| info.id)
                             .collect_vec();
-                        let tables = self
-                            .local_version_manager
-                            .pick_few_tables(&table_infos)
-                            .await?;
+                        let tables = self.sstable_store.sstables(&table_infos).await?;
                         for table in tables.into_iter().rev() {
                             table_counts += 1;
                             if let Some(v) = self.get_from_table(table, &internal_key, key).await? {
@@ -284,8 +281,8 @@ impl StateStore for HummockStorage {
                         // Because we will keep multiple version of one in the same sst file, we
                         // do not find it in the next adjacent file.
                         let tables = self
-                            .local_version_manager
-                            .pick_few_tables(&[level.table_infos[table_idx].id])
+                            .sstable_store
+                            .sstables(&[level.table_infos[table_idx].id])
                             .await?;
                         if let Some(v) = self
                             .get_from_table(tables.first().unwrap().clone(), &internal_key, key)
@@ -442,10 +439,7 @@ impl StateStore for HummockStorage {
                 if table_ids.is_empty() {
                     continue;
                 }
-                let tables = self
-                    .local_version_manager
-                    .pick_few_tables(&table_ids)
-                    .await?;
+                let tables = self.sstable_store.sstables(&table_ids).await?;
                 match level.level_type() {
                     LevelType::Overlapping => {
                         for table in tables.into_iter().rev() {
@@ -524,10 +518,7 @@ impl StateStore for HummockStorage {
                 if table_ids.is_empty() {
                     continue;
                 }
-                let mut tables = self
-                    .local_version_manager
-                    .pick_few_tables(&table_ids)
-                    .await?;
+                let mut tables = self.sstable_store.sstables(&table_ids).await?;
                 match level.level_type() {
                     LevelType::Overlapping => {
                         for table in tables.into_iter().rev() {

--- a/src/storage/src/hummock/shared_buffer/shared_buffer_manager.rs
+++ b/src/storage/src/hummock/shared_buffer/shared_buffer_manager.rs
@@ -403,7 +403,7 @@ mod tests {
             64 << 20,
             64 << 20,
         ));
-        let vm = Arc::new(LocalVersionManager::new(sstable_store.clone()));
+        let vm = Arc::new(LocalVersionManager::new());
         let (_env, hummock_manager_ref, _cluster_manager_ref, worker_node) =
             setup_compute_env(8080).await;
         let mock_hummock_meta_client = Arc::new(MockHummockMetaClient::new(

--- a/src/storage/src/hummock/shared_buffer/shared_buffer_uploader.rs
+++ b/src/storage/src/hummock/shared_buffer/shared_buffer_uploader.rs
@@ -104,7 +104,6 @@ impl SharedBufferUploader {
         // Compact buffers into SSTs
         let mem_compactor_ctx = CompactorContext {
             options: self.options.clone(),
-            local_version_manager: self.local_version_manager.clone(),
             hummock_meta_client: self.hummock_meta_client.clone(),
             sstable_store: self.sstable_store.clone(),
             stats: self.stats.clone(),

--- a/src/storage/src/hummock/snapshot_tests.rs
+++ b/src/storage/src/hummock/snapshot_tests.rs
@@ -65,7 +65,7 @@ async fn test_snapshot() {
         64 << 20,
         64 << 20,
     ));
-    let vm = Arc::new(LocalVersionManager::new(sstable_store.clone()));
+    let vm = Arc::new(LocalVersionManager::new());
     let (_env, hummock_manager_ref, _cluster_manager_ref, worker_node) =
         setup_compute_env(8080).await;
     let mock_hummock_meta_client = Arc::new(MockHummockMetaClient::new(
@@ -149,7 +149,7 @@ async fn test_snapshot_range_scan() {
         64 << 20,
         64 << 20,
     ));
-    let vm = Arc::new(LocalVersionManager::new(sstable_store.clone()));
+    let vm = Arc::new(LocalVersionManager::new());
     let (_env, hummock_manager_ref, _cluster_manager_ref, worker_node) =
         setup_compute_env(8080).await;
     let mock_hummock_meta_client = Arc::new(MockHummockMetaClient::new(
@@ -209,7 +209,7 @@ async fn test_snapshot_reverse_range_scan() {
         64 << 20,
         64 << 20,
     ));
-    let vm = Arc::new(LocalVersionManager::new(sstable_store.clone()));
+    let vm = Arc::new(LocalVersionManager::new());
     let (_env, hummock_manager_ref, _cluster_manager_ref, worker_node) =
         setup_compute_env(8080).await;
     let mock_hummock_meta_client = Arc::new(MockHummockMetaClient::new(

--- a/src/storage/src/hummock/sstable_store.rs
+++ b/src/storage/src/hummock/sstable_store.rs
@@ -184,6 +184,14 @@ impl SstableStore {
     pub fn store(&self) -> ObjectStoreRef {
         self.store.clone()
     }
+
+    pub async fn sstables(&self, sst_ids: &[u64]) -> HummockResult<Vec<Arc<Sstable>>> {
+        let mut ssts = Vec::with_capacity(sst_ids.len());
+        for sst_id in sst_ids {
+            ssts.push(self.sstable(*sst_id).await?);
+        }
+        Ok(ssts)
+    }
 }
 
 pub type SstableStoreRef = Arc<SstableStore>;

--- a/src/storage/src/hummock/state_store_tests.rs
+++ b/src/storage/src/hummock/state_store_tests.rs
@@ -41,7 +41,7 @@ async fn test_basic() {
         hummock_manager_ref.clone(),
         worker_node.id,
     ));
-    let local_version_manager = Arc::new(LocalVersionManager::new(sstable_store.clone()));
+    let local_version_manager = Arc::new(LocalVersionManager::new());
     let hummock_storage = HummockStorage::with_default_stats(
         hummock_options,
         sstable_store,
@@ -189,7 +189,7 @@ async fn test_state_store_sync() {
         hummock_manager_ref.clone(),
         worker_node.id,
     ));
-    let local_version_manager = Arc::new(LocalVersionManager::new(sstable_store.clone()));
+    let local_version_manager = Arc::new(LocalVersionManager::new());
     let hummock_storage = HummockStorage::with_default_stats(
         hummock_options,
         sstable_store,
@@ -280,7 +280,7 @@ async fn test_reload_storage() {
     let object_store = Arc::new(ObjectStoreImpl::Mem(InMemObjectStore::new()));
     let sstable_store = mock_sstable_store_with_object_store(object_store.clone());
     let hummock_options = Arc::new(default_config_for_test());
-    let local_version_manager = Arc::new(LocalVersionManager::new(sstable_store.clone()));
+    let local_version_manager = Arc::new(LocalVersionManager::new());
     let (_env, hummock_manager_ref, _cluster_manager_ref, worker_node) =
         setup_compute_env(8080).await;
     let hummock_meta_client = Arc::new(MockHummockMetaClient::new(

--- a/src/storage/src/hummock/test_utils.rs
+++ b/src/storage/src/hummock/test_utils.rs
@@ -60,7 +60,7 @@ pub async fn mock_hummock_storage() -> HummockStorage {
     HummockStorage::with_default_stats(
         Arc::new(StorageConfig::default()),
         sstable_store.clone(),
-        Arc::new(LocalVersionManager::new(sstable_store.clone())),
+        Arc::new(LocalVersionManager::new()),
         mock_hummock_meta_client,
         Arc::new(StateStoreMetrics::unused()),
     )

--- a/src/storage/src/storage_failpoints/test_hummock.rs
+++ b/src/storage/src/storage_failpoints/test_hummock.rs
@@ -40,7 +40,7 @@ async fn test_failpoint_state_store_read_upload() {
         worker_node.id,
     ));
 
-    let local_version_manager = Arc::new(LocalVersionManager::new(sstable_store.clone()));
+    let local_version_manager = Arc::new(LocalVersionManager::new());
 
     let hummock_storage = HummockStorage::with_default_stats(
         hummock_options,

--- a/src/storage/src/store_impl.rs
+++ b/src/storage/src/store_impl.rs
@@ -123,7 +123,7 @@ impl StateStoreImpl {
                 let inner = HummockStorage::new(
                     config.clone(),
                     sstable_store.clone(),
-                    Arc::new(LocalVersionManager::new(sstable_store)),
+                    Arc::new(LocalVersionManager::new()),
                     hummock_meta_client,
                     state_store_stats.clone(),
                 )


### PR DESCRIPTION
## What's changed and what's your intention?

Lift `LocalVersionManager::pick_few_tables` to `SstableStore::sstables`, then in turn removing some unnecessary references in `LocalVersionManager`, `CompactorContext` and `SharedBufferUploader`.

## Checklist

- [ ] I have written necessary docs and comments
- [ ] I have added necessary unit tests and integration tests

## Refer to a related PR or issue link (optional)
