### PR TITLE
refactor(stream, storage): use iter in TopNExecutor

### DIFF
--- a/src/storage/src/cell_based_row_deserializer.rs
+++ b/src/storage/src/cell_based_row_deserializer.rs
@@ -95,8 +95,11 @@ impl CellBasedRowDeserializer {
     }
 
     /// Since [`CellBasedRowDeserializer`] can be repetitively used with different inputs,
-    /// it needs to be reset so that pk is cleared for the next use.
+    /// it needs to be reset so that pk and data are both cleared for the next use.
     pub fn reset(&mut self) {
+        self.data.iter_mut().for_each(|datum| {
+            datum.take();
+        });
         self.pk_bytes.take();
     }
 }

--- a/src/storage/src/cell_based_row_deserializer.rs
+++ b/src/storage/src/cell_based_row_deserializer.rs
@@ -93,6 +93,12 @@ impl CellBasedRowDeserializer {
             (bytes, Row(ret))
         })
     }
+
+    /// Since [`CellBasedRowDeserializer`] can be repetitively used with different inputs,
+    /// it needs to be reset so that pk is cleared for the next use.
+    pub fn reset(&mut self) {
+        self.pk_bytes.take();
+    }
 }
 
 #[cfg(test)]

--- a/src/storage/src/keyspace.rs
+++ b/src/storage/src/keyspace.rs
@@ -12,12 +12,14 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use std::future::Future;
+
 use bytes::{BufMut, Bytes, BytesMut};
 use risingwave_common::catalog::TableId;
 use risingwave_hummock_sdk::key::next_key;
 
 use crate::error::StorageResult;
-use crate::StateStore;
+use crate::{StateStore, StateStoreIter};
 
 /// Provides API to read key-value pairs of a prefix in the storage backend.
 #[derive(Clone)]
@@ -166,8 +168,42 @@ impl<S: StateStore> Keyspace<S> {
         self.store.iter(range, epoch).await
     }
 
+    pub async fn iter_strip_prefix(
+        &'_ self,
+        epoch: u64,
+    ) -> StorageResult<impl StateStoreIter<Item = (Bytes, Bytes)> + '_> {
+        let iter = self.iter(epoch).await?;
+        let strip_prefix_iterator = StripPrefixIterator {
+            iter,
+            prefix_len: self.prefix.len(),
+        };
+        Ok(strip_prefix_iterator)
+    }
+
     /// Gets the underlying state store.
     pub fn state_store(&self) -> S {
         self.store.clone()
+    }
+}
+
+pub struct StripPrefixIterator<I: StateStoreIter<Item = (Bytes, Bytes)>> {
+    iter: I,
+    prefix_len: usize,
+}
+
+impl<I: StateStoreIter<Item = (Bytes, Bytes)>> StateStoreIter for StripPrefixIterator<I> {
+    type Item = (Bytes, Bytes);
+
+    type NextFuture<'a> =
+        impl Future<Output = crate::error::StorageResult<Option<Self::Item>>> + Send;
+
+    fn next(&mut self) -> Self::NextFuture<'_> {
+        async move {
+            Ok(self
+                .iter
+                .next()
+                .await?
+                .map(|(key, value)| (key.slice(self.prefix_len..), value)))
+        }
     }
 }

