### PR TITLE
fix: fix epoch check panic when checkpoint

### DIFF
--- a/src/meta/src/barrier/info.rs
+++ b/src/meta/src/barrier/info.rs
@@ -66,4 +66,12 @@ impl BarrierActorInfo {
             .map(|actor_ids| actor_ids.clone().into_iter())
             .unwrap_or_else(|| vec![].into_iter())
     }
+
+    pub fn nothing_to_do(&self) -> bool {
+        if self.actor_map.is_empty() {
+            assert!(self.actor_map_to_send.is_empty());
+            return true;
+        }
+        false
+    }
 }


### PR DESCRIPTION
## What's changed and what's your intention?

After investigation the bug mentioned in #1995 and reported in slack group, this bug is caused by injecting a barrier immediately after a quick checkpoint when there's no actors exist in the cluster. This means two equal epoch might generated and fail the epoch check in this situation.

After this PR merged, we should introduce or develop a monotonic clock lib for epoch generation.

## Checklist

- [x] I have written necessary docs and comments
- [x] I have added necessary unit tests and integration tests

## Refer to a related PR or issue link (optional)
Resolve https://github.com/singularity-data/risingwave/issues/1995