### PR TITLE
refactor(frontend): rename Expr::to_protobuf to Expr::to_expr_proto

### DIFF
--- a/src/frontend/src/expr/agg_call.rs
+++ b/src/frontend/src/expr/agg_call.rs
@@ -118,7 +118,7 @@ impl Expr for AggCall {
         self.return_type.clone()
     }
 
-    fn to_protobuf(&self) -> risingwave_pb::expr::ExprNode {
+    fn to_expr_proto(&self) -> risingwave_pb::expr::ExprNode {
         // This function is always called on the physical planning step, where
         // `ExprImpl::AggCall` must have been rewritten to aggregate operators.
 

--- a/src/frontend/src/expr/correlated_input_ref.rs
+++ b/src/frontend/src/expr/correlated_input_ref.rs
@@ -55,7 +55,7 @@ impl Expr for CorrelatedInputRef {
         self.data_type.clone()
     }
 
-    fn to_protobuf(&self) -> risingwave_pb::expr::ExprNode {
+    fn to_expr_proto(&self) -> risingwave_pb::expr::ExprNode {
         unreachable!("CorrelatedInputRef {:?} has not been decorrelated", self)
     }
 }

--- a/src/frontend/src/expr/function_call.rs
+++ b/src/frontend/src/expr/function_call.rs
@@ -169,14 +169,14 @@ impl Expr for FunctionCall {
         self.return_type.clone()
     }
 
-    fn to_protobuf(&self) -> risingwave_pb::expr::ExprNode {
+    fn to_expr_proto(&self) -> risingwave_pb::expr::ExprNode {
         use risingwave_pb::expr::expr_node::*;
         use risingwave_pb::expr::*;
         ExprNode {
             expr_type: self.get_expr_type().into(),
             return_type: Some(self.return_type().to_protobuf()),
             rex_node: Some(RexNode::FuncCall(FunctionCall {
-                children: self.inputs().iter().map(Expr::to_protobuf).collect(),
+                children: self.inputs().iter().map(Expr::to_expr_proto).collect(),
             })),
         }
     }

--- a/src/frontend/src/expr/input_ref.rs
+++ b/src/frontend/src/expr/input_ref.rs
@@ -122,7 +122,7 @@ impl Expr for InputRef {
         self.data_type.clone()
     }
 
-    fn to_protobuf(&self) -> risingwave_pb::expr::ExprNode {
+    fn to_expr_proto(&self) -> risingwave_pb::expr::ExprNode {
         use risingwave_pb::expr::expr_node::*;
         use risingwave_pb::expr::*;
         ExprNode {

--- a/src/frontend/src/expr/literal.rs
+++ b/src/frontend/src/expr/literal.rs
@@ -62,7 +62,7 @@ impl Expr for Literal {
         self.data_type.clone()
     }
 
-    fn to_protobuf(&self) -> risingwave_pb::expr::ExprNode {
+    fn to_expr_proto(&self) -> risingwave_pb::expr::ExprNode {
         use risingwave_pb::expr::*;
         ExprNode {
             expr_type: self.get_expr_type() as i32,

--- a/src/frontend/src/expr/mod.rs
+++ b/src/frontend/src/expr/mod.rs
@@ -52,7 +52,7 @@ pub trait Expr: Into<ExprImpl> {
     fn return_type(&self) -> DataType;
 
     /// Serialize the expression
-    fn to_protobuf(&self) -> ExprNode;
+    fn to_expr_proto(&self) -> ExprNode;
 }
 
 #[derive(Clone, Eq, PartialEq, Hash, EnumAsInner)]
@@ -195,14 +195,14 @@ impl Expr for ExprImpl {
         }
     }
 
-    fn to_protobuf(&self) -> ExprNode {
+    fn to_expr_proto(&self) -> ExprNode {
         match self {
-            ExprImpl::InputRef(e) => e.to_protobuf(),
-            ExprImpl::Literal(e) => e.to_protobuf(),
-            ExprImpl::FunctionCall(e) => e.to_protobuf(),
-            ExprImpl::AggCall(e) => e.to_protobuf(),
-            ExprImpl::Subquery(e) => e.to_protobuf(),
-            ExprImpl::CorrelatedInputRef(e) => e.to_protobuf(),
+            ExprImpl::InputRef(e) => e.to_expr_proto(),
+            ExprImpl::Literal(e) => e.to_expr_proto(),
+            ExprImpl::FunctionCall(e) => e.to_expr_proto(),
+            ExprImpl::AggCall(e) => e.to_expr_proto(),
+            ExprImpl::Subquery(e) => e.to_expr_proto(),
+            ExprImpl::CorrelatedInputRef(e) => e.to_expr_proto(),
         }
     }
 }

--- a/src/frontend/src/expr/subquery.rs
+++ b/src/frontend/src/expr/subquery.rs
@@ -78,7 +78,7 @@ impl Expr for Subquery {
         }
     }
 
-    fn to_protobuf(&self) -> risingwave_pb::expr::ExprNode {
+    fn to_expr_proto(&self) -> risingwave_pb::expr::ExprNode {
         unreachable!("Subquery {:?} has not been unnested", self)
     }
 }

--- a/src/frontend/src/optimizer/plan_node/batch_filter.rs
+++ b/src/frontend/src/optimizer/plan_node/batch_filter.rs
@@ -75,7 +75,7 @@ impl ToDistributedBatch for BatchFilter {
 impl ToBatchProst for BatchFilter {
     fn to_batch_prost_body(&self) -> NodeBody {
         NodeBody::Filter(FilterNode {
-            search_condition: Some(ExprImpl::from(self.logical.predicate().clone()).to_protobuf()),
+            search_condition: Some(ExprImpl::from(self.logical.predicate().clone()).to_expr_proto()),
         })
     }
 }

--- a/src/frontend/src/optimizer/plan_node/batch_filter.rs
+++ b/src/frontend/src/optimizer/plan_node/batch_filter.rs
@@ -75,7 +75,9 @@ impl ToDistributedBatch for BatchFilter {
 impl ToBatchProst for BatchFilter {
     fn to_batch_prost_body(&self) -> NodeBody {
         NodeBody::Filter(FilterNode {
-            search_condition: Some(ExprImpl::from(self.logical.predicate().clone()).to_expr_proto()),
+            search_condition: Some(
+                ExprImpl::from(self.logical.predicate().clone()).to_expr_proto(),
+            ),
         })
     }
 }

--- a/src/frontend/src/optimizer/plan_node/batch_project.rs
+++ b/src/frontend/src/optimizer/plan_node/batch_project.rs
@@ -103,7 +103,7 @@ impl ToBatchProst for BatchProject {
             .logical
             .exprs()
             .iter()
-            .map(Expr::to_protobuf)
+            .map(Expr::to_expr_proto)
             .collect::<Vec<ExprNode>>();
         NodeBody::Project(ProjectNode { select_list })
     }

--- a/src/frontend/src/optimizer/plan_node/batch_values.rs
+++ b/src/frontend/src/optimizer/plan_node/batch_values.rs
@@ -84,7 +84,7 @@ impl ToBatchProst for BatchValues {
 }
 
 fn row_to_protobuf(row: &[ExprImpl]) -> ExprTuple {
-    let cells = row.iter().map(Expr::to_protobuf).collect();
+    let cells = row.iter().map(Expr::to_expr_proto).collect();
     ExprTuple { cells }
 }
 

--- a/src/frontend/src/optimizer/plan_node/stream_filter.rs
+++ b/src/frontend/src/optimizer/plan_node/stream_filter.rs
@@ -72,7 +72,7 @@ impl_plan_tree_node_for_unary! { StreamFilter }
 impl ToStreamProst for StreamFilter {
     fn to_stream_prost_body(&self) -> ProstStreamNode {
         ProstStreamNode::FilterNode(FilterNode {
-            search_condition: Some(ExprImpl::from(self.predicate().clone()).to_protobuf()),
+            search_condition: Some(ExprImpl::from(self.predicate().clone()).to_expr_proto()),
         })
     }
 }

--- a/src/frontend/src/optimizer/plan_node/stream_hash_join.rs
+++ b/src/frontend/src/optimizer/plan_node/stream_hash_join.rs
@@ -159,7 +159,7 @@ impl ToStreamProst for StreamHashJoin {
                 .eq_join_predicate
                 .other_cond()
                 .as_expr_unless_true()
-                .map(|x| x.to_protobuf()),
+                .map(|x| x.to_expr_proto()),
             distribution_keys: self
                 .base
                 .dist

--- a/src/frontend/src/optimizer/plan_node/stream_hop_window.rs
+++ b/src/frontend/src/optimizer/plan_node/stream_hop_window.rs
@@ -73,9 +73,9 @@ impl ToStreamProst for StreamHopWindow {
             Literal::new(Some(interval.to_scalar_value()), DataType::Interval)
         };
         ProstStreamNode::HopWindowNode(HopWindowNode {
-            time_col: Some(self.logical.time_col.to_protobuf()),
-            window_slide: Some(interval_to_literal(self.logical.window_slide).to_protobuf()),
-            window_size: Some(interval_to_literal(self.logical.window_size).to_protobuf()),
+            time_col: Some(self.logical.time_col.to_expr_proto()),
+            window_slide: Some(interval_to_literal(self.logical.window_slide).to_expr_proto()),
+            window_size: Some(interval_to_literal(self.logical.window_size).to_expr_proto()),
         })
     }
 }

--- a/src/frontend/src/optimizer/plan_node/stream_project.rs
+++ b/src/frontend/src/optimizer/plan_node/stream_project.rs
@@ -69,7 +69,7 @@ impl_plan_tree_node_for_unary! {StreamProject}
 impl ToStreamProst for StreamProject {
     fn to_stream_prost_body(&self) -> ProstStreamNode {
         ProstStreamNode::ProjectNode(ProjectNode {
-            select_list: self.logical.exprs().iter().map(Expr::to_protobuf).collect(),
+            select_list: self.logical.exprs().iter().map(Expr::to_expr_proto).collect(),
         })
     }
 }

--- a/src/frontend/src/optimizer/plan_node/stream_project.rs
+++ b/src/frontend/src/optimizer/plan_node/stream_project.rs
@@ -69,7 +69,12 @@ impl_plan_tree_node_for_unary! {StreamProject}
 impl ToStreamProst for StreamProject {
     fn to_stream_prost_body(&self) -> ProstStreamNode {
         ProstStreamNode::ProjectNode(ProjectNode {
-            select_list: self.logical.exprs().iter().map(Expr::to_expr_proto).collect(),
+            select_list: self
+                .logical
+                .exprs()
+                .iter()
+                .map(Expr::to_expr_proto)
+                .collect(),
         })
     }
 }


### PR DESCRIPTION
Signed-off-by: TennyZhuang <zty0826@gmail.com>

## What's changed and what's your intention?

***PLEASE DO NOT LEAVE THIS EMPTY !!!***

Sometimes we need some raw proto message, e.g. `InputRefExpr`, it's better for each type to implement their own `to_proto`, and implement `to_expr_proto` to wrap them.

## Checklist

- [x] I have written necessary docs and comments
- [x] I have added necessary unit tests and integration tests

## Refer to a related PR or issue link (optional)
