### PR TITLE
feat(streaming): add proto for lookup executor

### DIFF
--- a/proto/stream_plan.proto
+++ b/proto/stream_plan.proto
@@ -52,6 +52,7 @@ message MaterializeNode {
   repeated plan.ColumnOrder column_orders = 3;
   // Column IDs of input schema
   repeated int32 column_ids = 4;
+  // TODO: remove this field, not used anywhere
   repeated int32 distribution_keys = 5;
 }
 
@@ -115,6 +116,27 @@ message BatchPlanNode {
   repeated int32 distribution_keys = 3;
 }
 
+// Special node for shared state. ArrangeNode will produce a special Materialize executor,
+// which materializes data for downstream to query.
+message ArrangeNode {
+  // The keys used to group the rows, aka. arrange key.
+  repeated int32 arrange_key_indexes = 1;
+}
+
+// Special node for shared state. LookupNode will join an arrangement with a stream.
+message LookupNode {
+  // Join keys of the arrangement side
+  repeated int32 arrange_key = 1;
+  // Join keys of the stream side
+  repeated int32 stream_key = 2;
+  // Whether to join the current epoch of arrangement
+  bool use_current_epoch = 3;
+  // Sometimes we need to re-order the output data to meet the requirement of schema.
+  // By default, lookup executor will produce `<arrangement side, stream side>`. We
+  // will then apply the column mapping to the combined result.
+  repeated int32 column_mapping = 4;
+}
+
 message StreamNode {
   oneof node {
     SourceNode source_node = 4;
@@ -131,6 +153,8 @@ message StreamNode {
     ExchangeNode exchange_node = 14;
     ChainNode chain_node = 15;
     BatchPlanNode batch_plan_node = 17;
+    LookupNode lookup_node = 20;
+    ArrangeNode arrange_node = 21;
   }
   // The id for the operator.
   uint64 operator_id = 1;

--- a/src/compute/tests/table_v2_materialize.rs
+++ b/src/compute/tests/table_v2_materialize.rs
@@ -173,7 +173,6 @@ async fn test_table_v2_materialize() -> Result<()> {
         all_column_ids.clone(),
         2,
         "MaterializeExecutor".to_string(),
-        vec![],
     ))
     .v1();
 

--- a/src/stream/src/executor/hash_join.rs
+++ b/src/stream/src/executor/hash_join.rs
@@ -19,7 +19,8 @@ use risingwave_common::catalog::Schema;
 use risingwave_common::error::Result;
 use risingwave_common::try_match_expand;
 use risingwave_common::types::{DataType, ToOwnedDatum};
-use risingwave_expr::expr::RowExpression;
+use risingwave_expr::expr::{build_from_prost, RowExpression};
+use risingwave_pb::plan::JoinType as JoinTypeProto;
 use risingwave_pb::stream_plan;
 use risingwave_pb::stream_plan::stream_node::Node;
 use risingwave_storage::{Keyspace, StateStore};
@@ -124,13 +125,73 @@ pub struct HashJoinExecutorBuilder {}
 
 impl ExecutorBuilder for HashJoinExecutorBuilder {
     fn new_boxed_executor(
-        params: ExecutorParams,
+        mut params: ExecutorParams,
         node: &stream_plan::StreamNode,
         store: impl StateStore,
-        stream: &mut LocalStreamManagerCore,
+        _stream: &mut LocalStreamManagerCore,
     ) -> Result<Box<dyn Executor>> {
         let node = try_match_expand!(node.get_node().unwrap(), Node::HashJoinNode)?;
-        stream.create_hash_join_node(params, node, store)
+        let source_r = params.input.remove(1);
+        let source_l = params.input.remove(0);
+        let params_l = JoinParams::new(
+            node.get_left_key()
+                .iter()
+                .map(|key| *key as usize)
+                .collect::<Vec<_>>(),
+        );
+        let params_r = JoinParams::new(
+            node.get_right_key()
+                .iter()
+                .map(|key| *key as usize)
+                .collect::<Vec<_>>(),
+        );
+
+        let condition = match node.get_condition() {
+            Ok(cond_prost) => Some(RowExpression::new(build_from_prost(cond_prost)?)),
+            Err(_) => None,
+        };
+        trace!("Join non-equi condition: {:?}", condition);
+
+        let key_indices = node
+            .get_distribution_keys()
+            .iter()
+            .map(|key| *key as usize)
+            .collect::<Vec<_>>();
+
+        macro_rules! impl_create_hash_join_executor {
+            ($( { $join_type_proto:ident, $join_type:ident } ),*) => {
+                |typ| match typ {
+                    $( JoinTypeProto::$join_type_proto => Box::new(HashJoinExecutor::<_, { JoinType::$join_type }>::new(
+                        source_l,
+                        source_r,
+                        params_l,
+                        params_r,
+                        params.pk_indices,
+                        Keyspace::shared_executor_root(store.clone(), params.operator_id),
+                        params.executor_id,
+                        condition,
+                        params.op_info,
+                        key_indices,
+                    )) as Box<dyn Executor>, )*
+                    _ => todo!("Join type {:?} not implemented", typ),
+                }
+            }
+        }
+
+        macro_rules! for_all_join_types {
+            ($macro:ident) => {
+                $macro! {
+                    { Inner, Inner },
+                    { LeftOuter, LeftOuter },
+                    { RightOuter, RightOuter },
+                    { FullOuter, FullOuter }
+                }
+            };
+        }
+        let create_hash_join_executor = for_all_join_types! { impl_create_hash_join_executor };
+        let join_type_proto = node.get_join_type()?;
+        let executor = create_hash_join_executor(join_type_proto);
+        Ok(executor)
     }
 }
 

--- a/src/stream/src/executor/mod.rs
+++ b/src/stream/src/executor/mod.rs
@@ -57,6 +57,7 @@ pub use top_n::*;
 pub use top_n_appendonly::*;
 use tracing::trace_span;
 
+use crate::executor_v2::LookupExecutorBuilder;
 use crate::task::{ActorId, ExecutorParams, LocalStreamManagerCore, ENABLE_BARRIER_AGGREGATION};
 
 mod actor;
@@ -492,7 +493,11 @@ pub fn create_executor(
     node: &stream_plan::StreamNode,
     store: impl StateStore,
 ) -> Result<Box<dyn Executor>> {
-    let real_executor = build_executor! { executor_params,node,store,stream,
+    let real_executor = build_executor! {
+        executor_params,
+        node,
+        store,
+        stream,
         Node::SourceNode => SourceExecutorBuilder,
         Node::ProjectNode => ProjectExecutorBuilder,
         Node::TopNNode => TopNExecutorBuilder,
@@ -505,7 +510,9 @@ pub fn create_executor(
         Node::BatchPlanNode => BatchQueryExecutorBuilder,
         Node::MergeNode => MergeExecutorBuilder,
         Node::MaterializeNode => MaterializeExecutorBuilder,
-        Node::FilterNode => FilterExecutorBuilder
+        Node::FilterNode => FilterExecutorBuilder,
+        Node::ArrangeNode => ArrangeExecutorBuilder,
+        Node::LookupNode => LookupExecutorBuilder
     }?;
     Ok(real_executor)
 }

--- a/src/stream/src/executor/mview/materialize.rs
+++ b/src/stream/src/executor/mview/materialize.rs
@@ -48,12 +48,6 @@ impl ExecutorBuilder for MaterializeExecutorBuilder {
 
         let keyspace = Keyspace::table_root(store, &table_id);
 
-        let key_indices = node
-            .get_distribution_keys()
-            .iter()
-            .map(|key| *key as usize)
-            .collect::<Vec<_>>();
-
         let v2 = Box::new(MaterializeExecutorV2::new_from_v1(
             params.input.remove(0),
             keyspace,
@@ -61,9 +55,23 @@ impl ExecutorBuilder for MaterializeExecutorBuilder {
             column_ids,
             params.executor_id,
             params.op_info,
-            key_indices,
         ));
 
         Ok(Box::new(v2.v1()))
+    }
+}
+
+pub struct ArrangeExecutorBuilder;
+
+impl ExecutorBuilder for ArrangeExecutorBuilder {
+    fn new_boxed_executor(
+        _params: ExecutorParams,
+        node: &stream_plan::StreamNode,
+        _store: impl StateStore,
+        _stream: &mut LocalStreamManagerCore,
+    ) -> Result<Box<dyn Executor>> {
+        let _node = try_match_expand!(node.get_node().unwrap(), Node::ArrangeNode)?;
+
+        todo!()
     }
 }

--- a/src/stream/src/executor_v2/lookup/tests.rs
+++ b/src/stream/src/executor_v2/lookup/tests.rs
@@ -128,7 +128,6 @@ async fn create_arrangement(
         arrangement_col_arrange_rules(),
         column_ids,
         1,
-        vec![],
     ))
 }
 

--- a/src/stream/src/executor_v2/mod.rs
+++ b/src/stream/src/executor_v2/mod.rs
@@ -60,7 +60,7 @@ pub use project::ProjectExecutor;
 pub(crate) use simple::{SimpleExecutor, SimpleExecutorWrapper};
 pub use top_n::TopNExecutor;
 pub use top_n_appendonly::AppendOnlyTopNExecutor;
-pub use v1_compat::StreamExecutorV1;
+pub use v1_compat::{ExecutorV1AsV2, StreamExecutorV1};
 
 pub type BoxedExecutor = Box<dyn Executor>;
 pub type BoxedMessageStream = BoxStream<'static, StreamExecutorResult<Message>>;

--- a/src/stream/src/executor_v2/mview/materialize.rs
+++ b/src/stream/src/executor_v2/mview/materialize.rs
@@ -36,10 +36,6 @@ pub struct MaterializeExecutor<S: StateStore> {
     /// Columns of arrange keys (including pk, group keys, join keys, etc.)
     arrange_columns: Vec<usize>,
 
-    #[allow(dead_code)]
-    /// Indices of the columns on which key distribution depends.
-    key_indices: Vec<usize>,
-
     info: ExecutorInfo,
 }
 
@@ -50,7 +46,6 @@ impl<S: StateStore> MaterializeExecutor<S> {
         keys: Vec<OrderPair>,
         column_ids: Vec<ColumnId>,
         executor_id: u64,
-        key_indices: Vec<usize>,
     ) -> Self {
         let arrange_columns: Vec<usize> = keys.iter().map(|k| k.column_idx).collect();
         let arrange_order_types = keys.iter().map(|k| k.order_type).collect();
@@ -64,7 +59,6 @@ impl<S: StateStore> MaterializeExecutor<S> {
                 pk_indices: arrange_columns,
                 identity: format!("MaterializeExecutor {:X}", executor_id),
             },
-            key_indices,
         }
     }
 
