### PR TITLE
feat(streaming): add cache for lookup

### DIFF
--- a/src/stream/src/executor/hash_join.rs
+++ b/src/stream/src/executor/hash_join.rs
@@ -32,6 +32,8 @@ use crate::common::StreamChunkBuilder;
 use crate::executor::ExecutorBuilder;
 use crate::task::{ExecutorParams, LocalStreamManagerCore};
 
+pub const JOIN_CACHE_SIZE: usize = 1 << 16;
+
 /// The `JoinType` and `SideType` are to mimic a enum, because currently
 /// enum is not supported in const generic.
 // TODO: Use enum to replace this once [feature(adt_const_params)](https://github.com/rust-lang/rust/issues/95174) get completed.
@@ -354,7 +356,7 @@ impl<S: StateStore, const T: JoinTypePrimitive> HashJoinExecutor<S, T> {
             },
             side_l: JoinSide {
                 ht: JoinHashMap::new(
-                    1 << 16,
+                    JOIN_CACHE_SIZE,
                     pk_indices_l.clone(),
                     col_l_datatypes.clone(),
                     ks_l.clone(),
@@ -367,7 +369,7 @@ impl<S: StateStore, const T: JoinTypePrimitive> HashJoinExecutor<S, T> {
             },
             side_r: JoinSide {
                 ht: JoinHashMap::new(
-                    1 << 16,
+                    JOIN_CACHE_SIZE,
                     pk_indices_r.clone(),
                     col_r_datatypes.clone(),
                     ks_r.clone(),

--- a/src/stream/src/executor_v2/lookup.rs
+++ b/src/stream/src/executor_v2/lookup.rs
@@ -27,7 +27,9 @@ use crate::executor::ExecutorBuilder;
 use crate::executor_v2::{Barrier, BoxedMessageStream, Executor, PkIndices, PkIndicesRef};
 use crate::task::{unique_operator_id, ExecutorParams, LocalStreamManagerCore};
 
+mod cache;
 mod sides;
+use self::cache::LookupCache;
 use self::sides::*;
 mod impl_;
 
@@ -82,6 +84,9 @@ pub struct LookupExecutor<S: StateStore> {
     ///
     /// This vector records such mapping.
     key_indices_mapping: Vec<usize>,
+
+    /// The cache for arrangement side.
+    lookup_cache: LookupCache,
 }
 
 #[async_trait]

--- a/src/stream/src/executor_v2/lookup/cache.rs
+++ b/src/stream/src/executor_v2/lookup/cache.rs
@@ -1,7 +1,23 @@
+// Copyright 2022 Singularity Data
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 use std::collections::BTreeSet;
 
 use risingwave_common::array::{Op, Row, StreamChunk};
 use risingwave_common::collection::evictable::EvictableHashMap;
+
+use crate::executor::JOIN_CACHE_SIZE;
 
 /// A cache for lookup's arrangement side.
 pub struct LookupCache {
@@ -45,7 +61,7 @@ impl LookupCache {
 
     pub fn new() -> Self {
         Self {
-            data: EvictableHashMap::new(1 << 16),
+            data: EvictableHashMap::new(JOIN_CACHE_SIZE),
         }
     }
 }

--- a/src/stream/src/executor_v2/lookup/cache.rs
+++ b/src/stream/src/executor_v2/lookup/cache.rs
@@ -1,0 +1,51 @@
+use std::collections::BTreeSet;
+
+use risingwave_common::array::{Op, Row, StreamChunk};
+use risingwave_common::collection::evictable::EvictableHashMap;
+
+/// A cache for lookup's arrangement side.
+pub struct LookupCache {
+    data: EvictableHashMap<Row, BTreeSet<Row>>,
+}
+
+impl LookupCache {
+    /// Lookup a row in cache. If not found, return `None`.
+    pub fn lookup(&mut self, key: &Row) -> Option<&BTreeSet<Row>> {
+        self.data.get(key)
+    }
+
+    /// Update a key after lookup cache misses.
+    pub fn batch_update(&mut self, key: Row, value: impl Iterator<Item = Row>) {
+        self.data.push(key, value.collect());
+    }
+
+    /// Apply a batch from the arrangement side
+    pub fn apply_batch(&mut self, chunk: StreamChunk, arrange_join_keys: &[usize]) {
+        for (op, row) in chunk.rows() {
+            let key = row.row_by_indices(arrange_join_keys);
+            if let Some(values) = self.data.get_mut(&key) {
+                // the item is in cache, update it
+                let value = row.to_owned_row();
+                match op {
+                    Op::Insert | Op::UpdateInsert => {
+                        values.insert(value);
+                    }
+                    Op::Delete | Op::UpdateDelete => {
+                        values.remove(&value);
+                    }
+                }
+            }
+        }
+    }
+
+    /// Flush the cache and evict the items.
+    pub fn flush(&mut self) {
+        self.data.evict_to_target_cap();
+    }
+
+    pub fn new() -> Self {
+        Self {
+            data: EvictableHashMap::new(1 << 16),
+        }
+    }
+}


### PR DESCRIPTION
Signed-off-by: Alex Chi <iskyzh@gmail.com>

## What's changed and what's your intention?

***PLEASE DO NOT LEAVE THIS EMPTY !!!***

e2e should be a lot faster. When we have multi-way join, we can move the cache to `ArrangeExecutor` and reimplement this in MVCC way.

## Checklist

- [x] I have written necessary docs and comments
- [x] I have added necessary unit tests and integration tests

## Refer to a related PR or issue link (optional)

close https://github.com/singularity-data/risingwave/issues/2045