### PR TITLE
refactor(streaming): use row iterator of `StreamChunk` in top-n

### DIFF
--- a/src/common/src/array/stream_chunk_iter.rs
+++ b/src/common/src/array/stream_chunk_iter.rs
@@ -13,8 +13,9 @@
 // limitations under the License.
 
 use super::column::Column;
+use super::Row;
 use crate::array::{Op, StreamChunk};
-use crate::types::DatumRef;
+use crate::types::{DatumRef, ToOwnedDatum};
 
 impl StreamChunk {
     pub fn rows(&self) -> impl Iterator<Item = RowRef<'_>> {
@@ -98,6 +99,10 @@ impl<'a> RowRef<'a> {
             columns: self.chunk.columns().iter(),
             row_idx: self.idx,
         }
+    }
+
+    pub fn to_owned_row(&self) -> Row {
+        Row(self.values().map(ToOwnedDatum::to_owned_datum).collect())
     }
 }
 

--- a/src/stream/src/executor_v2/hop_window.rs
+++ b/src/stream/src/executor_v2/hop_window.rs
@@ -208,9 +208,7 @@ mod tests {
     use itertools::Itertools;
     use risingwave_common::array::{Op, Row};
     use risingwave_common::catalog::{Field, Schema};
-    use risingwave_common::types::{
-        DataType, IntervalUnit, NaiveDateTimeWrapper, ScalarImpl, ToOwnedDatum,
-    };
+    use risingwave_common::types::{DataType, IntervalUnit, NaiveDateTimeWrapper, ScalarImpl};
 
     use crate::executor::Message;
     use crate::executor_v2::test_utils::MockSource;
@@ -285,12 +283,7 @@ mod tests {
         };
         let rows = chunk
             .rows()
-            .map(|r| {
-                (
-                    r.op(),
-                    Row::new(r.values().map(ToOwnedDatum::to_owned_datum).collect_vec()),
-                )
-            })
+            .map(|r| (r.op(), r.to_owned_row()))
             .collect_vec();
         assert_eq!(rows.len(), 8);
 
@@ -328,12 +321,7 @@ mod tests {
         };
         let rows = chunk
             .rows()
-            .map(|r| {
-                (
-                    r.op(),
-                    Row::new(r.values().map(ToOwnedDatum::to_owned_datum).collect_vec()),
-                )
-            })
+            .map(|r| (r.op(), r.to_owned_row()))
             .collect_vec();
         assert_eq!(rows.len(), 8);
 

--- a/src/stream/src/executor_v2/top_n.rs
+++ b/src/stream/src/executor_v2/top_n.rs
@@ -13,7 +13,7 @@
 // limitations under the License.
 
 use async_trait::async_trait;
-use risingwave_common::array::{DataChunk, Op, Row, StreamChunk};
+use risingwave_common::array::{Op, Row, StreamChunk};
 use risingwave_common::catalog::{ColumnDesc, ColumnId, Schema};
 use risingwave_common::error::Result;
 use risingwave_common::types::ToOwnedDatum;

--- a/src/stream/src/executor_v2/top_n.rs
+++ b/src/stream/src/executor_v2/top_n.rs
@@ -233,28 +233,20 @@ impl<S: StateStore> TopNExecutorBase for InnerTopNExecutor<S> {
             self.first_execution = false;
         }
 
-        let chunk = chunk.compact().map_err(StreamExecutorError::eval_error)?;
-
-        let (ops, columns, _visibility) = chunk.into_inner();
-
-        let data_chunk = DataChunk::builder().columns(columns).build();
         let num_limit = self.limit.unwrap_or(usize::MAX);
         let mut new_ops = vec![];
         let mut new_rows = vec![];
 
-        for (row_idx, op) in ops.iter().enumerate().take(data_chunk.capacity()) {
-            let row_ref = data_chunk
-                .row_at(row_idx)
-                .map_err(StreamExecutorError::eval_error)?
-                .0;
+        for row_ref in chunk.rows() {
             let pk_row = Row(self
                 .pk_indices
                 .iter()
-                .map(|idx| row_ref.0[*idx].to_owned_datum())
-                .collect::<Vec<_>>());
+                .map(|&idx| row_ref.value_at(idx).to_owned_datum())
+                .collect());
             let ordered_pk_row = OrderedRow::new(pk_row, &self.pk_order_types);
-            let row = row_ref.into();
-            match *op {
+            let row = row_ref.to_owned_row();
+
+            match row_ref.op() {
                 Op::Insert | Op::UpdateInsert => {
                     if self.managed_lowest_state.total_count() < self.offset {
                         // `elem` is in the range of `[0, offset)`,

--- a/src/stream/src/executor_v2/top_n_appendonly.rs
+++ b/src/stream/src/executor_v2/top_n_appendonly.rs
@@ -12,10 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use std::sync::Arc;
-
 use async_trait::async_trait;
-use risingwave_common::array::{DataChunk, Op, Row, StreamChunk};
+use risingwave_common::array::{Op, Row, StreamChunk};
 use risingwave_common::catalog::{ColumnDesc, ColumnId, Schema};
 use risingwave_common::error::Result;
 use risingwave_common::types::ToOwnedDatum;


### PR DESCRIPTION
Signed-off-by: Bugen Zhao <i@bugenzhao.com>

## What's changed and what's your intention?

As title. So that there's no need to compact the stream chunk.

## Checklist

- [x] I have written necessary docs and comments
- [x] I have added necessary unit tests and integration tests

## Refer to a related PR or issue link (optional)
- #1839