@@ -221,7 +215,6 @@ mod tests {
             vec![OrderPair::new(0, OrderType::Ascending)],
             column_ids,
             1,
-            vec![],
         ))
         .execute();
 

--- a/src/stream/src/executor_v2/v1_compat.rs
+++ b/src/stream/src/executor_v2/v1_compat.rs
@@ -212,7 +212,6 @@ impl<S: StateStore> MaterializeExecutor<S> {
         column_ids: Vec<ColumnId>,
         executor_id: u64,
         _op_info: String,
-        key_indices: Vec<usize>,
     ) -> Self {
         Self::new(
             Box::new(ExecutorV1AsV2(input)),
@@ -220,7 +219,6 @@ impl<S: StateStore> MaterializeExecutor<S> {
             keys,
             column_ids,
             executor_id,
-            key_indices,
         )
     }
 }

--- a/src/stream/src/task/stream_manager.rs
+++ b/src/stream/src/task/stream_manager.rs
@@ -26,12 +26,11 @@ use risingwave_common::try_match_expand;
 use risingwave_common::types::DataType;
 use risingwave_common::util::addr::{is_local_address, HostAddr};
 use risingwave_common::util::env_var::env_var_is_true;
-use risingwave_expr::expr::{build_from_prost, AggKind, RowExpression};
+use risingwave_expr::expr::AggKind;
 use risingwave_pb::common::ActorInfo;
