### PR TITLE
refactor(expr): decouple macro gen_binary_expr_atm from temporal operator signatures

### DIFF
--- a/src/expr/src/expr/expr_binary_nonnull.rs
+++ b/src/expr/src/expr/expr_binary_nonnull.rs
@@ -189,15 +189,7 @@ macro_rules! gen_binary_expr_atm {
         $ret:expr,
         $general_f:ident,
         {
-            $((Timestamp, Timestamp) => $timestamp_timestamp_f:ident,)?
-            $((Timestamp, Interval) => $timestamp_interval_f:ident,)?
-            $((Interval, Timestamp) => $interval_timestamp_f:ident,)?
-            $((Date, Date) => $date_date_f:ident,)?
-            $((Interval, Date) => $interval_date_f:ident,)?
-            $((Date, Interval) => $date_interval_f:ident,)?
-            $((Interval, Interval) => $interval_interval_f:ident,)?
-            $((Interval, Int) => $interval_int_f:ident,)?
-            $((Int, Interval) => $int_interval_f:ident,)?
+            $( { $i1:ident, $i2:ident, $cast:ident, $func:ident }, )*
         } $(,)?
     ) => {
         $macro! {
@@ -238,18 +230,9 @@ macro_rules! gen_binary_expr_atm {
             { decimal, decimal, decimal, $general_f },
             { float32, decimal, float64, $general_f },
             { float64, decimal, float64, $general_f },
-            $({ timestamp, timestamp, interval, $timestamp_timestamp_f },)?
-            $({ timestamp, interval, timestamp, $timestamp_interval_f },)?
-            $({ interval, timestamp, timestamp, $interval_timestamp_f },)?
-            $({ date, date, int32, $date_date_f },)?
-            $({ date, interval, timestamp, $date_interval_f },)?
-            $({ interval, date, timestamp, $interval_date_f },)?
-            $({ interval, int16, interval, $interval_int_f },)?
-            $({ interval, int32, interval, $interval_int_f },)?
-            $({ interval, int64, interval, $interval_int_f },)?
-            $({ int16, interval, interval, $int_interval_f },)?
-            $({ int32, interval, interval, $int_interval_f },)?
-            $({ int64, interval, interval, $int_interval_f },)?
+            $(
+                { $i1, $i2, $cast, $func },
+            )*
         }
     };
 }
@@ -309,11 +292,11 @@ pub fn new_binary_expr(
                 l, r, ret,
                 general_add,
                 {
-                    (Timestamp, Interval) => timestamp_interval_add,
-                    (Interval, Timestamp) => interval_timestamp_add,
-                    (Interval, Date) => interval_date_add,
-                    (Date, Interval) => date_interval_add,
-                    (Interval, Interval) => general_add,
+                    {timestamp, interval, timestamp, timestamp_interval_add},
+                    {interval, timestamp, timestamp, interval_timestamp_add},
+                    {interval, date, timestamp, interval_date_add},
+                    {date, interval, timestamp,  date_interval_add},
+                    {interval, interval, interval,  general_add},
                 },
             }
         }
@@ -323,11 +306,11 @@ pub fn new_binary_expr(
                 l, r, ret,
                 general_sub,
                 {
-                    (Timestamp, Timestamp) => timestamp_timestamp_sub,
-                    (Timestamp, Interval) => timestamp_interval_sub,
-                    (Date, Date) => date_date_sub,
-                    (Date, Interval) => date_interval_sub,
-                    (Interval, Interval) => general_sub,
+                    {timestamp, timestamp, interval, timestamp_timestamp_sub},
+                    {timestamp, interval, timestamp, timestamp_interval_sub},
+                    {date, date, int32, date_date_sub},
+                    {date, interval, timestamp,  date_interval_sub},
+                    {interval, interval, interval,  general_sub},
                 },
             }
         }
