### PR TITLE
chore(ci): fix slow playground prepare

### DIFF
--- a/.github/workflow-template/jobs/e2e-risedev.yml
+++ b/.github/workflow-template/jobs/e2e-risedev.yml
@@ -16,17 +16,28 @@ jobs:
         with:
           fetch-depth: 0
 
-      - name: Install rust toolchain
-        uses: actions-rs/toolchain@v1
-        with:
-          toolchain: ${{ env.RUST_TOOLCHAIN }}
-          components: rustfmt, clippy
-
       - name: Set up JDK 11
         uses: actions/setup-java@v2
         with:
           java-version: "11"
           distribution: "adopt"
+
+      - name: Install rust toolchain
+        uses: actions-rs/toolchain@v1
+        with:
+          toolchain: ${{ env.RUST_TOOLCHAIN }}
+          profile: minimal
+
+      - name: Cache Cargo home # cargo-make need this info to accelerate prepare process
+        uses: actions/cache@v2
+        id: cache
+        with:
+          path: |
+            ~/.cargo/bin/
+            ~/.cargo/registry/index/
+            ~/.cargo/registry/cache/
+            ~/.cargo/git/db/
+          key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}-${{ env.CACHE_KEY_SUFFIX }}-build
 
       - uses: actions/download-artifact@v2
         name: Download risingwave binary
@@ -77,8 +88,8 @@ jobs:
 
       - name: Prepare RiseDev playground
         run: |
-          ~/cargo-make/makers link-all-in-one-binaries
           ~/cargo-make/makers pre-start-playground
+          ~/cargo-make/makers link-all-in-one-binaries
 
       # --- Tests ---
       #

--- a/.github/workflow-template/jobs/e2e-source.yml
+++ b/.github/workflow-template/jobs/e2e-source.yml
@@ -40,6 +40,23 @@ jobs:
       # - name: Setup kafka cluster
       #   run: ./scripts/source/prepare_source.sh
 
+      - name: Install rust toolchain
+        uses: actions-rs/toolchain@v1
+        with:
+          toolchain: ${{ env.RUST_TOOLCHAIN }}
+          profile: minimal
+
+      - name: Cache Cargo home # cargo-make need this info to accelerate prepare process
+        uses: actions/cache@v2
+        id: cache
+        with:
+          path: |
+            ~/.cargo/bin/
+            ~/.cargo/registry/index/
+            ~/.cargo/registry/cache/
+            ~/.cargo/git/db/
+          key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}-${{ env.CACHE_KEY_SUFFIX }}-build
+
       - name: Download sqllogictest
         run: |
           wget ${RW_SQLLOGICTEST_URL} -O - | tar xz && mv ${BINARY} ${DIR}/${BINARY}
@@ -95,8 +112,8 @@ jobs:
 
       - name: Prepare RiseDev playground
         run: |
-          ~/cargo-make/makers link-all-in-one-binaries
           ~/cargo-make/makers pre-start-playground
+          ~/cargo-make/makers link-all-in-one-binaries
 
       # --- Tests ---
       #

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -205,16 +205,26 @@ jobs:
         uses: actions/checkout@v2
         with:
           fetch-depth: 0
-      - name: Install rust toolchain
-        uses: actions-rs/toolchain@v1
-        with:
-          toolchain: ${{ env.RUST_TOOLCHAIN }}
-          components: rustfmt, clippy
       - name: Set up JDK 11
         uses: actions/setup-java@v2
         with:
           java-version: "11"
           distribution: "adopt"
+      - name: Install rust toolchain
+        uses: actions-rs/toolchain@v1
+        with:
+          toolchain: ${{ env.RUST_TOOLCHAIN }}
+          profile: minimal
+      - name: Cache Cargo home
+        uses: actions/cache@v2
+        id: cache
+        with:
+          path: |
+            ~/.cargo/bin/
+            ~/.cargo/registry/index/
+            ~/.cargo/registry/cache/
+            ~/.cargo/git/db/
+          key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}-${{ env.CACHE_KEY_SUFFIX }}-build
       - uses: actions/download-artifact@v2
         name: Download risingwave binary
         with:
@@ -255,8 +265,8 @@ jobs:
           mv "${HOME}/${RW_CARGO_MAKE_DIRECTORY}" ~/cargo-make
       - name: Prepare RiseDev playground
         run: |
-          ~/cargo-make/makers link-all-in-one-binaries
           ~/cargo-make/makers pre-start-playground
+          ~/cargo-make/makers link-all-in-one-binaries
       - name: e2e test, streaming, Rust frontend, 3 node
         timeout-minutes: 2
         run: |
@@ -311,16 +321,26 @@ jobs:
         uses: actions/checkout@v2
         with:
           fetch-depth: 0
-      - name: Install rust toolchain
-        uses: actions-rs/toolchain@v1
-        with:
-          toolchain: ${{ env.RUST_TOOLCHAIN }}
-          components: rustfmt, clippy
       - name: Set up JDK 11
         uses: actions/setup-java@v2
         with:
           java-version: "11"
           distribution: "adopt"
+      - name: Install rust toolchain
+        uses: actions-rs/toolchain@v1
+        with:
+          toolchain: ${{ env.RUST_TOOLCHAIN }}
+          profile: minimal
+      - name: Cache Cargo home
+        uses: actions/cache@v2
+        id: cache
+        with:
+          path: |
+            ~/.cargo/bin/
+            ~/.cargo/registry/index/
+            ~/.cargo/registry/cache/
+            ~/.cargo/git/db/
+          key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}-${{ env.CACHE_KEY_SUFFIX }}-build
       - uses: actions/download-artifact@v2
         name: Download risingwave binary
         with:
