### PR TITLE
refactor(meta): use scheduled parallel unit in dispatcher's hash mapping

### DIFF
--- a/src/meta/src/rpc/service/ddl_service.rs
+++ b/src/meta/src/rpc/service/ddl_service.rs
@@ -19,6 +19,7 @@ use risingwave_common::catalog::CatalogVersion;
 use risingwave_common::error::{tonic_err, Result as RwResult};
 use risingwave_pb::catalog::table::OptionalAssociatedSourceId;
 use risingwave_pb::catalog::*;
+use risingwave_pb::common::ParallelUnitType;
 use risingwave_pb::ddl_service::ddl_service_server::DdlService;
 use risingwave_pb::ddl_service::*;
 use risingwave_pb::plan::TableRefId;
@@ -409,14 +410,19 @@ where
 
         // Resolve fragments.
         let hash_mapping = self.cluster_manager.get_hash_mapping().await;
+        let parallel_degree = self
+            .cluster_manager
+            .get_parallel_unit_count(Some(ParallelUnitType::Hash))
+            .await;
         let mut ctx = CreateMaterializedViewContext {
             affiliated_source,
+            hash_mapping,
             ..Default::default()
         };
         let fragmenter = StreamFragmenter::new(
             self.env.id_gen_manager_ref(),
             self.fragment_manager.clone(),
-            hash_mapping,
+            parallel_degree as u32,
             false,
         );
         let graph = fragmenter.generate_graph(&stream_node, &mut ctx).await?;

--- a/src/meta/src/rpc/service/stream_service.rs
+++ b/src/meta/src/rpc/service/stream_service.rs
@@ -14,6 +14,7 @@
 
 use risingwave_common::catalog::TableId;
 use risingwave_common::error::tonic_err;
+use risingwave_pb::common::ParallelUnitType;
 use risingwave_pb::meta::stream_manager_service_server::StreamManagerService;
 use risingwave_pb::meta::*;
 use tonic::{Request, Response, Status};
@@ -78,15 +79,20 @@ where
         );
 
         let hash_mapping = self.cluster_manager.get_hash_mapping().await;
+        let parallel_degree = self
+            .cluster_manager
+            .get_parallel_unit_count(Some(ParallelUnitType::Hash))
+            .await;
         let mut ctx = CreateMaterializedViewContext {
             is_legacy_frontend: true,
+            hash_mapping,
             ..Default::default()
         };
 
         let fragmenter = StreamFragmenter::new(
             self.env.id_gen_manager_ref(),
             self.fragment_manager.clone(),
-            hash_mapping,
+            parallel_degree as u32,
             true,
         );
         let graph = fragmenter

