### PR TITLE
refactor(frontend): cleanup infer_type and align with pg

### DIFF
--- a/src/frontend/src/expr/type_inference.rs
+++ b/src/frontend/src/expr/type_inference.rs
@@ -32,14 +32,14 @@ enum DataTypeName {
     Int16,
     Int32,
     Int64,
+    Decimal,
     Float32,
     Float64,
-    Decimal,
-    Date,
     Varchar,
-    Time,
+    Date,
     Timestamp,
     Timestampz,
+    Time,
     Interval,
     Struct,
     List,
@@ -47,18 +47,18 @@ enum DataTypeName {
 
 fn name_of(ty: &DataType) -> DataTypeName {
     match ty {
+        DataType::Boolean => DataTypeName::Boolean,
         DataType::Int16 => DataTypeName::Int16,
         DataType::Int32 => DataTypeName::Int32,
         DataType::Int64 => DataTypeName::Int64,
+        DataType::Decimal => DataTypeName::Decimal,
         DataType::Float32 => DataTypeName::Float32,
         DataType::Float64 => DataTypeName::Float64,
-        DataType::Boolean => DataTypeName::Boolean,
         DataType::Varchar => DataTypeName::Varchar,
         DataType::Date => DataTypeName::Date,
-        DataType::Time => DataTypeName::Time,
         DataType::Timestamp => DataTypeName::Timestamp,
         DataType::Timestampz => DataTypeName::Timestampz,
-        DataType::Decimal => DataTypeName::Decimal,
+        DataType::Time => DataTypeName::Time,
         DataType::Interval => DataTypeName::Interval,
         DataType::Struct { .. } => DataTypeName::Struct,
         DataType::List { .. } => DataTypeName::List,
@@ -72,18 +72,18 @@ pub fn infer_type(func_type: ExprType, inputs_type: Vec<DataType>) -> Option<Dat
     // by things like length or precision, the inference can be done with a map lookup.
     let input_type_names = inputs_type.iter().map(name_of).collect();
     infer_type_name(func_type, input_type_names).map(|type_name| match type_name {
+        DataTypeName::Boolean => DataType::Boolean,
         DataTypeName::Int16 => DataType::Int16,
         DataTypeName::Int32 => DataType::Int32,
         DataTypeName::Int64 => DataType::Int64,
+        DataTypeName::Decimal => DataType::Decimal,
         DataTypeName::Float32 => DataType::Float32,
         DataTypeName::Float64 => DataType::Float64,
-        DataTypeName::Boolean => DataType::Boolean,
         DataTypeName::Varchar => DataType::Varchar,
         DataTypeName::Date => DataType::Date,
-        DataTypeName::Time => DataType::Time,
         DataTypeName::Timestamp => DataType::Timestamp,
         DataTypeName::Timestampz => DataType::Timestampz,
-        DataTypeName::Decimal => DataType::Decimal,
+        DataTypeName::Time => DataType::Time,
         DataTypeName::Interval => DataType::Interval,
         DataTypeName::Struct => DataType::Struct {
             fields: Arc::new([]),
@@ -119,199 +119,189 @@ impl FuncSign {
     }
 }
 
-fn arithmetic_type_derive(t1: DataTypeName, t2: DataTypeName) -> DataTypeName {
-    if t2 as i32 > t1 as i32 {
-        t2
-    } else {
-        t1
+fn build_binary_cmp_funcs(
+    map: &mut HashMap<FuncSign, DataTypeName>,
+    exprs: &[ExprType],
+    args: &[DataTypeName],
+) {
+    for (e, lt, rt) in iproduct!(exprs, args, args) {
+        map.insert(FuncSign::new(*e, vec![*lt, *rt]), DataTypeName::Boolean);
     }
 }
 
-fn build_unary_funcs(
+fn build_binary_atm_funcs(
     map: &mut HashMap<FuncSign, DataTypeName>,
     exprs: &[ExprType],
-    arg1: &[DataTypeName],
-    ret: DataTypeName,
+    args: &[DataTypeName],
 ) {
-    for (expr, a1) in iproduct!(exprs, arg1) {
-        map.insert(FuncSign::new(*expr, vec![*a1]), ret);
+    for e in exprs {
+        for (li, lt) in args.iter().enumerate() {
+            for (ri, rt) in args.iter().enumerate() {
+                let ret = if li <= ri { rt } else { lt };
+                map.insert(FuncSign::new(*e, vec![*lt, *rt]), *ret);
+            }
+        }
     }
 }
 
-fn build_binary_funcs(
+fn build_commutative_funcs(
     map: &mut HashMap<FuncSign, DataTypeName>,
-    exprs: &[ExprType],
-    arg1: &[DataTypeName],
-    arg2: &[DataTypeName],
+    expr: ExprType,
+    arg0: DataTypeName,
+    arg1: DataTypeName,
     ret: DataTypeName,
 ) {
-    for (expr, a1, a2) in iproduct!(exprs, arg1, arg2) {
-        map.insert(FuncSign::new(*expr, vec![*a1, *a2]), ret);
-    }
-}
-
-fn build_commutative_binary_funcs(
-    map: &mut HashMap<FuncSign, DataTypeName>,
-    exprs: &[ExprType],
-    arg1: &[DataTypeName],
-    arg2: &[DataTypeName],
-    ret: DataTypeName,
-) {
-    build_binary_funcs(map, exprs, arg1, arg2, ret);
-    build_binary_funcs(map, exprs, arg2, arg1, ret);
+    map.insert(FuncSign::new(expr, vec![arg0, arg1]), ret);
+    map.insert(FuncSign::new(expr, vec![arg1, arg0]), ret);
 }
 
 fn build_type_derive_map() -> HashMap<FuncSign, DataTypeName> {
     use {DataTypeName as T, ExprType as E};
     let mut map = HashMap::new();
-    let num_types = vec![
-        T::Int16,
-        T::Int32,
-        T::Int64,
-        T::Float32,
-        T::Float64,
-        T::Decimal,
-    ];
-    let all_types = vec![
-        T::Int16,
-        T::Int32,
-        T::Int64,
-        T::Float32,
-        T::Float64,
+    let all_types = [
         T::Boolean,
-        T::Varchar,
+        T::Int16,
+        T::Int32,
+        T::Int64,
         T::Decimal,
-        T::Time,
-        T::Timestamp,
-        T::Interval,
+        T::Float32,
+        T::Float64,
+        T::Varchar,
         T::Date,
+        T::Timestamp,
         T::Timestampz,
+        T::Time,
+        T::Interval,
     ];
-    let str_types = vec![T::Varchar];
-    let atm_exprs = vec![E::Add, E::Subtract, E::Multiply, E::Divide, E::Modulus];
-    let cmp_exprs = vec![
+    let num_types = [
+        T::Int16,
+        T::Int32,
+        T::Int64,
+        T::Decimal,
+        T::Float32,
+        T::Float64,
+    ];
+
+    // logical expressions
+    for e in [E::Not, E::IsTrue, E::IsNotTrue, E::IsFalse, E::IsNotFalse] {
+        map.insert(FuncSign::new(e, vec![T::Boolean]), T::Boolean);
+    }
+    for e in [E::And, E::Or] {
+        map.insert(FuncSign::new(e, vec![T::Boolean, T::Boolean]), T::Boolean);
+    }
+
+    // comparison expressions
+    for e in [E::IsNull, E::IsNotNull] {
+        for t in all_types {
+            map.insert(FuncSign::new(e, vec![t]), T::Boolean);
+        }
+    }
+    let cmp_exprs = &[
         E::Equal,
         E::NotEqual,
         E::LessThan,
         E::LessThanOrEqual,
         E::GreaterThan,
         E::GreaterThanOrEqual,
-        E::In,
     ];
-    for (expr, t1, t2) in iproduct!(atm_exprs, num_types.clone(), num_types.clone()) {
-        map.insert(
-            FuncSign::new(expr, vec![t1, t2]),
-            arithmetic_type_derive(t1, t2),
-        );
+    build_binary_cmp_funcs(&mut map, cmp_exprs, &num_types);
+    build_binary_cmp_funcs(&mut map, cmp_exprs, &[T::Date, T::Timestamp, T::Timestampz]);
+    build_binary_cmp_funcs(&mut map, cmp_exprs, &[T::Time, T::Interval]);
+    for e in cmp_exprs {
+        for t in [T::Boolean, T::Varchar] {
+            map.insert(FuncSign::new(*e, vec![t, t]), T::Boolean);
+        }
     }
-    for t in num_types.clone() {
+
+    // arithmetic expressions
+    for t in num_types {
         map.insert(FuncSign::new(E::Neg, vec![t]), t);
     }
-    build_binary_funcs(&mut map, &cmp_exprs, &num_types, &num_types, T::Boolean);
-    build_binary_funcs(&mut map, &cmp_exprs, &str_types, &str_types, T::Boolean);
-    build_binary_funcs(
+    build_binary_atm_funcs(
         &mut map,
-        &cmp_exprs,
-        &[T::Boolean],
-        &[T::Boolean],
-        T::Boolean,
+        &[E::Add, E::Subtract, E::Multiply, E::Divide],
+        &num_types,
+    );
+    build_binary_atm_funcs(
+        &mut map,
+        &[E::Modulus],
+        &[T::Int16, T::Int32, T::Int64, T::Decimal],
+    );
+    map.insert(
+        FuncSign::new(E::RoundDigit, vec![T::Decimal, T::Int32]),
+        T::Decimal,
     );
 
-    // Date comparisons
-    build_binary_funcs(
-        &mut map,
-        &cmp_exprs,
-        &[T::Date, T::Timestamp],
-        &[T::Date, T::Timestamp],
-        T::Boolean,
-    );
-    // Date/Timestamp/Interval arithmetic
-    build_commutative_binary_funcs(
-        &mut map,
-        &[E::Add],
-        &[T::Timestamp, T::Date],
-        &[T::Interval],
-        T::Timestamp,
-    );
-    build_binary_funcs(
-        &mut map,
-        &[E::Subtract],
-        &[T::Timestamp, T::Date],
-        &[T::Interval],
-        T::Timestamp,
-    );
-    build_commutative_binary_funcs(
-        &mut map,
-        &[E::Multiply],
-        &[T::Interval],
-        &[T::Int16, T::Int32, T::Int64],
-        T::Interval,
-    );
+    // temporal expressions
+    for (base, delta) in [
+        (T::Date, T::Int32),
+        (T::Timestamp, T::Interval),
+        (T::Timestampz, T::Interval),
+        (T::Time, T::Interval),
+        (T::Interval, T::Interval),
+    ] {
+        build_commutative_funcs(&mut map, E::Add, base, delta, base);
+        map.insert(FuncSign::new(E::Subtract, vec![base, delta]), base);
+        map.insert(FuncSign::new(E::Subtract, vec![base, base]), delta);
+    }
 
-    build_binary_funcs(
-        &mut map,
-        &[E::And, E::Or],
-        &[T::Boolean],
-        &[T::Boolean],
-        T::Boolean,
+    // date + interval = timestamp, date - interval = timestamp
+    build_commutative_funcs(&mut map, E::Add, T::Date, T::Interval, T::Timestamp);
+    map.insert(
+        FuncSign::new(E::Subtract, vec![T::Date, T::Interval]),
+        T::Timestamp,
     );
-    build_unary_funcs(
-        &mut map,
-        &[E::IsTrue, E::IsNotTrue, E::IsFalse, E::IsNotFalse, E::Not],
-        &[T::Boolean],
-        T::Boolean,
+    // date + time = timestamp
+    build_commutative_funcs(&mut map, E::Add, T::Date, T::Time, T::Timestamp);
+    // interval * float8 = interval, interval / float8 = interval
+    for t in num_types {
+        build_commutative_funcs(&mut map, E::Multiply, T::Interval, t, T::Interval);
+        map.insert(FuncSign::new(E::Divide, vec![T::Interval, t]), T::Interval);
+    }
+
+    for t in [T::Timestamp, T::Time, T::Date] {
+        map.insert(FuncSign::new(E::Extract, vec![T::Varchar, t]), T::Decimal);
+    }
+    for t in [T::Timestamp, T::Date] {
+        map.insert(
+            FuncSign::new(E::TumbleStart, vec![t, T::Interval]),
+            T::Timestamp,
+        );
+    }
+
+    // string expressions
+    for e in [E::Trim, E::Ltrim, E::Rtrim, E::Lower, E::Upper] {
+        map.insert(FuncSign::new(e, vec![T::Varchar]), T::Varchar);
+    }
+    for e in [E::Trim, E::Ltrim, E::Rtrim] {
+        map.insert(FuncSign::new(e, vec![T::Varchar, T::Varchar]), T::Varchar);
+    }
+    map.insert(
+        FuncSign::new(E::Substr, vec![T::Varchar, T::Int32]),
+        T::Varchar,
     );
-    build_unary_funcs(
-        &mut map,
-        &[E::IsNull, E::IsNotNull, E::StreamNullByRowCount],
-        &all_types,
-        T::Boolean,
-    );
-    build_binary_funcs(&mut map, &[E::Substr], &str_types, &num_types, T::Varchar);
     map.insert(
         FuncSign::new(E::Substr, vec![T::Varchar, T::Int32, T::Int32]),
         T::Varchar,
     );
-    build_unary_funcs(&mut map, &[E::Length], &str_types, T::Int32);
-    build_unary_funcs(
-        &mut map,
-        &[E::Trim, E::Ltrim, E::Rtrim, E::Lower, E::Upper],
-        &str_types,
-        T::Varchar,
-    );
-    build_binary_funcs(
-        &mut map,
-        &[E::Trim, E::Ltrim, E::Rtrim, E::Position],
-        &str_types,
-        &str_types,
-        T::Varchar,
-    );
-    build_binary_funcs(&mut map, &[E::Like], &str_types, &str_types, T::Boolean);
+    for e in [E::Replace, E::Translate] {
+        map.insert(
+            FuncSign::new(e, vec![T::Varchar, T::Varchar, T::Varchar]),
+            T::Varchar,
+        );
+    }
+    for e in [E::Length, E::Ascii] {
+        map.insert(FuncSign::new(e, vec![T::Varchar]), T::Int32);
+    }
     map.insert(
-        FuncSign::new(E::Replace, vec![T::Varchar, T::Varchar, T::Varchar]),
-        T::Varchar,
+        FuncSign::new(E::Position, vec![T::Varchar, T::Varchar]),
+        T::Int32,
     );
-    build_binary_funcs(
-        &mut map,
-        &[E::RoundDigit],
-        &[T::Decimal],
-        &[T::Int32],
-        T::Decimal,
+    map.insert(
+        FuncSign::new(E::Like, vec![T::Varchar, T::Varchar]),
+        T::Boolean,
     );
-    build_binary_funcs(
-        &mut map,
-        &[E::Extract],
-        &[T::Varchar], // Time field, "YEAR", "DAY", etc
-        &[T::Timestamp, T::Time, T::Date],
-        T::Decimal,
-    );
-    build_binary_funcs(
-        &mut map,
-        &[E::TumbleStart],
-        &[T::Date, T::Timestamp],
-        &[T::Interval],
-        T::Timestamp,
-    );
+
     map
 }
 
@@ -467,45 +457,44 @@ mod tests {
             ExprType::Subtract,
             ExprType::Multiply,
             ExprType::Divide,
-            ExprType::Modulus,
         ];
         let num_promote_table = vec![
             (Int16, Int16, Int16),
             (Int16, Int32, Int32),
             (Int16, Int64, Int64),
+            (Int16, Decimal, Decimal),
             (Int16, Float32, Float32),
             (Int16, Float64, Float64),
-            (Int16, Decimal, Decimal),
             (Int32, Int16, Int32),
             (Int32, Int32, Int32),
             (Int32, Int64, Int64),
+            (Int32, Decimal, Decimal),
             (Int32, Float32, Float32),
             (Int32, Float64, Float64),
-            (Int32, Decimal, Decimal),
             (Int64, Int16, Int64),
             (Int64, Int32, Int64),
             (Int64, Int64, Int64),
+            (Int64, Decimal, Decimal),
             (Int64, Float32, Float32),
             (Int64, Float64, Float64),
-            (Int64, Decimal, Decimal),
-            (Float32, Int16, Float32),
-            (Float32, Int32, Float32),
-            (Float32, Int64, Float32),
-            (Float32, Float32, Float32),
-            (Float32, Float64, Float64),
-            (Float32, Decimal, Decimal),
-            (Float64, Int16, Float64),
-            (Float64, Int32, Float64),
-            (Float64, Int64, Float64),
-            (Float64, Float32, Float64),
-            (Float64, Float64, Float64),
-            (Float64, Decimal, Decimal),
             (Decimal, Int16, Decimal),
             (Decimal, Int32, Decimal),
             (Decimal, Int64, Decimal),
-            (Decimal, Float32, Decimal),
-            (Decimal, Float64, Decimal),
             (Decimal, Decimal, Decimal),
+            (Decimal, Float32, Float32),
+            (Decimal, Float64, Float64),
+            (Float32, Int16, Float32),
+            (Float32, Int32, Float32),
+            (Float32, Int64, Float32),
+            (Float32, Decimal, Float32),
+            (Float32, Float32, Float32),
+            (Float32, Float64, Float64),
+            (Float64, Int16, Float64),
+            (Float64, Int32, Float64),
+            (Float64, Int64, Float64),
+            (Float64, Decimal, Float64),
+            (Float64, Float32, Float64),
+            (Float64, Float64, Float64),
         ];
         for (expr, (t1, t2, tr)) in iproduct!(atm_exprs, num_promote_table) {
             test_simple_infer_type(expr, vec![t1, t2], tr);


### PR DESCRIPTION
## What's changed and what's your intention?

* Organize exprs into groups: logical, comparison, arithmetic, temporal, string.
* According to pg, the order of `num_types` should be `int2->int4->int8->numeric->float4->float8`.
* Remove unnecessary helper functions. It is actually shorter and more readable without them. For example `build_binary_funcs` produces all combinations of `exprs * arg1 * arg2` and requires the return types to be the same, which is only useful for `cmp`.
* Implicit cast on operands are still not supported yet.

## Checklist

- [x] I have written necessary docs and comments
- [x] I have added necessary unit tests and integration tests

## Refer to a related PR or issue link (optional)
