### PR TITLE
feat(streaming): enable lookup to scan from arrange keyspace

### DIFF
--- a/proto/stream_plan.proto
+++ b/proto/stream_plan.proto
@@ -143,6 +143,15 @@ message LookupNode {
   // By default, lookup executor will produce `<arrangement side, stream side>`. We
   // will then apply the column mapping to the combined result.
   repeated int32 column_mapping = 4;
+  // The fragment id of upstream arrangement
+  // TODO: record arrangements in catalog and use table_id
+  uint32 arrange_fragment_id = 5;
+  // Temporarily used when generating fragments on meta node. When generating lookup
+  // fragments, the global fragment id of upstream arrange won't be available. Therefore,
+  // we record local id here, and rewrite it into global id when sealing fragments.
+  uint32 arrange_local_fragment_id = 6;
+  // The operator id of upstream arrangement
+  uint64 arrange_operator_id = 7;
 }
 
 // Special node for shared state. Merge and align barrier from upstreams.

--- a/src/meta/src/stream/fragmenter.rs
+++ b/src/meta/src/stream/fragmenter.rs
@@ -14,6 +14,7 @@
 
 use std::collections::{BTreeMap, HashMap, VecDeque};
 use std::ops::Range;
+use std::sync::Arc;
 
 use itertools::Itertools;
 use risingwave_common::error::{ErrorCode, Result, RwError};
@@ -352,7 +353,7 @@ where
             self.hash_mapping.iter().unique().count() as u32
         };
 
-        let node = current_fragment.get_node();
+        let node = Arc::new(current_fragment.get_node().clone());
         let actor_ids = self
             .gen_actor_ids(parallel_degree)
             .into_iter()

--- a/src/meta/src/stream/rewrite/delta_join.rs
+++ b/src/meta/src/stream/rewrite/delta_join.rs
@@ -213,6 +213,7 @@ where
                 arrange_key: hash_join_node.left_key.clone(),
                 stream_key: hash_join_node.right_key.clone(),
                 use_current_epoch: false,
+                // will be filled later in StreamFragment::seal
                 arrange_fragment_id: u32::MAX,
                 arrange_local_fragment_id: arrange_0_frag.fragment_id.as_local_id(),
                 arrange_operator_id: arrange_0_frag.node.unwrap().operator_id,
@@ -227,6 +228,7 @@ where
                 arrange_key: hash_join_node.right_key.clone(),
                 stream_key: hash_join_node.left_key.clone(),
                 use_current_epoch: true,
+                // will be filled later in StreamFragment::seal
                 arrange_fragment_id: u32::MAX,
                 arrange_local_fragment_id: arrange_1_frag.fragment_id.as_local_id(),
                 arrange_operator_id: arrange_1_frag.node.unwrap().operator_id,

--- a/src/meta/src/stream/rewrite/delta_join.rs
+++ b/src/meta/src/stream/rewrite/delta_join.rs
@@ -213,6 +213,9 @@ where
                 arrange_key: hash_join_node.left_key.clone(),
                 stream_key: hash_join_node.right_key.clone(),
                 use_current_epoch: false,
+                arrange_fragment_id: u32::MAX,
+                arrange_local_fragment_id: arrange_0_frag.fragment_id.as_local_id(),
+                arrange_operator_id: arrange_0_frag.node.unwrap().operator_id,
                 column_mapping: vec![], // TODO: fill column mapping
             },
         );
@@ -224,6 +227,9 @@ where
                 arrange_key: hash_join_node.right_key.clone(),
                 stream_key: hash_join_node.left_key.clone(),
                 use_current_epoch: true,
+                arrange_fragment_id: u32::MAX,
+                arrange_local_fragment_id: arrange_1_frag.fragment_id.as_local_id(),
+                arrange_operator_id: arrange_1_frag.node.unwrap().operator_id,
                 column_mapping: vec![], // TODO: fill column mapping
             },
         );

