### PR TITLE
chore(streaming): switch to rearranged chain & remove no-cache e2e

### DIFF
--- a/.github/workflow-template/jobs/e2e-risedev.yml
+++ b/.github/workflow-template/jobs/e2e-risedev.yml
@@ -114,15 +114,6 @@ jobs:
       - name: Kill cluster
         run: ~/cargo-make/makers ci-kill
 
-      - name: e2e test streaming 3-node w/o cache
-        timeout-minutes: 4
-        run: |
-          RW_NO_CACHE=1 ~/cargo-make/makers ci-start ci-3node
-          sqllogictest -p 4567 -d dev './e2e_test/streaming/**/*.slt'
-
-      - name: Kill cluster
-        run: ~/cargo-make/makers ci-kill
-
       - name: e2e test batch 3-node
         timeout-minutes: 2
         run: |

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -279,13 +279,6 @@ jobs:
           sqllogictest -p 4567 -d dev './e2e_test/streaming/**/*.slt'
       - name: Kill cluster
         run: ~/cargo-make/makers ci-kill
-      - name: e2e test streaming 3-node w/o cache
-        timeout-minutes: 4
-        run: |
-          RW_NO_CACHE=1 ~/cargo-make/makers ci-start ci-3node
-          sqllogictest -p 4567 -d dev './e2e_test/streaming/**/*.slt'
-      - name: Kill cluster
-        run: ~/cargo-make/makers ci-kill
       - name: e2e test batch 3-node
         timeout-minutes: 2
         run: |
@@ -389,13 +382,6 @@ jobs:
         timeout-minutes: 4
         run: |
           ~/cargo-make/makers ci-start ci-3node
-          sqllogictest -p 4567 -d dev './e2e_test/streaming/**/*.slt'
-      - name: Kill cluster
-        run: ~/cargo-make/makers ci-kill
-      - name: e2e test streaming 3-node w/o cache
-        timeout-minutes: 4
-        run: |
-          RW_NO_CACHE=1 ~/cargo-make/makers ci-start ci-3node
           sqllogictest -p 4567 -d dev './e2e_test/streaming/**/*.slt'
       - name: Kill cluster
         run: ~/cargo-make/makers ci-kill

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -236,13 +236,6 @@ jobs:
           sqllogictest -p 4567 -d dev './e2e_test/streaming/**/*.slt'
       - name: Kill cluster
         run: ~/cargo-make/makers ci-kill
-      - name: e2e test streaming 3-node w/o cache
-        timeout-minutes: 4
-        run: |
-          RW_NO_CACHE=1 ~/cargo-make/makers ci-start ci-3node
-          sqllogictest -p 4567 -d dev './e2e_test/streaming/**/*.slt'
-      - name: Kill cluster
-        run: ~/cargo-make/makers ci-kill
       - name: e2e test batch 3-node
         timeout-minutes: 2
         run: |

--- a/src/stream/src/executor_v2/mod.rs
+++ b/src/stream/src/executor_v2/mod.rs
@@ -25,6 +25,7 @@ pub use super::executor::{
 
 mod agg;
 mod batch_query;
+#[allow(dead_code)]
 mod chain;
 mod filter;
 mod global_simple_agg;
@@ -35,7 +36,6 @@ mod lookup;
 pub mod merge;
 pub(crate) mod mview;
 mod project;
-#[allow(dead_code)]
 mod rearranged_chain;
 pub mod receiver;
 mod simple;
@@ -47,7 +47,6 @@ mod top_n_executor;
 mod v1_compat;
 
 pub use batch_query::BatchQueryExecutor;
-pub use chain::ChainExecutor;
 pub use filter::FilterExecutor;
 pub use global_simple_agg::SimpleAggExecutor;
 pub use hash_agg::HashAggExecutor;
@@ -57,6 +56,7 @@ pub use lookup::*;
 pub use merge::MergeExecutor;
 pub use mview::*;
 pub use project::ProjectExecutor;
+pub use rearranged_chain::RearrangedChainExecutor as ChainExecutor;
 pub(crate) use simple::{SimpleExecutor, SimpleExecutorWrapper};
 pub use top_n::TopNExecutor;
 pub use top_n_appendonly::AppendOnlyTopNExecutor;


### PR DESCRIPTION
Signed-off-by: Bugen Zhao <i@bugenzhao.com>

## What's changed and what's your intention?

As title. After #1556 and #1811 is merged, let's see whether we can successfully switch to `RearrangedChain`. 😢

This PR also removes no-cache e2e tests since all of the executor v2s are not able to clear cache now. Besides, the clear-cache of v1 `HashJoin` has also been disabled due to known issues in #1540.

## Checklist

- [x] I have written necessary docs and comments
- [x] I have added necessary unit tests and integration tests

## Refer to a related PR or issue link (optional)