--- a/src/meta/src/stream/fragmenter.rs
+++ b/src/meta/src/stream/fragmenter.rs
@@ -28,7 +28,6 @@ use risingwave_pb::stream_plan::{
 
 use super::graph::StreamFragmentEdge;
 use super::{CreateMaterializedViewContext, FragmentManagerRef};
-use crate::cluster::ParallelUnitId;
 use crate::manager::{IdCategory, IdGeneratorManagerRef};
 use crate::model::{FragmentId, LocalActorId, LocalFragmentId};
 use crate::storage::MetaStore;
@@ -47,9 +46,6 @@ pub struct StreamFragmenter<S> {
     /// id generator, used to generate actor id.
     id_gen_manager: IdGeneratorManagerRef<S>,
 
-    /// hash mapping, used for hash dispatcher
-    hash_mapping: Vec<ParallelUnitId>,
-
     /// local fragment id
     next_local_fragment_id: u32,
 
@@ -63,6 +59,9 @@ pub struct StreamFragmenter<S> {
     /// fragment.
     fragment_actors: HashMap<LocalFragmentId, Vec<LocalActorId>>,
 
+    /// degree of parallelism
+    parallel_degree: u32,
+
     // TODO: remove this when we deprecate Java frontend.
     is_legacy_frontend: bool,
 }
@@ -74,18 +73,18 @@ where
     pub fn new(
         id_gen_manager: IdGeneratorManagerRef<S>,
         fragment_manager: FragmentManagerRef<S>,
-        hash_mapping: Vec<ParallelUnitId>,
+        parallel_degree: u32,
         is_legacy_frontend: bool,
     ) -> Self {
         Self {
             fragment_graph: StreamFragmentGraph::new(),
             stream_graph: StreamGraphBuilder::new(fragment_manager),
             id_gen_manager,
-            hash_mapping,
             next_local_fragment_id: 0,
             next_local_actor_id: 0,
             next_operator_id: u32::MAX - 1,
             fragment_actors: HashMap::new(),
+            parallel_degree,
             is_legacy_frontend,
         }
     }
@@ -350,7 +349,7 @@ where
         let parallel_degree = if current_fragment.is_singleton {
             1
         } else {
-            self.hash_mapping.iter().unique().count() as u32
+            self.parallel_degree
         };
 
         let node = Arc::new(current_fragment.get_node().clone());
@@ -376,52 +375,8 @@ where
                 .clone();
 
             match dispatch_edge.dispatch_strategy.get_type()? {
-                // Construct a consistent hash mapping of actors based on that of parallel units.
-                // Set the new mapping into hash dispatchers.
-                DispatcherType::Hash => {
-                    // Theoretically, a hash dispatcher should have `self.hash_parallel_count` as
-                    // the number of its downstream actors. However, since the
-                    // frontend optimizer is still WIP, there exists some
-                    // unoptimized situation where a hash dispatcher has ONLY
-                    // ONE downstream actor, which makes it behave like a simple dispatcher. As an
-                    // expedient, we specially compute the consistent hash mapping here. The `if`
-                    // branch could be removed after the optimizer has been fully implemented.
-
-                    let streaming_hash_mapping = if downstream_actors.len() == 1 {
-                        Some(vec![downstream_actors[0]; self.hash_mapping.len()])
-                    } else {
-                        let hash_parallel_units = self.hash_mapping.iter().unique().collect_vec();
-                        assert_eq!(downstream_actors.len(), hash_parallel_units.len());
-                        let parallel_unit_actor_map: HashMap<_, _> = hash_parallel_units
-                            .into_iter()
-                            .zip_eq(downstream_actors.iter().copied())
-                            .collect();
-                        Some(
-                            self.hash_mapping
-                                .iter()
-                                .map(|parallel_unit_id| parallel_unit_actor_map[parallel_unit_id])
-                                .collect_vec(),
-                        )
-                    };
-
-                    let dispatcher = Dispatcher {
-                        r#type: DispatcherType::Hash.into(),
-                        column_indices: dispatch_edge.dispatch_strategy.column_indices.clone(),
-                        hash_mapping: None,
-                        downstream_actor_id: vec![],
-                    };
-
-                    self.stream_graph.add_link(
-                        &actor_ids,
-                        &downstream_actors,
-                        dispatch_edge.link_id,
-                        dispatcher,
-                        dispatch_edge.same_worker_node,
-                        streaming_hash_mapping,
-                    );
-                }
-
-                ty @ (DispatcherType::Simple
+                ty @ (DispatcherType::Hash
+                | DispatcherType::Simple
                 | DispatcherType::Broadcast
                 | DispatcherType::NoShuffle) => {
                     self.stream_graph.add_link(
@@ -435,7 +390,6 @@ where
                             downstream_actor_id: vec![],
                         },
                         dispatch_edge.same_worker_node,
-                        None,
                     );
                 }
                 DispatcherType::Invalid => unreachable!(),

--- a/src/meta/src/stream/stream_manager.rs
+++ b/src/meta/src/stream/stream_manager.rs
@@ -25,7 +25,7 @@ use risingwave_pb::catalog::Source;
 use risingwave_pb::common::{ActorInfo, WorkerType};
 use risingwave_pb::meta::table_fragments::{ActorState, ActorStatus};
 use risingwave_pb::stream_plan::stream_node::Node;
-use risingwave_pb::stream_plan::StreamSourceState;
+use risingwave_pb::stream_plan::{ActorMapping, DispatcherType, StreamSourceState};
 use risingwave_pb::stream_service::{
     BroadcastActorInfoTableRequest, BuildActorsRequest, HangingChannel, UpdateActorsRequest,
 };
@@ -33,7 +33,7 @@ use uuid::Uuid;
 
 use super::ScheduledLocations;
 use crate::barrier::{BarrierManagerRef, Command};
-use crate::cluster::{ClusterManagerRef, WorkerId};
+use crate::cluster::{ClusterManagerRef, ParallelUnitId, WorkerId};
 use crate::manager::{MetaSrvEnv, StreamClientsRef};
 use crate::model::{ActorId, FragmentId, TableFragments};
 use crate::storage::MetaStore;
@@ -54,6 +54,8 @@ pub struct CreateMaterializedViewContext {
     pub affiliated_source: Option<Source>,
     /// Memo for assigning upstream actors to parallelized chain node.
     pub chain_upstream_assignment: HashMap<FragmentId, Vec<ActorId>>,
+    /// Consistent hash mapping, used in hash dispatcher.
+    pub hash_mapping: Vec<ParallelUnitId>,
 
     /// TODO: remove this when we deprecate Java frontend.
     pub is_legacy_frontend: bool,
@@ -130,11 +132,63 @@ where
         let mut locations = ScheduledLocations::new();
         locations.node_locations = nodes.into_iter().map(|node| (node.id, node)).collect();
 
+        // Schedule each fragment(actors) to nodes.
         for fragment in table_fragments.fragments() {
             self.scheduler
                 .schedule(fragment.clone(), &mut locations)
                 .await?;
         }
+
+        // Fill hash dispatcher's mapping with scheduled locations.
+        table_fragments
+            .fragments
+            .iter_mut()
+            .for_each(|(_, fragment)| {
+                fragment.actors.iter_mut().for_each(|actor| {
+                    actor.dispatcher.iter_mut().for_each(|dispatcher| {
+                        if dispatcher.get_type().unwrap() == DispatcherType::Hash {
+                            let downstream_actors = &dispatcher.downstream_actor_id;
+
+                            // Theoretically, a hash dispatcher should have
+                            // `self.hash_parallel_count` as the number
+                            // of its downstream actors. However,
+                            // since the frontend optimizer is still WIP, there
+                            // exists some unoptimized situation where a hash
+                            // dispatcher has ONLY ONE downstream actor, which
+                            // makes it behave like a simple dispatcher. As an
+                            // expedient, we specially compute the consistent hash mapping here. The
+                            // `if` branch could be removed after the optimizer
+                            // has been fully implemented.
+                            let streaming_hash_mapping = if downstream_actors.len() == 1 {
+                                vec![downstream_actors[0]; ctx.hash_mapping.len()]
+                            } else {
+                                // extract "parallel unit -> downstream actor" mapping from
+                                // locations.
+                                let parallel_unit_actor_map = downstream_actors
+                                    .iter()
+                                    .map(|actor_id| {
+                                        (
+                                            locations.actor_locations.get(actor_id).unwrap().id,
+                                            *actor_id,
+                                        )
+                                    })
+                                    .collect::<HashMap<_, _>>();
+
+                                ctx.hash_mapping
+                                    .iter()
+                                    .map(|parallel_unit_id| {
+                                        parallel_unit_actor_map[parallel_unit_id]
+                                    })
+                                    .collect_vec()
+                            };
+
+                            dispatcher.hash_mapping = Some(ActorMapping {
+                                hash_mapping: streaming_hash_mapping,
+                            });
+                        }
+                    });
+                })
+            });
 
         let actor_info = locations
             .actor_locations

--- a/src/meta/src/stream/test_fragmenter.rs
+++ b/src/meta/src/stream/test_fragmenter.rs
@@ -15,7 +15,6 @@
 use std::collections::{HashMap, HashSet};
 use std::sync::Arc;
 
-use itertools::Itertools;
 use risingwave_common::catalog::TableId;
 use risingwave_common::error::Result;
 use risingwave_pb::data::data_type::TypeName;
@@ -259,11 +258,11 @@ async fn test_fragmenter() -> Result<()> {
     let env = MetaSrvEnv::for_test().await;
     let stream_node = make_stream_node();
     let fragment_manager = Arc::new(FragmentManager::new(env.meta_store_ref()).await?);
-    let hash_mapping = (1..5).flat_map(|id| vec![id; 512]).collect_vec();
+    let parallel_degree = 4;
     let fragmenter = StreamFragmenter::new(
         env.id_gen_manager_ref(),
         fragment_manager,
-        hash_mapping,
+        parallel_degree,
         false,
     );
 


### PR DESCRIPTION
## What's changed and what's your intention?

In the current implementation, fragmenter will create a one-on-one mapping of parallel unit with downstream actor id, which may be inconsistent with the actual scheduled location of downstream actor. This PR removed hash mapping related logic in fragmenter and assign hash mapping after fragments scheduled.

## Checklist

- [x] I have written necessary docs and comments
- [x] I have added necessary unit tests and integration tests

## Refer to a related PR or issue link (optional)

used by #1875 