### PR TITLE
chore(relational_state_store): define interfaces of relational layer

### DIFF
--- a/src/storage/src/table/mem_table.rs
+++ b/src/storage/src/table/mem_table.rs
@@ -13,8 +13,9 @@
 // limitations under the License.
 #![allow(dead_code)]
 #![allow(unused)]
-use std::collections::BTreeMap;
+use std::collections::{btree_map, BTreeMap};
 
+use futures::Future;
 use risingwave_common::array::Row;
 
 use crate::error::StorageResult;
@@ -27,11 +28,14 @@ pub enum RowOp {
 pub struct MemTable {
     pub buffer: BTreeMap<Row, RowOp>,
 }
+type MemTableIter<'a> = btree_map::Iter<'a, Row, RowOp>;
+
 impl Default for MemTable {
     fn default() -> Self {
         Self::new()
     }
 }
+
 impl MemTable {
     pub fn new() -> Self {
         Self {
@@ -66,17 +70,7 @@ impl MemTable {
         Ok(())
     }
 
-    pub async fn iter(&self, _pk: Row) -> StorageResult<MemTableIter> {
+    pub async fn iter(&self, _pk: Row) -> StorageResult<MemTableIter<'_>> {
         todo!();
-    }
-}
-
-pub struct MemTableIter {
-    mem_table: MemTable,
-}
-
-impl MemTableIter {
-    async fn next(&mut self) -> StorageResult<Option<RowOp>> {
-        todo!()
     }
 }

--- a/src/storage/src/table/mem_table.rs
+++ b/src/storage/src/table/mem_table.rs
@@ -1,0 +1,69 @@
+// Copyright 2022 Singularity Data
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+#![allow(dead_code)]
+#![allow(unused)]
+use std::collections::HashMap;
+
+use risingwave_common::array::Row;
+
+use crate::error::StorageResult;
+
+pub enum RowOp {
+    Insert(Row),
+    Delete(Row),
+    Update((Row, Row)),
+}
+pub struct MemTable {
+    pub buffer: HashMap<Row, RowOp>,
+}
+impl Default for MemTable {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+impl MemTable {
+    pub fn new() -> Self {
+        Self {
+            buffer: HashMap::new(),
+        }
+    }
+
+    /// read methods
+    pub async fn get_row(&self, pk: &Row) -> StorageResult<Option<RowOp>> {
+        todo!();
+    }
+
+    pub async fn get_row_by_scan(&self, pk: &Row) -> StorageResult<Option<RowOp>> {
+        todo!();
+    }
+
+    /// write methods
+    pub async fn insert(&mut self, pk: Row, value: Row) -> StorageResult<()> {
+        Ok(())
+    }
+
+    pub async fn delete(&mut self, pk: Row, old_value: Row) -> StorageResult<()> {
+        Ok(())
+    }
+
+    pub async fn update(&mut self, pk: Row, old_value: Row, new_value: Row) -> StorageResult<()> {
+        Ok(())
+    }
+
+    pub async fn iter(&self, pk: Row) -> StorageResult<MemTableIter> {
+        todo!();
+    }
+}
+
+pub struct MemTableIter {}

--- a/src/storage/src/table/mem_table.rs
+++ b/src/storage/src/table/mem_table.rs
@@ -20,6 +20,7 @@ use risingwave_common::array::Row;
 
 use crate::error::StorageResult;
 
+#[derive(Clone)]
 pub enum RowOp {
     Insert(Row),
     Delete(Row),
@@ -44,12 +45,8 @@ impl MemTable {
     }
 
     /// read methods
-    pub async fn get_row(&self, _pk: &Row) -> StorageResult<Option<RowOp>> {
-        todo!();
-    }
-
-    pub async fn get_row_by_scan(&self, _pk: &Row) -> StorageResult<Option<RowOp>> {
-        todo!();
+    pub async fn get_row(&self, pk: &Row) -> StorageResult<Option<RowOp>> {
+        todo!()
     }
 
     /// write methods

--- a/src/storage/src/table/mem_table.rs
+++ b/src/storage/src/table/mem_table.rs
@@ -69,11 +69,6 @@ impl MemTable {
     pub async fn iter(&self, _pk: Row) -> StorageResult<MemTableIter> {
         todo!();
     }
-
-    pub async fn drain(&mut self) -> StorageResult<MemTableIter> {
-        /// clear the memtable and flush them into cell_based table
-        todo!()
-    }
 }
 
 pub struct MemTableIter {

--- a/src/storage/src/table/mem_table.rs
+++ b/src/storage/src/table/mem_table.rs
@@ -13,7 +13,7 @@
 // limitations under the License.
 #![allow(dead_code)]
 #![allow(unused)]
-use std::collections::HashMap;
+use std::collections::BTreeMap;
 
 use risingwave_common::array::Row;
 
@@ -25,7 +25,7 @@ pub enum RowOp {
     Update((Row, Row)),
 }
 pub struct MemTable {
-    pub buffer: HashMap<Row, RowOp>,
+    pub buffer: BTreeMap<Row, RowOp>,
 }
 impl Default for MemTable {
     fn default() -> Self {
@@ -35,7 +35,7 @@ impl Default for MemTable {
 impl MemTable {
     pub fn new() -> Self {
         Self {
-            buffer: HashMap::new(),
+            buffer: BTreeMap::new(),
         }
     }
 
@@ -77,15 +77,10 @@ impl MemTable {
 }
 
 pub struct MemTableIter {
-    pk: Row,
-    op: RowOp,
+    mem_table: MemTable,
 }
 
 impl MemTableIter {
-    async fn new() -> StorageResult<Self> {
-        todo!()
-    }
-
     async fn next(&mut self) -> StorageResult<Option<RowOp>> {
         todo!()
     }

--- a/src/storage/src/table/mem_table.rs
+++ b/src/storage/src/table/mem_table.rs
@@ -40,30 +40,53 @@ impl MemTable {
     }
 
     /// read methods
-    pub async fn get_row(&self, pk: &Row) -> StorageResult<Option<RowOp>> {
+    pub async fn get_row(&self, _pk: &Row) -> StorageResult<Option<RowOp>> {
         todo!();
     }
 
-    pub async fn get_row_by_scan(&self, pk: &Row) -> StorageResult<Option<RowOp>> {
+    pub async fn get_row_by_scan(&self, _pk: &Row) -> StorageResult<Option<RowOp>> {
         todo!();
     }
 
     /// write methods
-    pub async fn insert(&mut self, pk: Row, value: Row) -> StorageResult<()> {
+    pub async fn insert(&mut self, _pk: Row, _value: Row) -> StorageResult<()> {
         Ok(())
     }
 
-    pub async fn delete(&mut self, pk: Row, old_value: Row) -> StorageResult<()> {
+    pub async fn delete(&mut self, _pk: Row, _old_value: Row) -> StorageResult<()> {
         Ok(())
     }
 
-    pub async fn update(&mut self, pk: Row, old_value: Row, new_value: Row) -> StorageResult<()> {
+    pub async fn update(
+        &mut self,
+        _pk: Row,
+        _old_value: Row,
+        _new_value: Row,
+    ) -> StorageResult<()> {
         Ok(())
     }
 
-    pub async fn iter(&self, pk: Row) -> StorageResult<MemTableIter> {
+    pub async fn iter(&self, _pk: Row) -> StorageResult<MemTableIter> {
         todo!();
+    }
+
+    pub async fn drain(&mut self) -> StorageResult<MemTableIter> {
+        /// clear the memtable and flush them into cell_based table
+        todo!()
     }
 }
 
-pub struct MemTableIter {}
+pub struct MemTableIter {
+    pk: Row,
+    op: RowOp,
+}
+
+impl MemTableIter {
+    async fn new() -> StorageResult<Self> {
+        todo!()
+    }
+
+    async fn next(&mut self) -> StorageResult<Option<RowOp>> {
+        todo!()
+    }
+}

--- a/src/storage/src/table/mod.rs
+++ b/src/storage/src/table/mod.rs
@@ -13,6 +13,8 @@
 // limitations under the License.
 
 pub mod cell_based_table;
+pub mod mem_table;
+pub mod state_table;
 
 use risingwave_common::array::Row;
 

--- a/src/storage/src/table/state_table.rs
+++ b/src/storage/src/table/state_table.rs
@@ -43,7 +43,7 @@ pub struct StateTable<S: StateStore> {
     /// Serializer to serialize keys from input rows
     key_serializer: OrderedRowSerializer,
 
-    /// buffer key/values
+    /// buffer RowOp
     mem_table: MemTable,
 
     /// Relation layer

--- a/src/storage/src/table/state_table.rs
+++ b/src/storage/src/table/state_table.rs
@@ -22,7 +22,7 @@ use risingwave_common::util::ordered::*;
 use risingwave_common::util::sort_util::OrderType;
 
 use super::cell_based_table::{CellBasedTable, CellBasedTableRowIter};
-use super::mem_table::{MemTable, MemTableIter};
+use super::mem_table::MemTable;
 use crate::cell_based_row_deserializer::CellBasedRowDeserializer;
 use crate::error::StorageResult;
 use crate::monitor::StateStoreMetrics;
@@ -43,7 +43,7 @@ pub struct StateTable<S: StateStore> {
     /// Serializer to serialize keys from input rows
     key_serializer: OrderedRowSerializer,
 
-    /// buffer RowOp
+    /// buffer key/values
     mem_table: MemTable,
 
     /// Relation layer
@@ -106,9 +106,10 @@ impl<S: StateStore> StateTable<S> {
         todo!()
     }
 }
+
 pub struct StateTableRowIter<S: StateStore> {
     cell_based_iter: CellBasedTableRowIter<S>,
-    mem_table_iter: MemTableIter,
+    mem_table: MemTable,
 }
 
 impl<S: StateStore> StateTableRowIter<S> {

--- a/src/storage/src/table/state_table.rs
+++ b/src/storage/src/table/state_table.rs
@@ -1,0 +1,133 @@
+// Copyright 2022 Singularity Data
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+#![allow(dead_code)]
+#![allow(unused)]
+use std::sync::Arc;
+
+use bytes::Bytes;
+use risingwave_common::array::Row;
+use risingwave_common::catalog::ColumnDesc;
+use risingwave_common::util::ordered::*;
+use risingwave_common::util::sort_util::OrderType;
+
+use super::cell_based_table::CellBasedTable;
+use super::mem_table::MemTable;
+use crate::cell_based_row_deserializer::CellBasedRowDeserializer;
+use crate::error::StorageResult;
+use crate::monitor::StateStoreMetrics;
+use crate::{Keyspace, StateStore};
+
+/// `CellBasedTable` is the interface accessing relational data in KV(`StateStore`) with encoding
+/// format: [keyspace | pk | `column_id` (4B)] -> value.
+/// if the key of the column id does not exist, it will be Null in the relation
+pub struct StateTable<S: StateStore> {
+    keyspace: Keyspace<S>,
+
+    /// `ColumnDesc` contains strictly more info than `schema`.
+    column_descs: Vec<ColumnDesc>,
+
+    /// Ordering of primary key (for assertion)
+    order_types: Vec<OrderType>,
+
+    /// Serializer to serialize keys from input rows
+    key_serializer: OrderedRowSerializer,
+
+    /// buffer key/values
+    mem_table: MemTable,
+
+    /// Relation layer
+    cell_based_table: CellBasedTable<S>,
+}
+impl<S: StateStore> StateTable<S> {
+    pub fn new(
+        keyspace: Keyspace<S>,
+        column_descs: Vec<ColumnDesc>,
+        order_types: Vec<OrderType>,
+    ) -> Self {
+        let cell_based_keyspace = keyspace.clone();
+        let cell_based_column_descs = column_descs.clone();
+        Self {
+            keyspace,
+            column_descs,
+            order_types: order_types.clone(),
+            key_serializer: OrderedRowSerializer::new(order_types),
+            mem_table: MemTable::new(),
+            cell_based_table: CellBasedTable::new_adhoc(
+                cell_based_keyspace,
+                cell_based_column_descs,
+                Arc::new(StateStoreMetrics::unused()),
+            ),
+        }
+    }
+
+    /// read methods
+    pub async fn get_row(&self, pk: &Row, epoch: u64) -> StorageResult<Option<Row>> {
+        todo!()
+    }
+
+    pub async fn get_row_by_scan(&self, pk: &Row, epoch: u64) -> StorageResult<Option<Row>> {
+        todo!()
+    }
+
+    /// write methods
+    pub async fn insert(&mut self, pk: Row, value: Row) -> StorageResult<()> {
+        todo!()
+    }
+
+    pub async fn delete(&mut self, pk: Row, old_value: Row) -> StorageResult<()> {
+        todo!()
+    }
+
+    pub async fn update(&mut self, pk: Row, old_value: Row, new_value: Row) -> StorageResult<()> {
+        todo!()
+    }
+
+    fn commit(&mut self, new_epoch: u64) -> StorageResult<()> {
+        todo!()
+    }
+
+    pub async fn iter(&self, pk: Row) -> StorageResult<StateTableRowIter<S>> {
+        todo!()
+    }
+}
+pub struct StateTableRowIter<S: StateStore> {
+    keyspace: Keyspace<S>,
+    /// A buffer to store prefetched kv pairs from state store
+    buf: Vec<(Bytes, Bytes)>,
+    /// The idx into `buf` for the next item
+    next_idx: usize,
+    /// A bool to indicate whether there are more data to fetch from state store
+    done: bool,
+    /// An epoch representing the read snapshot
+    epoch: u64,
+    /// Cell-based row deserializer
+    cell_based_row_deserializer: CellBasedRowDeserializer,
+    /// Statistics
+    _stats: Arc<StateStoreMetrics>,
+}
+
+impl<S: StateStore> StateTableRowIter<S> {
+    async fn new(
+        keyspace: Keyspace<S>,
+        table_descs: Vec<ColumnDesc>,
+        epoch: u64,
+        _stats: Arc<StateStoreMetrics>,
+    ) -> StorageResult<Self> {
+        todo!()
+    }
+
+    async fn next(&mut self) -> StorageResult<Option<Row>> {
+        todo!()
+    }
+}

--- a/src/storage/src/table/state_table.rs
+++ b/src/storage/src/table/state_table.rs
@@ -21,8 +21,8 @@ use risingwave_common::catalog::ColumnDesc;
 use risingwave_common::util::ordered::*;
 use risingwave_common::util::sort_util::OrderType;
 
-use super::cell_based_table::CellBasedTable;
-use super::mem_table::MemTable;
+use super::cell_based_table::{CellBasedTable, CellBasedTableRowIter};
+use super::mem_table::{MemTable, MemTableIter};
 use crate::cell_based_row_deserializer::CellBasedRowDeserializer;
 use crate::error::StorageResult;
 use crate::monitor::StateStoreMetrics;
@@ -72,56 +72,50 @@ impl<S: StateStore> StateTable<S> {
     }
 
     /// read methods
-    pub async fn get_row(&self, pk: &Row, epoch: u64) -> StorageResult<Option<Row>> {
+    pub async fn get_row(&self, _pk: &Row, _epoch: u64) -> StorageResult<Option<Row>> {
         todo!()
     }
 
-    pub async fn get_row_by_scan(&self, pk: &Row, epoch: u64) -> StorageResult<Option<Row>> {
+    pub async fn get_row_by_scan(&self, _pk: &Row, _epoch: u64) -> StorageResult<Option<Row>> {
         todo!()
     }
 
     /// write methods
-    pub async fn insert(&mut self, pk: Row, value: Row) -> StorageResult<()> {
+    pub async fn insert(&mut self, _pk: Row, _value: Row) -> StorageResult<()> {
         todo!()
     }
 
-    pub async fn delete(&mut self, pk: Row, old_value: Row) -> StorageResult<()> {
+    pub async fn delete(&mut self, _pk: Row, _old_value: Row) -> StorageResult<()> {
         todo!()
     }
 
-    pub async fn update(&mut self, pk: Row, old_value: Row, new_value: Row) -> StorageResult<()> {
+    pub async fn update(
+        &mut self,
+        _pk: Row,
+        _old_value: Row,
+        _new_value: Row,
+    ) -> StorageResult<()> {
         todo!()
     }
 
-    fn commit(&mut self, new_epoch: u64) -> StorageResult<()> {
+    fn commit(&mut self, _new_epoch: u64) -> StorageResult<()> {
         todo!()
     }
 
-    pub async fn iter(&self, pk: Row) -> StorageResult<StateTableRowIter<S>> {
+    pub async fn iter(&self, _pk: Row) -> StorageResult<StateTableRowIter<S>> {
         todo!()
     }
 }
 pub struct StateTableRowIter<S: StateStore> {
-    keyspace: Keyspace<S>,
-    /// A buffer to store prefetched kv pairs from state store
-    buf: Vec<(Bytes, Bytes)>,
-    /// The idx into `buf` for the next item
-    next_idx: usize,
-    /// A bool to indicate whether there are more data to fetch from state store
-    done: bool,
-    /// An epoch representing the read snapshot
-    epoch: u64,
-    /// Cell-based row deserializer
-    cell_based_row_deserializer: CellBasedRowDeserializer,
-    /// Statistics
-    _stats: Arc<StateStoreMetrics>,
+    cell_based_iter: CellBasedTableRowIter<S>,
+    mem_table_iter: MemTableIter,
 }
 
 impl<S: StateStore> StateTableRowIter<S> {
     async fn new(
-        keyspace: Keyspace<S>,
-        table_descs: Vec<ColumnDesc>,
-        epoch: u64,
+        _keyspace: Keyspace<S>,
+        _table_descs: Vec<ColumnDesc>,
+        _epoch: u64,
         _stats: Arc<StateStoreMetrics>,
     ) -> StorageResult<Self> {
         todo!()


### PR DESCRIPTION
## What's changed and what's your intention?
As described in doc [Relational State Store Layer](https://singularity-data.quip.com/J4JuAK9aSaYQ/RFC-Relational-State-Store-Layer-for-Stream-ExecutorWIP), this PR defines IO interfaces of `StateTable` and `MemTable`.

![image](https://user-images.githubusercontent.com/58715567/163749701-5c241304-ea47-4343-a07f-3070d0ad20e8.png)

## Checklist

- [x] I have written necessary docs and comments
- [x] I have added necessary unit tests and integration tests

## Refer to a related PR or issue link (optional)
