### PR TITLE
feat(streaming): use executor v2 in dispatcher, actor, and builder

### DIFF
--- a/src/compute/tests/table_v2_materialize.rs
+++ b/src/compute/tests/table_v2_materialize.rs
@@ -39,7 +39,7 @@ use risingwave_storage::{Keyspace, StateStore, StateStoreImpl};
 use risingwave_stream::executor::{
     Barrier, ExecutorV1, Message, PkIndices, SourceExecutor, StreamingMetrics,
 };
-use risingwave_stream::executor_v2::{Executor, MaterializeExecutor as MaterializeExecutorV2};
+use risingwave_stream::executor_v2::{Executor, MaterializeExecutor};
 use tokio::sync::mpsc::unbounded_channel;
 
 struct SingleChunkExecutor {
@@ -164,7 +164,7 @@ async fn test_table_v2_materialize() -> Result<()> {
 
     // Create a `Materialize` to write the changes to storage
     let keyspace = Keyspace::table_root(memory_state_store.clone(), &source_table_id);
-    let mut materialize = MaterializeExecutorV2::new_from_v1(
+    let mut materialize = MaterializeExecutor::new_from_v1(
         (Box::new(stream_source) as Box<dyn ExecutorV1>).v2(),
         keyspace.clone(),
         vec![OrderPair::new(1, OrderType::Ascending)],

--- a/src/compute/tests/table_v2_materialize.rs
+++ b/src/compute/tests/table_v2_materialize.rs
@@ -165,7 +165,9 @@ async fn test_table_v2_materialize() -> Result<()> {
     // Create a `Materialize` to write the changes to storage
     let keyspace = Keyspace::table_root(memory_state_store.clone(), &source_table_id);
     let mut materialize = MaterializeExecutor::new_from_v1(
-        (Box::new(stream_source) as Box<dyn ExecutorV1>).v2(),
+        (Box::new(stream_source) as Box<dyn ExecutorV1>)
+            .v2()
+            .boxed(),
         keyspace.clone(),
         vec![OrderPair::new(1, OrderType::Ascending)],
         all_column_ids.clone(),

--- a/src/compute/tests/table_v2_materialize.rs
+++ b/src/compute/tests/table_v2_materialize.rs
@@ -37,11 +37,9 @@ use risingwave_storage::table::cell_based_table::CellBasedTable;
 // use risingwave_storage::table::mview::MViewTable;
 use risingwave_storage::{Keyspace, StateStore, StateStoreImpl};
 use risingwave_stream::executor::{
-    Barrier, Executor as ExecutorV1, Message, PkIndices, SourceExecutor, StreamingMetrics,
+    Barrier, ExecutorV1, Message, PkIndices, SourceExecutor, StreamingMetrics,
 };
-use risingwave_stream::executor_v2::{
-    Executor as ExecutorV2, MaterializeExecutor as MaterializeExecutorV2,
-};
+use risingwave_stream::executor_v2::{Executor, MaterializeExecutor as MaterializeExecutorV2};
 use tokio::sync::mpsc::unbounded_channel;
 
 struct SingleChunkExecutor {

--- a/src/stream/src/executor/barrier_align.rs
+++ b/src/stream/src/executor/barrier_align.rs
@@ -17,8 +17,8 @@ use futures::StreamExt;
 use risingwave_common::error::Result;
 use tokio::select;
 
-use super::{Barrier, Executor, Message, StreamChunk};
-use crate::executor::BoxedExecutorStream;
+use super::{Barrier, ExecutorV1, Message, StreamChunk};
+use crate::executor::BoxedExecutorV1Stream;
 
 #[derive(Debug, PartialEq)]
 enum BarrierWaitState {
@@ -47,15 +47,15 @@ impl<'a> TryFrom<&'a AlignedMessage> for &'a Barrier {
 
 pub struct BarrierAligner {
     /// The input from the left executor
-    input_l: BoxedExecutorStream,
+    input_l: BoxedExecutorV1Stream,
     /// The input from the right executor
-    input_r: BoxedExecutorStream,
+    input_r: BoxedExecutorV1Stream,
     /// The barrier state
     state: BarrierWaitState,
 }
 
 impl BarrierAligner {
-    pub fn new(mut input_l: Box<dyn Executor>, mut input_r: Box<dyn Executor>) -> Self {
+    pub fn new(mut input_l: Box<dyn ExecutorV1>, mut input_r: Box<dyn ExecutorV1>) -> Self {
         // Wrap the input executors into streams to ensure cancellation-safety
         let input_l = try_stream! {
             loop {

--- a/src/stream/src/executor/batch_query.rs
+++ b/src/stream/src/executor/batch_query.rs
@@ -24,7 +24,7 @@ use risingwave_storage::monitor::StateStoreMetrics;
 use risingwave_storage::table::cell_based_table::CellBasedTable;
 use risingwave_storage::{Keyspace, StateStore};
 
-use crate::executor::{Executor, ExecutorBuilder};
+use crate::executor::ExecutorBuilder;
 use crate::executor_v2::{
     BatchQueryExecutor as BatchQueryExecutorV2, BoxedExecutor, Executor as ExecutorV2,
 };

--- a/src/stream/src/executor/batch_query.rs
+++ b/src/stream/src/executor/batch_query.rs
@@ -25,9 +25,7 @@ use risingwave_storage::table::cell_based_table::CellBasedTable;
 use risingwave_storage::{Keyspace, StateStore};
 
 use crate::executor::ExecutorBuilder;
-use crate::executor_v2::{
-    BatchQueryExecutor as BatchQueryExecutorV2, BoxedExecutor, Executor as ExecutorV2,
-};
+use crate::executor_v2::{BatchQueryExecutor as BatchQueryExecutorV2, BoxedExecutor, Executor};
 use crate::task::{ExecutorParams, LocalStreamManagerCore};
 
 pub struct BatchQueryExecutorBuilder;

--- a/src/stream/src/executor/batch_query.rs
+++ b/src/stream/src/executor/batch_query.rs
@@ -25,18 +25,20 @@ use risingwave_storage::table::cell_based_table::CellBasedTable;
 use risingwave_storage::{Keyspace, StateStore};
 
 use crate::executor::{Executor, ExecutorBuilder};
-use crate::executor_v2::{BatchQueryExecutor as BatchQueryExecutorV2, Executor as ExecutorV2};
+use crate::executor_v2::{
+    BatchQueryExecutor as BatchQueryExecutorV2, BoxedExecutor, Executor as ExecutorV2,
+};
 use crate::task::{ExecutorParams, LocalStreamManagerCore};
 
 pub struct BatchQueryExecutorBuilder;
 
 impl ExecutorBuilder for BatchQueryExecutorBuilder {
-    fn new_boxed_executor_v1(
+    fn new_boxed_executor(
         params: ExecutorParams,
         node: &stream_plan::StreamNode,
         state_store: impl StateStore,
         _stream: &mut LocalStreamManagerCore,
-    ) -> Result<Box<dyn Executor>> {
+    ) -> Result<BoxedExecutor> {
         let node = try_match_expand!(node.get_node().unwrap(), Node::BatchPlanNode)?;
         let table_id = TableId::from(&node.table_ref_id);
         let column_descs = node
@@ -58,14 +60,14 @@ impl ExecutorBuilder for BatchQueryExecutorBuilder {
 
         let parallel_info = node.get_parallel_info()?;
 
-        let v2 = Box::new(BatchQueryExecutorV2::new_from_v1(
+        let v2 = BatchQueryExecutorV2::new_from_v1(
             table,
             params.pk_indices,
             params.op_info,
             key_indices,
             parallel_info.clone(),
-        ));
+        );
 
-        Ok(Box::new(v2.v1_uninited()))
+        Ok(v2.boxed())
     }
 }

--- a/src/stream/src/executor/batch_query.rs
+++ b/src/stream/src/executor/batch_query.rs
@@ -31,7 +31,7 @@ use crate::task::{ExecutorParams, LocalStreamManagerCore};
 pub struct BatchQueryExecutorBuilder;
 
 impl ExecutorBuilder for BatchQueryExecutorBuilder {
-    fn new_boxed_executor(
+    fn new_boxed_executor_v1(
         params: ExecutorParams,
         node: &stream_plan::StreamNode,
         state_store: impl StateStore,

--- a/src/stream/src/executor/batch_query.rs
+++ b/src/stream/src/executor/batch_query.rs
@@ -25,7 +25,7 @@ use risingwave_storage::table::cell_based_table::CellBasedTable;
 use risingwave_storage::{Keyspace, StateStore};
 
 use crate::executor::ExecutorBuilder;
-use crate::executor_v2::{BatchQueryExecutor as BatchQueryExecutorV2, BoxedExecutor, Executor};
+use crate::executor_v2::{BatchQueryExecutor, BoxedExecutor, Executor};
 use crate::task::{ExecutorParams, LocalStreamManagerCore};
 
 pub struct BatchQueryExecutorBuilder;
@@ -58,7 +58,7 @@ impl ExecutorBuilder for BatchQueryExecutorBuilder {
 
         let parallel_info = node.get_parallel_info()?;
 
-        let v2 = BatchQueryExecutorV2::new_from_v1(
+        let executor = BatchQueryExecutor::new_from_v1(
             table,
             params.pk_indices,
             params.op_info,
@@ -66,6 +66,6 @@ impl ExecutorBuilder for BatchQueryExecutorBuilder {
             parallel_info.clone(),
         );
 
-        Ok(v2.boxed())
+        Ok(executor.boxed())
     }
 }

--- a/src/stream/src/executor/chain.rs
+++ b/src/stream/src/executor/chain.rs
@@ -19,7 +19,7 @@ use risingwave_pb::stream_plan::stream_node::Node;
 use risingwave_storage::StateStore;
 
 use crate::executor::ExecutorBuilder;
-use crate::executor_v2::{BoxedExecutor, ChainExecutor as ChainExecutorV2, Executor};
+use crate::executor_v2::{BoxedExecutor, ChainExecutor, Executor};
 use crate::task::{ExecutorParams, LocalStreamManagerCore};
 
 pub struct ChainExecutorBuilder;
@@ -49,7 +49,7 @@ impl ExecutorBuilder for ChainExecutorBuilder {
         // its schema.
         let schema = snapshot.schema().clone();
 
-        let v2 = ChainExecutorV2::new_from_v1(
+        let executor = ChainExecutor::new_from_v1(
             snapshot,
             mview,
             notifier,
@@ -58,6 +58,6 @@ impl ExecutorBuilder for ChainExecutorBuilder {
             params.op_info,
         );
 
-        Ok(v2.boxed())
+        Ok(executor.boxed())
     }
 }

--- a/src/stream/src/executor/chain.rs
+++ b/src/stream/src/executor/chain.rs
@@ -18,7 +18,6 @@ use risingwave_pb::stream_plan;
 use risingwave_pb::stream_plan::stream_node::Node;
 use risingwave_storage::StateStore;
 
-use super::Executor;
 use crate::executor::ExecutorBuilder;
 use crate::executor_v2::{BoxedExecutor, ChainExecutor as ChainExecutorV2, Executor as ExecutorV2};
 use crate::task::{ExecutorParams, LocalStreamManagerCore};

--- a/src/stream/src/executor/chain.rs
+++ b/src/stream/src/executor/chain.rs
@@ -19,7 +19,7 @@ use risingwave_pb::stream_plan::stream_node::Node;
 use risingwave_storage::StateStore;
 
 use crate::executor::ExecutorBuilder;
-use crate::executor_v2::{BoxedExecutor, ChainExecutor as ChainExecutorV2, Executor as ExecutorV2};
+use crate::executor_v2::{BoxedExecutor, ChainExecutor as ChainExecutorV2, Executor};
 use crate::task::{ExecutorParams, LocalStreamManagerCore};
 
 pub struct ChainExecutorBuilder;

--- a/src/stream/src/executor/chain.rs
+++ b/src/stream/src/executor/chain.rs
@@ -20,18 +20,18 @@ use risingwave_storage::StateStore;
 
 use super::Executor;
 use crate::executor::ExecutorBuilder;
-use crate::executor_v2::{ChainExecutor as ChainExecutorV2, Executor as ExecutorV2};
+use crate::executor_v2::{BoxedExecutor, ChainExecutor as ChainExecutorV2, Executor as ExecutorV2};
 use crate::task::{ExecutorParams, LocalStreamManagerCore};
 
 pub struct ChainExecutorBuilder;
 
 impl ExecutorBuilder for ChainExecutorBuilder {
-    fn new_boxed_executor_v1(
+    fn new_boxed_executor(
         mut params: ExecutorParams,
         node: &stream_plan::StreamNode,
         _store: impl StateStore,
         stream: &mut LocalStreamManagerCore,
-    ) -> Result<Box<dyn Executor>> {
+    ) -> Result<BoxedExecutor> {
         let node = try_match_expand!(node.get_node().unwrap(), Node::ChainNode)?;
         let snapshot = params.input.remove(1);
         let mview = params.input.remove(0);
@@ -50,15 +50,15 @@ impl ExecutorBuilder for ChainExecutorBuilder {
         // its schema.
         let schema = snapshot.schema().clone();
 
-        let v2 = Box::new(ChainExecutorV2::new_from_v1(
+        let v2 = ChainExecutorV2::new_from_v1(
             snapshot,
             mview,
             notifier,
             schema,
             column_idxs,
             params.op_info,
-        ));
+        );
 
-        Ok(Box::new(v2.v1()))
+        Ok(v2.boxed())
     }
 }

--- a/src/stream/src/executor/chain.rs
+++ b/src/stream/src/executor/chain.rs
@@ -26,7 +26,7 @@ use crate::task::{ExecutorParams, LocalStreamManagerCore};
 pub struct ChainExecutorBuilder;
 
 impl ExecutorBuilder for ChainExecutorBuilder {
-    fn new_boxed_executor(
+    fn new_boxed_executor_v1(
         mut params: ExecutorParams,
         node: &stream_plan::StreamNode,
         _store: impl StateStore,

--- a/src/stream/src/executor/debug/cache_clear.rs
+++ b/src/stream/src/executor/debug/cache_clear.rs
@@ -18,7 +18,7 @@ use std::sync::Once;
 use async_trait::async_trait;
 use risingwave_common::error::Result;
 
-use crate::executor::{Executor, Message};
+use crate::executor::{ExecutorV1, Message};
 
 pub const CACHE_CLEAR_ENABLED_ENV_VAR_KEY: &str = "RW_NO_CACHE";
 
@@ -26,11 +26,11 @@ pub const CACHE_CLEAR_ENABLED_ENV_VAR_KEY: &str = "RW_NO_CACHE";
 #[derive(Debug)]
 pub struct CacheClearExecutor {
     /// The input of the current executor.
-    input: Box<dyn Executor>,
+    input: Box<dyn ExecutorV1>,
 }
 
 impl CacheClearExecutor {
-    pub fn new(input: Box<dyn Executor>) -> Self {
+    pub fn new(input: Box<dyn ExecutorV1>) -> Self {
         static ONCE: Once = Once::new();
         ONCE.call_once(|| info!("CacheClearExecutor enabled."));
 
@@ -50,11 +50,11 @@ impl super::DebugExecutor for CacheClearExecutor {
         Ok(message)
     }
 
-    fn input(&self) -> &dyn Executor {
+    fn input(&self) -> &dyn ExecutorV1 {
         self.input.as_ref()
     }
 
-    fn input_mut(&mut self) -> &mut dyn Executor {
+    fn input_mut(&mut self) -> &mut dyn ExecutorV1 {
         self.input.as_mut()
     }
 }

--- a/src/stream/src/executor/debug/epoch_check.rs
+++ b/src/stream/src/executor/debug/epoch_check.rs
@@ -17,19 +17,19 @@ use std::fmt::Debug;
 use async_trait::async_trait;
 use risingwave_common::error::Result;
 
-use crate::executor::{Executor, Message};
+use crate::executor::{ExecutorV1, Message};
 
 #[derive(Debug)]
 pub struct EpochCheckExecutor {
     /// The input of the current executor.
-    input: Box<dyn Executor>,
+    input: Box<dyn ExecutorV1>,
 
     /// Epoch number recorded from last barrier message.
     last_epoch: Option<u64>,
 }
 
 impl EpochCheckExecutor {
-    pub fn new(input: Box<dyn Executor>) -> Self {
+    pub fn new(input: Box<dyn ExecutorV1>) -> Self {
         Self {
             input,
             last_epoch: None,
@@ -64,11 +64,11 @@ impl super::DebugExecutor for EpochCheckExecutor {
         Ok(message)
     }
 
-    fn input(&self) -> &dyn Executor {
+    fn input(&self) -> &dyn ExecutorV1 {
         self.input.as_ref()
     }
 
-    fn input_mut(&mut self) -> &mut dyn Executor {
+    fn input_mut(&mut self) -> &mut dyn ExecutorV1 {
         self.input.as_mut()
     }
 }

--- a/src/stream/src/executor/debug/mod.rs
+++ b/src/stream/src/executor/debug/mod.rs
@@ -28,7 +28,7 @@ pub use self::epoch_check::*;
 pub use self::schema_check::*;
 pub use self::trace::*;
 pub use self::update_check::*;
-use super::{Executor, Message};
+use super::{ExecutorV1, Message};
 
 /// [`DebugExecutor`] is an abstraction of wrapper executors, generally used for debug purpose. Data
 /// related functions are mostly delegated to the `input` executor.
@@ -36,13 +36,13 @@ use super::{Executor, Message};
 pub trait DebugExecutor: Send + Debug + 'static {
     async fn next(&mut self) -> Result<Message>;
 
-    fn input(&self) -> &dyn Executor;
+    fn input(&self) -> &dyn ExecutorV1;
 
-    fn input_mut(&mut self) -> &mut dyn Executor;
+    fn input_mut(&mut self) -> &mut dyn ExecutorV1;
 }
 
 #[async_trait]
-impl<E> Executor for E
+impl<E> ExecutorV1 for E
 where
     E: DebugExecutor,
 {

--- a/src/stream/src/executor/debug/schema_check.rs
+++ b/src/stream/src/executor/debug/schema_check.rs
@@ -20,7 +20,7 @@ use risingwave_common::error::Result;
 use risingwave_common::for_all_variants;
 use tracing::event;
 
-use crate::executor::{Executor, Message};
+use crate::executor::{ExecutorV1, Message};
 
 /// [`SchemaCheckExecutor`] checks the passing stream chunk against the expected schema.
 ///
@@ -28,11 +28,11 @@ use crate::executor::{Executor, Message};
 #[derive(Debug)]
 pub struct SchemaCheckExecutor {
     /// The input of the current executor.
-    input: Box<dyn Executor>,
+    input: Box<dyn ExecutorV1>,
 }
 
 impl SchemaCheckExecutor {
-    pub fn new(input: Box<dyn Executor>) -> Self {
+    pub fn new(input: Box<dyn ExecutorV1>) -> Self {
         Self { input }
     }
 }
@@ -86,11 +86,11 @@ impl super::DebugExecutor for SchemaCheckExecutor {
         Ok(message)
     }
 
-    fn input(&self) -> &dyn Executor {
+    fn input(&self) -> &dyn ExecutorV1 {
         self.input.as_ref()
     }
 
-    fn input_mut(&mut self) -> &mut dyn Executor {
+    fn input_mut(&mut self) -> &mut dyn ExecutorV1 {
         self.input.as_mut()
     }
 }

--- a/src/stream/src/executor/debug/trace.rs
+++ b/src/stream/src/executor/debug/trace.rs
@@ -21,7 +21,7 @@ use tracing::event;
 use tracing_futures::Instrument;
 
 use crate::executor::monitor::StreamingMetrics;
-use crate::executor::{Executor, Message};
+use crate::executor::{ExecutorV1, Message};
 use crate::task::ActorId;
 
 /// `TraceExecutor` prints data passing in the stream graph to stdout.
@@ -33,7 +33,7 @@ use crate::task::ActorId;
 /// ```
 pub struct TraceExecutor {
     /// The input of the current executor
-    input: Box<dyn Executor>,
+    input: Box<dyn ExecutorV1>,
     /// Description of input executor
     input_desc: String,
     /// Input position of the input executor
@@ -59,7 +59,7 @@ impl Debug for TraceExecutor {
 
 impl TraceExecutor {
     pub fn new(
-        input: Box<dyn Executor>,
+        input: Box<dyn ExecutorV1>,
         input_desc: String,
         input_pos: usize,
         actor_id: ActorId,
@@ -114,11 +114,11 @@ impl super::DebugExecutor for TraceExecutor {
         }
     }
 
-    fn input(&self) -> &dyn Executor {
+    fn input(&self) -> &dyn ExecutorV1 {
         self.input.as_ref()
     }
 
-    fn input_mut(&mut self) -> &mut dyn Executor {
+    fn input_mut(&mut self) -> &mut dyn ExecutorV1 {
         self.input.as_mut()
     }
 }

--- a/src/stream/src/executor/debug/update_check.rs
+++ b/src/stream/src/executor/debug/update_check.rs
@@ -20,17 +20,17 @@ use itertools::Itertools;
 use risingwave_common::array::Op;
 use risingwave_common::error::Result;
 
-use crate::executor::{Executor, Message};
+use crate::executor::{ExecutorV1, Message};
 
 /// [`UpdateCheckExecutor`] checks whether the two rows of updates are next to each other.
 #[derive(Debug)]
 pub struct UpdateCheckExecutor {
     /// The input of the current executor.
-    input: Box<dyn Executor>,
+    input: Box<dyn ExecutorV1>,
 }
 
 impl UpdateCheckExecutor {
-    pub fn new(input: Box<dyn Executor>) -> Self {
+    pub fn new(input: Box<dyn ExecutorV1>) -> Self {
         Self { input }
     }
 }
@@ -63,11 +63,11 @@ impl super::DebugExecutor for UpdateCheckExecutor {
         Ok(message)
     }
 
-    fn input(&self) -> &dyn Executor {
+    fn input(&self) -> &dyn ExecutorV1 {
         self.input.as_ref()
     }
 
-    fn input_mut(&mut self) -> &mut dyn Executor {
+    fn input_mut(&mut self) -> &mut dyn ExecutorV1 {
         self.input.as_mut()
     }
 }

--- a/src/stream/src/executor/dispatch.rs
+++ b/src/stream/src/executor/dispatch.rs
@@ -717,9 +717,8 @@ impl Dispatcher for SimpleDispatcher {
 
 #[cfg(test)]
 mod sender_consumer {
-    use crate::executor::Executor;
-
     use super::*;
+    use crate::executor::Executor;
 
     /// `SenderConsumer` consumes data from input executor and send it into a channel.
     #[derive(Debug)]

--- a/src/stream/src/executor/dispatch.rs
+++ b/src/stream/src/executor/dispatch.rs
@@ -718,17 +718,17 @@ impl Dispatcher for SimpleDispatcher {
 #[cfg(test)]
 mod sender_consumer {
     use super::*;
-    use crate::executor::Executor;
+    use crate::executor::ExecutorV1;
 
     /// `SenderConsumer` consumes data from input executor and send it into a channel.
     #[derive(Debug)]
     pub struct SenderConsumer {
-        input: Box<dyn Executor>,
+        input: Box<dyn ExecutorV1>,
         channel: BoxedOutput,
     }
 
     impl SenderConsumer {
-        pub fn new(input: Box<dyn Executor>, channel: BoxedOutput) -> Self {
+        pub fn new(input: Box<dyn ExecutorV1>, channel: BoxedOutput) -> Self {
             Self { input, channel }
         }
     }

--- a/src/stream/src/executor/filter.rs
+++ b/src/stream/src/executor/filter.rs
@@ -20,7 +20,7 @@ use risingwave_pb::stream_plan::stream_node::Node;
 use risingwave_storage::StateStore;
 
 use crate::executor::ExecutorBuilder;
-use crate::executor_v2::{BoxedExecutor, Executor, FilterExecutor as FilterExecutorV2};
+use crate::executor_v2::{BoxedExecutor, Executor, FilterExecutor};
 use crate::task::{ExecutorParams, LocalStreamManagerCore};
 
 pub struct FilterExecutorBuilder;
@@ -35,7 +35,7 @@ impl ExecutorBuilder for FilterExecutorBuilder {
         let node = try_match_expand!(node.get_node().unwrap(), Node::FilterNode)?;
         let search_condition = build_from_prost(node.get_search_condition()?)?;
 
-        Ok(FilterExecutorV2::new_from_v1(
+        Ok(FilterExecutor::new_from_v1(
             params.input.remove(0),
             search_condition,
             params.executor_id,

--- a/src/stream/src/executor/filter.rs
+++ b/src/stream/src/executor/filter.rs
@@ -19,11 +19,8 @@ use risingwave_pb::stream_plan;
 use risingwave_pb::stream_plan::stream_node::Node;
 use risingwave_storage::StateStore;
 
-
 use crate::executor::ExecutorBuilder;
-use crate::executor_v2::{
-    BoxedExecutor, Executor as ExecutorV2, FilterExecutor as FilterExecutorV2,
-};
+use crate::executor_v2::{BoxedExecutor, Executor, FilterExecutor as FilterExecutorV2};
 use crate::task::{ExecutorParams, LocalStreamManagerCore};
 
 pub struct FilterExecutorBuilder;

--- a/src/stream/src/executor/filter.rs
+++ b/src/stream/src/executor/filter.rs
@@ -19,7 +19,7 @@ use risingwave_pb::stream_plan;
 use risingwave_pb::stream_plan::stream_node::Node;
 use risingwave_storage::StateStore;
 
-use super::Executor;
+
 use crate::executor::ExecutorBuilder;
 use crate::executor_v2::{
     BoxedExecutor, Executor as ExecutorV2, FilterExecutor as FilterExecutorV2,

--- a/src/stream/src/executor/filter.rs
+++ b/src/stream/src/executor/filter.rs
@@ -27,7 +27,7 @@ use crate::task::{ExecutorParams, LocalStreamManagerCore};
 pub struct FilterExecutorBuilder;
 
 impl ExecutorBuilder for FilterExecutorBuilder {
-    fn new_boxed_executor(
+    fn new_boxed_executor_v1(
         mut params: ExecutorParams,
         node: &stream_plan::StreamNode,
         _store: impl StateStore,

--- a/src/stream/src/executor/global_simple_agg.rs
+++ b/src/stream/src/executor/global_simple_agg.rs
@@ -23,7 +23,7 @@ use risingwave_storage::{Keyspace, StateStore};
 
 use crate::executor::ExecutorBuilder;
 use crate::executor_v2::aggregation::AggCall;
-use crate::executor_v2::{BoxedExecutor, Executor, SimpleAggExecutor as SimpleAggExecutorV2};
+use crate::executor_v2::{BoxedExecutor, Executor, SimpleAggExecutor};
 use crate::task::{build_agg_call_from_prost, ExecutorParams, LocalStreamManagerCore};
 
 pub struct SimpleAggExecutorBuilder {}
@@ -48,7 +48,7 @@ impl ExecutorBuilder for SimpleAggExecutorBuilder {
             .map(|key| *key as usize)
             .collect::<Vec<_>>();
 
-        Ok(SimpleAggExecutorV2::new_from_v1(
+        Ok(SimpleAggExecutor::new_from_v1(
             params.input.remove(0),
             agg_calls,
             keyspace,

--- a/src/stream/src/executor/global_simple_agg.rs
+++ b/src/stream/src/executor/global_simple_agg.rs
@@ -29,7 +29,7 @@ use crate::task::{build_agg_call_from_prost, ExecutorParams, LocalStreamManagerC
 pub struct SimpleAggExecutorBuilder {}
 
 impl ExecutorBuilder for SimpleAggExecutorBuilder {
-    fn new_boxed_executor(
+    fn new_boxed_executor_v1(
         mut params: ExecutorParams,
         node: &stream_plan::StreamNode,
         store: impl StateStore,

--- a/src/stream/src/executor/global_simple_agg.rs
+++ b/src/stream/src/executor/global_simple_agg.rs
@@ -21,11 +21,9 @@ use risingwave_pb::stream_plan;
 use risingwave_pb::stream_plan::stream_node::Node;
 use risingwave_storage::{Keyspace, StateStore};
 
-use crate::executor::{ExecutorBuilder};
+use crate::executor::ExecutorBuilder;
 use crate::executor_v2::aggregation::AggCall;
-use crate::executor_v2::{
-    BoxedExecutor, Executor as ExecutorV2, SimpleAggExecutor as SimpleAggExecutorV2,
-};
+use crate::executor_v2::{BoxedExecutor, Executor, SimpleAggExecutor as SimpleAggExecutorV2};
 use crate::task::{build_agg_call_from_prost, ExecutorParams, LocalStreamManagerCore};
 
 pub struct SimpleAggExecutorBuilder {}

--- a/src/stream/src/executor/global_simple_agg.rs
+++ b/src/stream/src/executor/global_simple_agg.rs
@@ -21,7 +21,7 @@ use risingwave_pb::stream_plan;
 use risingwave_pb::stream_plan::stream_node::Node;
 use risingwave_storage::{Keyspace, StateStore};
 
-use crate::executor::{Executor, ExecutorBuilder};
+use crate::executor::{ExecutorBuilder};
 use crate::executor_v2::aggregation::AggCall;
 use crate::executor_v2::{
     BoxedExecutor, Executor as ExecutorV2, SimpleAggExecutor as SimpleAggExecutorV2,

--- a/src/stream/src/executor/hash_agg.rs
+++ b/src/stream/src/executor/hash_agg.rs
@@ -24,7 +24,6 @@ use risingwave_pb::stream_plan;
 use risingwave_pb::stream_plan::stream_node::Node;
 use risingwave_storage::{Keyspace, StateStore};
 
-use super::Executor;
 use crate::executor::{ExecutorBuilder, PkIndices};
 use crate::executor_v2::aggregation::AggCall;
 use crate::executor_v2::{BoxedExecutor, Executor as ExecutorV2, HashAggExecutor};

--- a/src/stream/src/executor/hash_agg.rs
+++ b/src/stream/src/executor/hash_agg.rs
@@ -26,7 +26,7 @@ use risingwave_storage::{Keyspace, StateStore};
 
 use crate::executor::{ExecutorBuilder, PkIndices};
 use crate::executor_v2::aggregation::AggCall;
-use crate::executor_v2::{BoxedExecutor, Executor as ExecutorV2, HashAggExecutor};
+use crate::executor_v2::{BoxedExecutor, Executor, HashAggExecutor};
 use crate::task::{build_agg_call_from_prost, ExecutorParams, LocalStreamManagerCore};
 
 struct HashAggExecutorDispatcher<S: StateStore>(PhantomData<S>);

--- a/src/stream/src/executor/hash_agg.rs
+++ b/src/stream/src/executor/hash_agg.rs
@@ -27,13 +27,13 @@ use risingwave_storage::{Keyspace, StateStore};
 use super::Executor;
 use crate::executor::{ExecutorBuilder, PkIndices};
 use crate::executor_v2::aggregation::AggCall;
-use crate::executor_v2::{Executor as ExecutorV2, HashAggExecutor};
+use crate::executor_v2::{Executor as ExecutorV2, HashAggExecutor, BoxedExecutor};
 use crate::task::{build_agg_call_from_prost, ExecutorParams, LocalStreamManagerCore};
 
 struct HashAggExecutorDispatcher<S: StateStore>(PhantomData<S>);
 
 struct HashAggExecutorDispatcherArgs<S: StateStore> {
-    input: Box<dyn Executor>,
+    input: BoxedExecutor,
     agg_calls: Vec<AggCall>,
     key_indices: Vec<usize>,
     keyspace: Keyspace<S>,
@@ -65,7 +65,7 @@ impl<S: StateStore> HashKeyDispatcher for HashAggExecutorDispatcher<S> {
 pub struct HashAggExecutorBuilder;
 
 impl ExecutorBuilder for HashAggExecutorBuilder {
-    fn new_boxed_executor(
+    fn new_boxed_executor_v1(
         mut params: ExecutorParams,
         node: &stream_plan::StreamNode,
         store: impl StateStore,

--- a/src/stream/src/executor/hash_join.rs
+++ b/src/stream/src/executor/hash_join.rs
@@ -124,15 +124,15 @@ impl<S: StateStore> JoinSide<S> {
 pub struct HashJoinExecutorBuilder {}
 
 impl ExecutorBuilder for HashJoinExecutorBuilder {
-    fn new_boxed_executor(
+    fn new_boxed_executor_v1(
         mut params: ExecutorParams,
         node: &stream_plan::StreamNode,
         store: impl StateStore,
         _stream: &mut LocalStreamManagerCore,
     ) -> Result<Box<dyn Executor>> {
         let node = try_match_expand!(node.get_node().unwrap(), Node::HashJoinNode)?;
-        let source_r = params.input.remove(1);
-        let source_l = params.input.remove(0);
+        let source_r = Box::new(params.input.remove(1).v1());
+        let source_l = Box::new(params.input.remove(0).v1());
         let params_l = JoinParams::new(
             node.get_left_key()
                 .iter()

--- a/src/stream/src/executor/integration_tests.rs
+++ b/src/stream/src/executor/integration_tests.rs
@@ -133,9 +133,9 @@ async fn test_merger_sum_aggr() {
     let schema = Schema {
         fields: vec![Field::unnamed(DataType::Int64)],
     };
-    let receiver_op = Box::new(ReceiverExecutor::new(schema.clone(), vec![], rx)).v1();
+    let receiver_op = Box::new(ReceiverExecutor::new(schema.clone(), vec![], rx));
     let dispatcher = DispatchExecutor::new(
-        Box::new(receiver_op),
+        receiver_op,
         vec![DispatcherImpl::RoundRobin(RoundRobinDataDispatcher::new(
             inputs,
         ))],

--- a/src/stream/src/executor/integration_tests.rs
+++ b/src/stream/src/executor/integration_tests.rs
@@ -78,33 +78,32 @@ async fn test_merger_sum_aggr() {
         let schema = Schema {
             fields: vec![Field::unnamed(DataType::Int64)],
         };
-        let input = Box::new(ReceiverExecutor::new(schema, vec![], input_rx)).v1();
+        let input = ReceiverExecutor::new(schema, vec![], input_rx);
         // for the local aggregator, we need two states: row count and sum
-        let aggregator = Box::new(
-            LocalSimpleAggExecutor::new_from_v1(
-                Box::new(input),
-                vec![
-                    AggCall {
-                        kind: AggKind::RowCount,
-                        args: AggArgs::None,
-                        return_type: DataType::Int64,
-                    },
-                    AggCall {
-                        kind: AggKind::Sum,
-                        args: AggArgs::Unary(DataType::Int64, 0),
-                        return_type: DataType::Int64,
-                    },
-                ],
-                vec![],
-                1,
-                "LocalSimpleAggExecutor".to_string(),
-            )
-            .unwrap(),
+        let aggregator = LocalSimpleAggExecutor::new_from_v1(
+            input.boxed(),
+            vec![
+                AggCall {
+                    kind: AggKind::RowCount,
+                    args: AggArgs::None,
+                    return_type: DataType::Int64,
+                },
+                AggCall {
+                    kind: AggKind::Sum,
+                    args: AggArgs::Unary(DataType::Int64, 0),
+                    return_type: DataType::Int64,
+                },
+            ],
+            vec![],
+            1,
+            "LocalSimpleAggExecutor".to_string(),
         )
-        .v1();
+        .unwrap();
         let (tx, rx) = channel(16);
-        let consumer =
-            SenderConsumer::new(Box::new(aggregator), Box::new(LocalOutput::new(233, tx)));
+        let consumer = SenderConsumer::new(
+            Box::new(aggregator.boxed().v1()),
+            Box::new(LocalOutput::new(233, tx)),
+        );
         let context = SharedContext::for_test().into();
         let actor = Actor::new(consumer, 0, context);
         (actor, rx)
@@ -147,36 +146,33 @@ async fn test_merger_sum_aggr() {
     handles.push(tokio::spawn(actor.run()));
 
     // use a merge operator to collect data from dispatchers before sending them to aggregator
-    let merger = Box::new(MergeExecutor::new(schema, vec![], 0, outputs)).v1();
+    let merger = MergeExecutor::new(schema, vec![], 0, outputs);
 
     // for global aggregator, we need to sum data and sum row count
-    let aggregator = Box::new(
-        SimpleAggExecutor::new_from_v1(
-            Box::new(merger),
-            vec![
-                AggCall {
-                    kind: AggKind::Sum,
-                    args: AggArgs::Unary(DataType::Int64, 0),
-                    return_type: DataType::Int64,
-                },
-                AggCall {
-                    kind: AggKind::Sum,
-                    args: AggArgs::Unary(DataType::Int64, 1),
-                    return_type: DataType::Int64,
-                },
-            ],
-            create_in_memory_keyspace(),
-            vec![],
-            2,
-            "SimpleAggExecutor".to_string(),
-            vec![],
-        )
-        .unwrap(),
+    let aggregator = SimpleAggExecutor::new_from_v1(
+        merger.boxed(),
+        vec![
+            AggCall {
+                kind: AggKind::Sum,
+                args: AggArgs::Unary(DataType::Int64, 0),
+                return_type: DataType::Int64,
+            },
+            AggCall {
+                kind: AggKind::Sum,
+                args: AggArgs::Unary(DataType::Int64, 1),
+                return_type: DataType::Int64,
+            },
+        ],
+        create_in_memory_keyspace(),
+        vec![],
+        2,
+        "SimpleAggExecutor".to_string(),
+        vec![],
     )
-    .v1();
+    .unwrap();
 
-    let projection = Box::new(ProjectExecutor::new_from_v1(
-        Box::new(aggregator),
+    let projection = ProjectExecutor::new_from_v1(
+        aggregator.boxed(),
         vec![],
         vec![
             // TODO: use the new streaming_if_null expression here, and add `None` tests
@@ -184,10 +180,10 @@ async fn test_merger_sum_aggr() {
         ],
         3,
         "ProjectExecutor".to_string(),
-    ))
-    .v1();
+    );
+
     let items = Arc::new(Mutex::new(vec![]));
-    let consumer = MockConsumer::new(Box::new(projection), items.clone());
+    let consumer = MockConsumer::new(Box::new(projection.boxed().v1()), items.clone());
     let context = SharedContext::for_test().into();
     let actor = Actor::new(consumer, 0, context);
     handles.push(tokio::spawn(actor.run()));

--- a/src/stream/src/executor/integration_tests.rs
+++ b/src/stream/src/executor/integration_tests.rs
@@ -28,13 +28,12 @@ use crate::executor::test_utils::create_in_memory_keyspace;
 use crate::executor_v2::aggregation::{AggArgs, AggCall};
 use crate::executor_v2::receiver::ReceiverExecutor;
 use crate::executor_v2::{
-    Executor as ExecutorV2, LocalSimpleAggExecutor, MergeExecutor, ProjectExecutor,
-    SimpleAggExecutor,
+    Executor, LocalSimpleAggExecutor, MergeExecutor, ProjectExecutor, SimpleAggExecutor,
 };
 use crate::task::SharedContext;
 
 pub struct MockConsumer {
-    input: Box<dyn Executor>,
+    input: Box<dyn ExecutorV1>,
     data: Arc<Mutex<Vec<StreamChunk>>>,
 }
 impl std::fmt::Debug for MockConsumer {
@@ -46,7 +45,7 @@ impl std::fmt::Debug for MockConsumer {
 }
 
 impl MockConsumer {
-    pub fn new(input: Box<dyn Executor>, data: Arc<Mutex<Vec<StreamChunk>>>) -> Self {
+    pub fn new(input: Box<dyn ExecutorV1>, data: Arc<Mutex<Vec<StreamChunk>>>) -> Self {
         Self { input, data }
     }
 }

--- a/src/stream/src/executor/local_simple_agg.rs
+++ b/src/stream/src/executor/local_simple_agg.rs
@@ -29,7 +29,7 @@ use crate::task::{build_agg_call_from_prost, ExecutorParams, LocalStreamManagerC
 pub struct LocalSimpleAggExecutorBuilder {}
 
 impl ExecutorBuilder for LocalSimpleAggExecutorBuilder {
-    fn new_boxed_executor(
+    fn new_boxed_executor_v1(
         mut params: ExecutorParams,
         node: &stream_plan::StreamNode,
         _store: impl StateStore,

--- a/src/stream/src/executor/local_simple_agg.rs
+++ b/src/stream/src/executor/local_simple_agg.rs
@@ -21,9 +21,7 @@ use risingwave_storage::StateStore;
 
 use crate::executor::ExecutorBuilder;
 use crate::executor_v2::aggregation::AggCall;
-use crate::executor_v2::{
-    BoxedExecutor, Executor, LocalSimpleAggExecutor as LocalSimpleAggExecutorV2,
-};
+use crate::executor_v2::{BoxedExecutor, Executor, LocalSimpleAggExecutor};
 use crate::task::{build_agg_call_from_prost, ExecutorParams, LocalStreamManagerCore};
 
 pub struct LocalSimpleAggExecutorBuilder {}
@@ -42,7 +40,7 @@ impl ExecutorBuilder for LocalSimpleAggExecutorBuilder {
             .map(build_agg_call_from_prost)
             .try_collect()?;
 
-        Ok(LocalSimpleAggExecutorV2::new_from_v1(
+        Ok(LocalSimpleAggExecutor::new_from_v1(
             params.input.remove(0),
             agg_calls,
             params.pk_indices,

--- a/src/stream/src/executor/local_simple_agg.rs
+++ b/src/stream/src/executor/local_simple_agg.rs
@@ -19,7 +19,7 @@ use risingwave_pb::stream_plan;
 use risingwave_pb::stream_plan::stream_node::Node;
 use risingwave_storage::StateStore;
 
-use crate::executor::{Executor, ExecutorBuilder};
+use crate::executor::{ExecutorBuilder};
 use crate::executor_v2::aggregation::AggCall;
 use crate::executor_v2::{
     BoxedExecutor, Executor as ExecutorV2, LocalSimpleAggExecutor as LocalSimpleAggExecutorV2,

--- a/src/stream/src/executor/local_simple_agg.rs
+++ b/src/stream/src/executor/local_simple_agg.rs
@@ -19,10 +19,10 @@ use risingwave_pb::stream_plan;
 use risingwave_pb::stream_plan::stream_node::Node;
 use risingwave_storage::StateStore;
 
-use crate::executor::{ExecutorBuilder};
+use crate::executor::ExecutorBuilder;
 use crate::executor_v2::aggregation::AggCall;
 use crate::executor_v2::{
-    BoxedExecutor, Executor as ExecutorV2, LocalSimpleAggExecutor as LocalSimpleAggExecutorV2,
+    BoxedExecutor, Executor, LocalSimpleAggExecutor as LocalSimpleAggExecutorV2,
 };
 use crate::task::{build_agg_call_from_prost, ExecutorParams, LocalStreamManagerCore};
 

--- a/src/stream/src/executor/merge.rs
+++ b/src/stream/src/executor/merge.rs
@@ -17,7 +17,7 @@ use risingwave_pb::stream_plan;
 use risingwave_pb::stream_plan::stream_node::Node;
 use risingwave_storage::StateStore;
 
-use super::{Result};
+use super::Result;
 use crate::executor::ExecutorBuilder;
 use crate::executor_v2::BoxedExecutor;
 use crate::task::{ExecutorParams, LocalStreamManagerCore};

--- a/src/stream/src/executor/merge.rs
+++ b/src/stream/src/executor/merge.rs
@@ -19,17 +19,18 @@ use risingwave_storage::StateStore;
 
 use super::{Executor, Result};
 use crate::executor::ExecutorBuilder;
+use crate::executor_v2::BoxedExecutor;
 use crate::task::{ExecutorParams, LocalStreamManagerCore};
 
 pub struct MergeExecutorBuilder {}
 
 impl ExecutorBuilder for MergeExecutorBuilder {
-    fn new_boxed_executor_v1(
+    fn new_boxed_executor(
         params: ExecutorParams,
         node: &stream_plan::StreamNode,
         _store: impl StateStore,
         stream: &mut LocalStreamManagerCore,
-    ) -> Result<Box<dyn Executor>> {
+    ) -> Result<BoxedExecutor> {
         let node = try_match_expand!(node.get_node().unwrap(), Node::MergeNode)?;
         stream.create_merge_node(params, node)
     }

--- a/src/stream/src/executor/merge.rs
+++ b/src/stream/src/executor/merge.rs
@@ -24,7 +24,7 @@ use crate::task::{ExecutorParams, LocalStreamManagerCore};
 pub struct MergeExecutorBuilder {}
 
 impl ExecutorBuilder for MergeExecutorBuilder {
-    fn new_boxed_executor(
+    fn new_boxed_executor_v1(
         params: ExecutorParams,
         node: &stream_plan::StreamNode,
         _store: impl StateStore,

--- a/src/stream/src/executor/merge.rs
+++ b/src/stream/src/executor/merge.rs
@@ -17,7 +17,7 @@ use risingwave_pb::stream_plan;
 use risingwave_pb::stream_plan::stream_node::Node;
 use risingwave_storage::StateStore;
 
-use super::{Executor, Result};
+use super::{Result};
 use crate::executor::ExecutorBuilder;
 use crate::executor_v2::BoxedExecutor;
 use crate::task::{ExecutorParams, LocalStreamManagerCore};

--- a/src/stream/src/executor/mod.rs
+++ b/src/stream/src/executor/mod.rs
@@ -91,7 +91,7 @@ pub const INVALID_EPOCH: u64 = 0;
 pub trait ExprFn = Fn(&DataChunk) -> Result<Bitmap> + Send + Sync + 'static;
 
 /// Boxed stream of [`StreamMessage`].
-pub type BoxedExecutorStream = Pin<Box<dyn Stream<Item = Result<Message>> + Send>>;
+pub type BoxedExecutorV1Stream = Pin<Box<dyn Stream<Item = Result<Message>> + Send>>;
 
 #[derive(Debug, Clone, PartialEq)]
 pub enum Mutation {
@@ -355,7 +355,7 @@ impl Message {
 
 /// `Executor` supports handling of control messages.
 #[async_trait]
-pub trait Executor: Send + Debug + 'static {
+pub trait ExecutorV1: Send + Debug + 'static {
     async fn next(&mut self) -> Result<Message>;
 
     /// Return the schema of the OUTPUT of the executor.
@@ -391,26 +391,26 @@ pub trait Executor: Send + Debug + 'static {
 }
 
 #[derive(Debug)]
-pub enum ExecutorState {
+pub enum ExecutorV1State {
     /// Waiting for the first barrier
     Init,
     /// Can read from and write to storage
     Active(u64),
 }
 
-impl ExecutorState {
+impl ExecutorV1State {
     pub fn epoch(&self) -> u64 {
         match self {
-            ExecutorState::Init => panic!("Executor is not active when getting the epoch"),
-            ExecutorState::Active(epoch) => *epoch,
+            ExecutorV1State::Init => panic!("Executor is not active when getting the epoch"),
+            ExecutorV1State::Active(epoch) => *epoch,
         }
     }
 }
 
-pub trait StatefulExecutor: Executor {
-    fn executor_state(&self) -> &ExecutorState;
+pub trait StatefulExecutorV1: ExecutorV1 {
+    fn executor_state(&self) -> &ExecutorV1State;
 
-    fn update_executor_state(&mut self, new_state: ExecutorState);
+    fn update_executor_state(&mut self, new_state: ExecutorV1State);
 
     /// Try initializing the executor if not done.
     /// Return:
@@ -421,16 +421,16 @@ pub trait StatefulExecutor: Executor {
         msg: impl TryInto<&'a Barrier, Error = ()>,
     ) -> Option<Barrier> {
         match self.executor_state() {
-            ExecutorState::Init => {
+            ExecutorV1State::Init => {
                 if let Ok(barrier) = msg.try_into() {
                     // Move to Active state
-                    self.update_executor_state(ExecutorState::Active(barrier.epoch.curr));
+                    self.update_executor_state(ExecutorV1State::Active(barrier.epoch.curr));
                     Some(barrier.clone())
                 } else {
                     panic!("The first message the executor receives is not a barrier");
                 }
             }
-            ExecutorState::Active(_) => None,
+            ExecutorV1State::Active(_) => None,
         }
     }
 }
@@ -465,7 +465,7 @@ pub trait ExecutorBuilder {
         _node: &stream_plan::StreamNode,
         _store: impl StateStore,
         _stream: &mut LocalStreamManagerCore,
-    ) -> Result<Box<dyn Executor>> {
+    ) -> Result<Box<dyn ExecutorV1>> {
         unimplemented!()
     }
 

--- a/src/stream/src/executor/mod.rs
+++ b/src/stream/src/executor/mod.rs
@@ -459,6 +459,7 @@ pub fn pk_input_array_refs<'a>(
 }
 
 pub trait ExecutorBuilder {
+    /// For compatibility.
     fn new_boxed_executor_v1(
         _executor_params: ExecutorParams,
         _node: &stream_plan::StreamNode,
@@ -468,6 +469,8 @@ pub trait ExecutorBuilder {
         unimplemented!()
     }
 
+    /// Create an executor. May directly override this function to create an executor v2, or it will
+    /// create an [`ExecutorV1`] and wrap it to v2.
     fn new_boxed_executor(
         executor_params: ExecutorParams,
         node: &stream_plan::StreamNode,

--- a/src/stream/src/executor/mod.rs
+++ b/src/stream/src/executor/mod.rs
@@ -36,7 +36,7 @@ pub use source::*;
 pub use top_n::*;
 pub use top_n_appendonly::*;
 
-use crate::executor_v2::{BoxedExecutor, LookupExecutorBuilder, UnionExecutorBuilder};
+use crate::executor_v2::{BoxedExecutor, Executor, LookupExecutorBuilder, UnionExecutorBuilder};
 use crate::task::{ActorId, ExecutorParams, LocalStreamManagerCore, ENABLE_BARRIER_AGGREGATION};
 
 mod actor;
@@ -477,7 +477,7 @@ pub trait ExecutorBuilder {
         store: impl StateStore,
         stream: &mut LocalStreamManagerCore,
     ) -> Result<BoxedExecutor> {
-        Self::new_boxed_executor_v1(executor_params, node, store, stream).map(|e| e.v2())
+        Self::new_boxed_executor_v1(executor_params, node, store, stream).map(|e| e.v2().boxed())
     }
 }
 

--- a/src/stream/src/executor/mod.rs
+++ b/src/stream/src/executor/mod.rs
@@ -531,7 +531,7 @@ pub fn create_executor(
 }
 
 /// `StreamConsumer` is the last step in an actor.
-pub trait StreamConsumer: Send + Debug + 'static {
+pub trait StreamConsumer: Send + 'static {
     type BarrierStream: Stream<Item = Result<Barrier>> + Send;
 
     fn execute(self: Box<Self>) -> Self::BarrierStream;

--- a/src/stream/src/executor/mod.rs
+++ b/src/stream/src/executor/mod.rs
@@ -465,7 +465,7 @@ pub trait ExecutorBuilder {
         _store: impl StateStore,
         _stream: &mut LocalStreamManagerCore,
     ) -> Result<Box<dyn Executor>> {
-        unimplemented!("directly build a v2 executor instead")
+        unimplemented!()
     }
 
     fn new_boxed_executor(

--- a/src/stream/src/executor/mview/materialize.rs
+++ b/src/stream/src/executor/mview/materialize.rs
@@ -66,12 +66,12 @@ impl ExecutorBuilder for MaterializeExecutorBuilder {
 pub struct ArrangeExecutorBuilder;
 
 impl ExecutorBuilder for ArrangeExecutorBuilder {
-    fn new_boxed_executor_v1(
+    fn new_boxed_executor(
         mut params: ExecutorParams,
         node: &stream_plan::StreamNode,
         store: impl StateStore,
         _stream: &mut LocalStreamManagerCore,
-    ) -> Result<Box<dyn Executor>> {
+    ) -> Result<BoxedExecutor> {
         let arrange_node = try_match_expand!(node.get_node().unwrap(), Node::ArrangeNode)?;
 
         let keyspace = Keyspace::shared_executor_root(store, params.operator_id);
@@ -96,15 +96,15 @@ impl ExecutorBuilder for ArrangeExecutorBuilder {
             .map(|(idx, _)| ColumnId::from(idx as i32))
             .collect();
 
-        let v2 = Box::new(MaterializeExecutorV2::new_from_v1(
+        let v2 = MaterializeExecutorV2::new_from_v1(
             params.input.remove(0),
             keyspace,
             keys,
             column_ids,
             params.executor_id,
             params.op_info,
-        ));
+        );
 
-        Ok(Box::new(v2.v1()))
+        Ok(v2.boxed())
     }
 }

--- a/src/stream/src/executor/mview/materialize.rs
+++ b/src/stream/src/executor/mview/materialize.rs
@@ -20,9 +20,7 @@ use risingwave_pb::stream_plan::stream_node::Node;
 use risingwave_storage::{Keyspace, StateStore};
 
 use crate::executor::{ExecutorBuilder, Result};
-use crate::executor_v2::{
-    BoxedExecutor, Executor as ExecutorV2, MaterializeExecutor as MaterializeExecutorV2,
-};
+use crate::executor_v2::{BoxedExecutor, Executor, MaterializeExecutor as MaterializeExecutorV2};
 use crate::task::{ExecutorParams, LocalStreamManagerCore};
 
 pub struct MaterializeExecutorBuilder;

--- a/src/stream/src/executor/mview/materialize.rs
+++ b/src/stream/src/executor/mview/materialize.rs
@@ -19,7 +19,7 @@ use risingwave_pb::stream_plan;
 use risingwave_pb::stream_plan::stream_node::Node;
 use risingwave_storage::{Keyspace, StateStore};
 
-use crate::executor::{Executor, ExecutorBuilder, Result};
+use crate::executor::{ExecutorBuilder, Result};
 use crate::executor_v2::{
     BoxedExecutor, Executor as ExecutorV2, MaterializeExecutor as MaterializeExecutorV2,
 };

--- a/src/stream/src/executor/mview/materialize.rs
+++ b/src/stream/src/executor/mview/materialize.rs
@@ -20,7 +20,9 @@ use risingwave_pb::stream_plan::stream_node::Node;
 use risingwave_storage::{Keyspace, StateStore};
 
 use crate::executor::{Executor, ExecutorBuilder, Result};
-use crate::executor_v2::{Executor as ExecutorV2, MaterializeExecutor as MaterializeExecutorV2};
+use crate::executor_v2::{
+    BoxedExecutor, Executor as ExecutorV2, MaterializeExecutor as MaterializeExecutorV2,
+};
 use crate::task::{ExecutorParams, LocalStreamManagerCore};
 
 pub struct MaterializeExecutorBuilder;
@@ -31,7 +33,7 @@ impl ExecutorBuilder for MaterializeExecutorBuilder {
         node: &stream_plan::StreamNode,
         store: impl StateStore,
         _stream: &mut LocalStreamManagerCore,
-    ) -> Result<Box<dyn Executor>> {
+    ) -> Result<BoxedExecutor> {
         let node = try_match_expand!(node.get_node().unwrap(), Node::MaterializeNode)?;
 
         let table_id = TableId::from(&node.table_ref_id);
@@ -48,23 +50,23 @@ impl ExecutorBuilder for MaterializeExecutorBuilder {
 
         let keyspace = Keyspace::table_root(store, &table_id);
 
-        let v2 = Box::new(MaterializeExecutorV2::new_from_v1(
+        let v2 = MaterializeExecutorV2::new_from_v1(
             params.input.remove(0),
             keyspace,
             keys,
             column_ids,
             params.executor_id,
             params.op_info,
-        ));
+        );
 
-        Ok(Box::new(v2.v1()))
+        Ok(v2.boxed())
     }
 }
 
 pub struct ArrangeExecutorBuilder;
 
 impl ExecutorBuilder for ArrangeExecutorBuilder {
-    fn new_boxed_executor(
+    fn new_boxed_executor_v1(
         mut params: ExecutorParams,
         node: &stream_plan::StreamNode,
         store: impl StateStore,

--- a/src/stream/src/executor/mview/materialize.rs
+++ b/src/stream/src/executor/mview/materialize.rs
@@ -20,7 +20,7 @@ use risingwave_pb::stream_plan::stream_node::Node;
 use risingwave_storage::{Keyspace, StateStore};
 
 use crate::executor::{ExecutorBuilder, Result};
-use crate::executor_v2::{BoxedExecutor, Executor, MaterializeExecutor as MaterializeExecutorV2};
+use crate::executor_v2::{BoxedExecutor, Executor, MaterializeExecutor};
 use crate::task::{ExecutorParams, LocalStreamManagerCore};
 
 pub struct MaterializeExecutorBuilder;
@@ -48,7 +48,7 @@ impl ExecutorBuilder for MaterializeExecutorBuilder {
 
         let keyspace = Keyspace::table_root(store, &table_id);
 
-        let v2 = MaterializeExecutorV2::new_from_v1(
+        let executor = MaterializeExecutor::new_from_v1(
             params.input.remove(0),
             keyspace,
             keys,
@@ -57,7 +57,7 @@ impl ExecutorBuilder for MaterializeExecutorBuilder {
             params.op_info,
         );
 
-        Ok(v2.boxed())
+        Ok(executor.boxed())
     }
 }
 
@@ -94,7 +94,7 @@ impl ExecutorBuilder for ArrangeExecutorBuilder {
             .map(|(idx, _)| ColumnId::from(idx as i32))
             .collect();
 
-        let v2 = MaterializeExecutorV2::new_from_v1(
+        let executor = MaterializeExecutor::new_from_v1(
             params.input.remove(0),
             keyspace,
             keys,
@@ -103,6 +103,6 @@ impl ExecutorBuilder for ArrangeExecutorBuilder {
             params.op_info,
         );
 
-        Ok(v2.boxed())
+        Ok(executor.boxed())
     }
 }

--- a/src/stream/src/executor/project.rs
+++ b/src/stream/src/executor/project.rs
@@ -19,7 +19,6 @@ use risingwave_pb::stream_plan;
 use risingwave_pb::stream_plan::stream_node::Node;
 use risingwave_storage::StateStore;
 
-use super::Executor;
 use crate::executor::ExecutorBuilder;
 use crate::executor_v2::{
     BoxedExecutor, Executor as ExecutorV2, ProjectExecutor as ProjectExecutorV2,

--- a/src/stream/src/executor/project.rs
+++ b/src/stream/src/executor/project.rs
@@ -27,7 +27,7 @@ use crate::task::{ExecutorParams, LocalStreamManagerCore};
 pub struct ProjectExecutorBuilder;
 
 impl ExecutorBuilder for ProjectExecutorBuilder {
-    fn new_boxed_executor(
+    fn new_boxed_executor_v1(
         mut params: ExecutorParams,
         node: &stream_plan::StreamNode,
         _store: impl StateStore,

--- a/src/stream/src/executor/project.rs
+++ b/src/stream/src/executor/project.rs
@@ -20,9 +20,7 @@ use risingwave_pb::stream_plan::stream_node::Node;
 use risingwave_storage::StateStore;
 
 use crate::executor::ExecutorBuilder;
-use crate::executor_v2::{
-    BoxedExecutor, Executor as ExecutorV2, ProjectExecutor as ProjectExecutorV2,
-};
+use crate::executor_v2::{BoxedExecutor, Executor, ProjectExecutor as ProjectExecutorV2};
 use crate::task::{ExecutorParams, LocalStreamManagerCore};
 
 pub struct ProjectExecutorBuilder;

--- a/src/stream/src/executor/project.rs
+++ b/src/stream/src/executor/project.rs
@@ -20,7 +20,7 @@ use risingwave_pb::stream_plan::stream_node::Node;
 use risingwave_storage::StateStore;
 
 use crate::executor::ExecutorBuilder;
-use crate::executor_v2::{BoxedExecutor, Executor, ProjectExecutor as ProjectExecutorV2};
+use crate::executor_v2::{BoxedExecutor, Executor, ProjectExecutor};
 use crate::task::{ExecutorParams, LocalStreamManagerCore};
 
 pub struct ProjectExecutorBuilder;
@@ -39,7 +39,7 @@ impl ExecutorBuilder for ProjectExecutorBuilder {
             .map(build_from_prost)
             .collect::<Result<Vec<_>>>()?;
 
-        Ok(ProjectExecutorV2::new_from_v1(
+        Ok(ProjectExecutor::new_from_v1(
             params.input.remove(0),
             params.pk_indices,
             project_exprs,

--- a/src/stream/src/executor/project.rs
+++ b/src/stream/src/executor/project.rs
@@ -21,33 +21,34 @@ use risingwave_storage::StateStore;
 
 use super::Executor;
 use crate::executor::ExecutorBuilder;
-use crate::executor_v2::{Executor as ExecutorV2, ProjectExecutor as ProjectExecutorV2};
+use crate::executor_v2::{
+    BoxedExecutor, Executor as ExecutorV2, ProjectExecutor as ProjectExecutorV2,
+};
 use crate::task::{ExecutorParams, LocalStreamManagerCore};
 
 pub struct ProjectExecutorBuilder;
 
 impl ExecutorBuilder for ProjectExecutorBuilder {
-    fn new_boxed_executor_v1(
+    fn new_boxed_executor(
         mut params: ExecutorParams,
         node: &stream_plan::StreamNode,
         _store: impl StateStore,
         _stream: &mut LocalStreamManagerCore,
-    ) -> Result<Box<dyn Executor>> {
+    ) -> Result<BoxedExecutor> {
         let node = try_match_expand!(node.get_node().unwrap(), Node::ProjectNode)?;
         let project_exprs = node
             .get_select_list()
             .iter()
             .map(build_from_prost)
             .collect::<Result<Vec<_>>>()?;
-        Ok(Box::new(
-            Box::new(ProjectExecutorV2::new_from_v1(
-                params.input.remove(0),
-                params.pk_indices,
-                project_exprs,
-                params.executor_id,
-                params.op_info,
-            ))
-            .v1(),
-        ))
+
+        Ok(ProjectExecutorV2::new_from_v1(
+            params.input.remove(0),
+            params.pk_indices,
+            project_exprs,
+            params.executor_id,
+            params.op_info,
+        )
+        .boxed())
     }
 }

--- a/src/stream/src/executor/source.rs
+++ b/src/stream/src/executor/source.rs
@@ -37,7 +37,7 @@ use risingwave_storage::{Keyspace, StateStore};
 use tokio::sync::mpsc::{unbounded_channel, UnboundedReceiver};
 
 use crate::executor::monitor::StreamingMetrics;
-use crate::executor::{Executor, ExecutorBuilder, Message, PkIndices, PkIndicesRef};
+use crate::executor::{ExecutorBuilder, ExecutorV1, Message, PkIndices, PkIndicesRef};
 use crate::task::{ExecutorParams, LocalStreamManagerCore};
 
 struct SourceReader {
@@ -100,7 +100,7 @@ impl ExecutorBuilder for SourceExecutorBuilder {
         node: &stream_plan::StreamNode,
         store: impl StateStore,
         stream: &mut LocalStreamManagerCore,
-    ) -> Result<Box<dyn Executor>> {
+    ) -> Result<Box<dyn ExecutorV1>> {
         let node = try_match_expand!(node.get_node().unwrap(), Node::SourceNode)?;
         let (sender, barrier_receiver) = unbounded_channel();
         stream
@@ -297,7 +297,7 @@ impl SourceReader {
 }
 
 #[async_trait]
-impl Executor for SourceExecutor {
+impl ExecutorV1 for SourceExecutor {
     async fn next(&mut self) -> Result<Message> {
         if let Some(mut reader) = self.reader.take() {
             reader

--- a/src/stream/src/executor/source.rs
+++ b/src/stream/src/executor/source.rs
@@ -95,7 +95,7 @@ pub struct SourceExecutor {
 pub struct SourceExecutorBuilder {}
 
 impl ExecutorBuilder for SourceExecutorBuilder {
-    fn new_boxed_executor(
+    fn new_boxed_executor_v1(
         params: ExecutorParams,
         node: &stream_plan::StreamNode,
         store: impl StateStore,

--- a/src/stream/src/executor/test_utils.rs
+++ b/src/stream/src/executor/test_utils.rs
@@ -84,7 +84,7 @@ impl MockSource {
 }
 
 #[async_trait]
-impl Executor for MockSource {
+impl ExecutorV1 for MockSource {
     async fn next(&mut self) -> Result<Message> {
         self.epoch += 1;
         match self.msgs.pop_front() {
@@ -173,7 +173,7 @@ impl MockAsyncSource {
 }
 
 #[async_trait]
-impl Executor for MockAsyncSource {
+impl ExecutorV1 for MockAsyncSource {
     async fn next(&mut self) -> Result<Message> {
         self.epoch += 1;
         match self.rx.recv().await {

--- a/src/stream/src/executor/top_n.rs
+++ b/src/stream/src/executor/top_n.rs
@@ -20,7 +20,7 @@ use risingwave_pb::stream_plan;
 use risingwave_pb::stream_plan::stream_node::Node;
 use risingwave_storage::{Keyspace, StateStore};
 
-use crate::executor::{Executor, ExecutorBuilder};
+use crate::executor::{ExecutorBuilder};
 use crate::executor_v2::{BoxedExecutor, Executor as ExecutorV2, TopNExecutor as TopNExecutorV2};
 use crate::task::{ExecutorParams, LocalStreamManagerCore};
 

--- a/src/stream/src/executor/top_n.rs
+++ b/src/stream/src/executor/top_n.rs
@@ -27,7 +27,7 @@ use crate::task::{ExecutorParams, LocalStreamManagerCore};
 pub struct TopNExecutorBuilder {}
 
 impl ExecutorBuilder for TopNExecutorBuilder {
-    fn new_boxed_executor(
+    fn new_boxed_executor_v1(
         mut params: ExecutorParams,
         node: &stream_plan::StreamNode,
         store: impl StateStore,

--- a/src/stream/src/executor/top_n.rs
+++ b/src/stream/src/executor/top_n.rs
@@ -21,7 +21,7 @@ use risingwave_pb::stream_plan::stream_node::Node;
 use risingwave_storage::{Keyspace, StateStore};
 
 use crate::executor::ExecutorBuilder;
-use crate::executor_v2::{BoxedExecutor, Executor, TopNExecutor as TopNExecutorV2};
+use crate::executor_v2::{BoxedExecutor, Executor, TopNExecutor};
 use crate::task::{ExecutorParams, LocalStreamManagerCore};
 
 pub struct TopNExecutorBuilder {}
@@ -55,7 +55,7 @@ impl ExecutorBuilder for TopNExecutorBuilder {
             .map(|key| *key as usize)
             .collect::<Vec<_>>();
 
-        Ok(TopNExecutorV2::new_from_v1(
+        Ok(TopNExecutor::new_from_v1(
             params.input.remove(0),
             order_types,
             (node.offset as usize, limit),

--- a/src/stream/src/executor/top_n.rs
+++ b/src/stream/src/executor/top_n.rs
@@ -20,8 +20,8 @@ use risingwave_pb::stream_plan;
 use risingwave_pb::stream_plan::stream_node::Node;
 use risingwave_storage::{Keyspace, StateStore};
 
-use crate::executor::{ExecutorBuilder};
-use crate::executor_v2::{BoxedExecutor, Executor as ExecutorV2, TopNExecutor as TopNExecutorV2};
+use crate::executor::ExecutorBuilder;
+use crate::executor_v2::{BoxedExecutor, Executor, TopNExecutor as TopNExecutorV2};
 use crate::task::{ExecutorParams, LocalStreamManagerCore};
 
 pub struct TopNExecutorBuilder {}

--- a/src/stream/src/executor/top_n.rs
+++ b/src/stream/src/executor/top_n.rs
@@ -21,18 +21,18 @@ use risingwave_pb::stream_plan::stream_node::Node;
 use risingwave_storage::{Keyspace, StateStore};
 
 use crate::executor::{Executor, ExecutorBuilder};
-use crate::executor_v2::{Executor as ExecutorV2, TopNExecutor as TopNExecutorV2};
+use crate::executor_v2::{BoxedExecutor, Executor as ExecutorV2, TopNExecutor as TopNExecutorV2};
 use crate::task::{ExecutorParams, LocalStreamManagerCore};
 
 pub struct TopNExecutorBuilder {}
 
 impl ExecutorBuilder for TopNExecutorBuilder {
-    fn new_boxed_executor_v1(
+    fn new_boxed_executor(
         mut params: ExecutorParams,
         node: &stream_plan::StreamNode,
         store: impl StateStore,
         _stream: &mut LocalStreamManagerCore,
-    ) -> Result<Box<dyn Executor>> {
+    ) -> Result<BoxedExecutor> {
         let node = try_match_expand!(node.get_node().unwrap(), Node::TopNNode)?;
         let order_types: Vec<_> = node
             .get_order_types()
@@ -54,20 +54,19 @@ impl ExecutorBuilder for TopNExecutorBuilder {
             .iter()
             .map(|key| *key as usize)
             .collect::<Vec<_>>();
-        Ok(Box::new(
-            Box::new(TopNExecutorV2::new_from_v1(
-                params.input.remove(0),
-                order_types,
-                (node.offset as usize, limit),
-                params.pk_indices,
-                keyspace,
-                cache_size,
-                total_count,
-                params.executor_id,
-                params.op_info,
-                key_indices,
-            )?)
-            .v1(),
-        ))
+
+        Ok(TopNExecutorV2::new_from_v1(
+            params.input.remove(0),
+            order_types,
+            (node.offset as usize, limit),
+            params.pk_indices,
+            keyspace,
+            cache_size,
+            total_count,
+            params.executor_id,
+            params.op_info,
+            key_indices,
+        )?
+        .boxed())
     }
 }

--- a/src/stream/src/executor/top_n_appendonly.rs
+++ b/src/stream/src/executor/top_n_appendonly.rs
@@ -20,9 +20,9 @@ use risingwave_pb::stream_plan;
 use risingwave_pb::stream_plan::stream_node::Node;
 use risingwave_storage::{Keyspace, StateStore};
 
-use crate::executor::{ExecutorBuilder};
+use crate::executor::ExecutorBuilder;
 use crate::executor_v2::{
-    AppendOnlyTopNExecutor as AppendOnlyTopNExecutorV2, BoxedExecutor, Executor as ExecutorV2,
+    AppendOnlyTopNExecutor as AppendOnlyTopNExecutorV2, BoxedExecutor, Executor,
 };
 use crate::task::{ExecutorParams, LocalStreamManagerCore};
 

--- a/src/stream/src/executor/top_n_appendonly.rs
+++ b/src/stream/src/executor/top_n_appendonly.rs
@@ -20,7 +20,7 @@ use risingwave_pb::stream_plan;
 use risingwave_pb::stream_plan::stream_node::Node;
 use risingwave_storage::{Keyspace, StateStore};
 
-use crate::executor::{Executor, ExecutorBuilder};
+use crate::executor::{ExecutorBuilder};
 use crate::executor_v2::{
     AppendOnlyTopNExecutor as AppendOnlyTopNExecutorV2, BoxedExecutor, Executor as ExecutorV2,
 };

--- a/src/stream/src/executor/top_n_appendonly.rs
+++ b/src/stream/src/executor/top_n_appendonly.rs
@@ -29,7 +29,7 @@ use crate::task::{ExecutorParams, LocalStreamManagerCore};
 pub struct AppendOnlyTopNExecutorBuilder {}
 
 impl ExecutorBuilder for AppendOnlyTopNExecutorBuilder {
-    fn new_boxed_executor(
+    fn new_boxed_executor_v1(
         mut params: ExecutorParams,
         node: &stream_plan::StreamNode,
         store: impl StateStore,

--- a/src/stream/src/executor/top_n_appendonly.rs
+++ b/src/stream/src/executor/top_n_appendonly.rs
@@ -21,9 +21,7 @@ use risingwave_pb::stream_plan::stream_node::Node;
 use risingwave_storage::{Keyspace, StateStore};
 
 use crate::executor::ExecutorBuilder;
-use crate::executor_v2::{
-    AppendOnlyTopNExecutor as AppendOnlyTopNExecutorV2, BoxedExecutor, Executor,
-};
+use crate::executor_v2::{AppendOnlyTopNExecutor, BoxedExecutor, Executor};
 use crate::task::{ExecutorParams, LocalStreamManagerCore};
 
 pub struct AppendOnlyTopNExecutorBuilder {}
@@ -57,7 +55,7 @@ impl ExecutorBuilder for AppendOnlyTopNExecutorBuilder {
             .map(|key| *key as usize)
             .collect::<Vec<_>>();
 
-        Ok(AppendOnlyTopNExecutorV2::new_from_v1(
+        Ok(AppendOnlyTopNExecutor::new_from_v1(
             params.input.remove(0),
             order_types,
             (node.offset as usize, limit),

--- a/src/stream/src/executor_v2/lookup.rs
+++ b/src/stream/src/executor_v2/lookup.rs
@@ -89,7 +89,7 @@ impl<S: StateStore> Executor for LookupExecutor<S> {
 pub struct LookupExecutorBuilder {}
 
 impl ExecutorBuilder for LookupExecutorBuilder {
-    fn new_boxed_executor(
+    fn new_boxed_executor_v1(
         mut params: ExecutorParams,
         node: &stream_plan::StreamNode,
         store: impl StateStore,
@@ -97,8 +97,8 @@ impl ExecutorBuilder for LookupExecutorBuilder {
     ) -> Result<Box<dyn ExecutorV1>> {
         let node = try_match_expand!(node.get_node().unwrap(), Node::LookupNode)?;
 
-        let stream = params.input.remove(1).v2();
-        let arrangement = params.input.remove(0).v2();
+        let stream = params.input.remove(1);
+        let arrangement = params.input.remove(0);
 
         let arrangement_col_descs = arrangement
             .schema()

--- a/src/stream/src/executor_v2/lookup.rs
+++ b/src/stream/src/executor_v2/lookup.rs
@@ -33,8 +33,6 @@ mod impl_;
 
 pub use impl_::LookupExecutorParams;
 
-use super::ExecutorV1AsV2;
-
 #[cfg(test)]
 mod tests;
 
@@ -99,10 +97,8 @@ impl ExecutorBuilder for LookupExecutorBuilder {
     ) -> Result<Box<dyn ExecutorV1>> {
         let node = try_match_expand!(node.get_node().unwrap(), Node::LookupNode)?;
 
-        let stream = params.input.remove(1);
-        let stream = Box::new(ExecutorV1AsV2(stream));
-        let arrangement = params.input.remove(0);
-        let arrangement = Box::new(ExecutorV1AsV2(arrangement));
+        let stream = params.input.remove(1).v2();
+        let arrangement = params.input.remove(0).v2();
 
         let arrangement_col_descs = arrangement
             .schema()

--- a/src/stream/src/executor_v2/lookup.rs
+++ b/src/stream/src/executor_v2/lookup.rs
@@ -23,7 +23,7 @@ use risingwave_pb::stream_plan;
 use risingwave_pb::stream_plan::stream_node::Node;
 use risingwave_storage::{Keyspace, StateStore};
 
-use crate::executor::{Executor as ExecutorV1, ExecutorBuilder};
+use crate::executor::ExecutorBuilder;
 use crate::executor_v2::{Barrier, BoxedMessageStream, Executor, PkIndices, PkIndicesRef};
 use crate::task::{unique_operator_id, ExecutorParams, LocalStreamManagerCore};
 

--- a/src/stream/src/executor_v2/merge.rs
+++ b/src/stream/src/executor_v2/merge.rs
@@ -231,9 +231,9 @@ mod tests {
     use tonic::{Request, Response, Status};
 
     use super::*;
-    use crate::executor::{Barrier, Executor, Mutation};
+    use crate::executor::{Barrier, ExecutorV1, Mutation};
     use crate::executor_v2::merge::RemoteInput;
-    use crate::executor_v2::Executor as ExecutorV2;
+    use crate::executor_v2::Executor;
 
     fn build_test_chunk(epoch: u64) -> StreamChunk {
         // The number of items in `ops` is the epoch count.

--- a/src/stream/src/executor_v2/merge.rs
+++ b/src/stream/src/executor_v2/merge.rs
@@ -278,7 +278,7 @@ mod tests {
             handles.push(handle);
         }
 
-        let mut merger = Box::new(merger).v1();
+        let mut merger = merger.boxed().v1();
         for epoch in epochs {
             // expect n chunks
             for _ in 0..CHANNEL_NUMBER {

--- a/src/stream/src/executor_v2/mod.rs
+++ b/src/stream/src/executor_v2/mod.rs
@@ -19,7 +19,6 @@ use futures::stream::BoxStream;
 pub use risingwave_common::array::StreamChunk;
 use risingwave_common::catalog::Schema;
 
-use self::v1_compat::StreamExecutorV1;
 pub use super::executor::{Barrier, ExecutorV1, Message, Mutation, PkIndices, PkIndicesRef};
 
 pub mod aggregation;
@@ -111,33 +110,6 @@ pub trait Executor: Send + 'static {
             schema,
             pk_indices,
             identity,
-        }
-    }
-
-    /// Return an executor which implements [`ExecutorV1`].
-    fn v1(self: Box<Self>) -> StreamExecutorV1 {
-        let info = self.info();
-        let stream = self.execute();
-
-        StreamExecutorV1 {
-            executor_v2: None,
-            stream: Some(stream),
-            info,
-        }
-    }
-
-    /// Return an executor which implements [`ExecutorV1`] and requires [`ExecutorV1::init`] to be
-    /// called before executing.
-    fn v1_uninited(self: Box<Self>) -> StreamExecutorV1
-    where
-        Self: Sized,
-    {
-        let info = self.info();
-
-        StreamExecutorV1 {
-            executor_v2: Some(self),
-            stream: None,
-            info,
         }
     }
 

--- a/src/stream/src/executor_v2/mod.rs
+++ b/src/stream/src/executor_v2/mod.rs
@@ -117,10 +117,7 @@ pub trait Executor: Send + 'static {
     }
 
     /// Return an executor which implements [`ExecutorV1`].
-    fn v1(self: Box<Self>) -> StreamExecutorV1
-    where
-        Self: Sized,
-    {
+    fn v1(self: Box<Self>) -> StreamExecutorV1 {
         let info = self.info();
         let stream = self.execute();
 

--- a/src/stream/src/executor_v2/mod.rs
+++ b/src/stream/src/executor_v2/mod.rs
@@ -20,9 +20,7 @@ pub use risingwave_common::array::StreamChunk;
 use risingwave_common::catalog::Schema;
 
 use self::v1_compat::StreamExecutorV1;
-pub use super::executor::{
-    Barrier, Executor as ExecutorV1, Message, Mutation, PkIndices, PkIndicesRef,
-};
+pub use super::executor::{Barrier, ExecutorV1, Message, Mutation, PkIndices, PkIndicesRef};
 
 pub mod aggregation;
 mod batch_query;

--- a/src/stream/src/executor_v2/mod.rs
+++ b/src/stream/src/executor_v2/mod.rs
@@ -19,6 +19,7 @@ use futures::stream::BoxStream;
 pub use risingwave_common::array::StreamChunk;
 use risingwave_common::catalog::Schema;
 
+use self::v1_compat::StreamExecutorV1;
 pub use super::executor::{
     Barrier, Executor as ExecutorV1, Message, Mutation, PkIndices, PkIndicesRef,
 };
@@ -62,7 +63,6 @@ pub(crate) use simple::{SimpleExecutor, SimpleExecutorWrapper};
 pub use top_n::TopNExecutor;
 pub use top_n_appendonly::AppendOnlyTopNExecutor;
 pub use union::{UnionExecutor, UnionExecutorBuilder};
-pub use v1_compat::{ExecutorV1AsV2, StreamExecutorV1};
 
 pub type BoxedExecutor = Box<dyn Executor>;
 pub type BoxedMessageStream = BoxStream<'static, StreamExecutorResult<Message>>;

--- a/src/stream/src/executor_v2/union.rs
+++ b/src/stream/src/executor_v2/union.rs
@@ -23,9 +23,7 @@ use risingwave_storage::StateStore;
 
 use super::error::StreamExecutorError;
 use super::{BoxedExecutor, Executor, Message, PkIndicesRef, StreamExecutorResult};
-use crate::executor::{
-    AlignedMessage, BarrierAligner, Executor as ExecutorV1, ExecutorBuilder, PkIndices,
-};
+use crate::executor::{AlignedMessage, BarrierAligner, ExecutorBuilder, PkIndices};
 use crate::executor_v2::error::TracedStreamExecutorError;
 use crate::executor_v2::{BoxedMessageStream, ExecutorInfo};
 use crate::task::{ExecutorParams, LocalStreamManagerCore};

--- a/src/stream/src/executor_v2/union.rs
+++ b/src/stream/src/executor_v2/union.rs
@@ -156,15 +156,13 @@ impl UnionExecutor {
 pub struct UnionExecutorBuilder {}
 
 impl ExecutorBuilder for UnionExecutorBuilder {
-    fn new_boxed_executor_v1(
+    fn new_boxed_executor(
         params: ExecutorParams,
         node: &stream_plan::StreamNode,
         _store: impl StateStore,
         _stream: &mut LocalStreamManagerCore,
-    ) -> risingwave_common::error::Result<Box<dyn ExecutorV1>> {
+    ) -> risingwave_common::error::Result<BoxedExecutor> {
         try_match_expand!(node.get_node().unwrap(), Node::UnionNode)?;
-        Ok(Box::new(
-            Box::new(UnionExecutor::new(params.pk_indices, params.input)).v1(),
-        ))
+        Ok(UnionExecutor::new(params.pk_indices, params.input).boxed())
     }
 }

--- a/src/stream/src/executor_v2/v1_compat.rs
+++ b/src/stream/src/executor_v2/v1_compat.rs
@@ -144,7 +144,7 @@ impl dyn ExecutorV1 {
 
 impl FilterExecutor {
     pub fn new_from_v1(
-        input: Box<dyn ExecutorV1>,
+        input: BoxedExecutor,
         expr: BoxedExpression,
         executor_id: u64,
         _op_info: String,
@@ -154,7 +154,7 @@ impl FilterExecutor {
             pk_indices: input.pk_indices().to_owned(),
             identity: "Filter".to_owned(),
         };
-        let input = input.v2();
+
         super::SimpleExecutorWrapper {
             input,
             inner: SimpleFilterExecutor::new(info, expr, executor_id),
@@ -164,7 +164,7 @@ impl FilterExecutor {
 
 impl ProjectExecutor {
     pub fn new_from_v1(
-        input: Box<dyn ExecutorV1>,
+        input: BoxedExecutor,
         pk_indices: PkIndices,
         exprs: Vec<BoxedExpression>,
         executor_id: u64,
@@ -175,7 +175,7 @@ impl ProjectExecutor {
             pk_indices,
             identity: "Project".to_owned(),
         };
-        let input = input.v2();
+
         super::SimpleExecutorWrapper {
             input,
             inner: SimpleProjectExecutor::new(info, exprs, executor_id),
@@ -185,8 +185,8 @@ impl ProjectExecutor {
 
 impl ChainExecutor {
     pub fn new_from_v1(
-        snapshot: Box<dyn ExecutorV1>,
-        mview: Box<dyn ExecutorV1>,
+        snapshot: BoxedExecutor,
+        mview: BoxedExecutor,
         notifier: FinishCreateMviewNotifier,
         schema: Schema,
         column_idxs: Vec<usize>,
@@ -200,46 +200,38 @@ impl ChainExecutor {
 
         let actor_id = notifier.actor_id;
 
-        Self::new(
-            snapshot.v2(),
-            mview.v2(),
-            column_idxs,
-            notifier,
-            actor_id,
-            info,
-        )
+        Self::new(snapshot, mview, column_idxs, notifier, actor_id, info)
     }
 }
 
 impl<S: StateStore> MaterializeExecutor<S> {
     pub fn new_from_v1(
-        input: Box<dyn ExecutorV1>,
+        input: BoxedExecutor,
         keyspace: Keyspace<S>,
         keys: Vec<OrderPair>,
         column_ids: Vec<ColumnId>,
         executor_id: u64,
         _op_info: String,
     ) -> Self {
-        Self::new(input.v2(), keyspace, keys, column_ids, executor_id)
+        Self::new(input, keyspace, keys, column_ids, executor_id)
     }
 }
 
 impl LocalSimpleAggExecutor {
     pub fn new_from_v1(
-        input: Box<dyn ExecutorV1>,
+        input: BoxedExecutor,
         agg_calls: Vec<AggCall>,
         pk_indices: PkIndices,
         executor_id: u64,
         _op_info: String,
     ) -> Result<Self> {
-        let input = input.v2();
         Self::new(input, agg_calls, pk_indices, executor_id)
     }
 }
 
 impl<S: StateStore> SimpleAggExecutor<S> {
     pub fn new_from_v1(
-        input: Box<dyn ExecutorV1>,
+        input: BoxedExecutor,
         agg_calls: Vec<AggCall>,
         keyspace: Keyspace<S>,
         pk_indices: PkIndices,
@@ -247,7 +239,6 @@ impl<S: StateStore> SimpleAggExecutor<S> {
         _op_info: String,
         key_indices: Vec<usize>,
     ) -> Result<Self> {
-        let input = input.v2();
         Self::new(
             input,
             agg_calls,
@@ -261,7 +252,7 @@ impl<S: StateStore> SimpleAggExecutor<S> {
 
 impl<K: HashKey, S: StateStore> HashAggExecutor<K, S> {
     pub fn new_from_v1(
-        input: Box<dyn ExecutorV1>,
+        input: BoxedExecutor,
         agg_calls: Vec<AggCall>,
         key_indices: Vec<usize>,
         keyspace: Keyspace<S>,
@@ -269,7 +260,6 @@ impl<K: HashKey, S: StateStore> HashAggExecutor<K, S> {
         executor_id: u64,
         _op_info: String,
     ) -> Result<Self> {
-        let input = input.v2();
         Self::new(
             input,
             agg_calls,
@@ -309,7 +299,7 @@ impl<S: StateStore> BatchQueryExecutor<S> {
 impl<S: StateStore> TopNExecutor<S> {
     #[allow(clippy::too_many_arguments)]
     pub fn new_from_v1(
-        input: Box<dyn ExecutorV1>,
+        input: BoxedExecutor,
         pk_order_types: Vec<OrderType>,
         offset_and_limit: (usize, Option<usize>),
         pk_indices: PkIndices,
@@ -320,7 +310,6 @@ impl<S: StateStore> TopNExecutor<S> {
         _op_info: String,
         key_indices: Vec<usize>,
     ) -> Result<Self> {
-        let input = input.v2();
         Self::new(
             input,
             pk_order_types,
@@ -338,7 +327,7 @@ impl<S: StateStore> TopNExecutor<S> {
 impl<S: StateStore> AppendOnlyTopNExecutor<S> {
     #[allow(clippy::too_many_arguments)]
     pub fn new_from_v1(
-        input: Box<dyn ExecutorV1>,
+        input: BoxedExecutor,
         pk_order_types: Vec<OrderType>,
         offset_and_limit: (usize, Option<usize>),
         pk_indices: PkIndices,
@@ -349,7 +338,6 @@ impl<S: StateStore> AppendOnlyTopNExecutor<S> {
         _op_info: String,
         key_indices: Vec<usize>,
     ) -> Result<Self> {
-        let input = input.v2();
         Self::new(
             input,
             pk_order_types,

--- a/src/stream/src/executor_v2/v1_compat.rs
+++ b/src/stream/src/executor_v2/v1_compat.rs
@@ -56,9 +56,9 @@ pub struct StreamExecutorV1 {
 
 impl fmt::Debug for StreamExecutorV1 {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        f.debug_struct("StreamExecutor")
+        f.debug_struct("StreamExecutorV1")
             .field("info", &self.info)
-            .finish()
+            .finish_non_exhaustive()
     }
 }
 
@@ -128,7 +128,7 @@ impl ExecutorV1AsV2 {
         loop {
             let msg = self.0.next().await;
             match msg {
-                // For snapshot input of `Chain`, we use `Eof` to represent the end of stream.
+                // We previously use `Eof` to represent the end of stream.
                 Err(e) if matches!(e.inner(), ErrorCode::Eof) => break,
                 _ => yield msg.map_err(StreamExecutorError::executor_v1)?,
             }

--- a/src/stream/src/task/mod.rs
+++ b/src/stream/src/task/mod.rs
@@ -71,6 +71,14 @@ pub struct SharedContext {
     pub(crate) barrier_manager: Arc<Mutex<LocalBarrierManager>>,
 }
 
+impl std::fmt::Debug for SharedContext {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("SharedContext")
+            .field("addr", &self.addr)
+            .finish_non_exhaustive()
+    }
+}
+
 impl SharedContext {
     pub fn new(addr: HostAddr) -> Self {
         Self {

--- a/src/stream/src/task/stream_manager.rs
+++ b/src/stream/src/task/stream_manager.rs
@@ -396,7 +396,8 @@ impl LocalStreamManagerCore {
         actor_id: ActorId,
     ) -> Result<impl StreamConsumer> {
         // create downstream receivers
-        let mut dispatcher_impls = vec![];
+        let mut dispatcher_impls = Vec::with_capacity(dispatchers.len());
+
         for dispatcher in dispatchers {
             let outputs = dispatcher
                 .downstream_actor_id
@@ -406,6 +407,7 @@ impl LocalStreamManagerCore {
                     new_output(&self.context, downstream_addr, actor_id, *down_id)
                 })
                 .collect::<Result<Vec<_>>>()?;
+
             use stream_plan::DispatcherType::*;
             let dispatcher_impl = match dispatcher.get_type()? {
                 Hash => {

--- a/src/stream/src/task/stream_manager.rs
+++ b/src/stream/src/task/stream_manager.rs
@@ -39,7 +39,7 @@ use crate::executor::*;
 use crate::executor_v2::aggregation::{AggArgs, AggCall};
 use crate::executor_v2::merge::RemoteInput;
 use crate::executor_v2::receiver::ReceiverExecutor;
-use crate::executor_v2::{BoxedExecutor, Executor as ExecutorV2, MergeExecutor as MergeExecutorV2};
+use crate::executor_v2::{BoxedExecutor, Executor, MergeExecutor as MergeExecutorV2};
 use crate::task::{
     ActorId, ConsumableChannelPair, SharedContext, StreamEnvironment, UpDownActorIds,
     LOCAL_OUTPUT_CHANNEL_SIZE,
@@ -527,11 +527,11 @@ impl LocalStreamManagerCore {
 
     #[allow(dead_code)]
     fn wrap_executor_for_debug(
-        mut executor: Box<dyn Executor>,
+        mut executor: Box<dyn ExecutorV1>,
         actor_id: ActorId,
         input_pos: usize,
         streaming_metrics: Arc<StreamingMetrics>,
-    ) -> Result<Box<dyn Executor>> {
+    ) -> Result<Box<dyn ExecutorV1>> {
         if !cfg!(debug_assertions) {
             return Ok(executor);
         }

--- a/src/stream/src/task/stream_manager.rs
+++ b/src/stream/src/task/stream_manager.rs
@@ -562,31 +562,16 @@ impl LocalStreamManagerCore {
         &mut self,
         params: ExecutorParams,
         node: &stream_plan::MergeNode,
-    ) -> Result<Box<dyn Executor>> {
+    ) -> Result<BoxedExecutor> {
         let upstreams = node.get_upstream_actor_id();
         let fields = node.fields.iter().map(Field::from).collect();
         let schema = Schema::new(fields);
         let mut rxs = self.get_receive_message(params.actor_id, upstreams)?;
 
         if upstreams.len() == 1 {
-            Ok(Box::new(
-                Box::new(ReceiverExecutor::new(
-                    schema,
-                    params.pk_indices,
-                    rxs.remove(0),
-                ))
-                .v1(),
-            ))
+            Ok(ReceiverExecutor::new(schema, params.pk_indices, rxs.remove(0)).boxed())
         } else {
-            Ok(Box::new(
-                Box::new(MergeExecutorV2::new(
-                    schema,
-                    params.pk_indices,
-                    params.actor_id,
-                    rxs,
-                ))
-                .v1(),
-            ))
+            Ok(MergeExecutorV2::new(schema, params.pk_indices, params.actor_id, rxs).boxed())
         }
     }
 

--- a/src/stream/src/task/stream_manager.rs
+++ b/src/stream/src/task/stream_manager.rs
@@ -457,7 +457,7 @@ impl LocalStreamManagerCore {
         fragment_id: u32,
         actor_id: ActorId,
         node: &stream_plan::StreamNode,
-        input_pos: usize,
+        _input_pos: usize,
         env: StreamEnvironment,
         store: impl StateStore,
     ) -> Result<BoxedExecutor> {
@@ -525,6 +525,7 @@ impl LocalStreamManagerCore {
         })
     }
 
+    #[allow(dead_code)]
     fn wrap_executor_for_debug(
         mut executor: Box<dyn Executor>,
         actor_id: ActorId,

--- a/src/stream/src/task/stream_manager.rs
+++ b/src/stream/src/task/stream_manager.rs
@@ -39,7 +39,7 @@ use crate::executor::*;
 use crate::executor_v2::aggregation::{AggArgs, AggCall};
 use crate::executor_v2::merge::RemoteInput;
 use crate::executor_v2::receiver::ReceiverExecutor;
-use crate::executor_v2::{BoxedExecutor, Executor, MergeExecutor as MergeExecutorV2};
+use crate::executor_v2::{BoxedExecutor, Executor, MergeExecutor};
 use crate::task::{
     ActorId, ConsumableChannelPair, SharedContext, StreamEnvironment, UpDownActorIds,
     LOCAL_OUTPUT_CHANNEL_SIZE,
@@ -572,7 +572,7 @@ impl LocalStreamManagerCore {
         if upstreams.len() == 1 {
             Ok(ReceiverExecutor::new(schema, params.pk_indices, rxs.remove(0)).boxed())
         } else {
-            Ok(MergeExecutorV2::new(schema, params.pk_indices, params.actor_id, rxs).boxed())
+            Ok(MergeExecutor::new(schema, params.pk_indices, params.actor_id, rxs).boxed())
         }
     }
 


### PR DESCRIPTION
## What's changed and what's your intention?

We directly build executor v2 with v2 inputs, and use v2 in _dispatcher_ and _actor_ in this PR. Note that the debug executors are not migrated now, so they're temporarily disabled.

https://github.com/singularity-data/risingwave/blob/45e5075e42f6d5b03ce2b0640b3e2241f45e269d/src/stream/src/executor/mod.rs#L461-L482

## Checklist

- [x] I have written necessary docs and comments
- [x] I have added necessary unit tests and integration tests

## Refer to a related PR or issue link (optional)
- Close #1479 
- Close #1966