### PR TITLE
feat(meta): add support for sending notifications asynchronously

### DIFF
--- a/src/meta/src/cluster/mod.rs
+++ b/src/meta/src/cluster/mod.rs
@@ -187,7 +187,7 @@ where
                 if worker.worker_node.r#type == WorkerType::ComputeNode as i32 {
                     self.env
                         .notification_manager()
-                        .notify_frontend(Operation::Add, &Info::Node(worker.worker_node))
+                        .notify_frontend(Operation::Add, Info::Node(worker.worker_node))
                         .await;
                 }
 
@@ -222,7 +222,7 @@ where
                 if worker_type == WorkerType::ComputeNode {
                     self.env
                         .notification_manager()
-                        .notify_frontend(Operation::Delete, &Info::Node(worker_node.clone()))
+                        .notify_frontend(Operation::Delete, Info::Node(worker_node.clone()))
                         .await;
                 }
 

--- a/src/meta/src/hummock/hummock_manager.rs
+++ b/src/meta/src/hummock/hummock_manager.rs
@@ -871,11 +871,10 @@ where
 
         self.env
             .notification_manager()
-            .notify_frontend(
+            .notify_frontend_asynchronously(
                 Operation::Update, // Frontends don't care about operation.
-                &Info::HummockSnapshot(HummockSnapshot { epoch }),
-            )
-            .await;
+                Info::HummockSnapshot(HummockSnapshot { epoch }),
+            );
 
         Ok(())
     }

--- a/src/meta/src/manager/catalog.rs
+++ b/src/meta/src/manager/catalog.rs
@@ -79,7 +79,7 @@ where
 
             // Notify frontends to create database.
             self.notification_manager
-                .notify_frontend(Operation::Add, &Info::Database(database))
+                .notify_frontend(Operation::Add, Info::Database(database))
                 .await;
 
             Ok(version)
@@ -101,7 +101,7 @@ where
 
             // Notify frontends to delete database.
             self.notification_manager
-                .notify_frontend(Operation::Delete, &Info::Database(database))
+                .notify_frontend(Operation::Delete, Info::Database(database))
                 .await;
 
             Ok(version)
@@ -127,7 +127,7 @@ where
 
             // Notify frontends to create schema.
             self.notification_manager
-                .notify_frontend(Operation::Add, &Info::Schema(schema))
+                .notify_frontend(Operation::Add, Info::Schema(schema))
                 .await;
 
             Ok(version)
@@ -150,7 +150,7 @@ where
 
             // Notify frontends to delete schema.
             self.notification_manager
-                .notify_frontend(Operation::Delete, &Info::Schema(schema))
+                .notify_frontend(Operation::Delete, Info::Schema(schema))
                 .await;
 
             Ok(version)
@@ -183,7 +183,7 @@ where
 
             // Notify frontends to create table.
             self.notification_manager
-                .notify_frontend(Operation::Add, &Info::Table(table))
+                .notify_frontend(Operation::Add, Info::Table(table))
                 .await;
 
             Ok(version)
@@ -233,7 +233,7 @@ where
 
                     // Notify frontends to delete table.
                     self.notification_manager
-                        .notify_frontend(Operation::Delete, &Info::Table(table))
+                        .notify_frontend(Operation::Delete, Info::Table(table))
                         .await;
 
                     Ok(version)

--- a/src/meta/src/manager/catalog_v2.rs
+++ b/src/meta/src/manager/catalog_v2.rs
@@ -118,7 +118,7 @@ where
             let version = self
                 .env
                 .notification_manager()
-                .notify_frontend(Operation::Add, &Info::DatabaseV2(database.to_owned()))
+                .notify_frontend(Operation::Add, Info::DatabaseV2(database.to_owned()))
                 .await;
 
             Ok(version)
@@ -139,7 +139,7 @@ where
             let version = self
                 .env
                 .notification_manager()
-                .notify_frontend(Operation::Delete, &Info::DatabaseV2(database))
+                .notify_frontend(Operation::Delete, Info::DatabaseV2(database))
                 .await;
 
             Ok(version)