@@ -337,8 +320,12 @@ pub fn new_binary_expr(
                 l, r, ret,
                 general_mul,
                 {
-                    (Interval, Int) => interval_int_mul,
-                    (Int, Interval) => int_interval_mul,
+                    {interval, int16, interval,  interval_int_mul},
+                    {interval, int32, interval,  interval_int_mul},
+                    {interval, int64, interval,  interval_int_mul},
+                    {int16, interval, interval,  int_interval_mul},
+                    {int32, interval, interval,  int_interval_mul},
+                    {int64, interval, interval,  int_interval_mul},
                 },
             }
         }

--- a/src/expr/src/expr/expr_binary_nonnull.rs
+++ b/src/expr/src/expr/expr_binary_nonnull.rs
@@ -41,15 +41,15 @@ pub fn cmp_placeholder<T1, T2, T3>(_l: T1, _r: T2) -> Result<bool> {
 /// In [], the parameters are for constructing new expression
 /// * $l: left expression
 /// * $r: right expression
-/// * ret: return array type
+/// * $ret: return array type
 /// In ()*, the parameters are for generating match cases
 /// * $i1: left array type
 /// * $i2: right array type
-/// * $cast: The cast type in that the operation will calculate
+/// * $rt: The return type in that the operation will calculate
 /// * $The scalar function for expression, it's a generic function and specialized by the type of
-///   `$i1, $i2, $cast`
+///   `$i1, $i2, $rt`
 macro_rules! gen_atm_impl {
-    ([$l:expr, $r:expr, $ret:expr], $( { $i1:ident, $i2:ident, $cast:ident, $func:ident },)*) => {
+    ([$l:expr, $r:expr, $ret:expr], $( { $i1:ident, $i2:ident, $rt:ident, $func:ident },)*) => {
         match ($l.return_type(), $r.return_type()) {
             $(
                 ($i1! { type_match_pattern }, $i2! { type_match_pattern }) => {
@@ -57,13 +57,13 @@ macro_rules! gen_atm_impl {
                         BinaryExpression::<
                             $i1! { type_array },
                             $i2! { type_array },
-                            $cast! { type_array },
+                            $rt! { type_array },
                             _
                         >::new(
                             $l,
                             $r,
                             $ret,
-                            $func::< <$i1! { type_array } as Array>::OwnedItem, <$i2! { type_array } as Array>::OwnedItem, <$cast! { type_array } as Array>::OwnedItem>,
+                            $func::< <$i1! { type_array } as Array>::OwnedItem, <$i2! { type_array } as Array>::OwnedItem, <$rt! { type_array } as Array>::OwnedItem>,
                         )
                     )
                 },
@@ -178,9 +178,8 @@ macro_rules! gen_binary_expr_cmp {
 ///  `atm` means arithmetic here.
 /// They are differentiate cuz one type may not support atm and cmp at the same time. For example,
 /// Varchar can support compare but not arithmetic.
-/// * `general_f`: generic atm function (require a common ``TryInto`` type for two input)
-/// * `interval_date_f`: atm function between interval and date
-/// * `interval_date_f`: atm function between date and interval
+/// * `$general_f`: generic atm function (require a common ``TryInto`` type for two input)
+/// * `$i1`, `$i2`, `$rt`, `$func`: extra list passed to `$macro` directly
 macro_rules! gen_binary_expr_atm {
     (
         $macro:ident,
@@ -189,7 +188,7 @@ macro_rules! gen_binary_expr_atm {
         $ret:expr,
         $general_f:ident,
         {
-            $( { $i1:ident, $i2:ident, $cast:ident, $func:ident }, )*
+            $( { $i1:ident, $i2:ident, $rt:ident, $func:ident }, )*
         } $(,)?
     ) => {
         $macro! {
@@ -231,7 +230,7 @@ macro_rules! gen_binary_expr_atm {
             { float32, decimal, float64, $general_f },
             { float64, decimal, float64, $general_f },
             $(
-                { $i1, $i2, $cast, $func },
+                { $i1, $i2, $rt, $func },
             )*
         }
     };

--- a/src/expr/src/expr/expr_binary_nonnull.rs
+++ b/src/expr/src/expr/expr_binary_nonnull.rs
@@ -187,8 +187,8 @@ macro_rules! gen_binary_expr_atm {
         $l:expr,
         $r:expr,
         $ret:expr,
+        $general_f:ident,
         {
-            $(General => $general_f:ident,)?
             $((Timestamp, Timestamp) => $timestamp_timestamp_f:ident,)?
             $((Timestamp, Interval) => $timestamp_interval_f:ident,)?
             $((Interval, Timestamp) => $interval_timestamp_f:ident,)?
@@ -202,42 +202,42 @@ macro_rules! gen_binary_expr_atm {
     ) => {
         $macro! {
             [$l, $r, $ret],
-            $({ int16, int16, int16, $general_f },)?
-            $({ int16, int32, int32, $general_f },)?
-            $({ int16, int64, int64, $general_f },)?
-            $({ int16, float32, float64, $general_f },)?
-            $({ int16, float64, float64, $general_f },)?
-            $({ int32, int16, int32, $general_f },)?
-            $({ int32, int32, int32, $general_f },)?
-            $({ int32, int64, int64, $general_f },)?
-            $({ int32, float32, float64, $general_f },)?
-            $({ int32, float64, float64, $general_f },)?
-            $({ int64, int16,int64, $general_f },)?
-            $({ int64, int32,int64, $general_f },)?
-            $({ int64, int64, int64, $general_f },)?
-            $({ int64, float32, float64 , $general_f},)?
-            $({ int64, float64, float64, $general_f },)?
-            $({ float32, int16, float64, $general_f },)?
-            $({ float32, int32, float64, $general_f },)?
-            $({ float32, int64, float64 , $general_f},)?
-            $({ float32, float32, float32, $general_f },)?
-            $({ float32, float64, float64, $general_f },)?
-            $({ float64, int16, float64, $general_f },)?
-            $({ float64, int32, float64, $general_f },)?
-            $({ float64, int64, float64, $general_f },)?
-            $({ float64, float32, float64, $general_f },)?
-            $({ float64, float64, float64, $general_f },)?
-            $({ decimal, int16, decimal, $general_f },)?
-            $({ decimal, int32, decimal, $general_f },)?
-            $({ decimal, int64, decimal, $general_f },)?
-            $({ decimal, float32, decimal, $general_f },)?
-            $({ decimal, float64, decimal, $general_f },)?
-            $({ int16, decimal, decimal, $general_f },)?
-            $({ int32, decimal, decimal, $general_f },)?
-            $({ int64, decimal, decimal, $general_f },)?
-            $({ decimal, decimal, decimal, $general_f },)?
-            $({ float32, decimal, float64, $general_f },)?
-            $({ float64, decimal, float64, $general_f },)?
+            { int16, int16, int16, $general_f },
+            { int16, int32, int32, $general_f },
+            { int16, int64, int64, $general_f },
+            { int16, float32, float64, $general_f },
+            { int16, float64, float64, $general_f },
+            { int32, int16, int32, $general_f },
+            { int32, int32, int32, $general_f },
+            { int32, int64, int64, $general_f },
+            { int32, float32, float64, $general_f },
+            { int32, float64, float64, $general_f },
+            { int64, int16,int64, $general_f },
+            { int64, int32,int64, $general_f },
+            { int64, int64, int64, $general_f },
+            { int64, float32, float64 , $general_f},
+            { int64, float64, float64, $general_f },
+            { float32, int16, float64, $general_f },
+            { float32, int32, float64, $general_f },
+            { float32, int64, float64 , $general_f},
+            { float32, float32, float32, $general_f },
+            { float32, float64, float64, $general_f },
+            { float64, int16, float64, $general_f },
+            { float64, int32, float64, $general_f },
+            { float64, int64, float64, $general_f },
+            { float64, float32, float64, $general_f },
+            { float64, float64, float64, $general_f },
+            { decimal, int16, decimal, $general_f },
+            { decimal, int32, decimal, $general_f },
+            { decimal, int64, decimal, $general_f },
+            { decimal, float32, decimal, $general_f },
+            { decimal, float64, decimal, $general_f },
+            { int16, decimal, decimal, $general_f },
+            { int32, decimal, decimal, $general_f },
+            { int64, decimal, decimal, $general_f },
+            { decimal, decimal, decimal, $general_f },
+            { float32, decimal, float64, $general_f },
+            { float64, decimal, float64, $general_f },
             $({ timestamp, timestamp, interval, $timestamp_timestamp_f },)?
             $({ timestamp, interval, timestamp, $timestamp_interval_f },)?
             $({ interval, timestamp, timestamp, $interval_timestamp_f },)?
@@ -307,8 +307,8 @@ pub fn new_binary_expr(
             gen_binary_expr_atm! {
                 gen_atm_impl,
                 l, r, ret,
+                general_add,
                 {
-                    General => general_add,
                     (Timestamp, Interval) => timestamp_interval_add,
                     (Interval, Timestamp) => interval_timestamp_add,
                     (Interval, Date) => interval_date_add,
@@ -321,8 +321,8 @@ pub fn new_binary_expr(
             gen_binary_expr_atm! {
                 gen_atm_impl,
                 l, r, ret,
+                general_sub,
                 {
-                    General => general_sub,
                     (Timestamp, Timestamp) => timestamp_timestamp_sub,
                     (Timestamp, Interval) => timestamp_interval_sub,
                     (Date, Date) => date_date_sub,
@@ -335,8 +335,8 @@ pub fn new_binary_expr(
             gen_binary_expr_atm! {
                 gen_atm_impl,
                 l, r, ret,
+                general_mul,
                 {
-                    General => general_mul,
                     (Interval, Int) => interval_int_mul,
                     (Int, Interval) => int_interval_mul,
                 },
@@ -346,8 +346,8 @@ pub fn new_binary_expr(
             gen_binary_expr_atm! {
                 gen_atm_impl,
                 l, r, ret,
+                general_div,
                 {
-                    General => general_div,
                 },
             }
         }
@@ -355,8 +355,8 @@ pub fn new_binary_expr(
             gen_binary_expr_atm! {
                 gen_atm_impl,
                 l, r, ret,
+                general_mod,
                 {
-                    General => general_mod,
                 },
             }
         }

--- a/src/expr/src/expr/expr_binary_nonnull.rs
+++ b/src/expr/src/expr/expr_binary_nonnull.rs
@@ -291,11 +291,11 @@ pub fn new_binary_expr(
                 l, r, ret,
                 general_add,
                 {
-                    {timestamp, interval, timestamp, timestamp_interval_add},
-                    {interval, timestamp, timestamp, interval_timestamp_add},
-                    {interval, date, timestamp, interval_date_add},
-                    {date, interval, timestamp,  date_interval_add},
-                    {interval, interval, interval,  general_add},
+                    { timestamp, interval, timestamp, timestamp_interval_add },
+                    { interval, timestamp, timestamp, interval_timestamp_add },
+                    { interval, date, timestamp, interval_date_add },
+                    { date, interval, timestamp, date_interval_add },
+                    { interval, interval, interval, general_add },
                 },
             }
         }
@@ -305,11 +305,11 @@ pub fn new_binary_expr(
                 l, r, ret,
                 general_sub,
                 {
-                    {timestamp, timestamp, interval, timestamp_timestamp_sub},
-                    {timestamp, interval, timestamp, timestamp_interval_sub},
-                    {date, date, int32, date_date_sub},
-                    {date, interval, timestamp,  date_interval_sub},
-                    {interval, interval, interval,  general_sub},
+                    { timestamp, timestamp, interval, timestamp_timestamp_sub },
+                    { timestamp, interval, timestamp, timestamp_interval_sub },
+                    { date, date, int32, date_date_sub },
+                    { date, interval, timestamp, date_interval_sub },
+                    { interval, interval, interval, general_sub },
                 },
             }
         }
@@ -319,12 +319,12 @@ pub fn new_binary_expr(
                 l, r, ret,
                 general_mul,
                 {
-                    {interval, int16, interval,  interval_int_mul},
-                    {interval, int32, interval,  interval_int_mul},
-                    {interval, int64, interval,  interval_int_mul},
-                    {int16, interval, interval,  int_interval_mul},
-                    {int32, interval, interval,  int_interval_mul},
-                    {int64, interval, interval,  int_interval_mul},
+                    { interval, int16, interval, interval_int_mul },
+                    { interval, int32, interval, interval_int_mul },
+                    { interval, int64, interval, interval_int_mul },
+                    { int16, interval, interval, int_interval_mul },
+                    { int32, interval, interval, int_interval_mul },
+                    { int64, interval, interval, int_interval_mul },
                 },
             }
         }


### PR DESCRIPTION
## What's changed and what's your intention?

The macro `gen_binary_expr_atm` currently list certain combinations of temporal types, e.g. `timestamp_timestamp_f`, `timestamp_interval_f`. This makes it harder to add more temporal operators as their signatures are not that regular compared to numbers. It makes less sense to reuse them across `add`/`sub`/`mul`/`div`. For details, check the pg operator table below.

This PR allows `gen_binary_expr_atm` to pass thru a list to `gen_atm_impl` directly, so that different operators (`add`/`sub`/`mul`/`div`) can add their own implementations without touching the definition of `gen_binary_expr_atm` any more.

```
     lhs     | oprname |     rhs     | ?column? |     ret     |         oprcode         
-------------+---------+-------------+----------+-------------+-------------------------
 float8      | *       | interval    | =        | interval    | mul_d_interval
 interval    | *       | float8      | =        | interval    | interval_mul
 date        | +       | int4        | =        | date        | date_pli
 int4        | +       | date        | =        | date        | integer_pl_date
 interval    | +       | interval    | =        | interval    | interval_pl
 interval    | +       | time        | =        | time        | interval_pl_time
 time        | +       | interval    | =        | time        | time_pl_interval
 date        | +       | interval    | =        | timestamp   | date_pl_interval
 date        | +       | time        | =        | timestamp   | datetime_pl
 interval    | +       | date        | =        | timestamp   | interval_pl_date
 interval    | +       | timestamp   | =        | timestamp   | interval_pl_timestamp
 time        | +       | date        | =        | timestamp   | timedate_pl
 timestamp   | +       | interval    | =        | timestamp   | timestamp_pl_interval
 interval    | +       | timestamptz | =        | timestamptz | interval_pl_timestamptz
 timestamptz | +       | interval    | =        | timestamptz | timestamptz_pl_interval
 date        | -       | int4        | =        | date        | date_mii
 date        | -       | date        | =        | int4        | date_mi
 interval    | -       | interval    | =        | interval    | interval_mi
 time        | -       | time        | =        | interval    | time_mi_time
 timestamp   | -       | timestamp   | =        | interval    | timestamp_mi
 timestamptz | -       | timestamptz | =        | interval    | timestamptz_mi
 time        | -       | interval    | =        | time        | time_mi_interval
 date        | -       | interval    | =        | timestamp   | date_mi_interval
 timestamp   | -       | interval    | =        | timestamp   | timestamp_mi_interval
 timestamptz | -       | interval    | =        | timestamptz | timestamptz_mi_interval
 interval    | /       | float8      | =        | interval    | interval_div
(26 rows)
```
Query:
```
with min_types as (
    select * from pg_type
    where typname in (
        'bool', 'int2', 'int4', 'int8', 'float4', 'float8', 'numeric',
        'text', 'date', 'time', 'timestamp', 'timestamptz', 'interval'
    )
) select
    type_l.typname as lhs,
    oprname,
    type_r.typname as rhs,
    '=',
    type_o.typname as ret,
    oprcode
from pg_operator
    join min_types as type_l on pg_operator.oprleft = type_l.oid
    join min_types as type_r on pg_operator.oprright = type_r.oid
    join min_types as type_o on pg_operator.oprresult = type_o.oid
where oprname in ('+', '-', '*', '/')
and (
    type_l.typname in ('date', 'timestamp', 'timestamptz', 'time', 'interval')
    or type_r.typname in ('date', 'timestamp', 'timestamptz', 'time', 'interval')
)
order by oprname, ret, lhs, rhs
```

## Checklist

- [x] I have written necessary docs and comments
~~- [ ] I have added necessary unit tests and integration tests~~ (Refactor does not break existing tests.)

## Refer to a related PR or issue link (optional)
