### PR TITLE
refactor(storage): remove lifetime on iterators

### DIFF
--- a/src/storage/benches/bench_merge_iter.rs
+++ b/src/storage/benches/bench_merge_iter.rs
@@ -28,7 +28,7 @@ use risingwave_storage::monitor::StateStoreMetrics;
 fn gen_interleave_shared_buffer_batch_iter(
     batch_size: usize,
     batch_count: usize,
-) -> Vec<BoxedForwardHummockIterator<'static>> {
+) -> Vec<BoxedForwardHummockIterator> {
     let mut iterators = Vec::new();
     for i in 0..batch_count {
         let mut batch_data = vec![];

--- a/src/storage/src/hummock/compactor.rs
+++ b/src/storage/src/hummock/compactor.rs
@@ -274,7 +274,7 @@ impl Compactor {
     async fn compact_key_range(
         &self,
         split_index: usize,
-        iter: MergeIterator<'_>,
+        iter: MergeIterator,
     ) -> HummockResult<(usize, Vec<Sstable>)> {
         let split = self.compact_task.splits[split_index].clone();
         let kr = KeyRange {
@@ -343,7 +343,7 @@ impl Compactor {
     }
 
     /// Build the merge iterator based on the given input ssts.
-    async fn build_sst_iter(&self) -> HummockResult<MergeIterator<'_>> {
+    async fn build_sst_iter(&self) -> HummockResult<MergeIterator> {
         let mut table_iters: Vec<BoxedForwardHummockIterator> = Vec::new();
         for LevelEntry {
             level_idx: _,
@@ -509,7 +509,7 @@ impl Compactor {
     async fn compact_and_build_sst<B, F>(
         sst_builder: &mut CapacitySplitTableBuilder<B>,
         kr: KeyRange,
-        mut iter: MergeIterator<'_>,
+        mut iter: MergeIterator,
         has_user_key_overlap: bool,
         watermark: Epoch,
     ) -> HummockResult<()>

--- a/src/storage/src/hummock/iterator/merge.rs
+++ b/src/storage/src/hummock/iterator/merge.rs
@@ -17,9 +17,9 @@ use crate::hummock::iterator::merge_inner::{
 };
 use crate::hummock::iterator::Forward;
 
-pub type MergeIterator<'a> = UnorderedMergeIteratorInner<'a, Forward>;
+pub type MergeIterator = UnorderedMergeIteratorInner<Forward>;
 #[allow(dead_code)]
-pub type OrderedAwareMergeIterator<'a> = OrderedMergeIteratorInner<'a, Forward>;
+pub type OrderedAwareMergeIterator = OrderedMergeIteratorInner<Forward>;
 
 #[cfg(test)]
 mod test {

--- a/src/storage/src/hummock/iterator/mod.rs
+++ b/src/storage/src/hummock/iterator/mod.rs
@@ -108,9 +108,9 @@ pub trait HummockIterator: Send + Sync {
 pub trait ForwardHummockIterator = HummockIterator<Direction = Forward>;
 pub trait BackwardHummockIterator = HummockIterator<Direction = Backward>;
 
-pub type BoxedForwardHummockIterator<'a> = Box<dyn ForwardHummockIterator + 'a>;
-pub type BoxedBackwardHummockIterator<'a> = Box<dyn BackwardHummockIterator + 'a>;
-pub type BoxedHummockIterator<'a, D> = Box<dyn HummockIterator<Direction = D> + 'a>;
+pub type BoxedForwardHummockIterator = Box<dyn ForwardHummockIterator>;
+pub type BoxedBackwardHummockIterator = Box<dyn BackwardHummockIterator>;
+pub type BoxedHummockIterator<D> = Box<dyn HummockIterator<Direction = D>>;
 
 pub enum DirectionEnum {
     Forward,

--- a/src/storage/src/hummock/iterator/reverse_merge.rs
+++ b/src/storage/src/hummock/iterator/reverse_merge.rs
@@ -15,7 +15,7 @@
 use crate::hummock::iterator::merge_inner::UnorderedMergeIteratorInner;
 use crate::hummock::iterator::Backward;
 
-pub type ReverseMergeIterator<'a> = UnorderedMergeIteratorInner<'a, Backward>;
+pub type ReverseMergeIterator = UnorderedMergeIteratorInner<Backward>;
 
 #[cfg(test)]
 mod test {

--- a/src/storage/src/hummock/iterator/reverse_user.rs
+++ b/src/storage/src/hummock/iterator/reverse_user.rs
@@ -23,9 +23,9 @@ use crate::hummock::value::HummockValue;
 use crate::hummock::HummockResult;
 
 /// [`ReverseUserIterator`] can be used by user directly.
-pub struct ReverseUserIterator<'a> {
+pub struct ReverseUserIterator {
     /// Inner table iterator.
-    iterator: ReverseMergeIterator<'a>,
+    iterator: ReverseMergeIterator,
 
     /// We just met a new key
     just_met_new_key: bool,
@@ -52,11 +52,11 @@ pub struct ReverseUserIterator<'a> {
     _version: Option<Arc<ScopedLocalVersion>>,
 }
 
-impl<'a> ReverseUserIterator<'a> {
+impl ReverseUserIterator {
     /// Creates [`ReverseUserIterator`] with maximum epoch.
     #[cfg(test)]
     pub(crate) fn new(
-        iterator: ReverseMergeIterator<'a>,
+        iterator: ReverseMergeIterator,
         key_range: (Bound<Vec<u8>>, Bound<Vec<u8>>),
     ) -> Self {
         Self::new_with_epoch(iterator, key_range, Epoch::MAX, None)
@@ -64,7 +64,7 @@ impl<'a> ReverseUserIterator<'a> {
 
     /// Creates [`ReverseUserIterator`] with given `read_epoch`.
     pub(crate) fn new_with_epoch(
-        iterator: ReverseMergeIterator<'a>,
+        iterator: ReverseMergeIterator,
         key_range: (Bound<Vec<u8>>, Bound<Vec<u8>>),
         read_epoch: u64,
         version: Option<Arc<ScopedLocalVersion>>,

--- a/src/storage/src/hummock/iterator/test_utils.rs
+++ b/src/storage/src/hummock/iterator/test_utils.rs
@@ -142,7 +142,7 @@ pub async fn gen_iterator_test_sstable_from_kv_pair(
 pub fn gen_merge_iterator_interleave_test_sstable_iters(
     key_count: usize,
     count: usize,
-) -> Vec<BoxedForwardHummockIterator<'static>> {
+) -> Vec<BoxedForwardHummockIterator> {
     let sstable_store = mock_sstable_store();
     (0..count)
         .map(|i: usize| {

--- a/src/storage/src/hummock/iterator/user.rs
+++ b/src/storage/src/hummock/iterator/user.rs
@@ -23,12 +23,12 @@ use crate::hummock::local_version_manager::ScopedLocalVersion;
 use crate::hummock::value::HummockValue;
 use crate::hummock::HummockResult;
 
-pub enum DirectedUserIterator<'a> {
-    Forward(UserIterator<'a>),
-    Backward(ReverseUserIterator<'a>),
+pub enum DirectedUserIterator {
+    Forward(UserIterator),
+    Backward(ReverseUserIterator),
 }
 
-impl DirectedUserIterator<'_> {
+impl DirectedUserIterator {
     pub async fn next(&mut self) -> HummockResult<()> {
         match self {
             Self::Forward(ref mut iter) => iter.next().await,
@@ -77,9 +77,9 @@ impl DirectedUserIterator<'_> {
 }
 
 /// [`UserIterator`] can be used by user directly.
-pub struct UserIterator<'a> {
+pub struct UserIterator {
     /// Inner table iterator.
-    iterator: MergeIterator<'a>,
+    iterator: MergeIterator,
 
     /// Last user key
     last_key: Vec<u8>,
@@ -101,11 +101,11 @@ pub struct UserIterator<'a> {
 }
 
 // TODO: decide whether this should also impl `HummockIterator`
-impl<'a> UserIterator<'a> {
+impl UserIterator {
     /// Create [`UserIterator`] with maximum epoch.
     #[cfg(test)]
     pub(crate) fn for_test(
-        iterator: MergeIterator<'a>,
+        iterator: MergeIterator,
         key_range: (Bound<Vec<u8>>, Bound<Vec<u8>>),
     ) -> Self {
         Self::new(iterator, key_range, Epoch::MAX, None)
@@ -113,7 +113,7 @@ impl<'a> UserIterator<'a> {
 
     /// Create [`UserIterator`] with given `read_epoch`.
     pub(crate) fn new(
-        iterator: MergeIterator<'a>,
+        iterator: MergeIterator,
         key_range: (Bound<Vec<u8>>, Bound<Vec<u8>>),
         read_epoch: u64,
         version: Option<Arc<ScopedLocalVersion>>,

--- a/src/storage/src/hummock/state_store.rs
+++ b/src/storage/src/hummock/state_store.rs
@@ -40,7 +40,7 @@ impl HummockStorage {
         key_range: R,
         epoch: u64,
         reversed: bool,
-    ) -> StorageResult<HummockStateStoreIter<'_>>
+    ) -> StorageResult<HummockStateStoreIter>
     where
         R: RangeBounds<B> + Send,
         B: AsRef<[u8]> + Send,
@@ -181,7 +181,7 @@ impl HummockStorage {
 }
 
 impl StateStore for HummockStorage {
-    type Iter<'a> = HummockStateStoreIter<'a>;
+    type Iter<'a> = HummockStateStoreIter;
 
     define_state_store_associated_type!();
 
@@ -391,12 +391,12 @@ impl StateStore for HummockStorage {
     }
 }
 
-pub struct HummockStateStoreIter<'a> {
-    inner: DirectedUserIterator<'a>,
+pub struct HummockStateStoreIter {
+    inner: DirectedUserIterator,
 }
 
-impl<'a> HummockStateStoreIter<'a> {
-    fn new(inner: DirectedUserIterator<'a>) -> Self {
+impl HummockStateStoreIter {
+    fn new(inner: DirectedUserIterator) -> Self {
         Self { inner }
     }
 
@@ -414,11 +414,11 @@ impl<'a> HummockStateStoreIter<'a> {
     }
 }
 
-impl<'a> StateStoreIter for HummockStateStoreIter<'a> {
+impl StateStoreIter for HummockStateStoreIter {
     // TODO: directly return `&[u8]` to user instead of `Bytes`.
     type Item = (Bytes, Bytes);
 
-    type NextFuture<'b> = impl Future<Output = crate::error::StorageResult<Option<Self::Item>>> where Self:'b;
+    type NextFuture<'a> = impl Future<Output = crate::error::StorageResult<Option<Self::Item>>> where Self:'a;
 
     fn next(&mut self) -> Self::NextFuture<'_> {
         async move {

--- a/src/storage/src/hummock/test_utils.rs
+++ b/src/storage/src/hummock/test_utils.rs
@@ -152,7 +152,7 @@ pub async fn gen_default_test_sstable(
     .await
 }
 
-pub async fn count_iter(iter: &mut HummockStateStoreIter<'_>) -> usize {
+pub async fn count_iter(iter: &mut HummockStateStoreIter) -> usize {
     let mut c: usize = 0;
     while iter.next().await.unwrap().is_some() {
         c += 1


### PR DESCRIPTION
## What's changed and what's your intention?
Remove all the lifetime associated with iterators defined in Hummock.

This PR conflicts with PR #1928 on `use XXX` statements only at one location. It seems #1928 is ready and this PR will wait for it to be merged first.

After this refactoring, we can bound the trait `StateStoreIter` by `'static`. This will bypass the compiler limitation described in #1930 when `Send` is used to bound `NextFuture` in `StateStoreIter`.

## Refer to a related PR or issue link (optional)
#1930