### PR TITLE
feat(meta): schedule fragments in topological order

### DIFF
--- a/src/meta/src/model/stream.rs
+++ b/src/meta/src/model/stream.rs
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use std::collections::{BTreeMap, HashMap, HashSet};
+use std::collections::{BTreeMap, HashMap, HashSet, VecDeque};
 
 use itertools::Itertools;
 use risingwave_common::catalog::TableId;
@@ -271,5 +271,86 @@ impl TableFragments {
             });
         });
         actor_map
+    }
+
+    /// Generate toplogical order of fragments. If `index(a) < index(b)` in vec, then a is the
+    /// downstream of b.
+    pub fn generate_topological_order(&self) -> Vec<FragmentId> {
+        let mut actionable_fragment_id = VecDeque::new();
+
+        // If downstream_edges[x][y] exists, then there's an edge from x to y.
+        let mut downstream_edges: HashMap<u32, HashSet<u32>> = HashMap::new();
+
+        // Counts how many upstreams are there for a given fragment
+        let mut upstream_cnts: HashMap<u32, usize> = HashMap::new();
+
+        let mut result = vec![];
+
+        let mut actor_to_fragment_mapping = HashMap::new();
+
+        // Firstly, record actor -> fragment mapping
+        for (fragment_id, fragment) in &self.fragments {
+            for actor in &fragment.actors {
+                let ret = actor_to_fragment_mapping.insert(actor.actor_id, *fragment_id);
+                assert!(ret.is_none(), "duplicated actor id found");
+            }
+        }
+
+        // Then, generate the DAG of fragments
+        for (fragment_id, fragment) in &self.fragments {
+            for upstream_actor in &fragment.actors {
+                for dispatcher in &upstream_actor.dispatcher {
+                    for downstream_actor in &dispatcher.downstream_actor_id {
+                        let downstream_fragment_id =
+                            actor_to_fragment_mapping.get(downstream_actor).unwrap();
+
+                        let did_not_have = downstream_edges
+                            .entry(*fragment_id)
+                            .or_default()
+                            .insert(*downstream_fragment_id);
+
+                        if did_not_have {
+                            *upstream_cnts.entry(*downstream_fragment_id).or_default() += 1;
+                        }
+                    }
+                }
+            }
+        }
+
+        // Find actionable fragments
+        for fragment_id in self.fragments.keys() {
+            if upstream_cnts.get(fragment_id).is_none() {
+                actionable_fragment_id.push_back(*fragment_id);
+            }
+        }
+
+        // After that, we can generate topological order
+        while let Some(fragment_id) = actionable_fragment_id.pop_front() {
+            result.push(fragment_id);
+
+            // Find if we can process more fragments
+            if let Some(downstreams) = downstream_edges.get(&fragment_id) {
+                for downstream_id in downstreams.iter() {
+                    let cnt = upstream_cnts
+                        .get_mut(downstream_id)
+                        .expect("the downstream should exist");
+
+                    *cnt -= 1;
+                    if *cnt == 0 {
+                        upstream_cnts.remove(downstream_id);
+                        actionable_fragment_id.push_back(*downstream_id);
+                    }
+                }
+            }
+        }
+
+        if !upstream_cnts.is_empty() {
+            // There are fragments that are not processed yet.
+            panic!("not a DAG");
+        }
+
+        assert_eq!(result.len(), self.fragments.len());
+
+        result
     }
 }

--- a/src/meta/src/stream/fragmenter.rs
+++ b/src/meta/src/stream/fragmenter.rs
@@ -414,7 +414,7 @@ where
         let mut actionable_fragment_id = VecDeque::new();
         let mut downstream_cnts = HashMap::new();
 
-        // Iterator all fragments
+        // Iterate all fragments
         for (fragment_id, _) in self.fragment_graph.fragments().iter() {
             // Count how many downstreams we have for a given fragment
             let downstream_cnt = self.fragment_graph.get_downstreams(*fragment_id).len();

--- a/src/meta/src/stream/stream_manager.rs
+++ b/src/meta/src/stream/stream_manager.rs
@@ -132,8 +132,11 @@ where
         let mut locations = ScheduledLocations::new();
         locations.node_locations = nodes.into_iter().map(|node| (node.id, node)).collect();
 
+        let topological_order = table_fragments.generate_topological_order();
+
         // Schedule each fragment(actors) to nodes.
-        for fragment in table_fragments.fragments() {
+        for fragment_id in topological_order {
+            let fragment = table_fragments.fragments.get(&fragment_id).unwrap();
             self.scheduler
                 .schedule(fragment.clone(), &mut locations)
                 .await?;


### PR DESCRIPTION
Signed-off-by: Alex Chi <iskyzh@gmail.com>

## What's changed and what's your intention?

Build fragments in topological order, so that we can enforce `same_worker_node_as_upstream` actor placement rule.

## Checklist

- [x] I have written necessary docs and comments
- [x] I have added necessary unit tests and integration tests

## Refer to a related PR or issue link (optional)

Prepare for https://github.com/singularity-data/risingwave/issues/1881