### PR TITLE
feat(meta): actor placement rule and dispatcher refactor

### DIFF
--- a/proto/stream_plan.proto
+++ b/proto/stream_plan.proto
@@ -209,4 +209,6 @@ message StreamActor {
   // It is painstaking to traverse through the node tree and get upstream actor id from the root StreamNode.
   // We duplicate the information here to ease the parsing logic in stream manager.
   repeated uint32 upstream_actor_id = 6;
+  // Placement rule for actor, need to stay on the same node as upstream.
+  bool same_worker_node_as_upstream = 7;
 }

--- a/src/meta/src/model/stream.rs
+++ b/src/meta/src/model/stream.rs
@@ -40,8 +40,10 @@ const TABLE_FRAGMENTS_CF_NAME: &str = "cf/table_fragments";
 pub struct TableFragments {
     /// The table id.
     table_id: TableId,
+
     /// The table fragments.
     pub(crate) fragments: BTreeMap<FragmentId, Fragment>,
+
     /// The status of actors
     actor_status: BTreeMap<ActorId, ActorStatus>,
 }

--- a/src/meta/src/stream/graph/fragment_graph.rs
+++ b/src/meta/src/stream/graph/fragment_graph.rs
@@ -28,6 +28,11 @@ pub struct StreamFragmentEdge {
 
     /// Whether the two linked nodes should be placed on the same worker node
     pub same_worker_node: bool,
+
+    /// A unique identifer of this edge. Generally it should be exchange node's operator id. When
+    /// rewriting fragments into delta joins or when inserting 1-to-1 exchange, there will be
+    /// virtual links generated.
+    pub link_id: u64,
 }
 
 /// [`StreamFragment`] represent a fragment node in fragment DAG.

--- a/src/meta/src/stream/rewrite/delta_join.rs
+++ b/src/meta/src/stream/rewrite/delta_join.rs
@@ -12,19 +12,18 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-mod fragmenter;
-mod graph;
-mod meta;
-mod rewrite;
-mod scheduler;
-mod source_manager;
-mod stream_manager;
+use risingwave_common::error::Result;
+use risingwave_pb::stream_plan::StreamNode;
 
-#[cfg(test)]
-mod test_fragmenter;
+use crate::storage::MetaStore;
+use crate::stream::graph::StreamFragment;
+use crate::stream::StreamFragmenter;
 
-pub use fragmenter::*;
-pub use meta::*;
-pub use scheduler::*;
-pub use source_manager::*;
-pub use stream_manager::*;
+impl<S> StreamFragmenter<S>
+where
+    S: MetaStore,
+{
+    pub fn rewrite_delta_join(&mut self, _node: &StreamNode) -> Result<StreamFragment> {
+        todo!()
+    }
+}

--- a/src/meta/src/stream/rewrite/mod.rs
+++ b/src/meta/src/stream/rewrite/mod.rs
@@ -12,19 +12,4 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-mod fragmenter;
-mod graph;
-mod meta;
-mod rewrite;
-mod scheduler;
-mod source_manager;
-mod stream_manager;
-
-#[cfg(test)]
-mod test_fragmenter;
-
-pub use fragmenter::*;
-pub use meta::*;
-pub use scheduler::*;
-pub use source_manager::*;
-pub use stream_manager::*;
+mod delta_join;

--- a/src/meta/src/stream/scheduler.rs
+++ b/src/meta/src/stream/scheduler.rs
@@ -203,6 +203,7 @@ mod test {
                         nodes: None,
                         dispatcher: vec![],
                         upstream_actor_id: vec![],
+                        same_worker_node_as_upstream: false,
                     }],
                 };
                 actor_id += 1;
@@ -219,6 +220,7 @@ mod test {
                         nodes: None,
                         dispatcher: vec![],
                         upstream_actor_id: vec![],
+                        same_worker_node_as_upstream: false,
                     })
                     .collect_vec();
                 actor_id += node_count * 7;

--- a/src/meta/src/stream/stream_manager.rs
+++ b/src/meta/src/stream/stream_manager.rs
@@ -100,8 +100,12 @@ where
     /// 1. schedule the actors to nodes in the cluster.
     /// 2. broadcast the actor info table.
     /// (optional) get the split information of the `StreamSource` via source manager and patch
-    /// actors 3. notify related nodes to update and build the actors.
+    /// actors .
+    /// 3. notify related nodes to update and build the actors.
     /// 4. store related meta data.
+    ///
+    /// Note the `table_fragments` is required to be sorted in topology order. (Downstream first,
+    /// then upstream.)
     pub async fn create_materialized_view(
         &self,
         mut table_fragments: TableFragments,


### PR DESCRIPTION
Signed-off-by: Alex Chi <iskyzh@gmail.com>

## What's changed and what's your intention?

* Remove `ExchangeNode` before fragment -> actor stage. As now fragments might have multiple dispatchers, information of exchange node is not useful anymore. Dispatch strategy is now recorded in FragmentEdge.
* Prepare for actor placement rule implementation. We need to ensure some actors stay on the same worker node. Now we add this field, set this field according to FragmentEdge. Will later add logic to enforce such rule.

## Checklist

- [x] I have written necessary docs and comments
- [x] I have added necessary unit tests and integration tests

## Refer to a related PR or issue link (optional)

ref https://github.com/singularity-data/risingwave/issues/719
