### PR TITLE
feat: make `create materialized view from source` available

### DIFF
--- a/.github/workflow-template/jobs/e2e-risedev.yml
+++ b/.github/workflow-template/jobs/e2e-risedev.yml
@@ -126,7 +126,7 @@ jobs:
         run: ~/cargo-make/makers ci-kill
 
       - name: e2e test batch 3-node
-        timeout-minutes: 2
+        timeout-minutes: 5
         run: |
           RW_IMPLICIT_FLUSH=1 ~/cargo-make/makers ci-start ci-3node
           sqllogictest -p 4567 -d dev --engine risingwave './e2e_test/batch/**/*.slt'

--- a/.github/workflow-template/jobs/e2e-risedev.yml
+++ b/.github/workflow-template/jobs/e2e-risedev.yml
@@ -98,7 +98,7 @@ jobs:
       # if the degradation is reasonable or to be fixed soon.
 
       - name: e2e test, streaming, Rust frontend, 3 node
-        timeout-minutes: 2
+        timeout-minutes: 5
         run: |
           ~/cargo-make/makers ci-start ci-3cn-1fe
           sqllogictest -p 4566 './e2e_test/v2/streaming/**/*.slt'
@@ -107,7 +107,7 @@ jobs:
         run: ~/cargo-make/makers ci-kill
 
       - name: e2e test w/ Rust frontend ci-3node, batch, distributed
-        timeout-minutes: 2
+        timeout-minutes: 5
         run: |
           ~/cargo-make/makers ci-start ci-3cn-1fe
           sqllogictest -p 4566 './e2e_test/v2/ddl/**/*.slt'
@@ -117,7 +117,7 @@ jobs:
         run: ~/cargo-make/makers ci-kill
 
       - name: e2e test streaming 3-node # Note: RiseDev cluster cannot be used to run e2e coverage unless we rebuild frontend in this workflow
-        timeout-minutes: 4
+        timeout-minutes: 10
         run: |
           ~/cargo-make/makers ci-start ci-3node
           sqllogictest -p 4567 -d dev './e2e_test/streaming/**/*.slt'

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -268,14 +268,14 @@ jobs:
           ~/cargo-make/makers pre-start-playground
           ~/cargo-make/makers link-all-in-one-binaries
       - name: e2e test, streaming, Rust frontend, 3 node
-        timeout-minutes: 2
+        timeout-minutes: 5
         run: |
           ~/cargo-make/makers ci-start ci-3cn-1fe
           sqllogictest -p 4566 './e2e_test/v2/streaming/**/*.slt'
       - name: Kill cluster
         run: ~/cargo-make/makers ci-kill
       - name: e2e test w/ Rust frontend ci-3node, batch, distributed
-        timeout-minutes: 2
+        timeout-minutes: 5
         run: |
           ~/cargo-make/makers ci-start ci-3cn-1fe
           sqllogictest -p 4566 './e2e_test/v2/ddl/**/*.slt'
@@ -283,7 +283,7 @@ jobs:
       - name: Kill cluster
         run: ~/cargo-make/makers ci-kill
       - name: e2e test streaming 3-node
-        timeout-minutes: 4
+        timeout-minutes: 10
         run: |
           ~/cargo-make/makers ci-start ci-3node
           sqllogictest -p 4567 -d dev './e2e_test/streaming/**/*.slt'
@@ -384,14 +384,14 @@ jobs:
           ~/cargo-make/makers pre-start-playground
           ~/cargo-make/makers link-all-in-one-binaries
       - name: e2e test, streaming, Rust frontend, 3 node
-        timeout-minutes: 2
+        timeout-minutes: 5
         run: |
           ~/cargo-make/makers ci-start ci-3cn-1fe
           sqllogictest -p 4566 './e2e_test/v2/streaming/**/*.slt'
       - name: Kill cluster
         run: ~/cargo-make/makers ci-kill
       - name: e2e test w/ Rust frontend ci-3node, batch, distributed
-        timeout-minutes: 2
+        timeout-minutes: 5
         run: |
           ~/cargo-make/makers ci-start ci-3cn-1fe
           sqllogictest -p 4566 './e2e_test/v2/ddl/**/*.slt'
@@ -399,7 +399,7 @@ jobs:
       - name: Kill cluster
         run: ~/cargo-make/makers ci-kill
       - name: e2e test streaming 3-node
-        timeout-minutes: 4
+        timeout-minutes: 10
         run: |
           ~/cargo-make/makers ci-start ci-3node
           sqllogictest -p 4567 -d dev './e2e_test/streaming/**/*.slt'

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -290,7 +290,7 @@ jobs:
       - name: Kill cluster
         run: ~/cargo-make/makers ci-kill
       - name: e2e test batch 3-node
-        timeout-minutes: 2
+        timeout-minutes: 5
         run: |
           RW_IMPLICIT_FLUSH=1 ~/cargo-make/makers ci-start ci-3node
           sqllogictest -p 4567 -d dev --engine risingwave './e2e_test/batch/**/*.slt'
@@ -406,7 +406,7 @@ jobs:
       - name: Kill cluster
         run: ~/cargo-make/makers ci-kill
       - name: e2e test batch 3-node
-        timeout-minutes: 2
+        timeout-minutes: 5
         run: |
           RW_IMPLICIT_FLUSH=1 ~/cargo-make/makers ci-start ci-3node
           sqllogictest -p 4567 -d dev --engine risingwave './e2e_test/batch/**/*.slt'

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -225,14 +225,14 @@ jobs:
           ~/cargo-make/makers pre-start-playground
           ~/cargo-make/makers link-all-in-one-binaries
       - name: e2e test, streaming, Rust frontend, 3 node
-        timeout-minutes: 2
+        timeout-minutes: 5
         run: |
           ~/cargo-make/makers ci-start ci-3cn-1fe
           sqllogictest -p 4566 './e2e_test/v2/streaming/**/*.slt'
       - name: Kill cluster
         run: ~/cargo-make/makers ci-kill
       - name: e2e test w/ Rust frontend ci-3node, batch, distributed
-        timeout-minutes: 2
+        timeout-minutes: 5
         run: |
           ~/cargo-make/makers ci-start ci-3cn-1fe
           sqllogictest -p 4566 './e2e_test/v2/ddl/**/*.slt'
@@ -240,7 +240,7 @@ jobs:
       - name: Kill cluster
         run: ~/cargo-make/makers ci-kill
       - name: e2e test streaming 3-node
-        timeout-minutes: 4
+        timeout-minutes: 10
         run: |
           ~/cargo-make/makers ci-start ci-3node
           sqllogictest -p 4567 -d dev './e2e_test/streaming/**/*.slt'

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -247,7 +247,7 @@ jobs:
       - name: Kill cluster
         run: ~/cargo-make/makers ci-kill
       - name: e2e test batch 3-node
-        timeout-minutes: 2
+        timeout-minutes: 5
         run: |
           RW_IMPLICIT_FLUSH=1 ~/cargo-make/makers ci-start ci-3node
           sqllogictest -p 4567 -d dev --engine risingwave './e2e_test/batch/**/*.slt'

