### PR TITLE
refactor(frontend): remove `FunctionCall::new_with_return_type` that bypass infer_type

### DIFF
--- a/src/frontend/src/binder/expr/binary_op.rs
+++ b/src/frontend/src/binder/expr/binary_op.rs
@@ -12,11 +12,11 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use risingwave_common::error::{ErrorCode, Result, RwError};
+use risingwave_common::error::{ErrorCode, Result};
 use risingwave_sqlparser::ast::{BinaryOperator, Expr};
 
 use crate::binder::Binder;
-use crate::expr::{Expr as _, ExprImpl, ExprType, FunctionCall};
+use crate::expr::{ExprImpl, ExprType, FunctionCall};
 
 impl Binder {
     pub(super) fn bind_binary_op(
@@ -45,34 +45,15 @@ impl Binder {
             BinaryOperator::NotLike => return self.bind_not_like(bound_left, bound_right),
             _ => return Err(ErrorCode::NotImplemented(format!("{:?}", op), 112.into()).into()),
         };
-        FunctionCall::new_or_else(func_type, vec![bound_left, bound_right], |inputs| {
-            Self::err_unsupported_binary_op(op, inputs)
-        })
+        FunctionCall::new(func_type, vec![bound_left, bound_right])
     }
 
     /// Apply a NOT on top of LIKE.
     fn bind_not_like(&mut self, left: ExprImpl, right: ExprImpl) -> Result<FunctionCall> {
         Ok(FunctionCall::new(
             ExprType::Not,
-            vec![
-                FunctionCall::new_or_else(ExprType::Like, vec![left, right], |inputs| {
-                    Self::err_unsupported_binary_op(BinaryOperator::NotLike, inputs)
-                })?
-                .into(),
-            ],
+            vec![FunctionCall::new(ExprType::Like, vec![left, right])?.into()],
         )
         .unwrap())
-    }
-
-    fn err_unsupported_binary_op(op: BinaryOperator, inputs: &[ExprImpl]) -> RwError {
-        let bound_left = inputs.get(0).unwrap();
-        let bound_right = inputs.get(1).unwrap();
-        let desc = format!(
-            "{:?} {:?} {:?}",
-            bound_left.return_type(),
-            op,
-            bound_right.return_type(),
-        );
-        ErrorCode::NotImplemented(desc, 112.into()).into()
     }
 }

--- a/src/frontend/src/binder/expr/function.rs
+++ b/src/frontend/src/binder/expr/function.rs
@@ -13,7 +13,7 @@
 // limitations under the License.
 
 use itertools::Itertools;
-use risingwave_common::error::{ErrorCode, Result, RwError};
+use risingwave_common::error::{ErrorCode, Result};
 use risingwave_common::types::DataType;
 use risingwave_expr::expr::AggKind;
 use risingwave_sqlparser::ast::{Function, FunctionArg, FunctionArgExpr};
@@ -76,10 +76,7 @@ impl Binder {
                     .into())
                 }
             };
-            Ok(FunctionCall::new_or_else(function_type, inputs, |args| {
-                Self::err_unsupported_func(&function_name, args)
-            })?
-            .into())
+            Ok(FunctionCall::new(function_type, inputs)?.into())
         } else {
             Err(ErrorCode::NotImplemented(
                 format!("unsupported function: {:?}", f.name),
@@ -87,18 +84,6 @@ impl Binder {
             )
             .into())
         }
-    }
-
-    fn err_unsupported_func(function_name: &str, inputs: &[ExprImpl]) -> RwError {
-        let args = inputs
-            .iter()
-            .map(|i| format!("{:?}", i.return_type()))
-            .join(",");
-        ErrorCode::NotImplemented(
-            format!("function {}({}) doesn't exist", function_name, args),
-            112.into(),
-        )
-        .into()
     }
 
     /// Rewrite the arguments to be consistent with the `round` signature:

