### PR TITLE
chore: change vnode number and fix code format

### DIFF
--- a/src/common/src/hash/dispatcher.rs
+++ b/src/common/src/hash/dispatcher.rs
@@ -19,7 +19,7 @@ use crate::types::{DataSize, DataType};
 /// `VirtualNode` is the logical key for consistent hash. Virtual nodes stand for the intermediate
 /// layer between data and physical nodes.
 pub type VirtualNode = u16;
-pub const VIRTUAL_NODE_COUNT: usize = 65536;
+pub const VIRTUAL_NODE_COUNT: usize = 2048;
 
 /// An enum to help to dynamically dispatch [`HashKey`] template.
 #[derive(Copy, Clone, Debug, Eq, PartialEq)]

--- a/src/storage/src/hummock/value.rs
+++ b/src/storage/src/hummock/value.rs
@@ -181,9 +181,7 @@ mod tests {
     #[test]
     fn test_vec_decode_encode() {
         let mut result = vec![];
-        let value_meta = ValueMeta {
-            vnode: 63492,
-        };
+        let value_meta = ValueMeta { vnode: 63492 };
         HummockValue::Put(value_meta, b"233333".to_vec()).encode(&mut result);
         assert_eq!(
             HummockValue::Put(value_meta, b"233333".to_vec()),
@@ -194,9 +192,7 @@ mod tests {
     #[test]
     fn test_slice_decode_encode() {
         let mut result = vec![];
-        let value_meta = ValueMeta {
-            vnode: 63492,
-        };
+        let value_meta = ValueMeta { vnode: 63492 };
         HummockValue::Put(value_meta, b"233333".to_vec()).encode(&mut result);
         assert_eq!(
             HummockValue::Put(value_meta, b"233333".as_slice()),

--- a/src/stream/src/executor/dispatch.rs
+++ b/src/stream/src/executor/dispatch.rs
@@ -814,7 +814,7 @@ mod tests {
             match guard[0] {
                 Message::Chunk(ref chunk1) => {
                     assert_eq!(chunk1.capacity(), 8, "Should keep capacity");
-                    assert_eq!(chunk1.cardinality(), 4);
+                    assert_eq!(chunk1.cardinality(), 5);
                     assert!(chunk1.visibility().as_ref().unwrap().is_set(4).unwrap());
                     assert_eq!(
                         chunk1.ops()[6],
@@ -830,12 +830,12 @@ mod tests {
             match guard[0] {
                 Message::Chunk(ref chunk1) => {
                     assert_eq!(chunk1.capacity(), 8, "Should keep capacity");
-                    assert_eq!(chunk1.cardinality(), 3);
+                    assert_eq!(chunk1.cardinality(), 2);
                     assert!(
                         !chunk1.visibility().as_ref().unwrap().is_set(3).unwrap(),
                         "Should keep original invisible mark"
                     );
-                    assert!(chunk1.visibility().as_ref().unwrap().is_set(6).unwrap());
+                    assert!(!chunk1.visibility().as_ref().unwrap().is_set(6).unwrap());
 
                     assert_eq!(
                         chunk1.ops()[4],


### PR DESCRIPTION
## What's changed and what's your intention?

- Change virtual node number from 65536 back to 2048.
- Format code in `value.rs`.

## Limitations

The change of virtual node number is just a workaround, since 65536 is too large for a gRPC message. We could use some other strategies later to encode long array and then enable 65536.