--- a/src/batch/src/executor/delete.rs
+++ b/src/batch/src/executor/delete.rs
@@ -202,7 +202,9 @@ mod tests {
         // Create reader
         let source_desc = source_manager.get_source(&table_id)?;
         let source = source_desc.source.as_table_v2().unwrap();
-        let mut reader = source.stream_reader(TableV2ReaderContext, vec![0.into(), 1.into()])?;
+        let mut reader = source
+            .stream_reader(TableV2ReaderContext, vec![0.into(), 1.into()])
+            .await?;
 
         // Delete
         let mut delete_executor =

--- a/src/batch/src/executor/insert.rs
+++ b/src/batch/src/executor/insert.rs
@@ -245,8 +245,9 @@ mod tests {
         // Create reader
         let source_desc = source_manager.get_source(&table_id)?;
         let source = source_desc.source.as_table_v2().unwrap();
-        let mut reader =
-            source.stream_reader(TableV2ReaderContext, vec![0.into(), 1.into(), 2.into()])?;
+        let mut reader = source
+            .stream_reader(TableV2ReaderContext, vec![0.into(), 1.into(), 2.into()])
+            .await?;
 
         // Insert
         let mut insert_executor = InsertExecutor::new(

--- a/src/compute/tests/table_v2_materialize.rs
+++ b/src/compute/tests/table_v2_materialize.rs
@@ -230,6 +230,21 @@ async fn test_table_v2_materialize() -> Result<()> {
     scan.open().await?;
     assert!(scan.next().await?.is_none());
 
+    // Send a barrier to start materialized view
+    let curr_epoch = 1919;
+    barrier_tx
+        .send(Message::Barrier(Barrier::new_test_barrier(curr_epoch)))
+        .unwrap();
+
+    assert!(matches!(
+        materialize.next().await?,
+        Message::Barrier(Barrier {
+            epoch,
+            mutation: None,
+            ..
+        }) if epoch.curr == curr_epoch
+    ));
+
     // Poll `Materialize`, should output the same insertion stream chunk
     let message = materialize.next().await?;
     match message {

--- a/src/connector/src/filesystem/s3/s3_dir.rs
+++ b/src/connector/src/filesystem/s3/s3_dir.rs
@@ -1,4 +1,3 @@
-use std::collections::HashMap;
 // Copyright 2022 Singularity Data
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
@@ -12,6 +11,7 @@ use std::collections::HashMap;
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
+use std::collections::HashMap;
 use std::time::Duration;
 
 use async_trait::async_trait;

--- a/src/connector/src/filesystem/s3/source/s3_file_reader.rs
+++ b/src/connector/src/filesystem/s3/source/s3_file_reader.rs
@@ -32,7 +32,7 @@ use tokio_stream::wrappers::ReceiverStream;
 use tokio_util::io;
 use tokio_util::io::ReaderStream;
 
-use crate::base::{SourceMessage, SourceSplit, SourceReader};
+use crate::base::{SourceMessage, SourceReader, SourceSplit};
 use crate::filesystem::file_common::{EntryStat, StatusWatch};
 use crate::filesystem::s3::s3_dir::FileSystemOptError::IllegalS3FilePath;
 use crate::filesystem::s3::s3_dir::{

--- a/src/connector/src/filesystem/s3/source/s3_file_reader.rs
+++ b/src/connector/src/filesystem/s3/source/s3_file_reader.rs
@@ -32,14 +32,14 @@ use tokio_stream::wrappers::ReceiverStream;
 use tokio_util::io;
 use tokio_util::io::ReaderStream;
 
-use crate::base::{SourceMessage, SourceSplit, SplitReader};
+use crate::base::{SourceMessage, SourceSplit, SourceReader};
 use crate::filesystem::file_common::{EntryStat, StatusWatch};
 use crate::filesystem::s3::s3_dir::FileSystemOptError::IllegalS3FilePath;
 use crate::filesystem::s3::s3_dir::{
     new_s3_client, new_share_config, AwsCredential, AwsCustomConfig, S3SourceBasicConfig,
     S3SourceConfig, SqsReceiveMsgConfig,
 };
-use crate::{ConnectorState, Properties};
+use crate::{ConnectorState, ConnectorStateV2, Properties};
 
 const MAX_CHANNEL_BUFFER_SIZE: usize = 2048;
 const READ_CHUNK_SIZE: usize = 1024;
@@ -316,7 +316,7 @@ impl S3FileReader {
 }
 
 #[async_trait]
-impl SplitReader for S3FileReader {
+impl SourceReader for S3FileReader {
     async fn next(&mut self) -> anyhow::Result<Option<Vec<SourceMessage>>> {
         let mut read_chunk = self
             .s3_receive_stream
@@ -350,7 +350,7 @@ impl SplitReader for S3FileReader {
     /// `s3.region_name, s3.bucket_name, s3-dd-storage-notify-queue` and the credential's access_key
     /// and secret. For now, only static credential is supported.
     /// 2. The identifier of the State is the Path of S3 - S3://bucket_name/object_key
-    async fn new(props: Properties, state: Option<crate::ConnectorState>) -> Result<Self>
+    async fn new(props: Properties, state: ConnectorStateV2) -> Result<Self>
     where
         Self: Sized,
     {
@@ -373,7 +373,7 @@ impl SplitReader for S3FileReader {
                 sqs_config: SqsReceiveMsgConfig::default(),
             };
             let mut s3_file_reader = S3FileReader::build_from_config(s3_source_config);
-            if let Some(s3_state) = state {
+            if let ConnectorStateV2::State(s3_state) = state {
                 if let Err(err) = s3_file_reader.add_s3_split(s3_state) {
                     Err(err)
                 } else {
@@ -394,9 +394,9 @@ mod test {
     use bytes::Bytes;
     use maplit::hashmap;
 
-    use crate::base::SplitReader;
+    use crate::base::SourceReader;
     use crate::filesystem::s3::source::s3_file_reader::{S3FileReader, S3FileSplit};
-    use crate::{ConnectorState, Properties};
+    use crate::{ConnectorState, ConnectorStateV2, Properties};
 
     const TEST_REGION_NAME: &str = "cn-north-1";
     const BUCKET_NAME: &str = "dd-storage-s3";
@@ -429,8 +429,10 @@ mod test {
     }
 
     async fn new_s3_file_reader(file_name: String) -> S3FileReader {
-        let s3_file_reader =
-            S3FileReader::new(test_config_map(), Some(new_test_connect_state(file_name)));
+        let s3_file_reader = S3FileReader::new(
+            test_config_map(),
+            ConnectorStateV2::State(new_test_connect_state(file_name)),
+        );
         s3_file_reader.await.unwrap()
     }
 

--- a/src/connector/src/filesystem/s3/source/s3_file_reader.rs
+++ b/src/connector/src/filesystem/s3/source/s3_file_reader.rs
@@ -32,7 +32,7 @@ use tokio_stream::wrappers::ReceiverStream;
 use tokio_util::io;
 use tokio_util::io::ReaderStream;
 
-use crate::base::{SourceMessage, SourceReader, SourceSplit};
+use crate::base::{SourceMessage, SourceSplit, SplitReader};
 use crate::filesystem::file_common::{EntryStat, StatusWatch};
 use crate::filesystem::s3::s3_dir::FileSystemOptError::IllegalS3FilePath;
 use crate::filesystem::s3::s3_dir::{
@@ -316,7 +316,7 @@ impl S3FileReader {
 }
 
 #[async_trait]
-impl SourceReader for S3FileReader {
+impl SplitReader for S3FileReader {
     async fn next(&mut self) -> anyhow::Result<Option<Vec<SourceMessage>>> {
         let mut read_chunk = self
             .s3_receive_stream
@@ -394,7 +394,7 @@ mod test {
     use bytes::Bytes;
     use maplit::hashmap;
 
-    use crate::base::SourceReader;
+    use crate::base::SplitReader;
     use crate::filesystem::s3::source::s3_file_reader::{S3FileReader, S3FileSplit};
     use crate::{ConnectorState, ConnectorStateV2, Properties};
 

--- a/src/connector/src/kafka/source/reader.rs
+++ b/src/connector/src/kafka/source/reader.rs
@@ -25,7 +25,7 @@ use rdkafka::{ClientConfig, Offset, TopicPartitionList};
 use risingwave_common::error::ErrorCode::InternalError;
 use risingwave_common::error::RwError;
 
-use crate::base::{SourceMessage, SourceReader};
+use crate::base::{SourceMessage, SplitReader};
 use crate::kafka::split::KafkaSplit;
 use crate::kafka::KAFKA_CONFIG_BROKERS_KEY;
 use crate::{ConnectorStateV2, Properties, SplitImpl};
@@ -38,7 +38,7 @@ pub struct KafkaSplitReader {
 }
 
 #[async_trait]
-impl SourceReader for KafkaSplitReader {
+impl SplitReader for KafkaSplitReader {
     async fn next(&mut self) -> Result<Option<Vec<SourceMessage>>> {
         let mut stream = self
             .consumer

--- a/src/connector/src/kafka/source/reader.rs
+++ b/src/connector/src/kafka/source/reader.rs
@@ -58,8 +58,8 @@ impl SourceReader for KafkaSplitReader {
     }
 
     async fn new(properties: Properties, state: ConnectorStateV2) -> Result<Self>
-        where
-            Self: Sized,
+    where
+        Self: Sized,
     {
         let bootstrap_servers = properties.get_kafka(KAFKA_CONFIG_BROKERS_KEY)?;
 
@@ -101,7 +101,7 @@ impl SourceReader for KafkaSplitReader {
                             k.partition,
                             Offset::Offset(offset),
                         )
-                            .map_err(|e| anyhow!(e.to_string()))?;
+                        .map_err(|e| anyhow!(e.to_string()))?;
                     } else {
                         tpl.add_partition(k.topic.as_str(), k.partition);
                     }

--- a/src/connector/src/kafka/source/reader.rs
+++ b/src/connector/src/kafka/source/reader.rs
@@ -20,15 +20,15 @@ use anyhow::{anyhow, Result};
 use async_trait::async_trait;
 use futures::StreamExt;
 use rdkafka::config::RDKafkaLogLevel;
-use rdkafka::consumer::{DefaultConsumerContext, StreamConsumer};
-use rdkafka::ClientConfig;
+use rdkafka::consumer::{Consumer, DefaultConsumerContext, StreamConsumer};
+use rdkafka::{ClientConfig, Offset, TopicPartitionList};
 use risingwave_common::error::ErrorCode::InternalError;
 use risingwave_common::error::RwError;
 
-use crate::base::{SourceMessage, SplitReader};
+use crate::base::{SourceMessage, SourceReader};
 use crate::kafka::split::KafkaSplit;
 use crate::kafka::KAFKA_CONFIG_BROKERS_KEY;
-use crate::{ConnectorState, Properties};
+use crate::{ConnectorStateV2, Properties, SplitImpl};
 
 const KAFKA_MAX_FETCH_MESSAGES: usize = 1024;
 
@@ -38,7 +38,7 @@ pub struct KafkaSplitReader {
 }
 
 #[async_trait]
-impl SplitReader for KafkaSplitReader {
+impl SourceReader for KafkaSplitReader {
     async fn next(&mut self) -> Result<Option<Vec<SourceMessage>>> {
         let mut stream = self
             .consumer
@@ -57,9 +57,9 @@ impl SplitReader for KafkaSplitReader {
             .map(Some)
     }
 
-    async fn new(properties: Properties, _state: Option<ConnectorState>) -> Result<Self>
-    where
-        Self: Sized,
+    async fn new(properties: Properties, state: ConnectorStateV2) -> Result<Self>
+        where
+            Self: Sized,
     {
         let bootstrap_servers = properties.get_kafka(KAFKA_CONFIG_BROKERS_KEY)?;
 
@@ -84,10 +84,32 @@ impl SplitReader for KafkaSplitReader {
             );
         }
 
-        let consumer = config
+        let consumer: StreamConsumer = config
             .set_log_level(RDKafkaLogLevel::Info)
             .create_with_context(DefaultConsumerContext)
             .map_err(|e| RwError::from(InternalError(format!("consumer creation failed {}", e))))?;
+
+        if let ConnectorStateV2::Splits(splits) = state {
+            log::debug!("Splits for kafka found! {:?}", splits);
+            let mut tpl = TopicPartitionList::with_capacity(splits.len());
+
+            for split in splits {
+                if let SplitImpl::Kafka(k) = split {
+                    if let Some(offset) = k.start_offset {
+                        tpl.add_partition_offset(
+                            k.topic.as_str(),
+                            k.partition,
+                            Offset::Offset(offset),
+                        )
+                            .map_err(|e| anyhow!(e.to_string()))?;
+                    } else {
+                        tpl.add_partition(k.topic.as_str(), k.partition);
+                    }
+                }
+            }
+
+            consumer.assign(&tpl).map_err(|e| anyhow!(e.to_string()))?;
+        }
 
         Ok(Self {
             consumer: Arc::new(consumer),

--- a/src/connector/src/kinesis/source/reader.rs
+++ b/src/connector/src/kinesis/source/reader.rs
@@ -24,7 +24,7 @@ use aws_sdk_kinesis::Client as kinesis_client;
 use aws_smithy_types::DateTime;
 use http::Uri;
 
-use crate::base::{SourceMessage, SourceReader};
+use crate::base::{SourceMessage, SplitReader};
 use crate::kinesis::config::AwsConfigInfo;
 use crate::kinesis::source::message::KinesisMessage;
 use crate::kinesis::source::state::KinesisSplitReaderState;
@@ -41,7 +41,7 @@ pub struct KinesisSplitReader {
 }
 
 #[async_trait]
-impl SourceReader for KinesisSplitReader {
+impl SplitReader for KinesisSplitReader {
     async fn next(&mut self) -> Result<Option<Vec<SourceMessage>>> {
         if self.assigned_split.is_none() {
             return Err(anyhow::Error::msg(

--- a/src/connector/src/kinesis/source/reader.rs
+++ b/src/connector/src/kinesis/source/reader.rs
@@ -24,12 +24,12 @@ use aws_sdk_kinesis::Client as kinesis_client;
 use aws_smithy_types::DateTime;
 use http::Uri;
 
-use crate::base::{SourceMessage, SplitReader};
+use crate::base::{SourceMessage, SourceReader};
 use crate::kinesis::config::AwsConfigInfo;
 use crate::kinesis::source::message::KinesisMessage;
 use crate::kinesis::source::state::KinesisSplitReaderState;
 use crate::kinesis::split::{KinesisOffset, KinesisSplit};
-use crate::Properties;
+use crate::{ConnectorStateV2, Properties};
 
 pub struct KinesisSplitReader {
     client: kinesis_client,
@@ -41,7 +41,7 @@ pub struct KinesisSplitReader {
 }
 
 #[async_trait]
-impl SplitReader for KinesisSplitReader {
+impl SourceReader for KinesisSplitReader {
     async fn next(&mut self) -> Result<Option<Vec<SourceMessage>>> {
         if self.assigned_split.is_none() {
             return Err(anyhow::Error::msg(
@@ -111,7 +111,7 @@ impl SplitReader for KinesisSplitReader {
     }
 
     /// For Kinesis, state identifier is split_id, stream_name is never changed
-    async fn new(config: Properties, state: Option<crate::ConnectorState>) -> Result<Self>
+    async fn new(config: Properties, state: ConnectorStateV2) -> Result<Self>
     where
         Self: Sized,
     {
@@ -134,7 +134,7 @@ impl SplitReader for KinesisSplitReader {
             assigned_split: None,
         };
 
-        if let Some(state) = state {
+        if let ConnectorStateV2::State(state) = state {
             let split_id = String::from_utf8(state.identifier.to_vec())?;
 
             let mut start_offset = KinesisOffset::Earliest;

--- a/src/connector/src/pulsar/source/reader.rs
+++ b/src/connector/src/pulsar/source/reader.rs
@@ -19,9 +19,9 @@ use async_trait::async_trait;
 use futures::StreamExt;
 use pulsar::{Consumer, Pulsar, TokioExecutor};
 
-use crate::base::{SourceMessage, SplitReader};
+use crate::base::{SourceMessage, SourceReader};
 use crate::pulsar::split::{PulsarOffset, PulsarSplit};
-use crate::Properties;
+use crate::{ConnectorStateV2, Properties};
 
 pub struct PulsarSplitReader {
     pulsar: Pulsar<TokioExecutor>,
@@ -32,7 +32,7 @@ pub struct PulsarSplitReader {
 const PULSAR_MAX_FETCH_MESSAGES: u32 = 1024;
 
 #[async_trait]
-impl SplitReader for PulsarSplitReader {
+impl SourceReader for PulsarSplitReader {
     async fn next(&mut self) -> anyhow::Result<Option<Vec<SourceMessage>>> {
         let mut stream = self
             .consumer
@@ -74,7 +74,7 @@ impl SplitReader for PulsarSplitReader {
         Ok(Some(ret))
     }
 
-    async fn new(_props: Properties, _state: Option<crate::ConnectorState>) -> Result<Self>
+    async fn new(_props: Properties, _state: ConnectorStateV2) -> Result<Self>
     where
         Self: Sized,
     {

--- a/src/connector/src/pulsar/source/reader.rs
+++ b/src/connector/src/pulsar/source/reader.rs
@@ -19,7 +19,7 @@ use async_trait::async_trait;
 use futures::StreamExt;
 use pulsar::{Consumer, Pulsar, TokioExecutor};
 
-use crate::base::{SourceMessage, SourceReader};
+use crate::base::{SourceMessage, SplitReader};
 use crate::pulsar::split::{PulsarOffset, PulsarSplit};
 use crate::{ConnectorStateV2, Properties};
 
@@ -32,7 +32,7 @@ pub struct PulsarSplitReader {
 const PULSAR_MAX_FETCH_MESSAGES: u32 = 1024;
 
 #[async_trait]
-impl SourceReader for PulsarSplitReader {
+impl SplitReader for PulsarSplitReader {
     async fn next(&mut self) -> anyhow::Result<Option<Vec<SourceMessage>>> {
         let mut stream = self
             .consumer

--- a/src/connector/src/utils.rs
+++ b/src/connector/src/utils.rs
@@ -17,7 +17,7 @@ use std::collections::HashMap;
 use risingwave_common::error::ErrorCode::ProtocolError;
 use risingwave_common::error::{Result, RwError};
 
-#[derive(Clone)]
+#[derive(Clone, Debug)]
 pub struct Properties(pub HashMap<String, String>);
 
 impl Properties {

--- a/src/source/src/connector_source.rs
+++ b/src/source/src/connector_source.rs
@@ -74,11 +74,12 @@ pub struct ConnectorReaderContext {
     pub(crate) splits: Vec<SplitImpl>,
 }
 
+#[async_trait]
 impl Source for ConnectorSource {
     type ReaderContext = ConnectorReaderContext;
     type StreamReader = ConnectorStreamSource;
 
-    fn stream_reader(
+    async fn stream_reader(
         &self,
         context: ConnectorReaderContext,
         column_ids: Vec<ColumnId>,

--- a/src/source/src/connector_source.rs
+++ b/src/source/src/connector_source.rs
@@ -17,7 +17,6 @@ use std::fmt::Debug;
 use std::sync::Arc;
 
 use async_trait::async_trait;
-use futures::executor::block_on;
 use risingwave_common::array::StreamChunk;
 
 use risingwave_common::error::ErrorCode::ProtocolError;
@@ -90,13 +89,11 @@ impl Source for ConnectorSource {
             context.splits
         );
 
-        let reader = block_on(async move {
-            SourceReaderImpl::create(
-                Properties::new(self.config.clone()),
-                ConnectorStateV2::Splits(context.splits),
-            )
-            .await
-        })
+        let reader = SourceReaderImpl::create(
+            Properties::new(self.config.clone()),
+            ConnectorStateV2::Splits(context.splits),
+        )
+        .await
         .to_rw_result()?;
 
         let columns = self.get_target_columns(column_ids)?;

--- a/src/source/src/connector_source.rs
+++ b/src/source/src/connector_source.rs
@@ -12,32 +12,37 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use std::collections::HashMap;
 use std::fmt::Debug;
 use std::sync::Arc;
 
 use async_trait::async_trait;
-use lazy_static::__Deref;
+use futures::executor::block_on;
 use risingwave_common::array::StreamChunk;
+
 use risingwave_common::error::ErrorCode::ProtocolError;
-use risingwave_common::error::{Result, RwError};
-use risingwave_connector::{state, SplitReaderImpl};
+use risingwave_connector::{state};
 use risingwave_storage::StateStore;
 use tokio::sync::Mutex;
 
+use risingwave_common::catalog::ColumnId;
+use risingwave_common::error::ErrorCode::InternalError;
+use risingwave_common::error::{Result, RwError, ToRwResult};
+use risingwave_connector::{ConnectorStateV2, Properties, SourceReaderImpl, SplitImpl};
+
+
 use crate::common::SourceChunkBuilder;
-use crate::{SourceColumnDesc, SourceParserImpl, StreamSourceReader};
+use crate::{Source, SourceColumnDesc, SourceParserImpl, StreamSourceReader};
 
 /// [`ConnectorSource`] serves as a bridge between external components and streaming or batch
 /// processing. [`ConnectorSource`] introduces schema at this level while [`SplitReaderImpl`]
 /// simply loads raw content from message queue or file system.
 #[derive(Clone)]
 pub struct ConnectorSource {
-    pub parser: Arc<SourceParserImpl>,
-    pub reader: Arc<Mutex<SplitReaderImpl>>,
+    pub config: HashMap<String, String>,
     pub column_descs: Vec<SourceColumnDesc>,
+    pub parser: Arc<SourceParserImpl>,
 }
-
-impl SourceChunkBuilder for ConnectorSource {}
 
 impl Debug for ConnectorSource {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
@@ -46,37 +51,88 @@ impl Debug for ConnectorSource {
 }
 
 impl ConnectorSource {
-    pub fn new(
-        parser: Arc<SourceParserImpl>,
-        reader: Arc<Mutex<SplitReaderImpl>>,
-        column_descs: Vec<SourceColumnDesc>,
-    ) -> Self {
-        Self {
-            parser,
+    fn get_target_columns(&self, column_ids: Vec<ColumnId>) -> Result<Vec<SourceColumnDesc>> {
+        column_ids
+            .iter()
+            .map(|id| {
+                self.column_descs
+                    .iter()
+                    .find(|c| c.column_id == *id)
+                    .ok_or_else(|| {
+                        RwError::from(InternalError(format!(
+                            "Failed to find column id: {} in source: {:?}",
+                            id, self
+                        )))
+                    })
+                    .map(|col| col.clone())
+            })
+            .collect::<Result<Vec<SourceColumnDesc>>>()
+    }
+}
+
+pub struct ConnectorReaderContext {
+    pub(crate) splits: Vec<SplitImpl>,
+}
+
+impl Source for ConnectorSource {
+    type ReaderContext = ConnectorReaderContext;
+    type StreamReader = ConnectorStreamSource;
+
+    fn stream_reader(
+        &self,
+        context: ConnectorReaderContext,
+        column_ids: Vec<ColumnId>,
+    ) -> Result<Self::StreamReader> {
+        log::debug!(
+            "Creating new connector source with config {:?}, splits {:?}",
+            self.config,
+            context.splits
+        );
+
+        let reader = block_on(async move {
+            SourceReaderImpl::create(
+                Properties::new(self.config.clone()),
+                ConnectorStateV2::Splits(context.splits),
+            )
+            .await
+        })
+        .to_rw_result()?;
+
+        let columns = self.get_target_columns(column_ids)?;
+
+        Ok(ConnectorStreamSource {
             reader,
-            column_descs,
-        }
+            parser: self.parser.clone(),
+            column_descs: columns,
+        })
+    }
+}
+
+pub struct ConnectorStreamSource {
+    pub reader: SourceReaderImpl,
+    pub parser: Arc<SourceParserImpl>,
+    pub column_descs: Vec<SourceColumnDesc>,
+}
+
+impl SourceChunkBuilder for ConnectorStreamSource {}
+
+#[async_trait]
+impl StreamSourceReader for ConnectorStreamSource {
+    async fn open(&mut self) -> Result<()> {
+        Ok(())
     }
 
-    pub async fn next(&mut self) -> Result<StreamChunk> {
-        let payload = self
-            .reader
-            .lock()
-            .await
-            .next()
-            .await
-            .map_err(|e| RwError::from(ProtocolError(e.to_string())))?;
-
-        match payload {
+    async fn next(&mut self) -> Result<StreamChunk> {
+        match self.reader.next().await.to_rw_result()? {
             None => Ok(StreamChunk::default()),
             Some(batch) => {
                 let mut events = Vec::with_capacity(batch.len());
+
                 for msg in batch {
                     if let Some(content) = msg.payload {
-                        events.push(self.parser.parse(content.deref(), &self.column_descs)?);
+                        events.push(self.parser.parse(content.as_ref(), &self.column_descs)?);
                     }
                 }
-
                 let mut ops = Vec::with_capacity(events.iter().map(|e| e.ops.len()).sum());
                 let mut rows = Vec::with_capacity(events.iter().map(|e| e.rows.len()).sum());
 
@@ -91,22 +147,5 @@ impl ConnectorSource {
                 ))
             }
         }
-    }
-}
-
-#[derive(Debug)]
-pub struct ConnectorStreamSource<S: StateStore> {
-    pub source_reader: ConnectorSource,
-    pub state_store: state::SourceStateHandler<S>,
-}
-
-#[async_trait]
-impl<S: StateStore> StreamSourceReader for ConnectorStreamSource<S> {
-    async fn open(&mut self) -> Result<()> {
-        Ok(())
-    }
-
-    async fn next(&mut self) -> Result<StreamChunk> {
-        self.source_reader.next().await
     }
 }

--- a/src/source/src/connector_source.rs
+++ b/src/source/src/connector_source.rs
@@ -27,7 +27,7 @@ use crate::common::SourceChunkBuilder;
 use crate::{Source, SourceColumnDesc, SourceParserImpl, StreamSourceReader};
 
 /// [`ConnectorSource`] serves as a bridge between external components and streaming or batch
-/// processing. [`ConnectorSource`] introduces schema at this level while [`SplitReaderImpl`]
+/// processing. [`ConnectorSource`] introduces schema at this level while [`SourceReaderImpl`]
 /// simply loads raw content from message queue or file system.
 #[derive(Clone)]
 pub struct ConnectorSource {

--- a/src/source/src/lib.rs
+++ b/src/source/src/lib.rs
@@ -108,9 +108,11 @@ impl SourceImpl {
         match (self, context) {
             (SourceImpl::TableV2(x), SourceReaderContext::None(_)) => x
                 .stream_reader(TableV2ReaderContext {}, column_ids)
+                .await
                 .map(SourceStreamReaderImpl::TableV2),
             (SourceImpl::Connector(c), SourceReaderContext::ConnectorReaderContext(context)) => c
                 .stream_reader(ConnectorReaderContext { splits: context }, column_ids)
+                .await
                 .map(SourceStreamReaderImpl::Connector),
             _ => Err(RwError::from(InternalError(
                 "unmatched source and context".to_string(),
@@ -125,7 +127,7 @@ pub trait Source: Send + Sync + 'static {
     type StreamReader: StreamSourceReader;
 
     /// Create a stream reader
-    fn stream_reader(
+    async fn stream_reader(
         &self,
         context: Self::ReaderContext,
         column_ids: Vec<ColumnId>,

--- a/src/source/src/lib.rs
+++ b/src/source/src/lib.rs
@@ -32,14 +32,17 @@
 use std::fmt::Debug;
 
 use async_trait::async_trait;
-use connector_source::ConnectorSource;
 use enum_as_inner::EnumAsInner;
 pub use manager::*;
 pub use parser::*;
 use risingwave_common::array::StreamChunk;
 use risingwave_common::catalog::ColumnId;
-use risingwave_common::error::Result;
+use risingwave_common::error::ErrorCode::InternalError;
+use risingwave_common::error::{Result, RwError};
+use risingwave_connector::SplitImpl;
 pub use table_v2::*;
+
+use crate::connector_source::{ConnectorReaderContext, ConnectorSource, ConnectorStreamSource};
 
 pub mod parser;
 
@@ -49,6 +52,7 @@ mod manager;
 mod common;
 mod table_v2;
 
+extern crate core;
 extern crate maplit;
 
 #[derive(Clone, Debug, PartialEq, Eq)]
@@ -64,6 +68,55 @@ pub enum SourceFormat {
 pub enum SourceImpl {
     TableV2(TableSourceV2),
     Connector(ConnectorSource),
+}
+
+pub enum SourceStreamReaderImpl {
+    TableV2(TableV2StreamReader),
+    Connector(ConnectorStreamSource),
+}
+
+#[async_trait]
+impl StreamSourceReader for SourceStreamReaderImpl {
+    async fn open(&mut self) -> Result<()> {
+        match self {
+            SourceStreamReaderImpl::TableV2(t) => t.open().await,
+            SourceStreamReaderImpl::Connector(c) => c.open().await,
+        }
+    }
+
+    async fn next(&mut self) -> Result<StreamChunk> {
+        match self {
+            SourceStreamReaderImpl::TableV2(t) => t.next().await,
+            SourceStreamReaderImpl::Connector(c) => c.next().await,
+        }
+    }
+}
+
+pub enum SourceReaderContext {
+    None(()),
+    ConnectorReaderContext(Vec<SplitImpl>),
+}
+
+impl SourceImpl {
+    pub async fn stream_reader(
+        &self,
+        context: SourceReaderContext,
+        column_ids: Vec<ColumnId>,
+    ) -> Result<SourceStreamReaderImpl> {
+        log::debug!("Creating new stream reader");
+
+        match (self, context) {
+            (SourceImpl::TableV2(x), SourceReaderContext::None(_)) => x
+                .stream_reader(TableV2ReaderContext {}, column_ids)
+                .map(SourceStreamReaderImpl::TableV2),
+            (SourceImpl::Connector(c), SourceReaderContext::ConnectorReaderContext(context)) => c
+                .stream_reader(ConnectorReaderContext { splits: context }, column_ids)
+                .map(SourceStreamReaderImpl::Connector),
+            _ => Err(RwError::from(InternalError(
+                "unmatched source and context".to_string(),
+            ))),
+        }
+    }
 }
 
 #[async_trait]

--- a/src/source/src/lib.rs
+++ b/src/source/src/lib.rs
@@ -42,7 +42,7 @@ use risingwave_common::error::{Result, RwError};
 use risingwave_connector::SplitImpl;
 pub use table_v2::*;
 
-use crate::connector_source::{ConnectorReaderContext, ConnectorSource, ConnectorStreamSource};
+use crate::connector_source::{ConnectorReaderContext, ConnectorSource, ConnectorStreamReader};
 
 pub mod parser;
 
@@ -72,7 +72,7 @@ pub enum SourceImpl {
 
 pub enum SourceStreamReaderImpl {
     TableV2(TableV2StreamReader),
-    Connector(ConnectorStreamSource),
+    Connector(ConnectorStreamReader),
 }
 
 #[async_trait]

--- a/src/source/src/manager.rs
+++ b/src/source/src/manager.rs
@@ -142,7 +142,7 @@ impl SourceManager for MemSourceManager {
         };
 
         let source = SourceImpl::Connector(ConnectorSource {
-            config: properties.0,
+            config: properties,
             columns: columns.clone(),
             parser,
         });

--- a/src/source/src/manager.rs
+++ b/src/source/src/manager.rs
@@ -23,7 +23,7 @@ use risingwave_common::ensure;
 use risingwave_common::error::ErrorCode::{InternalError, ProtocolError};
 use risingwave_common::error::{Result, RwError};
 use risingwave_common::types::DataType;
-use risingwave_connector::{Properties, SplitReaderImpl};
+use risingwave_connector::Properties;
 use risingwave_pb::catalog::{RowFormatType, StreamSourceInfo};
 
 use crate::connector_source::ConnectorSource;
@@ -141,15 +141,10 @@ impl SourceManager for MemSourceManager {
             }
         };
 
-        let split_reader = Arc::new(tokio::sync::Mutex::new(
-            SplitReaderImpl::create(properties, None)
-                .await
-                .map_err(|e| RwError::from(InternalError(e.to_string())))?,
-        ));
         let source = SourceImpl::Connector(ConnectorSource {
-            parser: parser.clone(),
-            reader: split_reader,
+            config: properties.0,
             column_descs: columns.clone(),
+            parser,
         });
 
         let desc = SourceDesc {

--- a/src/source/src/manager.rs
+++ b/src/source/src/manager.rs
@@ -143,7 +143,7 @@ impl SourceManager for MemSourceManager {
 
         let source = SourceImpl::Connector(ConnectorSource {
             config: properties.0,
-            column_descs: columns.clone(),
+            columns: columns.clone(),
             parser,
         });
 

--- a/src/source/src/table_v2.rs
+++ b/src/source/src/table_v2.rs
@@ -161,7 +161,7 @@ impl Source for TableSourceV2 {
     type ReaderContext = TableV2ReaderContext;
     type StreamReader = TableV2StreamReader;
 
-    fn stream_reader(
+    async fn stream_reader(
         &self,
         _context: Self::ReaderContext,
         column_ids: Vec<ColumnId>,
@@ -211,7 +211,9 @@ mod tests {
     #[tokio::test]
     async fn test_table_source_v2() -> Result<()> {
         let source = Arc::new(new_source());
-        let mut reader = source.stream_reader(TableV2ReaderContext, vec![ColumnId::from(0)])?;
+        let mut reader = source
+            .stream_reader(TableV2ReaderContext, vec![ColumnId::from(0)])
+            .await?;
 
         macro_rules! write_chunk {
             ($i:expr) => {{

--- a/src/stream/Cargo.toml
+++ b/src/stream/Cargo.toml
@@ -30,6 +30,7 @@ parking_lot = "0.12"
 paste = "1"
 prometheus = { version = "0.13", features = ["process"] }
 prost = "0.10"
+rand = "0.8.5"
 rdkafka = { version = "0.28", features = ["cmake-build"] }
 risingwave_common = { path = "../common" }
 risingwave_connector = { path = "../connector" }

--- a/src/stream/src/executor/source.rs
+++ b/src/stream/src/executor/source.rs
@@ -72,12 +72,7 @@ pub struct SourceExecutor {
     /// Logical Operator Info
     op_info: String,
 
-    // fixme
     barrier_receiver: Option<UnboundedReceiver<Message>>,
-
-    /// The reader object. When `next` is called for the first time on `SourceExecutor`, the
-    /// `reader` will be turned into `reader_stream`, and this field will become `None`.
-    //    reader: Option<SourceReader>,
 
     /// Stream object for reader. When `next` is called for the first time on `SourceExecutor`, the
     /// `reader` will be turned into a `futures::Stream`.
@@ -158,22 +153,6 @@ impl ExecutorBuilder for SourceExecutorBuilder {
         )?))
     }
 }
-
-// async fn _build_stream_reader<S: StateStore>(
-//     source: Arc<SourceImpl>,
-//     _operator_id: u64,
-//     column_ids: Vec<ColumnId>,
-//     _keyspace: Keyspace<S>,
-// ) -> Result<Box<dyn StreamSourceReader>> {
-//     let stream_reader: Box<dyn StreamSourceReader> = match source.as_ref() {
-//         SourceImpl::TableV2(s) => {
-//             Box::new(s.stream_reader(TableV2ReaderContext, column_ids).await?)
-//         }
-//         SourceImpl::Connector(_s) => unimplemented!(),
-//     };
-//
-//     Ok(stream_reader)
-// }
 
 impl SourceExecutor {
     #[allow(clippy::too_many_arguments)]

--- a/src/stream/src/executor/source.rs
+++ b/src/stream/src/executor/source.rs
@@ -74,7 +74,6 @@ pub struct SourceExecutor {
 
     // fixme
     barrier_receiver: Option<UnboundedReceiver<Message>>,
-    stream_reader: Option<Box<dyn StreamSourceReader>>,
 
     /// The reader object. When `next` is called for the first time on `SourceExecutor`, the
     /// `reader` will be turned into `reader_stream`, and this field will become `None`.
@@ -160,27 +159,21 @@ impl ExecutorBuilder for SourceExecutorBuilder {
     }
 }
 
-async fn build_stream_reader<S: StateStore>(
-    source: Arc<SourceImpl>,
-    _operator_id: u64,
-    column_ids: Vec<ColumnId>,
-    _keyspace: Keyspace<S>,
-) -> Result<Box<dyn StreamSourceReader>> {
-    let stream_reader: Box<dyn StreamSourceReader> = match source.as_ref() {
-        SourceImpl::TableV2(s) => Box::new(s.stream_reader(TableV2ReaderContext, column_ids)?),
-        SourceImpl::Connector(_s) => unimplemented!(),
-        //  Box::new(ConnectorStreamSource {
-        // //            source_reader: s.clone(),
-        //             //state_store: state::SourceStateHandler::new(keyspace),
-        //
-        //             reader: (),
-        //             parser: Arc::new(()),
-        //             column_descs: vec![]
-        //         }),
-    };
-
-    Ok(stream_reader)
-}
+// async fn _build_stream_reader<S: StateStore>(
+//     source: Arc<SourceImpl>,
+//     _operator_id: u64,
+//     column_ids: Vec<ColumnId>,
+//     _keyspace: Keyspace<S>,
+// ) -> Result<Box<dyn StreamSourceReader>> {
+//     let stream_reader: Box<dyn StreamSourceReader> = match source.as_ref() {
+//         SourceImpl::TableV2(s) => {
+//             Box::new(s.stream_reader(TableV2ReaderContext, column_ids).await?)
+//         }
+//         SourceImpl::Connector(_s) => unimplemented!(),
+//     };
+//
+//     Ok(stream_reader)
+// }
 
 impl SourceExecutor {
     #[allow(clippy::too_many_arguments)]
@@ -208,7 +201,6 @@ impl SourceExecutor {
             schema,
             pk_indices,
             barrier_receiver: Some(barrier_receiver),
-            stream_reader: None,
             // fixme(chen): may conflict
             next_row_id: AtomicU64::from(
                 SystemTime::now()

--- a/src/stream/src/executor/source.rs
+++ b/src/stream/src/executor/source.rs
@@ -16,11 +16,12 @@ use std::fmt::{Debug, Formatter};
 use std::pin::Pin;
 use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::Arc;
+use std::time::{Duration, SystemTime, UNIX_EPOCH};
 
 use async_trait::async_trait;
 use either::Either;
 use futures::stream::{select_with_strategy, PollNext};
-use futures::{Future, Stream, StreamExt};
+use futures::{Stream, StreamExt};
 use futures_async_stream::try_stream;
 use risingwave_common::array::column::Column;
 use risingwave_common::array::{ArrayBuilder, ArrayImpl, I64ArrayBuilder, StreamChunk};
@@ -28,10 +29,9 @@ use risingwave_common::catalog::{ColumnId, Field, Schema, TableId};
 use risingwave_common::error::ErrorCode::InternalError;
 use risingwave_common::error::{Result, RwError, ToRwResult};
 use risingwave_common::try_match_expand;
-use risingwave_connector::{state, SplitImpl};
+use risingwave_connector::SplitImpl;
 use risingwave_pb::stream_plan;
 use risingwave_pb::stream_plan::stream_node::Node;
-use risingwave_source::connector_source::ConnectorStreamSource;
 use risingwave_source::*;
 use risingwave_storage::{Keyspace, StateStore};
 use tokio::sync::mpsc::{unbounded_channel, UnboundedReceiver};
@@ -43,7 +43,6 @@ use crate::task::{ExecutorParams, LocalStreamManagerCore};
 struct SourceReader {
     /// the future that builds stream_reader. It is required because source should not establish
     /// connections to the upstream before `next` is called
-    pub stream_reader_future: Option<StreamReaderFuture>,
     /// The reader for stream source
     pub stream_reader: Option<Box<dyn StreamSourceReader>>,
     /// The reader for barrier
@@ -53,14 +52,13 @@ struct SourceReader {
 /// `SourceReader` will be turned into this stream type.
 type ReaderStream =
     Pin<Box<dyn Stream<Item = Either<Result<Message>, Result<StreamChunk>>> + Send>>;
-type StreamReaderFuture =
-    Pin<Box<dyn Future<Output = Result<Box<dyn StreamSourceReader>>> + Send + Sync>>;
 
 /// [`SourceExecutor`] is a streaming source, from risingwave's batch table, or external systems
 /// such as Kafka.
 pub struct SourceExecutor {
     source_id: TableId,
     source_desc: SourceDesc,
+
     column_ids: Vec<ColumnId>,
     schema: Schema,
     pk_indices: PkIndices,
@@ -74,9 +72,13 @@ pub struct SourceExecutor {
     /// Logical Operator Info
     op_info: String,
 
+    // fixme
+    barrier_receiver: Option<UnboundedReceiver<Message>>,
+    stream_reader: Option<Box<dyn StreamSourceReader>>,
+
     /// The reader object. When `next` is called for the first time on `SourceExecutor`, the
     /// `reader` will be turned into `reader_stream`, and this field will become `None`.
-    reader: Option<SourceReader>,
+    //    reader: Option<SourceReader>,
 
     /// Stream object for reader. When `next` is called for the first time on `SourceExecutor`, the
     /// `reader` will be turned into a `futures::Stream`.
@@ -162,14 +164,19 @@ async fn build_stream_reader<S: StateStore>(
     source: Arc<SourceImpl>,
     _operator_id: u64,
     column_ids: Vec<ColumnId>,
-    keyspace: Keyspace<S>,
+    _keyspace: Keyspace<S>,
 ) -> Result<Box<dyn StreamSourceReader>> {
     let stream_reader: Box<dyn StreamSourceReader> = match source.as_ref() {
         SourceImpl::TableV2(s) => Box::new(s.stream_reader(TableV2ReaderContext, column_ids)?),
-        SourceImpl::Connector(s) => Box::new(ConnectorStreamSource {
-            source_reader: s.clone(),
-            state_store: state::SourceStateHandler::new(keyspace),
-        }),
+        SourceImpl::Connector(_s) => unimplemented!(),
+        //  Box::new(ConnectorStreamSource {
+        // //            source_reader: s.clone(),
+        //             //state_store: state::SourceStateHandler::new(keyspace),
+        //
+        //             reader: (),
+        //             parser: Arc::new(()),
+        //             column_descs: vec![]
+        //         }),
     };
 
     Ok(stream_reader)
@@ -180,24 +187,19 @@ impl SourceExecutor {
     pub fn new<S: StateStore>(
         source_id: TableId,
         source_desc: SourceDesc,
-        keyspace: Keyspace<S>,
+        _keyspace: Keyspace<S>,
         column_ids: Vec<ColumnId>,
         schema: Schema,
         pk_indices: PkIndices,
         barrier_receiver: UnboundedReceiver<Message>,
         executor_id: u64,
-        operator_id: u64,
+        _operator_id: u64,
         op_info: String,
         streaming_metrics: Arc<StreamingMetrics>,
         stream_source_splits: Vec<SplitImpl>,
     ) -> Result<Self> {
-        let source = source_desc.clone().source;
-        let stream_reader_future: StreamReaderFuture = Box::pin(build_stream_reader(
-            source,
-            operator_id,
-            column_ids.clone(),
-            keyspace,
-        ));
+        // fixme(chen): sleep to avoid conflict
+        std::thread::sleep(Duration::from_millis(rand::random::<u64>() % 1000));
 
         Ok(Self {
             source_id,
@@ -205,12 +207,15 @@ impl SourceExecutor {
             column_ids,
             schema,
             pk_indices,
-            reader: Some(SourceReader {
-                stream_reader_future: Some(stream_reader_future),
-                stream_reader: None,
-                barrier_receiver,
-            }),
-            next_row_id: AtomicU64::from(0u64),
+            barrier_receiver: Some(barrier_receiver),
+            stream_reader: None,
+            // fixme(chen): may conflict
+            next_row_id: AtomicU64::from(
+                SystemTime::now()
+                    .duration_since(UNIX_EPOCH)
+                    .unwrap()
+                    .as_nanos() as u64,
+            ),
             identity: format!("SourceExecutor {:X}", executor_id),
             op_info,
             reader_stream: None,
@@ -299,39 +304,75 @@ impl SourceReader {
 #[async_trait]
 impl Executor for SourceExecutor {
     async fn next(&mut self) -> Result<Message> {
-        if let Some(mut reader) = self.reader.take() {
-            reader
-                .stream_reader
-                .replace(reader.stream_reader_future.as_mut().unwrap().await?);
-            reader.stream_reader.as_mut().unwrap().open().await?;
-            self.reader_stream.replace(reader.into_stream().boxed());
-        }
+        match self.reader_stream.as_mut() {
+            None => {
+                let msg = self
+                    .barrier_receiver
+                    .as_mut()
+                    .unwrap()
+                    .recv()
+                    .await
+                    .unwrap();
 
-        match self.reader_stream.as_mut().unwrap().next().await {
-            // This branch will be preferred.
-            Some(Either::Left(message)) => message,
+                // todo: use epoch from msg to restore state from state store
 
-            // If there's barrier, this branch will be deferred.
-            Some(Either::Right(chunk)) => {
-                let mut chunk = chunk?;
+                assert!(matches!(msg, Message::Barrier(_)));
 
-                // Refill row id only if not a table source.
-                // Note(eric): Currently, rows from external sources are filled with row_ids here,
-                // but rows from tables (by insert statements) are filled in InsertExecutor.
-                //
-                // TODO: in the future, we may add row_id column here for TableV2 as well
-                if !matches!(self.source_desc.source.as_ref(), SourceImpl::TableV2(_)) {
-                    chunk = self.refill_row_id_column(chunk);
-                }
+                let reader = self
+                    .source_desc
+                    .source
+                    .stream_reader(
+                        match self.source_desc.source.as_ref() {
+                            SourceImpl::TableV2(_) => SourceReaderContext::None(()),
+                            SourceImpl::Connector(_c) => {
+                                SourceReaderContext::ConnectorReaderContext(
+                                    self.stream_source_splits.clone(),
+                                )
+                            }
+                        },
+                        self.column_ids.clone(),
+                    )
+                    .await?;
 
-                self.metrics
-                    .source_output_row_count
-                    .with_label_values(&[self.source_identify.as_str()])
-                    .inc_by(chunk.cardinality() as u64);
-                Ok(Message::Chunk(chunk))
+                let barrier = self.barrier_receiver.take().unwrap();
+
+                let reader = SourceReader {
+                    stream_reader: Some(Box::new(reader)),
+                    barrier_receiver: barrier,
+                };
+
+                self.reader_stream.replace(reader.into_stream().boxed());
+
+                Ok(msg)
             }
+            Some(stream) => {
+                match stream.as_mut().next().await {
+                    // This branch will be preferred.
+                    Some(Either::Left(message)) => message,
 
-            None => unreachable!(),
+                    // If there's barrier, this branch will be deferred.
+                    Some(Either::Right(chunk)) => {
+                        let mut chunk = chunk?;
+                        // Refill row id only if not a table source.
+                        // Note(eric): Currently, rows from external sources are filled with row_ids
+                        // here, but rows from tables (by insert statements)
+                        // are filled in InsertExecutor.
+                        //
+                        // TODO: in the future, we may add row_id column here for TableV2 as well
+                        if !matches!(self.source_desc.source.as_ref(), SourceImpl::TableV2(_)) {
+                            chunk = self.refill_row_id_column(chunk);
+                        }
+
+                        self.metrics
+                            .source_output_row_count
+                            .with_label_values(&[self.source_identify.as_str()])
+                            .inc_by(chunk.cardinality() as u64);
+                        Ok(Message::Chunk(chunk))
+                    }
+
+                    None => unreachable!(),
+                }
+            }
         }
     }
 


### PR DESCRIPTION
## What's changed and what's your intention?

This PR fixes the `create materialized view from source` feature

It is now possible to `create materialized views` from the rust frontend 

However, the state storage of the source executor is not currently handled and requires a PR from @tabVersion  to complete

Since we need to start the whole MV with the first barrier, we modified `/src/compute/tests/table_v2_materialize.rs` to inject the first barrier

## Checklist

- [x] I have written necessary docs and comments
- [x] I have added necessary unit tests and integration tests

## Refer to a related PR or issue link (optional)