-use risingwave_pb::plan::JoinType as JoinTypeProto;
 use risingwave_pb::stream_plan::stream_node::Node;
 use risingwave_pb::{expr, stream_plan, stream_service};
-use risingwave_storage::{dispatch_state_store, Keyspace, StateStore, StateStoreImpl};
+use risingwave_storage::{dispatch_state_store, StateStore, StateStoreImpl};
 use tokio::sync::oneshot;
 use tokio::task::JoinHandle;
 
@@ -493,6 +492,8 @@ impl LocalStreamManagerCore {
 
         // We assume that the operator_id of different instances from the same RelNode will be the
         // same.
+
+        assert!(node.get_operator_id() <= u32::MAX as u64);
         let executor_id = ((actor_id as u64) << 32) + node.get_operator_id();
         let operator_id = ((fragment_id as u64) << 32) + node.get_operator_id();
 
@@ -559,75 +560,6 @@ impl LocalStreamManagerCore {
         // Update check
         executor = Box::new(UpdateCheckExecutor::new(executor));
 
-        Ok(executor)
-    }
-
-    pub(crate) fn create_hash_join_node(
-        &mut self,
-        mut params: ExecutorParams,
-        node: &stream_plan::HashJoinNode,
-        store: impl StateStore,
-    ) -> Result<Box<dyn Executor>> {
-        let source_r = params.input.remove(1);
-        let source_l = params.input.remove(0);
-        let params_l = JoinParams::new(
-            node.get_left_key()
-                .iter()
-                .map(|key| *key as usize)
-                .collect::<Vec<_>>(),
-        );
-        let params_r = JoinParams::new(
-            node.get_right_key()
-                .iter()
-                .map(|key| *key as usize)
-                .collect::<Vec<_>>(),
-        );
-
-        let condition = match node.get_condition() {
-            Ok(cond_prost) => Some(RowExpression::new(build_from_prost(cond_prost)?)),
-            Err(_) => None,
-        };
-        trace!("Join non-equi condition: {:?}", condition);
-
-        let key_indices = node
-            .get_distribution_keys()
-            .iter()
-            .map(|key| *key as usize)
-            .collect::<Vec<_>>();
-
-        macro_rules! impl_create_hash_join_executor {
-            ($( { $join_type_proto:ident, $join_type:ident } ),*) => {
-                |typ| match typ {
-                    $( JoinTypeProto::$join_type_proto => Box::new(HashJoinExecutor::<_, { JoinType::$join_type }>::new(
-                        source_l,
-                        source_r,
-                        params_l,
-                        params_r,
-                        params.pk_indices,
-                        Keyspace::shared_executor_root(store.clone(), params.operator_id),
-                        params.executor_id,
-                        condition,
-                        params.op_info,
-                        key_indices,
-                    )) as Box<dyn Executor>, )*
-                    _ => todo!("Join type {:?} not implemented", typ),
-                }
-            }
-        }
-
-        macro_rules! for_all_join_types {
-            ($macro:ident) => {
-                $macro! {
-                    { Inner, Inner },
-                    { LeftOuter, LeftOuter },
-                    { RightOuter, RightOuter },
-                    { FullOuter, FullOuter }
-                }
-            };
-        }
-        let create_hash_join_executor = for_all_join_types! { impl_create_hash_join_executor };
-        let join_type_proto = node.get_join_type()?;
-        let executor = create_hash_join_executor(join_type_proto);
         Ok(executor)
     }
 


### PR DESCRIPTION
Signed-off-by: Alex Chi <iskyzh@gmail.com>

## What's changed and what's your intention?

As title. The pseudo ArrangeNode is used to construct MaterializeExecutor (but without table id).

## Checklist

- [x] I have written necessary docs and comments
- [x] I have added necessary unit tests and integration tests

## Refer to a related PR or issue link (optional)

ref https://github.com/singularity-data/risingwave/issues/719