### PR TITLE
feat(array): introduce zero-cost data chunk row-iterator

### DIFF
--- a/src/batch/src/executor/join/nested_loop_join.rs
+++ b/src/batch/src/executor/join/nested_loop_join.rs
@@ -15,13 +15,14 @@
 use std::option::Option::Some;
 use std::sync::Arc;
 
+use itertools::Itertools;
 use risingwave_common::array::column::Column;
 use risingwave_common::array::data_chunk_iter::RowRef;
 use risingwave_common::array::{ArrayBuilderImpl, DataChunk, Row};
 use risingwave_common::catalog::Schema;
 use risingwave_common::error::ErrorCode::InternalError;
 use risingwave_common::error::{ErrorCode, Result};
-use risingwave_common::types::DataType;
+use risingwave_common::types::{DataType, DatumRef};
 use risingwave_common::util::chunk_coalesce::{DataChunkBuilder, SlicedDataChunk};
 use risingwave_expr::expr::{build_from_prost as expr_build_from_prost, BoxedExpression};
 use risingwave_pb::plan::plan_node::NodeBody;
@@ -165,25 +166,20 @@ impl Executor for NestedLoopJoinExecutor {
 }
 
 impl NestedLoopJoinExecutor {
-    /// Create constant data chunk (one tuple repeat `capacity` times).
-    fn convert_row_to_chunk(
+    /// Create constant data chunk (one tuple repeat `num_tuples` times).
+    fn convert_datum_refs_to_chunk(
         &self,
-        row_ref: &RowRef<'_>,
+        datum_refs: &[DatumRef<'_>],
         num_tuples: usize,
         data_types: &[DataType],
     ) -> Result<DataChunk> {
-        let num_columns = data_types.len();
         let mut output_array_builders = data_types
             .iter()
             .map(|data_type| data_type.create_array_builder(num_tuples))
             .collect::<Result<Vec<ArrayBuilderImpl>>>()?;
         for _i in 0..num_tuples {
-            for (col_idx, builder) in output_array_builders
-                .iter_mut()
-                .enumerate()
-                .take(num_columns)
-            {
-                builder.append_datum_ref(row_ref.value_at(col_idx))?;
+            for (builder, datum_ref) in output_array_builders.iter_mut().zip(datum_refs) {
+                builder.append_datum_ref(*datum_ref)?;
             }
         }
 
@@ -194,6 +190,17 @@ impl NestedLoopJoinExecutor {
             .collect::<Result<Vec<Column>>>()?;
 
         Ok(DataChunk::builder().columns(result_columns).build())
+    }
+
+    /// Create constant data chunk (one tuple repeat `num_tuples` times).
+    fn convert_row_to_chunk(
+        &self,
+        row_ref: &RowRef<'_>,
+        num_tuples: usize,
+        data_types: &[DataType],
+    ) -> Result<DataChunk> {
+        let datum_refs = row_ref.values().collect_vec();
+        self.convert_datum_refs_to_chunk(&datum_refs, num_tuples, data_types)
     }
 }
 
@@ -392,12 +399,17 @@ impl NestedLoopJoinExecutor {
         // find any match.
         if ret.cur_row_finished && !self.probe_side_source.get_cur_row_matched() {
             assert!(ret.chunk.is_none());
-            let mut probe_row = self.probe_side_source.get_current_row_ref().unwrap();
+            let mut probe_datum_refs = self
+                .probe_side_source
+                .get_current_row_ref()
+                .unwrap()
+                .values()
+                .collect_vec();
             for _ in 0..self.build_table.get_schema().fields.len() {
-                probe_row.0.push(None);
+                probe_datum_refs.push(None);
             }
             let one_row_chunk =
-                self.convert_row_to_chunk(&probe_row, 1, &self.schema.data_types())?;
+                self.convert_datum_refs_to_chunk(&probe_datum_refs, 1, &self.schema.data_types())?;
             return Ok(ProbeResult {
                 cur_row_finished: true,
                 chunk: Some(one_row_chunk),
@@ -509,13 +521,16 @@ impl NestedLoopJoinExecutor {
                 .build_table
                 .is_build_matched(self.build_table.get_current_row_id())?
             {
-                let mut cur_row_vec = cur_row.0;
-                for _ in 0..self.probe_side_source.get_schema().fields.len() {
-                    cur_row_vec.insert(0, None);
-                }
+                let datum_refs = std::iter::repeat(None)
+                    .take(self.probe_side_source.get_schema().len())
+                    .chain(cur_row.values());
+                // let mut cur_row_vec = cur_row.0;
+                // for _ in 0..self.probe_side_source.get_schema().fields.len() {
+                //     cur_row_vec.insert(0, None);
+                // }
                 if let Some(ret_chunk) = self
                     .chunk_builder
-                    .append_one_row_ref(RowRef::new(cur_row_vec))?
+                    .append_one_row_from_datum_refs(datum_refs)?
                 {
                     return Ok(Some(ret_chunk));
                 }
@@ -635,7 +650,7 @@ mod tests {
     /// Test the function of convert row into constant row chunk (one row repeat multiple times).
     #[test]
     fn test_convert_row_to_chunk() {
-        let row = RowRef::new(vec![Some(ScalarRefImpl::Int32(3))]);
+        let row = vec![Some(ScalarRefImpl::Int32(3))];
         let probe_side_schema = Schema {
             fields: vec![Field::unnamed(DataType::Int32)],
         };
@@ -658,7 +673,7 @@ mod tests {
             identity: "NestedLoopJoinExecutor".to_string(),
         };
         let const_row_chunk = source
-            .convert_row_to_chunk(&row, 5, &probe_side_schema.data_types())
+            .convert_datum_refs_to_chunk(&row, 5, &probe_side_schema.data_types())
             .unwrap();
         assert_eq!(const_row_chunk.capacity(), 5);
         assert_eq!(

--- a/src/batch/src/executor/join/nested_loop_join.rs
+++ b/src/batch/src/executor/join/nested_loop_join.rs
@@ -178,7 +178,7 @@ impl NestedLoopJoinExecutor {
             .map(|data_type| data_type.create_array_builder(num_tuples))
             .collect::<Result<Vec<ArrayBuilderImpl>>>()?;
         for _i in 0..num_tuples {
-            for (builder, datum_ref) in output_array_builders.iter_mut().zip(datum_refs) {
+            for (builder, datum_ref) in output_array_builders.iter_mut().zip_eq(datum_refs) {
                 builder.append_datum_ref(*datum_ref)?;
             }
         }

--- a/src/batch/src/executor/join/nested_loop_join.rs
+++ b/src/batch/src/executor/join/nested_loop_join.rs
@@ -482,7 +482,7 @@ impl NestedLoopJoinExecutor {
                     if !self.build_table.is_build_matched(row_id)?
                         && self.join_type == JoinType::RightSemi
                     {
-                        rows_ref.push(row_ref.row_by_slice(
+                        rows_ref.push(row_ref.row_by_indices(
                             &(self.probe_side_schema.len()..row_ref.size()).collect::<Vec<usize>>(),
                         ));
                     }
@@ -524,10 +524,6 @@ impl NestedLoopJoinExecutor {
                 let datum_refs = std::iter::repeat(None)
                     .take(self.probe_side_source.get_schema().len())
                     .chain(cur_row.values());
-                // let mut cur_row_vec = cur_row.0;
-                // for _ in 0..self.probe_side_source.get_schema().fields.len() {
-                //     cur_row_vec.insert(0, None);
-                // }
                 if let Some(ret_chunk) = self
                     .chunk_builder
                     .append_one_row_from_datum_refs(datum_refs)?

--- a/src/batch/src/executor/join/sort_merge_join.rs
+++ b/src/batch/src/executor/join/sort_merge_join.rs
@@ -18,6 +18,7 @@ use risingwave_common::array::{DataChunk, Row, RowRef};
 use risingwave_common::catalog::Schema;
 use risingwave_common::error::ErrorCode;
 use risingwave_common::error::ErrorCode::InternalError;
+use risingwave_common::types::to_datum_ref;
 use risingwave_common::util::chunk_coalesce::DataChunkBuilder;
 use risingwave_common::util::sort_util::OrderType;
 use risingwave_pb::plan::plan_node::NodeBody;
@@ -81,9 +82,15 @@ impl Executor for SortMergeJoinExecutor {
                         let build_row = &self.last_join_results[self.last_join_results_write_idx];
                         self.last_join_results_write_idx += 1;
                         // Concatenate to get the final join results.
-                        let join_row =
-                            Self::combine_two_row_ref(cur_probe_row.clone(), build_row.into());
-                        if let Some(ret_chunk) = self.chunk_builder.append_one_row_ref(join_row)? {
+                        let datum_refs = cur_probe_row
+                            .values()
+                            .chain(build_row.0.iter().map(to_datum_ref));
+                        // let join_row =
+                        //     Self::combine_two_row_ref(cur_probe_row.clone(), build_row.into());
+                        if let Some(ret_chunk) = self
+                            .chunk_builder
+                            .append_one_row_from_datum_refs(datum_refs)?
+                        {
                             return Ok(Some(ret_chunk));
                         }
                     }
@@ -104,16 +111,8 @@ impl Executor for SortMergeJoinExecutor {
 
             match (cur_probe_row_opt, cur_build_row_opt) {
                 (Some(cur_probe_row_ref), Some(cur_build_row_ref)) => {
-                    let probe_key = Row::from(
-                        cur_probe_row_ref
-                            .value_by_slice(&self.probe_key_idxs)
-                            .clone(),
-                    );
-                    let build_key = Row::from(
-                        cur_build_row_ref
-                            .value_by_slice(&self.build_key_idxs)
-                            .clone(),
-                    );
+                    let probe_key = cur_probe_row_ref.row_by_slice(&self.probe_key_idxs);
+                    let build_key = cur_build_row_ref.row_by_slice(&self.build_key_idxs);
 
                     // TODO: [`Row`] may not be PartialOrd. May use some trait like
                     // [`ScalarPartialOrd`].
@@ -151,12 +150,12 @@ impl Executor for SortMergeJoinExecutor {
                             // Matched rows. Write into chunk builder and maintain last join
                             // results.
                             self.last_join_results
-                                .push(cur_build_row_ref.clone().into());
-                            let join_row = Self::combine_two_row_ref(
-                                cur_probe_row_ref.clone(),
-                                cur_build_row_ref.clone(),
-                            );
-                            let ret = self.chunk_builder.append_one_row_ref(join_row.clone())?;
+                                .push(cur_build_row_ref.to_owned_row());
+                            let join_datum_refs =
+                                cur_probe_row_ref.values().chain(cur_build_row_ref.values());
+                            let ret = self
+                                .chunk_builder
+                                .append_one_row_from_datum_refs(join_datum_refs)?;
                             self.build_side_source.advance_row();
                             if let Some(ret_chunk) = ret {
                                 return Ok(Some(ret_chunk));
@@ -166,11 +165,8 @@ impl Executor for SortMergeJoinExecutor {
                 }
 
                 (Some(cur_probe_row_ref), None) => {
-                    self.last_probe_key = Some(
-                        cur_probe_row_ref
-                            .value_by_slice(&self.probe_key_idxs)
-                            .into(),
-                    );
+                    self.last_probe_key =
+                        Some(cur_probe_row_ref.row_by_slice(&self.probe_key_idxs));
                     self.probe_side_source.advance_row();
                 }
                 // Once probe row is None, consume all results or terminate.
@@ -229,17 +225,8 @@ impl SortMergeJoinExecutor {
             .clone()
             .zip(cur_row)
             .map_or(false, |(row1, row2)| {
-                row1 == row2.value_by_slice(&self.probe_key_idxs).into()
+                row1 == row2.row_by_slice(&self.probe_key_idxs)
             })
-    }
-
-    fn combine_two_row_ref<'a>(left_row: RowRef<'a>, right_row: RowRef<'a>) -> RowRef<'a> {
-        let row_vec = left_row
-            .0
-            .into_iter()
-            .chain(right_row.0.into_iter())
-            .collect::<Vec<_>>();
-        RowRef::new(row_vec)
     }
 }
 

--- a/src/batch/src/executor/join/sort_merge_join.rs
+++ b/src/batch/src/executor/join/sort_merge_join.rs
@@ -85,8 +85,6 @@ impl Executor for SortMergeJoinExecutor {
                         let datum_refs = cur_probe_row
                             .values()
                             .chain(build_row.0.iter().map(to_datum_ref));
-                        // let join_row =
-                        //     Self::combine_two_row_ref(cur_probe_row.clone(), build_row.into());
                         if let Some(ret_chunk) = self
                             .chunk_builder
                             .append_one_row_from_datum_refs(datum_refs)?
@@ -111,8 +109,8 @@ impl Executor for SortMergeJoinExecutor {
 
             match (cur_probe_row_opt, cur_build_row_opt) {
                 (Some(cur_probe_row_ref), Some(cur_build_row_ref)) => {
-                    let probe_key = cur_probe_row_ref.row_by_slice(&self.probe_key_idxs);
-                    let build_key = cur_build_row_ref.row_by_slice(&self.build_key_idxs);
+                    let probe_key = cur_probe_row_ref.row_by_indices(&self.probe_key_idxs);
+                    let build_key = cur_build_row_ref.row_by_indices(&self.build_key_idxs);
 
                     // TODO: [`Row`] may not be PartialOrd. May use some trait like
                     // [`ScalarPartialOrd`].
@@ -166,7 +164,7 @@ impl Executor for SortMergeJoinExecutor {
 
                 (Some(cur_probe_row_ref), None) => {
                     self.last_probe_key =
-                        Some(cur_probe_row_ref.row_by_slice(&self.probe_key_idxs));
+                        Some(cur_probe_row_ref.row_by_indices(&self.probe_key_idxs));
                     self.probe_side_source.advance_row();
                 }
                 // Once probe row is None, consume all results or terminate.
@@ -225,7 +223,7 @@ impl SortMergeJoinExecutor {
             .clone()
             .zip(cur_row)
             .map_or(false, |(row1, row2)| {
-                row1 == row2.row_by_slice(&self.probe_key_idxs)
+                row1 == row2.row_by_indices(&self.probe_key_idxs)
             })
     }
 }

--- a/src/common/src/array/data_chunk.rs
+++ b/src/common/src/array/data_chunk.rs
@@ -383,10 +383,7 @@ impl DataChunk {
     /// # Arguments
     /// * `pos` - Index of look up tuple
     pub fn row_at_unchecked_vis(&self, pos: usize) -> RowRef<'_> {
-        RowRef {
-            chunk: self,
-            idx: pos,
-        }
+        RowRef::new(self, pos)
     }
 
     /// `to_pretty_string` returns a table-like text representation of the `DataChunk`.

--- a/src/common/src/array/data_chunk.rs
+++ b/src/common/src/array/data_chunk.rs
@@ -21,7 +21,7 @@ use itertools::Itertools;
 use risingwave_pb::data::DataChunk as ProstDataChunk;
 
 use crate::array::column::Column;
-use crate::array::data_chunk_iter::{DataChunkRefIter, Row, RowRef};
+use crate::array::data_chunk_iter::{Row, RowRef};
 use crate::array::{ArrayBuilderImpl, ArrayImpl};
 use crate::buffer::Bitmap;
 use crate::error::{Result, RwError};
@@ -364,11 +364,6 @@ impl DataChunk {
             .collect_vec())
     }
 
-    /// Get an iterator for visible rows.
-    pub fn rows(&self) -> DataChunkRefIter<'_> {
-        DataChunkRefIter::new(self)
-    }
-
     /// Random access a tuple in a data chunk. Return in a row format.
     /// # Arguments
     /// * `pos` - Index of look up tuple
@@ -388,11 +383,10 @@ impl DataChunk {
     /// # Arguments
     /// * `pos` - Index of look up tuple
     pub fn row_at_unchecked_vis(&self, pos: usize) -> RowRef<'_> {
-        let mut row = Vec::with_capacity(self.columns.len());
-        for column in &self.columns {
-            row.push(column.array_ref().value_at(pos));
+        RowRef {
+            chunk: self,
+            idx: pos,
         }
-        RowRef::new(row)
     }
 
     /// `to_pretty_string` returns a table-like text representation of the `DataChunk`.
@@ -402,8 +396,7 @@ impl DataChunk {
         table.load_preset("||--+-++|    ++++++\n");
         for row in self.rows() {
             let cells: Vec<_> = row
-                .0
-                .iter()
+                .values()
                 .map(|v| {
                     match v {
                         None => "".to_owned(), // null

--- a/src/common/src/array/data_chunk_iter.rs
+++ b/src/common/src/array/data_chunk_iter.rs
@@ -17,6 +17,7 @@ use std::ops;
 
 use itertools::Itertools;
 
+use super::column::Column;
 use crate::array::DataChunk;
 use crate::types::{
     deserialize_datum_from, deserialize_datum_not_null_from, serialize_datum_into,
@@ -24,85 +25,145 @@ use crate::types::{
 };
 use crate::util::sort_util::OrderType;
 
-pub struct DataChunkRefIter<'a> {
+impl DataChunk {
+    /// Get an iterator for visible rows.
+    pub fn rows(&self) -> impl Iterator<Item = RowRef> {
+        DataChunkRefIter {
+            chunk: self,
+            idx: 0,
+        }
+    }
+}
+
+struct DataChunkRefIter<'a> {
     chunk: &'a DataChunk,
     idx: usize,
 }
 
-/// Data Chunk iter only iterate visible tuples.
 impl<'a> Iterator for DataChunkRefIter<'a> {
     type Item = RowRef<'a>;
 
     fn next(&mut self) -> Option<Self::Item> {
-        loop {
-            if self.idx >= self.chunk.capacity() {
-                return None;
+        match self.chunk.visibility() {
+            Some(bitmap) => {
+                loop {
+                    let idx = self.idx;
+                    if idx >= self.chunk.capacity() {
+                        return None;
+                    }
+                    // SAFETY: idx is checked.
+                    let vis = unsafe { bitmap.is_set_unchecked(idx) };
+                    self.idx += 1;
+                    if vis {
+                        return Some(RowRef {
+                            chunk: self.chunk,
+                            idx,
+                        });
+                    }
+                }
             }
-            let (cur_val, vis) = self.chunk.row_at(self.idx).ok()?;
-            self.idx += 1;
-            if vis {
-                return Some(cur_val);
+            None => {
+                let idx = self.idx;
+                if idx >= self.chunk.capacity() {
+                    return None;
+                }
+                self.idx += 1;
+                Some(RowRef {
+                    chunk: self.chunk,
+                    idx,
+                })
             }
         }
     }
 }
 
-impl<'a> DataChunkRefIter<'a> {
-    pub fn new(chunk: &'a DataChunk) -> Self {
-        Self { chunk, idx: 0 }
+pub struct RowRef<'a> {
+    pub(super) chunk: &'a DataChunk,
+    pub(super) idx: usize,
+}
+
+impl<'a> std::fmt::Debug for RowRef<'a> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_list().entries(self.values()).finish()
     }
 }
 
-#[derive(Debug, PartialEq, Clone)]
-pub struct RowRef<'a>(pub Vec<DatumRef<'a>>);
-
 impl<'a> RowRef<'a> {
-    pub fn new(values: Vec<DatumRef<'a>>) -> Self {
-        Self(values)
-    }
-
-    pub fn value_at(&self, pos: usize) -> DatumRef<'a> {
-        self.0[pos]
+    pub fn value_at(&self, pos: usize) -> DatumRef<'_> {
+        debug_assert!(self.idx < self.chunk.capacity());
+        // TODO: It's safe to use value_at_unchecked here.
+        self.chunk.columns()[pos].array_ref().value_at(self.idx)
     }
 
     pub fn size(&self) -> usize {
-        self.0.len()
+        self.chunk.columns().len()
+    }
+
+    pub fn values<'b>(&'b self) -> impl Iterator<Item = DatumRef<'a>>
+    where
+        'a: 'b,
+    {
+        debug_assert!(self.idx < self.chunk.capacity());
+        RowRefIter::<'a> {
+            columns: self.chunk.columns().iter(),
+            row_idx: self.idx,
+        }
+    }
+
+    pub fn to_owned_row(&self) -> Row {
+        Row(self.values().map(ToOwnedDatum::to_owned_datum).collect())
     }
 
     /// Get `Row` by slice of index from current row ref.
     pub fn row_by_slice(&self, indices: &[usize]) -> Row {
         Row(indices
             .iter()
-            .map(|idx| self.0[*idx].to_owned_datum())
+            .map(|&idx| self.value_at(idx).to_owned_datum())
             .collect_vec())
     }
 
-    /// Get value by slice of index from current row ref.
-    pub fn value_by_slice(&self, idxs: &[usize]) -> RowRef<'_> {
-        let mut row_vec = vec![];
-        for idx in idxs {
-            row_vec.push(self.value_at(*idx));
-        }
-        RowRef::new(row_vec)
+    pub fn project<'b, 'c>(&'b self, indices: &'c [usize]) -> impl Iterator<Item = DatumRef<'c>>
+    where
+        'a: 'b,
+        'b: 'c,
+    {
+        indices.iter().map(|&idx| self.value_at(idx))
+    }
+
+    // /// Get value by slice of index from current row ref.
+    // pub fn value_by_slice(&self, idxs: &[usize]) -> RowRef<'_> {
+    //     let mut row_vec = vec![];
+    //     for idx in idxs {
+    //         row_vec.push(self.value_at(*idx));
+    //     }
+    //     RowRef::new(row_vec)
+    // }
+}
+
+impl<'a> PartialEq for RowRef<'a> {
+    fn eq(&self, other: &Self) -> bool {
+        self.values()
+            .zip_longest(other.values())
+            .all(|pair| pair.both().map(|(a, b)| a == b).unwrap_or(false))
     }
 }
 
-impl<'a> From<&'a Row> for RowRef<'a> {
-    fn from(row: &'a Row) -> Self {
-        RowRef(
-            row.0
-                .iter()
-                .map(|datum| datum.as_ref().map(|v| v.as_scalar_ref_impl()))
-                .collect::<Vec<_>>(),
-        )
-    }
+impl<'a> Eq for RowRef<'a> {}
+
+#[derive(Clone)]
+struct RowRefIter<'a> {
+    columns: std::slice::Iter<'a, Column>,
+    row_idx: usize,
 }
 
-impl<'a> ops::Index<usize> for RowRef<'a> {
-    type Output = DatumRef<'a>;
+impl<'a> Iterator for RowRefIter<'a> {
+    type Item = DatumRef<'a>;
 
-    fn index(&self, index: usize) -> &Self::Output {
-        &self.0[index]
+    fn next(&mut self) -> Option<Self::Item> {
+        // TODO: It's safe to use value_at_unchecked here.
+        self.columns
+            .next()
+            .map(|col| col.array_ref().value_at(self.row_idx))
     }
 }
 
@@ -119,11 +180,7 @@ impl ops::Index<usize> for Row {
 
 impl From<RowRef<'_>> for Row {
     fn from(row_ref: RowRef<'_>) -> Self {
-        Row(row_ref
-            .0
-            .into_iter()
-            .map(ToOwnedDatum::to_owned_datum)
-            .collect::<Vec<_>>())
+        row_ref.to_owned_row()
     }
 }
 

--- a/src/common/src/array/data_chunk_iter.rs
+++ b/src/common/src/array/data_chunk_iter.rs
@@ -78,8 +78,9 @@ impl<'a> Iterator for DataChunkRefIter<'a> {
 }
 
 pub struct RowRef<'a> {
-    pub(super) chunk: &'a DataChunk,
-    pub(super) idx: usize,
+    chunk: &'a DataChunk,
+
+    idx: usize,
 }
 
 impl<'a> std::fmt::Debug for RowRef<'a> {
@@ -89,6 +90,11 @@ impl<'a> std::fmt::Debug for RowRef<'a> {
 }
 
 impl<'a> RowRef<'a> {
+    pub fn new(chunk: &'a DataChunk, idx: usize) -> Self {
+        debug_assert!(idx < chunk.capacity());
+        Self { chunk, idx }
+    }
+
     pub fn value_at(&self, pos: usize) -> DatumRef<'_> {
         debug_assert!(self.idx < self.chunk.capacity());
         // TODO: It's safe to use value_at_unchecked here.

--- a/src/common/src/array/list_array.rs
+++ b/src/common/src/array/list_array.rs
@@ -26,7 +26,7 @@ use super::{
 };
 use crate::buffer::{Bitmap, BitmapBuilder};
 use crate::error::Result;
-use crate::types::{DataType, Datum, DatumRef, Scalar, ScalarRefImpl};
+use crate::types::{to_datum_ref, DataType, Datum, DatumRef, Scalar, ScalarRefImpl};
 
 /// This is a naive implementation of list array.
 /// We will eventually move to a more efficient flatten implementation.
@@ -294,11 +294,7 @@ impl<'a> ListRef<'a> {
             ListRef::Indexed { arr, idx } => (arr.offsets[*idx]..arr.offsets[*idx + 1])
                 .map(|o| arr.value.value_at(o))
                 .collect(),
-            ListRef::ValueRef { val } => val
-                .values
-                .iter()
-                .map(|d| d.as_ref().map(|s| s.as_scalar_ref_impl()))
-                .collect::<Vec<DatumRef<'a>>>(),
+            ListRef::ValueRef { val } => val.values.iter().map(to_datum_ref).collect(),
         }
     }
 }

--- a/src/common/src/array/struct_array.rs
+++ b/src/common/src/array/struct_array.rs
@@ -26,7 +26,7 @@ use super::{
 };
 use crate::buffer::{Bitmap, BitmapBuilder};
 use crate::error::Result;
-use crate::types::{DataType, Datum, DatumRef, Scalar, ScalarRefImpl};
+use crate::types::{to_datum_ref, DataType, Datum, DatumRef, Scalar, ScalarRefImpl};
 
 /// This is a naive implementation of struct array.
 /// We will eventually move to a more efficient flatten implementation.
@@ -297,11 +297,7 @@ impl<'a> StructRef<'a> {
             StructRef::Indexed { arr, idx } => {
                 arr.children.iter().map(|a| a.value_at(*idx)).collect()
             }
-            StructRef::ValueRef { val } => val
-                .fields
-                .iter()
-                .map(|d| d.as_ref().map(|s| s.as_scalar_ref_impl()))
-                .collect::<Vec<DatumRef<'a>>>(),
+            StructRef::ValueRef { val } => val.fields.iter().map(to_datum_ref).collect(),
         }
     }
 }

--- a/src/common/src/types/mod.rs
+++ b/src/common/src/types/mod.rs
@@ -302,6 +302,10 @@ for_all_scalar_variants! { scalar_impl_enum }
 pub type Datum = Option<ScalarImpl>;
 pub type DatumRef<'a> = Option<ScalarRefImpl<'a>>;
 
+pub fn to_datum_ref(datum: &Datum) -> DatumRef<'_> {
+    datum.as_ref().map(|d| d.as_scalar_ref_impl())
+}
+
 // TODO: specify `NULL FIRST` or `NULL LAST`.
 pub fn serialize_datum_ref_into(
     datum_ref: &DatumRef,

--- a/src/common/src/types/mod.rs
+++ b/src/common/src/types/mod.rs
@@ -302,6 +302,7 @@ for_all_scalar_variants! { scalar_impl_enum }
 pub type Datum = Option<ScalarImpl>;
 pub type DatumRef<'a> = Option<ScalarRefImpl<'a>>;
 
+/// Convert a [`Datum`] to a [`DatumRef`].
 pub fn to_datum_ref(datum: &Datum) -> DatumRef<'_> {
     datum.as_ref().map(|d| d.as_scalar_ref_impl())
 }

--- a/src/common/src/util/ordered/mod.rs
+++ b/src/common/src/util/ordered/mod.rs
@@ -20,7 +20,7 @@ use itertools::Itertools;
 use OrderedDatum::{NormalOrder, ReversedOrder};
 
 pub use self::serde::*;
-use crate::array::{Row, RowRef};
+use crate::array::Row;
 use crate::types::{serialize_datum_into, Datum};
 use crate::util::sort_util::OrderType;
 
@@ -58,21 +58,6 @@ impl OrderedRow {
                 ReversedOrder(datum) => datum.0,
             })
             .collect::<Vec<_>>())
-    }
-
-    pub fn as_row_ref(&self) -> RowRef<'_> {
-        let datum_refs = self
-            .0
-            .iter()
-            .map(|ordered_datum| {
-                let datum = match ordered_datum {
-                    NormalOrder(datum) => datum,
-                    ReversedOrder(datum) => &datum.0,
-                };
-                datum.as_ref().map(|scalar| scalar.as_scalar_ref_impl())
-            })
-            .collect::<Vec<_>>();
-        RowRef(datum_refs)
     }
 
     /// Serialize the row into a memcomparable bytes.

--- a/src/common/src/util/ordered/serde.rs
+++ b/src/common/src/util/ordered/serde.rs
@@ -19,11 +19,11 @@ use memcomparable::from_slice;
 
 use super::OrderedDatum::{NormalOrder, ReversedOrder};
 use super::OrderedRow;
-use crate::array::{ArrayImpl, Row, RowRef};
+use crate::array::{ArrayImpl, Row};
 use crate::catalog::ColumnId;
 use crate::error::Result;
 use crate::types::{
-    deserialize_datum_from, serialize_datum_into, serialize_datum_ref_into, DataType,
+    deserialize_datum_from, serialize_datum_into, serialize_datum_ref_into, DataType, DatumRef,
 };
 use crate::util::sort_util::{OrderPair, OrderType};
 use crate::util::value_encoding::serialize_cell;
@@ -83,11 +83,15 @@ impl OrderedRowSerializer {
         }
     }
 
-    pub fn serialize_row_ref(&self, row: &RowRef<'_>, append_to: &mut Vec<u8>) {
-        for (datum, order_type) in row.0.iter().zip_eq(self.order_types.iter()) {
+    pub fn serialize_row_ref<'a>(
+        &self,
+        datum_refs: impl Iterator<Item = DatumRef<'a>>,
+        append_to: &mut Vec<u8>,
+    ) {
+        for (datum, order_type) in datum_refs.zip_eq(self.order_types.iter()) {
             let mut serializer = memcomparable::Serializer::new(vec![]);
             serializer.set_reverse(*order_type == OrderType::Descending);
-            serialize_datum_ref_into(datum, &mut serializer).unwrap();
+            serialize_datum_ref_into(&datum, &mut serializer).unwrap();
             append_to.extend(serializer.into_inner());
         }
     }

--- a/src/frontend/src/handler/util.rs
+++ b/src/frontend/src/handler/util.rs
@@ -50,7 +50,7 @@ pub fn to_pg_rows(chunk: DataChunk) -> Vec<Row> {
         .rows()
         .map(|r| {
             Row::new(
-                r.0.into_iter()
+                r.values()
                     .map(|data| data.map(pg_value_format))
                     .collect_vec(),
             )

--- a/src/stream/src/common/builder.rs
+++ b/src/stream/src/common/builder.rs
@@ -66,7 +66,7 @@ impl StreamChunkBuilder {
     pub fn append_row(&mut self, op: Op, row_update: &RowRef<'_>, row_matched: &Row) -> Result<()> {
         self.ops.push(op);
         for i in 0..row_update.size() {
-            self.column_builders[i + self.update_start_pos].append_datum_ref(row_update[i])?;
+            self.column_builders[i + self.update_start_pos].append_datum_ref(row_update.value_at(i))?;
         }
         for i in 0..row_matched.size() {
             self.column_builders[i + self.matched_start_pos].append_datum(&row_matched[i])?;
@@ -78,7 +78,7 @@ impl StreamChunkBuilder {
     pub fn append_row_update(&mut self, op: Op, row_update: &RowRef<'_>) -> Result<()> {
         self.ops.push(op);
         for i in 0..row_update.size() {
-            self.column_builders[i + self.update_start_pos].append_datum_ref(row_update[i])?;
+            self.column_builders[i + self.update_start_pos].append_datum_ref(row_update.value_at(i))?;
         }
         for i in 0..self.column_builders.len() - row_update.size() {
             self.column_builders[i + self.matched_start_pos].append_datum(&None)?;

--- a/src/stream/src/common/builder.rs
+++ b/src/stream/src/common/builder.rs
@@ -88,7 +88,8 @@ impl StreamChunkBuilder {
     ) -> Result<Option<StreamChunk>> {
         self.ops.push(op);
         for i in 0..row_update.size() {
-            self.column_builders[i + self.update_start_pos].append_datum_ref(row_update[i])?;
+            self.column_builders[i + self.update_start_pos]
+                .append_datum_ref(row_update.value_at(i))?;
         }
         for i in 0..row_matched.size() {
             self.column_builders[i + self.matched_start_pos].append_datum(&row_matched[i])?;
@@ -109,7 +110,8 @@ impl StreamChunkBuilder {
     pub fn append_row(&mut self, op: Op, row_update: &RowRef<'_>, row_matched: &Row) -> Result<()> {
         self.ops.push(op);
         for i in 0..row_update.size() {
-            self.column_builders[i + self.update_start_pos].append_datum_ref(row_update.value_at(i))?;
+            self.column_builders[i + self.update_start_pos]
+                .append_datum_ref(row_update.value_at(i))?;
         }
         for i in 0..row_matched.size() {
             self.column_builders[i + self.matched_start_pos].append_datum(&row_matched[i])?;
@@ -121,7 +123,8 @@ impl StreamChunkBuilder {
     pub fn append_row_update(&mut self, op: Op, row_update: &RowRef<'_>) -> Result<()> {
         self.ops.push(op);
         for i in 0..row_update.size() {
-            self.column_builders[i + self.update_start_pos].append_datum_ref(row_update.value_at(i))?;
+            self.column_builders[i + self.update_start_pos]
+                .append_datum_ref(row_update.value_at(i))?;
         }
         for i in 0..self.column_builders.len() - row_update.size() {
             self.column_builders[i + self.matched_start_pos].append_datum(&None)?;

--- a/src/stream/src/executor/hash_join.rs
+++ b/src/stream/src/executor/hash_join.rs
@@ -418,18 +418,11 @@ impl<S: StateStore, const T: JoinTypePrimitive> HashJoinExecutor<S, T> {
     }
 
     fn hash_key_from_row_ref(row: &RowRef, key_indices: &[usize]) -> HashKeyType {
-        let key = key_indices
-            .iter()
-            .map(|idx| row[*idx].to_owned_datum())
-            .collect_vec();
+        let key = row
+            .project(key_indices)
+            .map(ToOwnedDatum::to_owned_datum)
+            .collect();
         Row(key)
-    }
-
-    fn row_from_row_ref(row: &RowRef) -> Row {
-        let value = (0..row.size())
-            .map(|idx| row[idx].to_owned_datum())
-            .collect_vec();
-        Row(value)
     }
 
     fn pk_from_row_ref(row: &RowRef, pk_indices: &[usize]) -> Row {
@@ -443,8 +436,8 @@ impl<S: StateStore, const T: JoinTypePrimitive> HashJoinExecutor<S, T> {
         matched_start_pos: usize,
     ) -> Row {
         let mut new_row = vec![None; row_update.size() + row_matched.size()];
-        for i in 0..row_update.size() {
-            new_row[i + update_start_pos] = row_update[i].to_owned_datum();
+        for (i, datum_ref) in row_update.values().enumerate() {
+            new_row[i + update_start_pos] = datum_ref.to_owned_datum();
         }
         for i in 0..row_matched.size() {
             new_row[i + matched_start_pos] = row_matched[i].clone();
@@ -508,7 +501,7 @@ impl<S: StateStore, const T: JoinTypePrimitive> HashJoinExecutor<S, T> {
 
         for (row, op) in data_chunk.rows().zip_eq(ops.iter()) {
             let key = Self::hash_key_from_row_ref(&row, &side_update.key_indices);
-            let value = Self::row_from_row_ref(&row);
+            let value = row.to_owned_row();
             let pk = Self::pk_from_row_ref(&row, &side_update.pk_indices);
             let matched_rows = Self::hash_eq_match(&key, &mut side_match.ht).await;
             if let Some(matched_rows) = matched_rows {

--- a/src/stream/src/executor_v2/lookup/impl_.rs
+++ b/src/stream/src/executor_v2/lookup/impl_.rs
@@ -281,18 +281,19 @@ impl<S: StateStore> LookupExecutor<S> {
 
         // Serialize join key to a state store key.
         let key_prefix = {
-            let row = RowRef(
-                self.arrangement
-                    .join_key_indices
-                    .iter()
-                    .map(|x| row.0[*x])
-                    .collect_vec(),
-            );
-            tracing::trace!(target: "events::stream::lookup::one_row", "{:?}", row);
+            let row = row.project(&self.arrangement.join_key_indices);
+            // let row = RowRef(
+            //     self.arrangement
+            //         .join_key_indices
+            //         .iter()
+            //         .map(|x| row.0[*x])
+            //         .collect_vec(),
+            // );
+            // tracing::trace!(target: "events::stream::lookup::one_row", "{:?}", row);
             let mut key_prefix = vec![];
             self.arrangement
                 .serializer
-                .serialize_row_ref(&row, &mut key_prefix);
+                .serialize_row_ref(row, &mut key_prefix);
             key_prefix
         };
 

--- a/src/stream/src/executor_v2/lookup/impl_.rs
+++ b/src/stream/src/executor_v2/lookup/impl_.rs
@@ -284,19 +284,13 @@ impl<S: StateStore> LookupExecutor<S> {
 
         // Serialize join key to a state store key.
         let key_prefix = {
-            let row = row.project(&self.arrangement.join_key_indices);
-            // let row = RowRef(
-            //     self.arrangement
-            //         .join_key_indices
-            //         .iter()
-            //         .map(|x| row.0[*x])
-            //         .collect_vec(),
-            // );
-            // tracing::trace!(target: "events::stream::lookup::one_row", "{:?}", row);
+            tracing::trace!(target: "events::stream::lookup::one_row", "{:?}", row.row_by_indices(&self.arrangement.join_key_indices));
+
+            let row = row.datum_refs_by_indices(&self.arrangement.join_key_indices);
             let mut key_prefix = vec![];
             self.arrangement
                 .serializer
-                .serialize_row_ref(row, &mut key_prefix);
+                .serialize_datum_refs(row, &mut key_prefix);
             key_prefix
         };
 

--- a/src/stream/src/executor_v2/top_n_executor.rs
+++ b/src/stream/src/executor_v2/top_n_executor.rs
@@ -120,7 +120,7 @@ pub(crate) fn generate_output(
         let mut data_chunk_builder = DataChunkBuilder::new_with_default_size(schema.data_types());
         for row in &new_rows {
             data_chunk_builder
-                .append_one_row_ref(row.into())
+                .append_one_row_from_datums(row.0.iter())
                 .map_err(StreamExecutorError::eval_error)?;
         }
         // since `new_rows` is not empty, we unwrap directly


### PR DESCRIPTION
## What's changed and what's your intention?

This PR introduces a zero-cost row-iterator for `DataChunk`, like what we did in #1818.

https://github.com/singularity-data/risingwave/blob/62fb15b87f1ccbf97fb8f61554862a3eb7b722c7/src/common/src/array/data_chunk_iter.rs#L28-L41

There're lots of usages that rely on "the `RowRef` is a vector of datum refs". In fact, this assumption is unnecessary and in most of the cases, they are just requiring an iterator of `DatumRef`s. This PR also refactors them and avoids the allocation as much as possible.

## Checklist

- [x] I have written necessary docs and comments
- [x] I have added necessary unit tests and integration tests

## Refer to a related PR or issue link (optional)
- Close #1840.