@@ -159,7 +159,7 @@ where
             let version = self
                 .env
                 .notification_manager()
-                .notify_frontend(Operation::Add, &Info::SchemaV2(schema.to_owned()))
+                .notify_frontend(Operation::Add, Info::SchemaV2(schema.to_owned()))
                 .await;
 
             Ok(version)
@@ -180,7 +180,7 @@ where
             let version = self
                 .env
                 .notification_manager()
-                .notify_frontend(Operation::Delete, &Info::SchemaV2(schema))
+                .notify_frontend(Operation::Delete, Info::SchemaV2(schema))
                 .await;
 
             Ok(version)
@@ -218,7 +218,7 @@ where
             let version = self
                 .env
                 .notification_manager()
-                .notify_frontend(Operation::Add, &Info::TableV2(table.to_owned()))
+                .notify_frontend(Operation::Add, Info::TableV2(table.to_owned()))
                 .await;
 
             Ok(version)
@@ -257,7 +257,7 @@ where
             let version = self
                 .env
                 .notification_manager()
-                .notify_frontend(Operation::Add, &Info::TableV2(table.to_owned()))
+                .notify_frontend(Operation::Add, Info::TableV2(table.to_owned()))
                 .await;
 
             Ok(version)
@@ -292,7 +292,7 @@ where
                     let version = self
                         .env
                         .notification_manager()
-                        .notify_frontend(Operation::Delete, &Info::TableV2(table))
+                        .notify_frontend(Operation::Delete, Info::TableV2(table))
                         .await;
 
                     Ok(version)
@@ -329,7 +329,7 @@ where
             let version = self
                 .env
                 .notification_manager()
-                .notify_frontend(Operation::Add, &Info::Source(source.to_owned()))
+                .notify_frontend(Operation::Add, Info::Source(source.to_owned()))
                 .await;
 
             Ok(version)
@@ -362,7 +362,7 @@ where
             let version = self
                 .env
                 .notification_manager()
-                .notify_frontend(Operation::Add, &Info::Source(source.to_owned()))
+                .notify_frontend(Operation::Add, Info::Source(source.to_owned()))
                 .await;
 
             Ok(version)
@@ -394,7 +394,7 @@ where
                     let version = self
                         .env
                         .notification_manager()
-                        .notify_frontend(Operation::Delete, &Info::Source(source))
+                        .notify_frontend(Operation::Delete, Info::Source(source))
                         .await;
 
                     Ok(version)
@@ -456,13 +456,13 @@ where
 
             self.env
                 .notification_manager()
-                .notify_frontend(Operation::Add, &Info::TableV2(mview.to_owned()))
+                .notify_frontend(Operation::Add, Info::TableV2(mview.to_owned()))
                 .await;
             // Currently frontend uses source's version
             let version = self
                 .env
                 .notification_manager()
-                .notify_frontend(Operation::Add, &Info::Source(source.to_owned()))
+                .notify_frontend(Operation::Add, Info::Source(source.to_owned()))
                 .await;
             Ok(version)
         } else {
@@ -556,12 +556,12 @@ where
 
                 self.env
                     .notification_manager()
-                    .notify_frontend(Operation::Delete, &Info::TableV2(mview))
+                    .notify_frontend(Operation::Delete, Info::TableV2(mview))
                     .await;
                 let version = self
                     .env
                     .notification_manager()
-                    .notify_frontend(Operation::Delete, &Info::Source(source))
+                    .notify_frontend(Operation::Delete, Info::Source(source))
                     .await;
                 Ok(version)
             }


### PR DESCRIPTION
## What's changed and what's your intention?

Add support for sending notifications asynchronously.
It is used where it is only necessary to ensure that the message will be sent, but not that the message must be sent successfully at the end of the method.

## Checklist

- [x] I have written necessary docs and comments
- [x] I have added necessary unit tests and integration tests

## Refer to a related PR or issue link (optional)