--- a/src/frontend/src/binder/expr/function.rs
+++ b/src/frontend/src/binder/expr/function.rs
@@ -49,7 +49,6 @@ impl Binder {
             let function_type = match function_name.as_str() {
                 "substr" => ExprType::Substr,
                 "length" => ExprType::Length,
-                "like" => ExprType::Like,
                 "upper" => ExprType::Upper,
                 "lower" => ExprType::Lower,
                 "trim" => ExprType::Trim,
@@ -57,13 +56,6 @@ impl Binder {
                 "position" => ExprType::Position,
                 "ltrim" => ExprType::Ltrim,
                 "rtrim" => ExprType::Rtrim,
-                "case" => ExprType::Case,
-                "is true" => ExprType::IsTrue,
-                "is not true" => ExprType::IsNotTrue,
-                "is false" => ExprType::IsFalse,
-                "is not false" => ExprType::IsNotFalse,
-                "is null" => ExprType::IsNull,
-                "is not null" => ExprType::IsNotNull,
                 "round" => {
                     inputs = Self::rewrite_round_args(inputs);
                     ExprType::RoundDigit

--- a/src/frontend/src/binder/expr/mod.rs
+++ b/src/frontend/src/binder/expr/mod.rs
@@ -102,23 +102,12 @@ impl Binder {
     }
 
     pub(super) fn bind_extract(&mut self, field: DateTimeField, expr: Expr) -> Result<ExprImpl> {
-        Ok(FunctionCall::new_or_else(
+        Ok(FunctionCall::new(
             ExprType::Extract,
             vec![
                 self.bind_string(field.to_string())?.into(),
                 self.bind_expr(expr)?,
             ],
-            |inputs| {
-                ErrorCode::NotImplemented(
-                    format!(
-                        "function extract({} from {:?}) doesn't exist",
-                        field,
-                        inputs[1].return_type()
-                    ),
-                    112.into(),
-                )
-                .into()
-            },
         )?
         .into())
     }

--- a/src/frontend/src/binder/expr/mod.rs
+++ b/src/frontend/src/binder/expr/mod.rs
@@ -164,16 +164,7 @@ impl Binder {
             }
         };
         let expr = self.bind_expr(expr)?;
-        let return_type = expr.return_type();
-        FunctionCall::new(func_type, vec![expr])
-            .ok_or_else(|| {
-                ErrorCode::NotImplemented(
-                    format!("unsupported unary expression {:?} {:?}", op, return_type),
-                    112.into(),
-                )
-                .into()
-            })
-            .map(|f| f.into())
+        FunctionCall::new(func_type, vec![expr]).map(|f| f.into())
     }
 
     /// Directly returns the expression itself if it is a positive number.
@@ -312,9 +303,7 @@ impl Binder {
         expr: Expr,
     ) -> Result<FunctionCall> {
         let expr = self.bind_expr(expr)?;
-        FunctionCall::new(func_type, vec![expr]).ok_or_else(|| {
-            ErrorCode::NotImplemented(format!("{:?}", &func_type), None.into()).into()
-        })
+        FunctionCall::new(func_type, vec![expr])
     }
 
     pub(super) fn bind_cast(&mut self, expr: Expr, data_type: AstDataType) -> Result<ExprImpl> {

--- a/src/frontend/src/binder/expr/mod.rs
+++ b/src/frontend/src/binder/expr/mod.rs
@@ -102,13 +102,21 @@ impl Binder {
     }
 
     pub(super) fn bind_extract(&mut self, field: DateTimeField, expr: Expr) -> Result<ExprImpl> {
+        let arg = self.bind_expr(expr)?;
+        let arg_type = arg.return_type();
         Ok(FunctionCall::new(
             ExprType::Extract,
-            vec![
-                self.bind_string(field.to_string())?.into(),
-                self.bind_expr(expr)?,
-            ],
-        )?
+            vec![self.bind_string(field.to_string())?.into(), arg],
+        )
+        .map_err(|_| {
+            ErrorCode::NotImplemented(
+                format!(
+                    "function extract({} from {:?}) doesn't exist",
+                    field, arg_type
+                ),
+                112.into(),
+            )
+        })?
         .into())
     }
 

--- a/src/frontend/src/expr/expr_rewriter.rs
+++ b/src/frontend/src/expr/expr_rewriter.rs
@@ -34,7 +34,7 @@ pub trait ExprRewriter {
             .into_iter()
             .map(|expr| self.rewrite_expr(expr))
             .collect();
-        FunctionCall::new_with_return_type(func_type, inputs, ret).into()
+        FunctionCall::new_unchecked(func_type, inputs, ret).into()
     }
     fn rewrite_agg_call(&mut self, agg_call: AggCall) -> ExprImpl {
         let (func_type, inputs) = agg_call.decompose();

--- a/src/frontend/src/expr/function_call.rs
+++ b/src/frontend/src/expr/function_call.rs
@@ -90,7 +90,11 @@ impl FunctionCall {
             func_type,
             inputs.iter().map(|expr| expr.return_type()).collect(),
         )?; // should be derived from inputs
-        Ok(Self::new_with_return_type(func_type, inputs, return_type))
+        Ok(Self {
+            func_type,
+            return_type,
+            inputs,
+        })
     }
 
     /// Create a cast expr over `child` to `target` type in `allows` context.
@@ -117,7 +121,7 @@ impl FunctionCall {
     }
 
     /// used for expressions like cast
-    pub fn new_with_return_type(
+    pub fn new_unchecked(
         func_type: ExprType,
         inputs: Vec<ExprImpl>,
         return_type: DataType,

--- a/src/frontend/src/expr/function_call.rs
+++ b/src/frontend/src/expr/function_call.rs
@@ -94,16 +94,16 @@ impl FunctionCall {
             func_type,
             inputs.iter().map(|expr| expr.return_type()).collect(),
         )
-        .ok_or_else(|| err_f(&inputs))
+        .map_err(|_| err_f(&inputs))
         .map(|return_type| Self::new_with_return_type(func_type, inputs, return_type))
     }
 
-    pub fn new(func_type: ExprType, inputs: Vec<ExprImpl>) -> Option<Self> {
+    pub fn new(func_type: ExprType, inputs: Vec<ExprImpl>) -> Result<Self> {
         let return_type = infer_type(
             func_type,
             inputs.iter().map(|expr| expr.return_type()).collect(),
         )?; // should be derived from inputs
-        Some(Self::new_with_return_type(func_type, inputs, return_type))
+        Ok(Self::new_with_return_type(func_type, inputs, return_type))
     }
 
     /// Create a cast expr over `child` to `target` type in `allows` context.

--- a/src/frontend/src/expr/function_call.rs
+++ b/src/frontend/src/expr/function_call.rs
@@ -85,6 +85,8 @@ impl std::fmt::Debug for FunctionCall {
 }
 
 impl FunctionCall {
+    /// Create a `FunctionCall` expr with the return type inferred from `func_type` and types of
+    /// `inputs`.
     pub fn new(func_type: ExprType, inputs: Vec<ExprImpl>) -> Result<Self> {
         let return_type = infer_type(
             func_type,
@@ -120,7 +122,8 @@ impl FunctionCall {
         }
     }
 
-    /// used for expressions like cast
+    /// Construct a `FunctionCall` expr directly with the provided `return_type`, bypassing type
+    /// inference. Use with caution.
     pub fn new_unchecked(
         func_type: ExprType,
         inputs: Vec<ExprImpl>,

--- a/src/frontend/src/expr/function_call.rs
+++ b/src/frontend/src/expr/function_call.rs
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use risingwave_common::error::{ErrorCode, Result, RwError};
+use risingwave_common::error::{ErrorCode, Result};
 use risingwave_common::types::DataType;
 
 use super::{cast_ok, infer_type, CastContext, Expr, ExprImpl, Literal};
@@ -85,19 +85,6 @@ impl std::fmt::Debug for FunctionCall {
 }
 
 impl FunctionCall {
-    /// Returns error if the function call is not valid.
-    pub fn new_or_else<F>(func_type: ExprType, inputs: Vec<ExprImpl>, err_f: F) -> Result<Self>
-    where
-        F: FnOnce(&Vec<ExprImpl>) -> RwError,
-    {
-        infer_type(
-            func_type,
-            inputs.iter().map(|expr| expr.return_type()).collect(),
-        )
-        .map_err(|_| err_f(&inputs))
-        .map(|return_type| Self::new_with_return_type(func_type, inputs, return_type))
-    }
-
     pub fn new(func_type: ExprType, inputs: Vec<ExprImpl>) -> Result<Self> {
         let return_type = infer_type(
             func_type,

--- a/src/frontend/src/expr/type_inference.rs
+++ b/src/frontend/src/expr/type_inference.rs
@@ -100,7 +100,7 @@ fn infer_type_name(func_type: ExprType, inputs_type: Vec<DataTypeName>) -> Resul
         .get(&FuncSign::new(func_type, inputs_type.clone()))
         .cloned()
         .ok_or_else(|| {
-            ErrorCode::NotImplemented(format!("{:?}{:?}", func_type, inputs_type), 122.into())
+            ErrorCode::NotImplemented(format!("{:?}{:?}", func_type, inputs_type), 112.into())
                 .into()
         })
 }

--- a/src/frontend/src/expr/type_inference.rs
+++ b/src/frontend/src/expr/type_inference.rs
@@ -65,7 +65,7 @@ fn name_of(ty: &DataType) -> DataTypeName {
     }
 }
 
-/// Infers the return type of a function. Returns `None` if the function with specified data types
+/// Infers the return type of a function. Returns `Err` if the function with specified data types
 /// is not supported on backend.
 pub fn infer_type(func_type: ExprType, inputs_type: Vec<DataType>) -> Result<DataType> {
     // With our current simplified type system, where all types are nullable and not parameterized

--- a/src/frontend/src/expr/type_inference.rs
+++ b/src/frontend/src/expr/type_inference.rs
@@ -67,7 +67,7 @@ fn name_of(ty: &DataType) -> DataTypeName {
 
 /// Infers the return type of a function. Returns `None` if the function with specified data types
 /// is not supported on backend.
-pub fn infer_type(func_type: ExprType, inputs_type: Vec<DataType>) -> Option<DataType> {
+pub fn infer_type(func_type: ExprType, inputs_type: Vec<DataType>) -> Result<DataType> {
     // With our current simplified type system, where all types are nullable and not parameterized
     // by things like length or precision, the inference can be done with a map lookup.
     let input_type_names = inputs_type.iter().map(name_of).collect();
@@ -95,13 +95,14 @@ pub fn infer_type(func_type: ExprType, inputs_type: Vec<DataType>) -> Option<Dat
 }
 
 /// Infer the return type name without parameters like length or precision.
-fn infer_type_name(func_type: ExprType, inputs_type: Vec<DataTypeName>) -> Option<DataTypeName> {
+fn infer_type_name(func_type: ExprType, inputs_type: Vec<DataTypeName>) -> Result<DataTypeName> {
     FUNC_SIG_MAP
-        .get(&FuncSign {
-            func: func_type,
-            inputs_type,
-        })
+        .get(&FuncSign::new(func_type, inputs_type.clone()))
         .cloned()
+        .ok_or_else(|| {
+            ErrorCode::NotImplemented(format!("{:?}{:?}", func_type, inputs_type), 122.into())
+                .into()
+        })
 }
 
 #[derive(PartialEq, Hash)]
@@ -446,7 +447,7 @@ mod tests {
 
     fn test_infer_type_not_exist(func_type: ExprType, inputs_type: Vec<DataType>) {
         let ret = infer_type(func_type, inputs_type);
-        assert_eq!(ret, None);
+        assert!(ret.is_err());
     }
 
     #[test]

--- a/src/frontend/src/expr/utils.rs
+++ b/src/frontend/src/expr/utils.rs
@@ -118,7 +118,7 @@ impl ExprRewriter for BooleanConstantFolding {
                 _ => {}
             }
         }
-        FunctionCall::new_with_return_type(func_type, inputs, ret).into()
+        FunctionCall::new_unchecked(func_type, inputs, ret).into()
     }
 }
 
@@ -178,7 +178,7 @@ impl ExprRewriter for NotPushDown {
                 .into_iter()
                 .map(|expr| self.rewrite_expr(expr))
                 .collect();
-            FunctionCall::new_with_return_type(func_type, inputs, ret).into()
+            FunctionCall::new_unchecked(func_type, inputs, ret).into()
         } else {
             // func_type == Type::Not here
 
@@ -223,7 +223,7 @@ impl ExprRewriter for NotPushDown {
                                 .unwrap()
                                 .into())
                         }
-                        _ => Err(FunctionCall::new_with_return_type(func_type, inputs, ret).into()),
+                        _ => Err(FunctionCall::new_unchecked(func_type, inputs, ret).into()),
                     }
                 }
                 _ => Err(input),

--- a/src/frontend/src/optimizer/plan_node/logical_agg.rs
+++ b/src/frontend/src/optimizer/plan_node/logical_agg.rs
@@ -235,7 +235,7 @@ impl ExprRewriter for ExprHandler {
                 .into_iter()
                 .map(|expr| self.rewrite_expr(expr))
                 .collect();
-            FunctionCall::new_with_return_type(func_type, inputs, ret).into()
+            FunctionCall::new_unchecked(func_type, inputs, ret).into()
         }
     }
 

--- a/src/frontend/test_runner/tests/testdata/expr.yaml
+++ b/src/frontend/test_runner/tests/testdata/expr.yaml
@@ -49,7 +49,7 @@
     BatchValues { rows: [[RoundDigit(42.4382:Decimal, 0:Int32)]] }
 - sql: |
     values(round('abc'));
-  binder_error: 'Feature is not yet implemented: function round(Varchar) doesn''t exist, Tracking issue: https://github.com/singularity-data/risingwave/issues/112'
+  binder_error: 'Feature is not yet implemented: RoundDigit[Varchar], Tracking issue: https://github.com/singularity-data/risingwave/issues/112'
 - sql: |
     values(extract(hour from timestamp '2001-02-16 20:38:40'));
   batch_plan: |
@@ -60,7 +60,7 @@
     BatchValues { rows: [[Not(Like('Postgres':Varchar, 'Post%':Varchar))]] }
 - sql: |
     values(1 not like 1.23);
-  binder_error: 'Feature is not yet implemented: Int32 NotLike Decimal, Tracking issue: https://github.com/singularity-data/risingwave/issues/112'
+  binder_error: 'Feature is not yet implemented: Like[Int32, Decimal], Tracking issue: https://github.com/singularity-data/risingwave/issues/112'
 - sql: |
     select length(trim(trailing '1' from '12'))+length(trim(leading '2' from '23'))+length(trim(both '3' from '34'));
   batch_plan: |


### PR DESCRIPTION
## What's changed and what's your intention?

- `infer_type` returns `Err` rather than `None` so that callers do not need to construct errors with repeatedly.
- `FunctionCall` now has 3 constructors:
  - `new` should be used in most cases. Return type is inferred.
  - `new_cast` dedicates to create cast expression, which needs the "return_type" as input argument.
  - `new_unchecked` constructs the struct directly bypassing type inference. Mainly for internal expr rewriting where inferring again is less desirable.

To handle in later PR: `CASE` and `IN` should be handled by `FunctionCall::new` rather than `new_unchecked`.

## Checklist

- [x] I have written necessary docs and comments
~~- [ ] I have added necessary unit tests and integration tests~~ (Refactor does not break existing tests.)

## Refer to a related PR or issue link (optional)
