### PR TITLE
feat(frontend): support complex expr in group by

### DIFF
--- a/src/frontend/src/optimizer/plan_node/logical_agg.rs
+++ b/src/frontend/src/optimizer/plan_node/logical_agg.rs
@@ -97,15 +97,15 @@ pub struct LogicalAgg {
 /// `ExprHandler` extracts agg calls and references to group columns from select list, in
 /// preparation for generating a plan like `LogicalProject - LogicalAgg - LogicalProject`.
 struct ExprHandler {
-    // `project` contains all the ExprImpl inside GROUP BY clause (e.g. v1 for group by v1)
-    // followed by those inside aggregates (e.g. v1 + v2 for min(v1 + v2)).
+    /// `project` contains all the ExprImpl inside GROUP BY clause (e.g. v1 for group by v1)
+    /// followed by those inside aggregates (e.g. v1 + v2 for min(v1 + v2)).
     pub project: Vec<ExprImpl>,
     group_key_len: usize,
-    // When dedup (rewriting AggCall inputs), it is the index into projects.
-    // When rewriting InputRef outside AggCall, where it is required to refer to a group column,
-    // this is the index into LogicalAgg::schema.
-    // This 2 indices happen to be the same because we always put group exprs at the beginning of
-    // schema, and they are at the beginning of projects.
+    /// When dedup (rewriting AggCall inputs), it is the index into projects.
+    /// When rewriting InputRef outside AggCall, where it is required to refer to a group column,
+    /// this is the index into LogicalAgg::schema.
+    /// This 2 indices happen to be the same because we always put group exprs at the beginning of
+    /// schema, and they are at the beginning of projects.
     expr_index: HashMap<ExprImpl, usize>,
     pub agg_calls: Vec<PlanAggCall>,
     pub error: Option<ErrorCode>,
@@ -113,8 +113,6 @@ struct ExprHandler {
 
 impl ExprHandler {
     fn new(group_exprs: Vec<ExprImpl>) -> Result<Self> {
-        // TODO: support more complicated expression in GROUP BY clause, because we currently
-        // assume the only thing can appear in GROUP BY clause is an input column name.
         let group_key_len = group_exprs.len();
 
         // Please note that we currently don't dedup columns in GROUP BY clause.
@@ -123,13 +121,12 @@ impl ExprHandler {
             .iter()
             .enumerate()
             .try_for_each(|(index, expr)| {
-                if matches!(expr, ExprImpl::InputRef(_)) {
+                if !expr.has_subquery() && !expr.has_agg_call() {
                     expr_index.insert(expr.clone(), index);
                     Ok(())
                 } else {
-                    Err(ErrorCode::NotImplemented(
-                        "GROUP BY only supported on input column names!".into(),
-                        1637.into(),
+                    Err(ErrorCode::InvalidInputSyntax(
+                        "GROUP BY expr should not contain subquery or aggregation function".into(),
                     ))
                 }
             })?;
@@ -145,12 +142,12 @@ impl ExprHandler {
 }
 
 impl ExprRewriter for ExprHandler {
-    // When there is an agg call, there are 3 things to do:
-    // 1. eval its inputs via project;
-    // 2. add a PlanAggCall to agg;
-    // 3. rewrite it as an InputRef to the agg result in select list.
-    //
-    // Note that the rewriter does not traverse into inputs of agg calls.
+    /// When there is an agg call, there are 3 things to do:
+    /// 1. eval its inputs via project;
+    /// 2. add a `PlanAggCall` to agg;
+    /// 3. rewrite it as an `InputRef` to the agg result in select list.
+    ///
+    /// Note that the rewriter does not traverse into inputs of agg calls.
     fn rewrite_agg_call(&mut self, agg_call: AggCall) -> ExprImpl {
         let return_type = agg_call.return_type();
         let (agg_kind, inputs) = agg_call.decompose();
@@ -217,7 +214,7 @@ impl ExprRewriter for ExprHandler {
         }
     }
 
-    // When there is an InputRef (outside of agg call), it must refers to a group column.
+    /// When there is an `InputRef` (outside of agg call), it must refers to a group column.
     fn rewrite_input_ref(&mut self, input_ref: InputRef) -> ExprImpl {
         let expr = input_ref.into();
         if let Some(index) = self.expr_index.get(&expr) && *index < self.group_key_len {
@@ -336,7 +333,7 @@ impl LogicalAgg {
         let expr_alias = vec![None; expr_handler.project.len()];
         let logical_project = LogicalProject::create(input, expr_handler.project, expr_alias);
 
-        // This LogicalAgg foucuses on calculating the aggregates and grouping.
+        // This LogicalAgg focuses on calculating the aggregates and grouping.
         let agg_call_alias = vec![None; expr_handler.agg_calls.len()];
         let logical_agg = LogicalAgg::new(
             expr_handler.agg_calls,

--- a/src/frontend/src/optimizer/plan_node/logical_agg.rs
+++ b/src/frontend/src/optimizer/plan_node/logical_agg.rs
@@ -224,6 +224,7 @@ impl ExprRewriter for ExprHandler {
     }
 
     /// When there is an `FunctionCall` (outside of agg call), it must refers to a group column.
+    /// Or all `InputRef`s appears in it must refer to a group column.
     fn rewrite_function_call(&mut self, func_call: FunctionCall) -> ExprImpl {
         let expr = func_call.into();
         if let Some(index) = self.expr_index.get(&expr) && *index < self.group_key_len {

--- a/src/frontend/test_runner/tests/testdata/basic_query_2.yaml
+++ b/src/frontend/test_runner/tests/testdata/basic_query_2.yaml
@@ -148,6 +148,7 @@
             StreamExchange { dist: HashShard([2]) }
               StreamTableScan { table: t, columns: [v1, v2, v3, _row_id#0], pk_indices: [3] }
 - sql: |
+    /* test logical_agg with complex group expression */
     create table t(v1 int, v2 int);
     select min(v1), sum(v1 + v2) from t group by v1 + v2;
   logical_plan: |
@@ -156,6 +157,7 @@
         LogicalProject { exprs: [($1 + $2), $1], expr_alias: [ ,  ] }
           LogicalScan { table: t, columns: [_row_id#0, v1, v2] }
 - sql: |
+    /* test logical_agg with complex group expression */
     create table t(v1 int, v2 int, v3 int);
     select v1, sum(v1 * v2) as sum from t group by (v1 + v2) / v3, v1;
   logical_plan: |
@@ -163,6 +165,21 @@
       LogicalAgg { group_keys: [0, 1], agg_calls: [sum($2)] }
         LogicalProject { exprs: [(($1 + $2) / $3), $1, ($1 * $2)], expr_alias: [ ,  ,  ] }
           LogicalScan { table: t, columns: [_row_id#0, v1, v2, v3] }
+- sql: |
+    /* test logical_agg with complex group expression */
+    create table t(v1 int, v2 int);
+    select v1 + v2 from t group by v1 + v2
+  logical_plan: |
+    LogicalProject { exprs: [$0], expr_alias: [ ] }
+      LogicalAgg { group_keys: [0], agg_calls: [] }
+        LogicalProject { exprs: [($1 + $2)], expr_alias: [ ] }
+          LogicalScan { table: t, columns: [_row_id#0, v1, v2] }
+- sql: |
+    /* test logical_agg with complex group expression */
+    /* should complain about nested agg call */
+    create table t(v1 int, v2 int);
+    select avg(sum(v1 + v2)) from t group by v1 + v2
+  planner_error: 'Invalid input syntax: Aggregation calls should not be nested'
 - sql: |
     create table t(v1 int, v2 int);
     select v1 from t group by v1 + v2;

--- a/src/frontend/test_runner/tests/testdata/basic_query_2.yaml
+++ b/src/frontend/test_runner/tests/testdata/basic_query_2.yaml
@@ -168,7 +168,7 @@
 - sql: |
     /* test logical_agg with complex group expression */
     create table t(v1 int, v2 int);
-    select v1 + v2 from t group by v1 + v2
+    select v1 + v2 from t group by v1 + v2;
   logical_plan: |
     LogicalProject { exprs: [$0], expr_alias: [ ] }
       LogicalAgg { group_keys: [0], agg_calls: [] }
@@ -178,8 +178,17 @@
     /* test logical_agg with complex group expression */
     /* should complain about nested agg call */
     create table t(v1 int, v2 int);
-    select avg(sum(v1 + v2)) from t group by v1 + v2
+    select avg(sum(v1 + v2)) from t group by v1 + v2;
   planner_error: 'Invalid input syntax: Aggregation calls should not be nested'
+- sql: |
+    /* test logical_agg with complex select expression */
+    create table t(v1 int, v2 int);
+    select v1 + v2 from t group by v1, v2;
+  logical_plan: |
+    LogicalProject { exprs: [($0 + $1)], expr_alias: [ ] }
+      LogicalAgg { group_keys: [0, 1], agg_calls: [] }
+        LogicalProject { exprs: [$1, $2], expr_alias: [ ,  ] }
+          LogicalScan { table: t, columns: [_row_id#0, v1, v2] }
 - sql: |
     create table t(v1 int, v2 int);
     select v1 from t group by v1 + v2;

--- a/src/frontend/test_runner/tests/testdata/basic_query_2.yaml
+++ b/src/frontend/test_runner/tests/testdata/basic_query_2.yaml
@@ -149,6 +149,26 @@
               StreamTableScan { table: t, columns: [v1, v2, v3, _row_id#0], pk_indices: [3] }
 - sql: |
     create table t(v1 int, v2 int);
+    select min(v1), sum(v1 + v2) from t group by v1 + v2;
+  logical_plan: |
+    LogicalProject { exprs: [$1, $2], expr_alias: [ ,  ] }
+      LogicalAgg { group_keys: [0], agg_calls: [min($1), sum($0)] }
+        LogicalProject { exprs: [($1 + $2), $1], expr_alias: [ ,  ] }
+          LogicalScan { table: t, columns: [_row_id#0, v1, v2] }
+- sql: |
+    create table t(v1 int, v2 int, v3 int);
+    select v1, sum(v1 * v2) as sum from t group by (v1 + v2) / v3, v1;
+  logical_plan: |
+    LogicalProject { exprs: [$1, $2], expr_alias: [v1, sum] }
+      LogicalAgg { group_keys: [0, 1], agg_calls: [sum($2)] }
+        LogicalProject { exprs: [(($1 + $2) / $3), $1, ($1 * $2)], expr_alias: [ ,  ,  ] }
+          LogicalScan { table: t, columns: [_row_id#0, v1, v2, v3] }
+- sql: |
+    create table t(v1 int, v2 int);
+    select v1 from t group by v1 + v2;
+  planner_error: 'Invalid input syntax: column must appear in the GROUP BY clause or be used in an aggregate function'
+- sql: |
+    create table t(v1 int, v2 int);
     select count(v1 + v2), sum(v1 + v2) from t;
   batch_plan: |
     BatchSimpleAgg { aggs: [count($0), sum($0)] }


### PR DESCRIPTION
## What's changed and what's your intention?

Previously, only `InputRef`s are allowed in the `group by` expression. This pr adds support for complex expressions in the `group by`. 

Note that it seems that the current code already supports complex expressions in `group by`, so I only change the error code and the condition. Other chores like comment improvement and typo fix are also included in this pr.

## Checklist

- [x] I have written the necessary docs and comments
- [x] I have added necessary unit tests and integration tests

## Refer to a related PR or issue link (optional)

This pr resolves #1637.