### PR TITLE
refactor(batch): Use `futures-async-stream` to implement batch executor.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3100,6 +3100,7 @@ dependencies = [
  "either",
  "farmhash",
  "futures",
+ "futures-async-stream",
  "itertools",
  "lazy_static",
  "log",

--- a/src/batch/Cargo.toml
+++ b/src/batch/Cargo.toml
@@ -14,6 +14,7 @@ crc32fast = "1"
 either = "1"
 farmhash = "1"
 futures = { version = "0.3", default-features = false, features = ["alloc"] }
+futures-async-stream = "0.2"
 itertools = "0.10"
 lazy_static = "1"
 log = "0.4"

--- a/src/batch/src/executor/executor2_wrapper.rs
+++ b/src/batch/src/executor/executor2_wrapper.rs
@@ -1,3 +1,17 @@
+// Copyright 2022 Singularity Data
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 use std::mem::swap;
 
 use futures::stream::StreamExt;

--- a/src/batch/src/executor/executor2_wrapper.rs
+++ b/src/batch/src/executor/executor2_wrapper.rs
@@ -1,0 +1,79 @@
+use std::mem::swap;
+
+use futures::stream::StreamExt;
+use risingwave_common::array::DataChunk;
+use risingwave_common::catalog::Schema;
+use risingwave_common::error::ErrorCode::InternalError;
+use risingwave_common::error::Result;
+
+use crate::executor::executor2_wrapper::WrapperState::{Closed, Created, Opened};
+use crate::executor::Executor;
+use crate::executor2::{BoxedDataChunkStream, BoxedExecutor2, ExecutorInfo};
+
+enum WrapperState {
+    Created { executor: BoxedExecutor2 },
+    Opened { stream: BoxedDataChunkStream },
+    Closed,
+}
+
+/// Wrap an `Executor2` instance to convert it into an `Executor`.
+pub struct Executor2Wrapper {
+    info: ExecutorInfo,
+    state: WrapperState,
+}
+
+#[async_trait::async_trait]
+impl Executor for Executor2Wrapper {
+    async fn open(&mut self) -> Result<()> {
+        let mut tmp = WrapperState::Closed;
+        swap(&mut tmp, &mut self.state);
+        match tmp {
+            Created { executor } => {
+                self.state = Opened {
+                    stream: executor.execute(),
+                };
+                Ok(())
+            }
+            _ => Err(InternalError("Executor already opened!".to_string()).into()),
+        }
+    }
+
+    async fn next(&mut self) -> Result<Option<DataChunk>> {
+        match &mut self.state {
+            Opened { ref mut stream } => match stream.next().await {
+                Some(r) => Ok(Some(r?)),
+                None => Ok(None),
+            },
+            _ => Err(InternalError("Executor not in open state!".to_string()).into()),
+        }
+    }
+
+    async fn close(&mut self) -> Result<()> {
+        self.state = Closed;
+        Ok(())
+    }
+
+    fn schema(&self) -> &Schema {
+        &self.info.schema
+    }
+
+    fn identity(&self) -> &str {
+        self.info.id.as_str()
+    }
+}
+
+impl From<BoxedExecutor2> for Executor2Wrapper {
+    fn from(executor2: BoxedExecutor2) -> Self {
+        let executor_info = ExecutorInfo {
+            schema: executor2.schema().to_owned(),
+            id: executor2.identity().to_string(),
+        };
+
+        Self {
+            info: executor_info,
+            state: WrapperState::Created {
+                executor: executor2,
+            },
+        }
+    }
+}

--- a/src/batch/src/executor2/executor_wrapper.rs
+++ b/src/batch/src/executor2/executor_wrapper.rs
@@ -1,0 +1,51 @@
+use futures_async_stream::try_stream;
+use risingwave_common::array::DataChunk;
+use risingwave_common::catalog::Schema;
+use risingwave_common::error::RwError;
+
+use crate::executor::BoxedExecutor;
+use crate::executor2::{BoxedDataChunkStream, Executor2, ExecutorInfo};
+
+/// A wrapper to convert `Executor` to `Executor2`
+pub struct ExecutorWrapper {
+    info: ExecutorInfo,
+    executor: BoxedExecutor,
+}
+
+impl Executor2 for ExecutorWrapper {
+    fn schema(&self) -> &Schema {
+        &self.info.schema
+    }
+
+    fn identity(&self) -> &str {
+        self.info.id.as_str()
+    }
+
+    fn execute(self: Box<Self>) -> BoxedDataChunkStream {
+        self.do_execute()
+    }
+}
+
+impl From<BoxedExecutor> for ExecutorWrapper {
+    fn from(executor: BoxedExecutor) -> Self {
+        let info = ExecutorInfo {
+            schema: executor.schema().to_owned(),
+            id: executor.identity().to_string(),
+        };
+
+        Self { info, executor }
+    }
+}
+
+impl ExecutorWrapper {
+    #[try_stream(boxed, ok = DataChunk, error = RwError)]
+    async fn do_execute(mut self: Box<Self>) {
+        self.executor.open().await?;
+
+        while let Some(d) = self.executor.next().await? {
+            yield d;
+        }
+
+        self.executor.close().await?;
+    }
+}

--- a/src/batch/src/executor2/executor_wrapper.rs
+++ b/src/batch/src/executor2/executor_wrapper.rs
@@ -1,3 +1,17 @@
+// Copyright 2022 Singularity Data
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 use futures_async_stream::try_stream;
 use risingwave_common::array::DataChunk;
 use risingwave_common::catalog::Schema;

--- a/src/batch/src/executor2/filter.rs
+++ b/src/batch/src/executor2/filter.rs
@@ -12,69 +12,26 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use futures_async_stream::try_stream;
 use risingwave_common::array::ArrayImpl::Bool;
 use risingwave_common::array::DataChunk;
 use risingwave_common::catalog::Schema;
 use risingwave_common::error::ErrorCode::InternalError;
-use risingwave_common::error::Result;
-use risingwave_common::util::chunk_coalesce::{
-    DataChunkBuilder, SlicedDataChunk, DEFAULT_CHUNK_BUFFER_SIZE,
-};
+use risingwave_common::error::{Result, RwError};
+use risingwave_common::util::chunk_coalesce::{DataChunkBuilder, SlicedDataChunk};
 use risingwave_expr::expr::{build_from_prost, BoxedExpression};
 use risingwave_pb::plan::plan_node::NodeBody;
 
-use super::{BoxedExecutor, BoxedExecutorBuilder};
-use crate::executor::{Executor, ExecutorBuilder};
+use crate::executor::ExecutorBuilder;
+use crate::executor2::{BoxedDataChunkStream, BoxedExecutor2, BoxedExecutor2Builder, Executor2};
 
-pub(super) struct FilterExecutor {
+pub struct FilterExecutor2 {
     expr: BoxedExpression,
-    child: BoxedExecutor,
-    chunk_builder: DataChunkBuilder,
-    last_input: Option<SlicedDataChunk>,
+    child: BoxedExecutor2,
     identity: String,
-    // FIXME: This is a quick fix as later we would use generator to limit chunk size.
-    child_can_be_nexted: bool,
 }
 
-#[async_trait::async_trait]
-impl Executor for FilterExecutor {
-    async fn open(&mut self) -> Result<()> {
-        self.child.open().await
-    }
-
-    async fn next(&mut self) -> Result<Option<DataChunk>> {
-        loop {
-            let tmp_last_input = self.last_input.take();
-
-            // We have something left from last poll of child
-            if let Some(existing_data_chunk) = tmp_last_input {
-                let (left_data_chunk, return_data_chunk) =
-                    self.chunk_builder.append_chunk(existing_data_chunk)?;
-                self.last_input = left_data_chunk;
-
-                if let Some(data_chunk) = return_data_chunk {
-                    return Ok(Some(data_chunk));
-                }
-            } else {
-                let child_input = self.fetch_one_chunk().await?;
-                if let Some(data_chunk) = child_input {
-                    self.last_input = Some(SlicedDataChunk::new_checked(data_chunk)?);
-                } else {
-                    // We should return here since nothing come from child.
-                    return if let Some(left) = self.chunk_builder.consume_all()? {
-                        Ok(Some(left))
-                    } else {
-                        Ok(None)
-                    };
-                }
-            }
-        }
-    }
-
-    async fn close(&mut self) -> Result<()> {
-        self.child.close().await
-    }
-
+impl Executor2 for FilterExecutor2 {
     fn schema(&self) -> &Schema {
         self.child.schema()
     }
@@ -82,34 +39,57 @@ impl Executor for FilterExecutor {
     fn identity(&self) -> &str {
         &self.identity
     }
+
+    fn execute(self: Box<Self>) -> BoxedDataChunkStream {
+        self.do_execute()
+    }
 }
 
-impl FilterExecutor {
-    /// Fetch one chunk from child.
-    async fn fetch_one_chunk(&mut self) -> Result<Option<DataChunk>> {
-        if self.child_can_be_nexted {
-            if let Some(data_chunk) = self.child.next().await? {
-                let data_chunk = data_chunk.compact()?;
-                let vis_array = self.expr.eval(&data_chunk)?;
-                return if let Bool(vis) = vis_array.as_ref() {
-                    let vis = vis.try_into()?;
-                    let data_chunk = data_chunk.with_visibility(vis);
-                    Ok(Some(data_chunk))
-                } else {
-                    Err(InternalError("Filter can only receive bool array".to_string()).into())
-                };
+impl FilterExecutor2 {
+    #[try_stream(boxed, ok = DataChunk, error = RwError)]
+    async fn do_execute(self: Box<Self>) {
+        let mut data_chunk_builder =
+            DataChunkBuilder::new_with_default_size(self.child.schema().data_types());
+
+        #[for_await]
+        for data_chunk in self.child.execute() {
+            let data_chunk = data_chunk?.compact()?;
+            let vis_array = self.expr.eval(&data_chunk)?;
+
+            if let Bool(vis) = vis_array.as_ref() {
+                let mut sliced_data_chunk =
+                    SlicedDataChunk::new_checked(data_chunk.with_visibility(vis.try_into()?))?;
+
+                loop {
+                    let (left_data, output) = data_chunk_builder.append_chunk(sliced_data_chunk)?;
+                    match (left_data, output) {
+                        (Some(left_data), Some(output)) => {
+                            sliced_data_chunk = left_data;
+                            yield output;
+                        }
+                        (None, Some(output)) => {
+                            yield output;
+                            break;
+                        }
+                        (None, None) => {
+                            break;
+                        }
+                        _ => {
+                            return Err(
+                                InternalError("Data chunk builder error".to_string()).into()
+                            );
+                        }
+                    }
+                }
             } else {
-                self.child_can_be_nexted = false;
-                Ok(None)
+                return Err(InternalError("Filter can only receive bool array".to_string()).into());
             }
-        } else {
-            Ok(None)
         }
     }
 }
 
-impl BoxedExecutorBuilder for FilterExecutor {
-    fn new_boxed_executor(source: &ExecutorBuilder) -> Result<BoxedExecutor> {
+impl BoxedExecutor2Builder for FilterExecutor2 {
+    fn new_boxed_executor2(source: &ExecutorBuilder) -> Result<BoxedExecutor2> {
         ensure!(source.plan_node().get_children().len() == 1);
 
         let filter_node = try_match_expand!(
@@ -120,22 +100,14 @@ impl BoxedExecutorBuilder for FilterExecutor {
         let expr_node = filter_node.get_search_condition()?;
         let expr = build_from_prost(expr_node)?;
         if let Some(child_plan) = source.plan_node.get_children().get(0) {
-            let child = source.clone_for_plan(child_plan).build()?;
+            let child = source.clone_for_plan(child_plan).build2()?;
             debug!("Child schema: {:?}", child.schema());
-            let chunk_builder =
-                DataChunkBuilder::new(child.schema().data_types(), DEFAULT_CHUNK_BUFFER_SIZE);
 
-            return Ok(Box::new(
-                Self {
-                    expr,
-                    child,
-                    chunk_builder,
-                    last_input: None,
-                    identity: source.plan_node().get_identity().clone(),
-                    child_can_be_nexted: true,
-                }
-                .fuse(),
-            ));
+            return Ok(Box::new(Self {
+                expr,
+                child,
+                identity: source.plan_node().get_identity().clone(),
+            }));
         }
         Err(InternalError("Filter must have one children".to_string()).into())
     }
@@ -146,9 +118,11 @@ mod tests {
     use std::sync::Arc;
 
     use assert_matches::assert_matches;
+    use futures::stream::StreamExt;
     use risingwave_common::array::column::Column;
     use risingwave_common::array::{Array, DataChunk, PrimitiveArray};
     use risingwave_common::catalog::{Field, Schema};
+    use risingwave_common::error::Result;
     use risingwave_common::types::DataType;
     use risingwave_expr::expr::build_from_prost;
     use risingwave_pb::data::data_type::TypeName;
@@ -156,8 +130,8 @@ mod tests {
     use risingwave_pb::expr::expr_node::{RexNode, Type};
     use risingwave_pb::expr::{ExprNode, FunctionCall, InputRefExpr};
 
-    use super::*;
     use crate::executor::test_utils::MockExecutor;
+    use crate::executor2::{Executor2, FilterExecutor2};
 
     #[tokio::test]
     async fn test_filter_executor() {
@@ -173,40 +147,35 @@ mod tests {
         let mut mock_executor = MockExecutor::new(schema);
         mock_executor.add(data_chunk);
         let expr = make_expression(Type::Equal);
-        let chunk_builder = DataChunkBuilder::new(mock_executor.schema().data_types(), 1);
-        let mut filter_executor = FilterExecutor {
+        let filter_executor = Box::new(FilterExecutor2 {
             expr: build_from_prost(&expr).unwrap(),
             child: Box::new(mock_executor),
-            chunk_builder,
-            last_input: None,
-            identity: "FilterExecutor".to_string(),
-            child_can_be_nexted: true,
-        };
+            identity: "FilterExecutor2".to_string(),
+        });
         let fields = &filter_executor.schema().fields;
         assert_eq!(fields[0].data_type, DataType::Int32);
         assert_eq!(fields[1].data_type, DataType::Int32);
-        filter_executor.open().await.unwrap();
-        let res = filter_executor.next().await.unwrap();
-        assert_matches!(res, Some(_));
-        if let Some(res) = res {
+        let mut stream = filter_executor.execute();
+        let res = stream.next().await.unwrap();
+        assert_matches!(res, Ok(_));
+        if let Ok(res) = res {
             let col1 = res.column_at(0);
             let array = col1.array();
             let col1 = array.as_int32();
             assert_eq!(col1.len(), 1);
             assert_eq!(col1.value_at(0), Some(2));
         }
-        let res = filter_executor.next().await.unwrap();
-        assert_matches!(res, Some(_));
-        if let Some(res) = res {
+        let res = stream.next().await.unwrap();
+        assert_matches!(res, Ok(_));
+        if let Ok(res) = res {
             let col1 = res.column_at(0);
             let array = col1.array();
             let col1 = array.as_int32();
             assert_eq!(col1.len(), 1);
             assert_eq!(col1.value_at(0), Some(3));
         }
-        let res = filter_executor.next().await.unwrap();
+        let res = stream.next().await;
         assert_matches!(res, None);
-        filter_executor.close().await.unwrap();
     }
 
     fn make_expression(kind: Type) -> ExprNode {

--- a/src/batch/src/executor2/filter.rs
+++ b/src/batch/src/executor2/filter.rs
@@ -85,6 +85,10 @@ impl FilterExecutor2 {
                 return Err(InternalError("Filter can only receive bool array".to_string()).into());
             }
         }
+
+        if let Some(chunk) = data_chunk_builder.consume_all()? {
+            yield chunk;
+        }
     }
 }
 
@@ -162,17 +166,9 @@ mod tests {
             let col1 = res.column_at(0);
             let array = col1.array();
             let col1 = array.as_int32();
-            assert_eq!(col1.len(), 1);
+            assert_eq!(col1.len(), 2);
             assert_eq!(col1.value_at(0), Some(2));
-        }
-        let res = stream.next().await.unwrap();
-        assert_matches!(res, Ok(_));
-        if let Ok(res) = res {
-            let col1 = res.column_at(0);
-            let array = col1.array();
-            let col1 = array.as_int32();
-            assert_eq!(col1.len(), 1);
-            assert_eq!(col1.value_at(0), Some(3));
+            assert_eq!(col1.value_at(1), Some(3));
         }
         let res = stream.next().await;
         assert_matches!(res, None);

--- a/src/batch/src/executor2/mod.rs
+++ b/src/batch/src/executor2/mod.rs
@@ -1,0 +1,48 @@
+pub mod executor_wrapper;
+mod filter;
+pub use filter::*;
+mod trace;
+use futures::stream::BoxStream;
+use risingwave_common::array::DataChunk;
+use risingwave_common::catalog::Schema;
+use risingwave_common::error::Result;
+pub use trace::*;
+
+use crate::executor::executor2_wrapper::Executor2Wrapper;
+use crate::executor::{BoxedExecutor, ExecutorBuilder};
+
+pub type BoxedExecutor2 = Box<dyn Executor2>;
+pub type BoxedDataChunkStream = BoxStream<'static, Result<DataChunk>>;
+
+pub struct ExecutorInfo {
+    pub schema: Schema,
+    pub id: String,
+}
+
+/// Refactoring of `Executor` using `Stream`.
+pub trait Executor2: Send + 'static {
+    /// Returns the schema of the executor's return data.
+    ///
+    /// Schema must be available before `init`.
+    fn schema(&self) -> &Schema;
+
+    /// Identity string of the executor
+    fn identity(&self) -> &str;
+
+    /// Executes to return the data chunk stream.
+    ///
+    /// The implementation should guaranteed that each `DataChunk`'s cardinality is not zero.
+    fn execute(self: Box<Self>) -> BoxedDataChunkStream;
+}
+
+/// Every Executor should impl this trait to provide a static method to build a `BoxedExecutor2`
+/// from proto and global environment.
+pub trait BoxedExecutor2Builder {
+    fn new_boxed_executor2(source: &ExecutorBuilder) -> Result<BoxedExecutor2>;
+
+    fn new_boxed_executor(source: &ExecutorBuilder) -> Result<BoxedExecutor> {
+        Ok(Box::new(Executor2Wrapper::from(Self::new_boxed_executor2(
+            source,
+        )?)))
+    }
+}

--- a/src/batch/src/executor2/mod.rs
+++ b/src/batch/src/executor2/mod.rs
@@ -1,3 +1,17 @@
+// Copyright 2022 Singularity Data
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 pub mod executor_wrapper;
 mod filter;
 pub use filter::*;

--- a/src/batch/src/executor2/trace.rs
+++ b/src/batch/src/executor2/trace.rs
@@ -1,0 +1,74 @@
+// Copyright 2022 Singularity Data
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use futures::stream::StreamExt;
+use futures_async_stream::try_stream;
+use risingwave_common::array::DataChunk;
+use risingwave_common::catalog::Schema;
+use risingwave_common::error::RwError;
+use tracing::event;
+use tracing_futures::Instrument;
+
+use crate::executor2::{BoxedDataChunkStream, BoxedExecutor2, Executor2};
+
+/// If tracing is enabled, we build a [`TraceExecutor2`] on top of the underlying executor.
+/// So the duration of performance-critical operations will be traced, such as open/next/close.
+pub struct TraceExecutor2 {
+    child: BoxedExecutor2,
+    /// Description of input executor
+    input_desc: String,
+}
+
+impl TraceExecutor2 {
+    pub fn new(child: BoxedExecutor2, input_desc: String) -> Self {
+        Self { child, input_desc }
+    }
+}
+
+impl Executor2 for TraceExecutor2 {
+    fn schema(&self) -> &Schema {
+        self.child.schema()
+    }
+
+    fn identity(&self) -> &str {
+        "TraceExecutor"
+    }
+
+    fn execute(self: Box<Self>) -> BoxedDataChunkStream {
+        self.do_execute()
+    }
+}
+
+impl TraceExecutor2 {
+    #[try_stream(boxed, ok = DataChunk, error = RwError)]
+    async fn do_execute(self: Box<Self>) {
+        let input_desc = self.input_desc.as_str();
+        let span_name = format!("{input_desc}_next");
+        let mut child_stream = self.child.execute();
+        while let Some(chunk) = child_stream
+            .next()
+            .instrument(tracing::trace_span!(
+                "next",
+                otel.name = span_name.as_str(),
+                next = input_desc,
+            ))
+            .await
+        {
+            let chunk = chunk?;
+            event!(tracing::Level::TRACE, prev = %input_desc, msg = "chunk", "input = \n{:#?}", 
+                chunk);
+            yield chunk;
+        }
+    }
+}

--- a/src/batch/src/lib.rs
+++ b/src/batch/src/lib.rs
@@ -31,12 +31,14 @@
 #![feature(exact_size_is_empty)]
 #![feature(type_alias_impl_trait)]
 #![cfg_attr(coverage, feature(no_coverage))]
+#![feature(generators)]
+#![feature(proc_macro_hygiene, stmt_expr_attributes)]
 
 pub mod execution;
 pub mod executor;
+pub mod executor2;
 pub mod rpc;
 pub mod task;
-
 #[macro_use]
 extern crate log;
 #[macro_use]


### PR DESCRIPTION
## What's changed and what's your intention?

1. Implement `Executor2` using `Stream`.
2. Implement `Filter` using `Executor2` trait.
3. Some infra for refactoring.

## Checklist

- [x] I have written necessary docs and comments
- [x] I have added necessary unit tests and integration tests

## Refer to a related PR or issue link (optional)

Closes #1190 