### PR TITLE
refactor(streaming): use iterator directly instead of materializing all kv pairs from iterator

### DIFF
--- a/src/stream/src/executor/managed_state/top_n/top_n_bottom_n_state.rs
+++ b/src/stream/src/executor/managed_state/top_n/top_n_bottom_n_state.rs
@@ -28,8 +28,8 @@ use risingwave_storage::storage_value::StorageValue;
 use risingwave_storage::{Keyspace, StateStore};
 
 use crate::executor::managed_state::flush_status::BtreeMapFlushStatus as FlushStatus;
-use crate::executor::managed_state::top_n::deserialize_bytes_to_pk_and_row;
 use crate::executor::managed_state::top_n::variants::TOP_N_MIN;
+use crate::executor::managed_state::top_n::PkAndRowIterator;
 
 /// This state is used for `[offset, offset+limit)` part in the `TopNExecutor`.
 ///
@@ -206,7 +206,16 @@ impl<S: StateStore> ManagedTopNBottomNState<S> {
 
     /// The same as the one in `ManagedTopNState`.
     pub async fn scan_and_merge(&mut self, epoch: u64) -> Result<()> {
-        let mut kv_pairs = self.scan_from_storage(None, epoch).await?;
+        let iter = self.keyspace.iter(epoch).await?;
+        let mut pk_and_row_iter = PkAndRowIterator::<_, TOP_N_MIN>::new(
+            iter,
+            &mut self.ordered_row_deserializer,
+            &mut self.cell_based_row_deserializer,
+        );
+        let mut kv_pairs = vec![];
+        while let Some((pk, row)) = pk_and_row_iter.next().await? {
+            kv_pairs.push((pk, row));
+        }
         let mut flush_buffer_iter = self.flush_buffer.iter().peekable();
         let mut insert_process =
             |cache: &mut BTreeMap<OrderedRow, Row>, part_kv_pairs: Drain<(OrderedRow, Row)>| {
@@ -253,34 +262,17 @@ impl<S: StateStore> ManagedTopNBottomNState<S> {
         Ok(())
     }
 
-    async fn scan_from_storage(
-        &mut self,
-        number_rows: Option<usize>,
-        epoch: u64,
-    ) -> Result<Vec<(OrderedRow, Row)>> {
-        let iter = self.keyspace.iter(epoch).await?;
-        let pk_and_rows = deserialize_bytes_to_pk_and_row::<TOP_N_MIN, _>(
-            iter,
-            &mut self.ordered_row_deserializer,
-            &mut self.cell_based_row_deserializer,
-            number_rows,
-        )
-        .await;
-        self.cell_based_row_deserializer.reset();
-        pk_and_rows
-    }
-
     /// We can fill in the cache from storage only when state is not dirty, i.e. right after
     /// `flush`.
     pub async fn fill_in_cache(&mut self, epoch: u64) -> Result<()> {
         debug_assert!(!self.is_dirty());
-        let mut pk_row_bytes = self.scan_from_storage(None, epoch).await?;
-        // cell-based storage format, so `self.schema.len()`
-        for (pk, row) in pk_row_bytes.drain(0..pk_row_bytes.len() / 2) {
+        let mut pk_and_row_iter = PkAndRowIterator::<_, TOP_N_MIN>::new(
+            self.keyspace.iter(epoch).await?,
+            &mut self.ordered_row_deserializer,
+            &mut self.cell_based_row_deserializer,
+        );
+        while let Some((pk, row)) = pk_and_row_iter.next().await? {
             self.bottom_n.insert(pk, row);
-        }
-        for (pk, row) in pk_row_bytes.drain(..) {
-            self.top_n.insert(pk, row);
         }
         // We don't retain `n` elements as we have a all-or-nothing policy for now.
         Ok(())

--- a/src/stream/src/executor/managed_state/top_n/top_n_state.rs
+++ b/src/stream/src/executor/managed_state/top_n/top_n_state.rs
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use std::cmp::Ordering;
 use std::collections::BTreeMap;
 
 use risingwave_common::array::Row;
@@ -24,8 +25,8 @@ use risingwave_storage::storage_value::StorageValue;
 use risingwave_storage::{Keyspace, StateStore};
 
 use crate::executor::managed_state::flush_status::BtreeMapFlushStatus as FlushStatus;
-use crate::executor::managed_state::top_n::deserialize_bytes_to_pk_and_row;
 use crate::executor::managed_state::top_n::variants::*;
+use crate::executor::managed_state::top_n::PkAndRowIterator;
 
 /// This state is used for several ranges (e.g `[0, offset)`, `[offset+limit, +inf)` of elements in
 /// the `AppendOnlyTopNExecutor` and `TopNExecutor`. For these ranges, we only care about one of the
@@ -187,66 +188,93 @@ impl<S: StateStore, const TOP_N_TYPE: usize> ManagedTopNState<S, TOP_N_TYPE> {
         // This `order` is defined by the order between two `OrderedRow`.
         // We have to scan all because the top n on the storage may have been deleted by the flush
         // buffer.
-        let kv_pairs = self.scan_from_storage(None, epoch).await?;
-        let mut inserted = 0;
+        let iter = self.keyspace.iter(epoch).await?;
+        let mut pk_and_row_iter = PkAndRowIterator::<_, TOP_N_TYPE>::new(
+            iter,
+            &mut self.ordered_row_deserializer,
+            &mut self.cell_based_row_deserializer,
+        );
         match TOP_N_TYPE {
             TOP_N_MIN => {
                 let mut flush_buffer_iter = self.flush_buffer.iter().peekable();
-                for (key_from_storage, row_from_storage) in kv_pairs {
+                while let Some((key_from_storage, row_from_storage)) =
+                    pk_and_row_iter.next().await?
+                {
                     // If we inserted enough values, break as we will only retain `top_n_count`
                     // elements in the cache.
-                    if let Some(top_n_count) = self.top_n_count && inserted >= top_n_count {
+                    if let Some(top_n_count) = self.top_n_count && self.top_n.len() >= top_n_count {
                         break;
                     }
                     let mut encounter_same_key = false;
                     while let Some((key_from_buffer, value_from_buffer)) = flush_buffer_iter.peek()
-                        && **key_from_buffer <= key_from_storage
                     {
+                        match key_from_buffer.cmp(&&key_from_storage) {
+                            Ordering::Greater => {
+                                // We need to break to determine whether the next `key_from_storage`
+                                // will be shadowed by `key_from_buffer` in the next for loop.
+                                break;
+                            }
+                            Ordering::Equal => {
+                                // The `key_from_storage` is shadowed by `key_from_buffer`.
+                                // We do not want to add `key_from_storage` into the result set
+                                // after the while loop.
+                                encounter_same_key = true;
+                            }
+                            _ => {
+                                // do nothing
+                            }
+                        }
                         match value_from_buffer {
                             FlushStatus::Insert(row) | FlushStatus::DeleteInsert(row) => {
                                 self.top_n.insert((*key_from_buffer).clone(), row.clone());
-                                inserted += 1;
                             }
                             FlushStatus::Delete => {
-                                //do nothing
+                                // do nothing
                             }
                         }
-                        encounter_same_key = (**key_from_buffer) == key_from_storage;
                         flush_buffer_iter.next();
                     }
                     if !encounter_same_key {
                         self.top_n.insert(key_from_storage, row_from_storage);
-                        inserted += 1;
                     }
                 }
             }
             TOP_N_MAX => {
                 let mut flush_buffer_iter = self.flush_buffer.iter().rev().peekable();
-                for (key_from_storage, row_from_storage) in kv_pairs {
-                    if let Some(top_n_count) = self.top_n_count {
-                        if inserted >= top_n_count {
-                            break;
-                        }
+                while let Some((key_from_storage, row_from_storage)) =
+                    pk_and_row_iter.next().await?
+                {
+                    if let Some(top_n_count) = self.top_n_count && self.top_n.len() >= top_n_count {
+                        break;
                     }
                     let mut encounter_same_key = false;
+                    // This is similar to `TOP_N_MIN` branch above. May refer to its comments for
+                    // the code below.
                     while let Some((key_from_buffer, value_from_buffer)) = flush_buffer_iter.peek()
-                        && **key_from_buffer >= key_from_storage
                     {
+                        match key_from_buffer.cmp(&&key_from_storage) {
+                            Ordering::Less => {
+                                break;
+                            }
+                            Ordering::Equal => {
+                                encounter_same_key = true;
+                            }
+                            _ => {
+                                // do nothing
+                            }
+                        }
                         match value_from_buffer {
                             FlushStatus::Insert(row) | FlushStatus::DeleteInsert(row) => {
                                 self.top_n.insert((*key_from_buffer).clone(), row.clone());
-                                inserted += 1;
                             }
                             FlushStatus::Delete => {
-                                //do nothing
+                                // do nothing
                             }
                         }
-                        encounter_same_key = (**key_from_buffer) == key_from_storage;
                         flush_buffer_iter.next();
                     }
                     if !encounter_same_key {
                         self.top_n.insert(key_from_storage, row_from_storage);
-                        inserted += 1;
                     }
                 }
             }
@@ -267,23 +295,6 @@ impl<S: StateStore, const TOP_N_TYPE: usize> ManagedTopNState<S, TOP_N_TYPE> {
         Ok(prev_entry)
     }
 
-    async fn scan_from_storage(
-        &mut self,
-        number_rows: Option<usize>,
-        epoch: u64,
-    ) -> Result<Vec<(OrderedRow, Row)>> {
-        let iter = self.keyspace.iter(epoch).await?;
-        let pk_and_rows = deserialize_bytes_to_pk_and_row::<TOP_N_TYPE, _>(
-            iter,
-            &mut self.ordered_row_deserializer,
-            &mut self.cell_based_row_deserializer,
-            number_rows,
-        )
-        .await;
-        self.cell_based_row_deserializer.reset();
-        pk_and_rows
-    }
-
     /// We can fill in the cache from storage only when state is not dirty, i.e. right after
     /// `flush`.
     ///
@@ -292,14 +303,21 @@ impl<S: StateStore, const TOP_N_TYPE: usize> ManagedTopNState<S, TOP_N_TYPE> {
     /// the same key in the cache, and their value must be the same.
     pub async fn fill_in_cache(&mut self, epoch: u64) -> Result<()> {
         debug_assert!(!self.is_dirty());
-        let kv_pairs = self.scan_from_storage(self.top_n_count, epoch).await?;
-        for (key, value) in kv_pairs {
-            let prev_row = self.top_n.insert(key, value.clone());
+        let iter = self.keyspace.iter(epoch).await?;
+        let mut pk_and_row_iter = PkAndRowIterator::<_, TOP_N_TYPE>::new(
+            iter,
+            &mut self.ordered_row_deserializer,
+            &mut self.cell_based_row_deserializer,
+        );
+        while let Some((pk, row)) = pk_and_row_iter.next().await? {
+            let prev_row = self.top_n.insert(pk, row.clone());
             if let Some(prev_row) = prev_row {
-                debug_assert_eq!(prev_row, value);
+                debug_assert_eq!(prev_row, row);
+            }
+            if let Some(top_n_count) = self.top_n_count && top_n_count == self.top_n.len() {
+                break;
             }
         }
-        self.retain_top_n();
         Ok(())
     }
 


### PR DESCRIPTION
## What's changed and what's your intention?
In #1969, we replace `scan` in `TopNExecutor` with `iter`. However, we still first materialize all the kv pairs from `iter`.

This PR adds a `PkAndRowIterator` so that two TopN's states only need to deal with `OrderedRow` and `Row` instead of raw `Bytes`.

Also eliminate an extra comparison between `key_from_storage` and `key_from_buffer` due to `encounter_same_key` check.

## Checklist

- [x] I have written necessary docs and comments

## Refer to a related PR or issue link (optional)