--- a/src/stream/src/executor/mview/materialize.rs
+++ b/src/stream/src/executor/mview/materialize.rs
@@ -72,7 +72,7 @@ impl ExecutorBuilder for ArrangeExecutorBuilder {
     ) -> Result<Box<dyn Executor>> {
         let arrange_node = try_match_expand!(node.get_node().unwrap(), Node::ArrangeNode)?;
 
-        let keyspace = Keyspace::shared_executor_root(store, params.executor_id);
+        let keyspace = Keyspace::shared_executor_root(store, params.operator_id);
 
         // Set materialize keys as arrange key + pk
         let keys = arrange_node

--- a/src/stream/src/executor_v2/lookup.rs
+++ b/src/stream/src/executor_v2/lookup.rs
@@ -14,7 +14,7 @@
 
 use async_trait::async_trait;
 use futures::StreamExt;
-use risingwave_common::catalog::{ColumnDesc, Schema};
+use risingwave_common::catalog::{ColumnDesc, ColumnId, Schema};
 use risingwave_common::error::Result;
 use risingwave_common::try_match_expand;
 use risingwave_common::types::DataType;
@@ -25,7 +25,7 @@ use risingwave_storage::{Keyspace, StateStore};
 
 use crate::executor::{Executor as ExecutorV1, ExecutorBuilder};
 use crate::executor_v2::{Barrier, BoxedMessageStream, Executor, PkIndices, PkIndicesRef};
-use crate::task::{ExecutorParams, LocalStreamManagerCore};
+use crate::task::{unique_operator_id, ExecutorParams, LocalStreamManagerCore};
 
 mod sides;
 use self::sides::*;
@@ -109,6 +109,14 @@ impl ExecutorBuilder for LookupExecutorBuilder {
             .fields()
             .iter()
             .map(ColumnDesc::from_field_without_column_id)
+            .enumerate()
+            .map(|(idx, desc)| {
+                assert!(desc.field_descs.is_empty(), "sub-field not supported yet");
+                ColumnDesc {
+                    column_id: ColumnId::new(idx as i32),
+                    ..desc
+                }
+            })
             .collect();
 
         let arrangement_order_rules = node
@@ -117,11 +125,22 @@ impl ExecutorBuilder for LookupExecutorBuilder {
             .map(|x| OrderPair::new(*x as usize, OrderType::Ascending))
             .collect();
 
+        assert_ne!(
+            node.arrange_fragment_id,
+            u32::MAX,
+            "arrange fragment id is not available"
+        );
+        let arrangement_keyspace_id =
+            unique_operator_id(node.arrange_fragment_id, node.arrange_operator_id);
+
         Ok(Box::new(
             Box::new(LookupExecutor::new(LookupExecutorParams {
                 arrangement,
                 stream,
-                arrangement_keyspace: Keyspace::shared_executor_root(store, u64::MAX), // TODO: specify keyspace
+                arrangement_keyspace: Keyspace::shared_executor_root(
+                    store,
+                    arrangement_keyspace_id,
+                ),
                 arrangement_col_descs,
                 arrangement_order_rules,
                 pk_indices: params.pk_indices,

--- a/src/stream/src/executor_v2/lookup/sides.rs
+++ b/src/stream/src/executor_v2/lookup/sides.rs
@@ -81,6 +81,7 @@ pub(crate) struct ArrangeJoinSide<S: StateStore> {
 }
 
 /// Message from the `arrange_join_stream`.
+#[derive(Debug)]
 pub enum ArrangeMessage {
     /// Arrangement sides' update in this epoch. There will be only one arrange batch message
     /// within epoch. Once the executor receives an arrange batch message, it can start doing

--- a/src/stream/src/task/mod.rs
+++ b/src/stream/src/task/mod.rs
@@ -177,3 +177,15 @@ impl SharedContext {
         self.lock_channel_map().len() as u32
     }
 }
+
+/// Generate a globally unique executor id. Useful when constructing per-actor keyspace
+pub fn unique_executor_id(actor_id: u32, operator_id: u64) -> u64 {
+    assert!(operator_id <= u32::MAX as u64);
+    ((actor_id as u64) << 32) + operator_id
+}
+
+/// Generate a globally unique operator id. Useful when constructing per-fragment keyspace.
+pub fn unique_operator_id(fragment_id: u32, operator_id: u64) -> u64 {
+    assert!(operator_id <= u32::MAX as u64);
+    ((fragment_id as u64) << 32) + operator_id
+}


### PR DESCRIPTION
Signed-off-by: Alex Chi <iskyzh@gmail.com>

## What's changed and what's your intention?

Refactor meta to allow lookup executor to scan from arrangements. We store a fragment_id in lookup stream node.

## Checklist

- [x] I have written necessary docs and comments
- [x] I have added necessary unit tests and integration tests

## Refer to a related PR or issue link (optional)

close https://github.com/singularity-data/risingwave/issues/719