--- a/src/stream/src/executor/managed_state/flush_status.rs
+++ b/src/stream/src/executor/managed_state/flush_status.rs
@@ -23,6 +23,7 @@ macro_rules! impl_flush_status {
         ///        \------(delete)-> Delete --(insert)-> DeleteInsert --(delete)-> Delete
         /// ```
         $(
+            #[derive(Debug)]
             pub enum $struct_name<T> {
                 /// The entry will be deleted.
                 Delete,

--- a/src/stream/src/executor/managed_state/top_n/mod.rs
+++ b/src/stream/src/executor/managed_state/top_n/mod.rs
@@ -20,6 +20,7 @@ use risingwave_common::array::Row;
 use risingwave_common::error::Result;
 use risingwave_common::util::ordered::{OrderedRow, OrderedRowDeserializer};
 use risingwave_storage::cell_based_row_deserializer::CellBasedRowDeserializer;
+use risingwave_storage::StateStoreIter;
 pub use top_n_bottom_n_state::ManagedTopNBottomNState;
 pub use top_n_state::ManagedTopNState;
 
@@ -40,30 +41,43 @@ fn deserialize_pk<const TOP_N_TYPE: usize>(
     Ok(pk)
 }
 
-fn deserialize_bytes_to_pk_and_row<const TOP_N_TYPE: usize>(
-    pk_row_bytes: Vec<(Bytes, Bytes)>,
+// The function moves `pk_row_bytes_iter` as it is possible that we would take one extra cell from
+// it than the returned result. Allowing it to be reused after this function via borrowing may cause
+// confusion and bugs.
+async fn deserialize_bytes_to_pk_and_row<
+    const TOP_N_TYPE: usize,
+    I: StateStoreIter<Item = (Bytes, Bytes)>,
+>(
+    mut pk_row_bytes_iter: I,
     ordered_row_deserializer: &mut OrderedRowDeserializer,
     cell_based_row_deserializer: &mut CellBasedRowDeserializer,
+    num_rows: Option<usize>,
 ) -> Result<Vec<(OrderedRow, Row)>> {
-    if pk_row_bytes.is_empty() {
-        return Ok(vec![]);
-    }
     let mut result = vec![];
-    // We initialize the `pk_buf` to be the first element so that we don't need to put a check
-    // inside the loop to specially check the first corner case.
-    for (key, value) in pk_row_bytes {
+    while let Some((key, value)) = pk_row_bytes_iter.next().await? {
         let pk_buf_and_row = cell_based_row_deserializer.deserialize(&key, &value)?;
         match pk_buf_and_row {
             Some((mut pk_buf, row)) => {
                 let pk = deserialize_pk::<TOP_N_TYPE>(&mut pk_buf, ordered_row_deserializer)?;
                 result.push((pk, row));
+                if let Some(num_rows) = num_rows && result.len() == num_rows {
+                    break;
+                }
             }
             None => {}
         }
     }
-    // Take out the final row.
-    let mut pk_buf_and_row = cell_based_row_deserializer.take().unwrap();
-    let pk = deserialize_pk::<TOP_N_TYPE>(&mut pk_buf_and_row.0, ordered_row_deserializer)?;
-    result.push((pk, pk_buf_and_row.1));
+    if let Some(num_rows) = num_rows && result.len() == num_rows {
+        // do nothing
+    } else {
+        // This branch implies that all the key value pairs have been drained from `pk_row_bytes_iter`.
+        // Try to take out the final row.
+        // It is possible that `iter` is empty, so we may read nothing and there is no such final row.
+        let pk_buf_and_row = cell_based_row_deserializer.take();
+        if let Some(mut pk_buf_and_row) = pk_buf_and_row {
+            let pk = deserialize_pk::<TOP_N_TYPE>(&mut pk_buf_and_row.0, ordered_row_deserializer)?;
+            result.push((pk, pk_buf_and_row.1));
+        }
+    }
     Ok(result)
 }

--- a/src/stream/src/executor/managed_state/top_n/mod.rs
+++ b/src/stream/src/executor/managed_state/top_n/mod.rs
@@ -61,23 +61,19 @@ async fn deserialize_bytes_to_pk_and_row<
                 let pk = deserialize_pk::<TOP_N_TYPE>(&mut pk_buf, ordered_row_deserializer)?;
                 result.push((pk, row));
                 if let Some(num_rows) = num_rows && result.len() == num_rows {
-                    break;
+                    return Ok(result);
                 }
             }
             None => {}
         }
     }
-    if let Some(num_rows) = num_rows && result.len() == num_rows {
-        // do nothing
-    } else {
-        // This branch implies that all the key value pairs have been drained from `pk_row_bytes_iter`.
-        // Try to take out the final row.
-        // It is possible that `iter` is empty, so we may read nothing and there is no such final row.
-        let pk_buf_and_row = cell_based_row_deserializer.take();
-        if let Some(mut pk_buf_and_row) = pk_buf_and_row {
-            let pk = deserialize_pk::<TOP_N_TYPE>(&mut pk_buf_and_row.0, ordered_row_deserializer)?;
-            result.push((pk, pk_buf_and_row.1));
-        }
+    // Reaching here implies that all the key value pairs have been drained from
+    // `pk_row_bytes_iter`. Try to take out the final row.
+    // It is possible that `iter` is empty, so we may read nothing and there is no such final row.
+    let pk_buf_and_row = cell_based_row_deserializer.take();
+    if let Some(mut pk_buf_and_row) = pk_buf_and_row {
+        let pk = deserialize_pk::<TOP_N_TYPE>(&mut pk_buf_and_row.0, ordered_row_deserializer)?;
+        result.push((pk, pk_buf_and_row.1));
     }
     Ok(result)
 }

--- a/src/stream/src/executor/managed_state/top_n/top_n_bottom_n_state.rs
+++ b/src/stream/src/executor/managed_state/top_n/top_n_bottom_n_state.rs
@@ -258,7 +258,7 @@ impl<S: StateStore> ManagedTopNBottomNState<S> {
         number_rows: Option<usize>,
         epoch: u64,
     ) -> Result<Vec<(OrderedRow, Row)>> {
-        let iter = self.keyspace.iter_strip_prefix(epoch).await?;
+        let iter = self.keyspace.iter(epoch).await?;
         let pk_and_rows = deserialize_bytes_to_pk_and_row::<TOP_N_MIN, _>(
             iter,
             &mut self.ordered_row_deserializer,

--- a/src/stream/src/executor/managed_state/top_n/top_n_bottom_n_state.rs
+++ b/src/stream/src/executor/managed_state/top_n/top_n_bottom_n_state.rs
@@ -18,7 +18,6 @@
 use std::collections::BTreeMap;
 use std::vec::Drain;
 
-use itertools::Itertools;
 use risingwave_common::array::Row;
 use risingwave_common::catalog::ColumnId;
 use risingwave_common::error::Result;
@@ -259,21 +258,16 @@ impl<S: StateStore> ManagedTopNBottomNState<S> {
         number_rows: Option<usize>,
         epoch: u64,
     ) -> Result<Vec<(OrderedRow, Row)>> {
-        let pk_row_bytes = self
-            .keyspace
-            .scan_strip_prefix(
-                number_rows.map(|top_n_count| top_n_count * self.data_types.len()),
-                epoch,
-            )
-            .await?
-            .into_iter()
-            .map(|(k, v)| (k, v))
-            .collect_vec();
-        deserialize_bytes_to_pk_and_row::<TOP_N_MIN>(
-            pk_row_bytes,
+        let iter = self.keyspace.iter_strip_prefix(epoch).await?;
+        let pk_and_rows = deserialize_bytes_to_pk_and_row::<TOP_N_MIN, _>(
+            iter,
             &mut self.ordered_row_deserializer,
             &mut self.cell_based_row_deserializer,
+            number_rows,
         )
+        .await;
+        self.cell_based_row_deserializer.reset();
+        pk_and_rows
     }
 
     /// We can fill in the cache from storage only when state is not dirty, i.e. right after

--- a/src/stream/src/executor/managed_state/top_n/top_n_state.rs
+++ b/src/stream/src/executor/managed_state/top_n/top_n_state.rs
@@ -14,7 +14,6 @@
 
 use std::collections::BTreeMap;
 
-use itertools::Itertools;
 use risingwave_common::array::Row;
 use risingwave_common::catalog::ColumnId;
 use risingwave_common::error::Result;
@@ -273,24 +272,16 @@ impl<S: StateStore, const TOP_N_TYPE: usize> ManagedTopNState<S, TOP_N_TYPE> {
         number_rows: Option<usize>,
         epoch: u64,
     ) -> Result<Vec<(OrderedRow, Row)>> {
-        // We remark that since we uses a sentinel column by encoding a special none cell.
-        // `top_n_count * self.data_types.len()` over-calculates the number of kv-pairs that
-        // we need to read from storage. But it is fine.
-        let pk_row_bytes = self
-            .keyspace
-            .scan_strip_prefix(
-                number_rows.map(|top_n_count| top_n_count * (self.data_types.len() + 1)),
-                epoch,
-            )
-            .await?
-            .into_iter()
-            .map(|(k, v)| (k, v))
-            .collect_vec();
-        deserialize_bytes_to_pk_and_row::<TOP_N_TYPE>(
-            pk_row_bytes,
+        let iter = self.keyspace.iter_strip_prefix(epoch).await?;
+        let pk_and_rows = deserialize_bytes_to_pk_and_row::<TOP_N_TYPE, _>(
+            iter,
             &mut self.ordered_row_deserializer,
             &mut self.cell_based_row_deserializer,
+            number_rows,
         )
+        .await;
+        self.cell_based_row_deserializer.reset();
+        pk_and_rows
     }
 
     /// We can fill in the cache from storage only when state is not dirty, i.e. right after

--- a/src/stream/src/executor/managed_state/top_n/top_n_state.rs
+++ b/src/stream/src/executor/managed_state/top_n/top_n_state.rs
@@ -272,7 +272,7 @@ impl<S: StateStore, const TOP_N_TYPE: usize> ManagedTopNState<S, TOP_N_TYPE> {
         number_rows: Option<usize>,
         epoch: u64,
     ) -> Result<Vec<(OrderedRow, Row)>> {
-        let iter = self.keyspace.iter_strip_prefix(epoch).await?;
+        let iter = self.keyspace.iter(epoch).await?;
         let pk_and_rows = deserialize_bytes_to_pk_and_row::<TOP_N_TYPE, _>(
             iter,
             &mut self.ordered_row_deserializer,


### PR DESCRIPTION
## What's changed and what's your intention?
Use `iter` instead of `scan` in TopNExecutor as we don't know exactly how many kv pairs we need to scan from Hummock.

Add a `StripPrefixIterator` to get rid of the prefix in the keyspace.

Add a `reset` method to `CellBasedRowDeserializer` to clear `pk_bytes` when we need to use it repetitively across different inputs. 

## Checklist

- [x] I have written necessary docs and comments

## Refer to a related PR or issue link (optional)
