### PR TITLE
chore(streaming): rename consistent hash related value to vnode

### DIFF
--- a/proto/meta.proto
+++ b/proto/meta.proto
@@ -11,7 +11,7 @@ import "common.proto";
 import "plan.proto";
 import "stream_plan.proto";
 
-// Hash mapping for meta. Stores mapping from virtual key to parallel unit id.
+// Hash mapping for meta. Stores mapping from virtual node to parallel unit id.
 message ParallelUnitMapping {
   repeated uint32 hash_mapping = 1;
 }

--- a/proto/stream_plan.proto
+++ b/proto/stream_plan.proto
@@ -9,7 +9,7 @@ option optimize_for = SPEED;
 import "expr.proto";
 import "plan.proto";
 
-// Hash mapping for compute node. Stores mapping from virtual key to actor id.
+// Hash mapping for compute node. Stores mapping from virtual node to actor id.
 message ActorMapping {
   repeated uint32 hash_mapping = 1;
 }

--- a/src/common/src/hash/dispatcher.rs
+++ b/src/common/src/hash/dispatcher.rs
@@ -16,7 +16,10 @@ use super::HashKey;
 use crate::hash;
 use crate::types::{DataSize, DataType};
 
-pub const VIRTUAL_KEY_COUNT: usize = 2048;
+/// `VirtualNode` is the logical key for consistent hash. Virtual nodes stand for the intermediate
+/// layer between data and physical nodes.
+pub type VirtualNode = u16;
+pub const VIRTUAL_NODE_COUNT: usize = 65536;
 
 /// An enum to help to dynamically dispatch [`HashKey`] template.
 #[derive(Copy, Clone, Debug, Eq, PartialEq)]

--- a/src/storage/src/hummock/value.rs
+++ b/src/storage/src/hummock/value.rs
@@ -182,7 +182,7 @@ mod tests {
     fn test_vec_decode_encode() {
         let mut result = vec![];
         let value_meta = ValueMeta {
-            consistent_hash_value: 63492,
+            vnode: 63492,
         };
         HummockValue::Put(value_meta, b"233333".to_vec()).encode(&mut result);
         assert_eq!(
@@ -195,7 +195,7 @@ mod tests {
     fn test_slice_decode_encode() {
         let mut result = vec![];
         let value_meta = ValueMeta {
-            consistent_hash_value: 63492,
+            vnode: 63492,
         };
         HummockValue::Put(value_meta, b"233333".to_vec()).encode(&mut result);
         assert_eq!(


### PR DESCRIPTION
## What's changed and what's your intention?

Please explain **IN DETAIL** what the changes are in this PR and why they are needed:

- Summarize your change 
  - Rename `consistent_hash_value` to `vnode`
  - Rename `VirtualKey` to `VirtualNode`
  - Set the number of total virtual node as 65536 (previously 2048)

## Checklist

- [x] I have written necessary docs and comments
- [x] I have added necessary unit tests and integration tests
