### PR TITLE
feat(frontend): support create index

### DIFF
--- a/e2e_test/v2/streaming/index.slt
+++ b/e2e_test/v2/streaming/index.slt
@@ -1,0 +1,55 @@
+statement ok
+create table iii_t1 (v1 int, v2 int);
+
+statement ok
+create table iii_t2 (v3 int, v4 int);
+
+statement ok
+create table iii_t3 (v5 int, v6 int);
+
+statement ok
+create materialized view iii_mv1 as select * from iii_t1, iii_t2, iii_t3 where iii_t1.v1 = iii_t2.v3 and iii_t1.v1 = iii_t3.v5;
+
+statement ok
+insert into iii_t1 values (2, 0), (3, 0), (0, 0), (1, 0);
+
+statement ok
+insert into iii_t2 values (2, 5), (3, 4), (0, 3), (1, 2);
+
+statement ok
+insert into iii_t3 values (2, 0), (3, 0), (0, 0), (1, 0);
+
+statement ok
+flush;
+
+statement ok
+create index iii_index on iii_mv1(v4);
+
+# TODO: disable direct select from index
+
+query IIII
+select v4, v1, v3, v5 from iii_index;
+----
+2 1 1 1
+3 0 0 0
+4 3 3 3
+5 2 2 2
+
+halt
+
+# TODO: support drop index
+
+statement ok
+drop index iii_index_t1;
+
+statement ok
+drop materialized view iii_mv1;
+
+statement ok
+drop table iii_t1;
+
+statement ok
+drop table iii_t2;
+
+statement ok
+drop table iii_t3;

--- a/src/frontend/src/handler/create_index.rs
+++ b/src/frontend/src/handler/create_index.rs
@@ -1,0 +1,169 @@
+// Copyright 2022 Singularity Data
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::collections::HashMap;
+use std::rc::Rc;
+
+use fixedbitset::FixedBitSet;
+use itertools::Itertools;
+use pgwire::pg_response::{PgResponse, StatementType};
+use risingwave_common::error::{ErrorCode, Result, RwError};
+use risingwave_pb::catalog::Table as ProstTable;
+use risingwave_sqlparser::ast::{ObjectName, OrderByExpr};
+
+use crate::binder::Binder;
+use crate::optimizer::plan_node::{LogicalScan, StreamTableScan};
+use crate::optimizer::property::{Distribution, FieldOrder, Order};
+use crate::optimizer::{PlanRef, PlanRoot};
+use crate::session::{OptimizerContext, OptimizerContextRef, SessionImpl};
+
+pub(crate) fn gen_create_index_plan(
+    session: &SessionImpl,
+    context: OptimizerContextRef,
+    index_name: ObjectName,
+    table_name: ObjectName,
+    columns: Vec<OrderByExpr>,
+) -> Result<(PlanRef, ProstTable)> {
+    let columns = columns
+        .iter()
+        .map(|column| {
+            if column.asc.is_some() {
+                return Err(
+                    ErrorCode::NotImplemented("asc not supported".into(), None.into()).into(),
+                );
+            }
+
+            if column.nulls_first.is_some() {
+                return Err(ErrorCode::NotImplemented(
+                    "nulls_first not supported".into(),
+                    None.into(),
+                )
+                .into());
+            }
+
+            use risingwave_sqlparser::ast::Expr;
+
+            if let Expr::Identifier(ref ident) = column.expr {
+                Ok::<_, RwError>(ident)
+            } else {
+                Err(ErrorCode::NotImplemented(
+                    "only identifier is supported for create index".into(),
+                    None.into(),
+                )
+                .into())
+            }
+        })
+        .try_collect::<_, Vec<_>, _>()?;
+
+    let (schema_name, table_name) = Binder::resolve_table_name(table_name)?;
+    let catalog_reader = session.env().catalog_reader();
+    let table = catalog_reader
+        .read_guard()
+        .get_table_by_name(session.database(), &schema_name, &table_name)?
+        .clone();
+
+    let table_desc = Rc::new(table.table_desc());
+    let table_desc_map = table_desc
+        .columns
+        .iter()
+        .enumerate()
+        .map(|(x, y)| (y.name.clone(), x))
+        .collect::<HashMap<_, _>>();
+    let arrange_keys = columns
+        .iter()
+        .map(|x| {
+            let x = x.to_string();
+            table_desc_map
+                .get(&x)
+                .cloned()
+                .ok_or_else(|| ErrorCode::ItemNotFound(x).into())
+        })
+        .try_collect::<_, Vec<_>, RwError>()?;
+
+    // Manually assemble the materialization plan for the index MV.
+    let materialize = {
+        let scan_node = StreamTableScan::new(LogicalScan::new(
+            table_name,
+            (0..table_desc.columns.len()).into_iter().collect(),
+            table_desc,
+            context,
+        ));
+        let mut required_cols = FixedBitSet::with_capacity(scan_node.schema().len());
+        required_cols.toggle_range(..);
+        required_cols.toggle(0);
+
+        PlanRoot::new(
+            scan_node.into(),
+            Distribution::AnyShard,
+            Order::new(
+                arrange_keys
+                    .iter()
+                    .map(|id| FieldOrder::ascending(*id))
+                    .collect(),
+            ),
+            required_cols,
+        )
+        .gen_create_mv_plan(index_name.to_string())?
+    };
+
+    let (index_schema_name, index_table_name) = Binder::resolve_table_name(index_name)?;
+    let (index_database_id, index_schema_id) = session
+        .env()
+        .catalog_reader()
+        .read_guard()
+        .check_relation_name_duplicated(
+            session.database(),
+            &index_schema_name,
+            &index_table_name,
+        )?;
+
+    let index_table = materialize
+        .table()
+        .to_prost(index_schema_id, index_database_id);
+
+    Ok((materialize.into(), index_table))
+}
+
+pub async fn handle_create_index(
+    context: OptimizerContext,
+    name: ObjectName,
+    table_name: ObjectName,
+    columns: Vec<OrderByExpr>,
+) -> Result<PgResponse> {
+    let session = context.session_ctx.clone();
+
+    let (plan, table) = {
+        let (plan, table) = gen_create_index_plan(
+            &session,
+            context.into(),
+            name.clone(),
+            table_name.clone(),
+            columns,
+        )?;
+        let plan = plan.to_stream_prost();
+
+        (plan, table)
+    };
+
+    log::trace!(
+        "name={}, plan=\n{}",
+        table_name,
+        serde_json::to_string_pretty(&plan).unwrap()
+    );
+
+    let catalog_writer = session.env().catalog_writer();
+    catalog_writer.create_materialized_view(table, plan).await?;
+
+    Ok(PgResponse::empty_result(StatementType::CREATE_TABLE))
+}