@@ -361,8 +381,8 @@ jobs:
           mv "${HOME}/${RW_CARGO_MAKE_DIRECTORY}" ~/cargo-make
       - name: Prepare RiseDev playground
         run: |
-          ~/cargo-make/makers link-all-in-one-binaries
           ~/cargo-make/makers pre-start-playground
+          ~/cargo-make/makers link-all-in-one-binaries
       - name: e2e test, streaming, Rust frontend, 3 node
         timeout-minutes: 2
         run: |
@@ -435,6 +455,21 @@ jobs:
         run: |
           sudo apt-get update -yy -o Acquire::Retries=3
           sudo apt-get install --upgrade -yy tmux postgresql -o Acquire::Retries=3
+      - name: Install rust toolchain
+        uses: actions-rs/toolchain@v1
+        with:
+          toolchain: ${{ env.RUST_TOOLCHAIN }}
+          profile: minimal
+      - name: Cache Cargo home
+        uses: actions/cache@v2
+        id: cache
+        with:
+          path: |
+            ~/.cargo/bin/
+            ~/.cargo/registry/index/
+            ~/.cargo/registry/cache/
+            ~/.cargo/git/db/
+          key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}-${{ env.CACHE_KEY_SUFFIX }}-build
       - name: Download sqllogictest
         run: |
           wget ${RW_SQLLOGICTEST_URL} -O - | tar xz && mv ${BINARY} ${DIR}/${BINARY}
@@ -481,8 +516,8 @@ jobs:
           cp risedev-components.ci.env risedev-components.user.env
       - name: Prepare RiseDev playground
         run: |
-          ~/cargo-make/makers link-all-in-one-binaries
           ~/cargo-make/makers pre-start-playground
+          ~/cargo-make/makers link-all-in-one-binaries
       - name: regress test batch 3-node
         timeout-minutes: 1
         run: |

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -162,16 +162,26 @@ jobs:
         uses: actions/checkout@v2
         with:
           fetch-depth: 0
-      - name: Install rust toolchain
-        uses: actions-rs/toolchain@v1
-        with:
-          toolchain: ${{ env.RUST_TOOLCHAIN }}
-          components: rustfmt, clippy
       - name: Set up JDK 11
         uses: actions/setup-java@v2
         with:
           java-version: "11"
           distribution: "adopt"
+      - name: Install rust toolchain
+        uses: actions-rs/toolchain@v1
+        with:
+          toolchain: ${{ env.RUST_TOOLCHAIN }}
+          profile: minimal
+      - name: Cache Cargo home
+        uses: actions/cache@v2
+        id: cache
+        with:
+          path: |
+            ~/.cargo/bin/
+            ~/.cargo/registry/index/
+            ~/.cargo/registry/cache/
+            ~/.cargo/git/db/
+          key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}-${{ env.CACHE_KEY_SUFFIX }}-build
       - uses: actions/download-artifact@v2
         name: Download risingwave binary
         with:
@@ -212,8 +222,8 @@ jobs:
           mv "${HOME}/${RW_CARGO_MAKE_DIRECTORY}" ~/cargo-make
       - name: Prepare RiseDev playground
         run: |
-          ~/cargo-make/makers link-all-in-one-binaries
           ~/cargo-make/makers pre-start-playground
+          ~/cargo-make/makers link-all-in-one-binaries
       - name: e2e test, streaming, Rust frontend, 3 node
         timeout-minutes: 2
         run: |
@@ -286,6 +296,21 @@ jobs:
         run: |
           sudo apt-get update -yy -o Acquire::Retries=3
           sudo apt-get install --upgrade -yy tmux postgresql -o Acquire::Retries=3
+      - name: Install rust toolchain
+        uses: actions-rs/toolchain@v1
+        with:
+          toolchain: ${{ env.RUST_TOOLCHAIN }}
+          profile: minimal
+      - name: Cache Cargo home
+        uses: actions/cache@v2
+        id: cache
+        with:
+          path: |
+            ~/.cargo/bin/
+            ~/.cargo/registry/index/
+            ~/.cargo/registry/cache/
+            ~/.cargo/git/db/
+          key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}-${{ env.CACHE_KEY_SUFFIX }}-build
       - name: Download sqllogictest
         run: |
           wget ${RW_SQLLOGICTEST_URL} -O - | tar xz && mv ${BINARY} ${DIR}/${BINARY}
@@ -332,8 +357,8 @@ jobs:
           cp risedev-components.ci.env risedev-components.user.env
       - name: Prepare RiseDev playground
         run: |
-          ~/cargo-make/makers link-all-in-one-binaries
           ~/cargo-make/makers pre-start-playground
+          ~/cargo-make/makers link-all-in-one-binaries
       - name: regress test batch 3-node
         timeout-minutes: 1
         run: |


### PR DESCRIPTION
Signed-off-by: Alex Chi <iskyzh@gmail.com>

## What's changed and what's your intention?

Due to Rust toolchain not present, cargo make will stuck on setup env for a minute. This PR fixes the issue.

## Checklist

- [x] I have written necessary docs and comments
- [x] I have added necessary unit tests and integration tests

## Refer to a related PR or issue link (optional)
