### PR TITLE
refactor(frontend/expr): remove impl From<&Condition> for ExprImpl

### DIFF
--- a/src/frontend/src/expr/mod.rs
+++ b/src/frontend/src/expr/mod.rs
@@ -253,18 +253,6 @@ impl From<Condition> for ExprImpl {
     }
 }
 
-impl<'a> From<&'a Condition> for ExprImpl {
-    // TODO(TaoWu): We might also use `Vec<ExprImpl>` form of predicates in compute node,
-    // rather than using `AND` to combine them.
-    fn from(c: &'a Condition) -> Self {
-        merge_expr_by_binary(
-            c.conjunctions.iter().cloned(),
-            ExprType::And,
-            ExprImpl::literal_bool(true),
-        )
-    }
-}
-
 /// A custom Debug implementation that is more concise and suitable to use with
 /// [`std::fmt::Formatter::debug_list`] in plan nodes. If the verbose output is preferred, it is
 /// still available via `{:#?}`.

--- a/src/frontend/src/expr/utils.rs
+++ b/src/frontend/src/expr/utils.rs
@@ -50,7 +50,7 @@ where
 /// (expr1 AND expr2 AND expr3) the function will return Vec[expr1, expr2, expr3].
 pub fn to_conjunctions(expr: ExprImpl) -> Vec<ExprImpl> {
     let mut rets = vec![];
-    // TODO: extract common factors fromm the conjunctions with OR expression.
+    // TODO: extract common factors from the conjunctions with OR expression.
     // e.g: transform (a AND ((b AND c) OR (b AND d))) to (a AND b AND (c OR d))
     split_expr_by(expr, ExprType::And, &mut rets);
     rets

--- a/src/frontend/src/optimizer/plan_node/batch_filter.rs
+++ b/src/frontend/src/optimizer/plan_node/batch_filter.rs
@@ -75,7 +75,7 @@ impl ToDistributedBatch for BatchFilter {
 impl ToBatchProst for BatchFilter {
     fn to_batch_prost_body(&self) -> NodeBody {
         NodeBody::Filter(FilterNode {
-            search_condition: Some(ExprImpl::from(self.logical.predicate()).to_protobuf()),
+            search_condition: Some(ExprImpl::from(self.logical.predicate().clone()).to_protobuf()),
         })
     }
 }

--- a/src/frontend/src/optimizer/plan_node/logical_join.rs
+++ b/src/frontend/src/optimizer/plan_node/logical_join.rs
@@ -646,12 +646,15 @@ mod tests {
 
         // Expected plan: Filter($2 == 42) --> HashJoin($1 = $3)
         let batch_filter = result.as_batch_filter().unwrap();
-        assert_eq!(ExprImpl::from(batch_filter.predicate().clone()), non_eq_cond);
+        assert_eq!(
+            ExprImpl::from(batch_filter.predicate().clone()),
+            non_eq_cond
+        );
 
         let input = batch_filter.input();
         let hash_join = input.as_batch_hash_join().unwrap();
         assert_eq!(
-            ExprImpl::from(hash_join.eq_join_predicate().eq_cond().clone()),
+            ExprImpl::from(hash_join.eq_join_predicate().eq_cond()),
             eq_cond
         );
     }

--- a/src/frontend/src/optimizer/plan_node/logical_join.rs
+++ b/src/frontend/src/optimizer/plan_node/logical_join.rs
@@ -646,12 +646,12 @@ mod tests {
 
         // Expected plan: Filter($2 == 42) --> HashJoin($1 = $3)
         let batch_filter = result.as_batch_filter().unwrap();
-        assert_eq!(ExprImpl::from(batch_filter.predicate()), non_eq_cond);
+        assert_eq!(ExprImpl::from(batch_filter.predicate().clone()), non_eq_cond);
 
         let input = batch_filter.input();
         let hash_join = input.as_batch_hash_join().unwrap();
         assert_eq!(
-            ExprImpl::from(hash_join.eq_join_predicate().eq_cond()),
+            ExprImpl::from(hash_join.eq_join_predicate().eq_cond().clone()),
             eq_cond
         );
     }

--- a/src/frontend/src/optimizer/plan_node/stream_filter.rs
+++ b/src/frontend/src/optimizer/plan_node/stream_filter.rs
@@ -72,7 +72,7 @@ impl_plan_tree_node_for_unary! { StreamFilter }
 impl ToStreamProst for StreamFilter {
     fn to_stream_prost_body(&self) -> ProstStreamNode {
         ProstStreamNode::FilterNode(FilterNode {
-            search_condition: Some(ExprImpl::from(self.predicate()).to_protobuf()),
+            search_condition: Some(ExprImpl::from(self.predicate().clone()).to_protobuf()),
         })
     }
 }

--- a/src/frontend/src/utils/condition.rs
+++ b/src/frontend/src/utils/condition.rs
@@ -77,7 +77,7 @@ impl Condition {
         if self.always_true() {
             None
         } else {
-            Some(self.into())
+            Some(self.clone().into())
         }
     }
 


### PR DESCRIPTION
## What's changed and what's your intention?

As title. Follow up to #1816 

I think `impl From<&T>` is not very common, especially when there's `impl FROM<T>`. Replace it's usage with a `clone`

## Checklist

- [x] I have written necessary docs and comments
- [x] I have added necessary unit tests and integration tests

## Refer to a related PR or issue link (optional)