--- a/src/frontend/src/handler/create_table.rs
+++ b/src/frontend/src/handler/create_table.rs
@@ -31,6 +31,7 @@ use crate::optimizer::plan_node::{LogicalSource, StreamSource};
 use crate::optimizer::property::{Distribution, Order};
 use crate::optimizer::{PlanRef, PlanRoot};
 use crate::session::{OptimizerContext, OptimizerContextRef, SessionImpl};
+
 // FIXME: store PK columns in ProstTableSourceInfo as Catalog information, and then remove this
 
 /// Binds the column schemas declared in CREATE statement into `ColumnCatalog`.

--- a/src/frontend/src/optimizer/mod.rs
+++ b/src/frontend/src/optimizer/mod.rs
@@ -180,9 +180,6 @@ impl PlanRoot {
     }
 
     /// Optimize and generate a create materialize view plan.
-    ///
-    /// The `MaterializeExecutor` won't be generated at this stage, and will be attached in
-    /// `gen_create_mv_plan`.
     pub fn gen_create_mv_plan(&mut self, mv_name: String) -> Result<StreamMaterialize> {
         let stream_plan = match self.plan.convention() {
             Convention::Logical => {
@@ -203,12 +200,6 @@ impl PlanRoot {
                 .enforce_if_not_satisfies(self.plan.clone(), Order::any()),
             _ => panic!(),
         };
-
-        // Ignore the required_dist and required_order, as they are provided by user now.
-        // TODO: need more thinking and refactor.
-
-        // Convert to physical plan node, using distribution of the input node
-        // After that, we will need to wrap a `MaterializeExecutor` on it in `gen_create_mv_plan`.
 
         StreamMaterialize::create(
             stream_plan,


### PR DESCRIPTION
Signed-off-by: Alex Chi <iskyzh@gmail.com>

## What's changed and what's your intention?

```
create index index_1 on t(v1);
```

... has the same effect as:

```
create materialized view index_1 as select * from t order by v1;
```

## Checklist

- [x] I have written necessary docs and comments
- [x] I have added necessary unit tests and integration tests

## Refer to a related PR or issue link (optional)

close https://github.com/singularity-data/risingwave/issues/1909