### PR TITLE
refactor(storage): add Send bound to NextFuture in StateStoreIter

### DIFF
--- a/src/storage/src/hummock/state_store.rs
+++ b/src/storage/src/hummock/state_store.rs
@@ -418,7 +418,8 @@ impl StateStoreIter for HummockStateStoreIter {
     // TODO: directly return `&[u8]` to user instead of `Bytes`.
     type Item = (Bytes, Bytes);
 
-    type NextFuture<'a> = impl Future<Output = crate::error::StorageResult<Option<Self::Item>>> where Self:'a;
+    type NextFuture<'a> =
+        impl Future<Output = crate::error::StorageResult<Option<Self::Item>>> + Send;
 
     fn next(&mut self) -> Self::NextFuture<'_> {
         async move {

--- a/src/storage/src/memory.rs
+++ b/src/storage/src/memory.rs
@@ -219,7 +219,8 @@ impl MemoryStateStoreIter {
 impl StateStoreIter for MemoryStateStoreIter {
     type Item = (Bytes, Bytes);
 
-    type NextFuture<'a> = impl Future<Output = crate::error::StorageResult<Option<Self::Item>>>;
+    type NextFuture<'a> =
+        impl Future<Output = crate::error::StorageResult<Option<Self::Item>>> + Send;
 
     fn next(&mut self) -> Self::NextFuture<'_> {
         async move { Ok(self.inner.next()) }

--- a/src/storage/src/monitor/monitored_store.rs
+++ b/src/storage/src/monitor/monitored_store.rs
@@ -211,7 +211,8 @@ where
 {
     type Item = (Bytes, Bytes);
 
-    type NextFuture<'a> = impl Future<Output = crate::error::StorageResult<Option<Self::Item>>> where Self: 'a;
+    type NextFuture<'a> =
+        impl Future<Output = crate::error::StorageResult<Option<Self::Item>>> + Send;
 
     fn next(&mut self) -> Self::NextFuture<'_> {
         async move {

--- a/src/storage/src/panic_store.rs
+++ b/src/storage/src/panic_store.rs
@@ -125,7 +125,8 @@ pub struct PanicStateStoreIter {}
 impl StateStoreIter for PanicStateStoreIter {
     type Item = (Bytes, Bytes);
 
-    type NextFuture<'a> = impl Future<Output = crate::error::StorageResult<Option<Self::Item>>>;
+    type NextFuture<'a> =
+        impl Future<Output = crate::error::StorageResult<Option<Self::Item>>> + Send;
 
     fn next(&'_ mut self) -> Self::NextFuture<'_> {
         async move { unreachable!() }

--- a/src/storage/src/rocksdb_local.rs
+++ b/src/storage/src/rocksdb_local.rs
@@ -196,7 +196,8 @@ impl RocksDBStateStoreIter {
 impl StateStoreIter for RocksDBStateStoreIter {
     type Item = (Bytes, Bytes);
 
-    type NextFuture<'a> = impl Future<Output = crate::error::StorageResult<Option<Self::Item>>>;
+    type NextFuture<'a> =
+        impl Future<Output = crate::error::StorageResult<Option<Self::Item>>> + Send;
 
     fn next(&mut self) -> Self::NextFuture<'_> {
         async move {

--- a/src/storage/src/rocksdb_local_mock.rs
+++ b/src/storage/src/rocksdb_local_mock.rs
@@ -125,7 +125,8 @@ impl RocksDBStateStoreIter {
 impl StateStoreIter for RocksDBStateStoreIter {
     type Item = (Bytes, Bytes);
 
-    type NextFuture<'a> = impl Future<Output = crate::error::StorageResult<Option<Self::Item>>>;
+    type NextFuture<'a> =
+        impl Future<Output = crate::error::StorageResult<Option<Self::Item>>> + Send;
 
     fn next(&mut self) -> Self::NextFuture<'_> {
         async move { unimplemented!() }

--- a/src/storage/src/store.rs
+++ b/src/storage/src/store.rs
@@ -163,11 +163,9 @@ pub trait StateStore: Send + Sync + 'static + Clone {
     }
 }
 
-pub trait StateStoreIter: Send {
+pub trait StateStoreIter: Send + 'static {
     type Item;
-    type NextFuture<'a>: Future<Output = StorageResult<Option<Self::Item>>>
-    where
-        Self: 'a;
+    type NextFuture<'a>: Future<Output = StorageResult<Option<Self::Item>>> + Send;
 
     fn next(&mut self) -> Self::NextFuture<'_>;
 }

--- a/src/storage/src/tikv.rs
+++ b/src/storage/src/tikv.rs
@@ -218,7 +218,8 @@ impl TikvStateStoreIter {
 impl StateStoreIter for TikvStateStoreIter {
     type Item = (Bytes, Bytes);
 
-    type NextFuture<'a> = impl Future<Output = crate::error::StorageResult<Option<Self::Item>>>;
+    type NextFuture<'a> =
+        impl Future<Output = crate::error::StorageResult<Option<Self::Item>>> + Send;
 
     fn next(&mut self) -> Self::NextFuture<'_> {
         async move {

--- a/src/storage/src/tikv_mock.rs
+++ b/src/storage/src/tikv_mock.rs
@@ -118,7 +118,8 @@ impl TikvStateStoreIter {
 impl StateStoreIter for TikvStateStoreIter {
     type Item = (Bytes, Bytes);
 
-    type NextFuture<'a> = impl Future<Output = crate::error::StorageResult<Option<Self::Item>>>;
+    type NextFuture<'a> =
+        impl Future<Output = crate::error::StorageResult<Option<Self::Item>>> + Send;
 
     fn next(&mut self) -> Self::NextFuture<'_> {
         async move { unimplemented!() }


### PR DESCRIPTION
## What's changed and what's your intention?
As title.

Related details can be found in the issue #1930 and PR #1956. 

In essence, we need this `Send` bound to use iter in some async functions.

## Refer to a related PR or issue link (optional)
closes #1930 