### PR TITLE
refactor(state-store): Different actors should use the same table id

### DIFF
--- a/src/meta/src/stream/fragmenter/mod.rs
+++ b/src/meta/src/stream/fragmenter/mod.rs
@@ -53,6 +53,17 @@ struct BuildFragmentGraphState {
     fragment_graph: StreamFragmentGraph,
     /// local fragment id
     next_local_fragment_id: u32,
+
+    /// Next local table id to be allocated. It equals to total table ids cnt when finish stream
+    /// node traversing.
+    next_local_table_id: u32,
+
+    /// Table id map. operator id -> table id.
+    /// This map will be dynamically inserted when allocate local table id. For operators need 2
+    /// table ids, (e.g. HashJoin), only record the left table id (right table id = left table
+    /// id + 1). If you need to apply relation states to stateful op, should insert into this map.
+    table_ids_map: HashMap<u64, u32>,
+
     /// rewrite will produce new operators, and we need to track next operator id
     #[derivative(Default(value = "u32::MAX - 1"))]
     next_operator_id: u32,
@@ -113,6 +124,8 @@ impl StreamFragmenter {
         Self {
             parallel_degree,
             is_legacy_frontend,
+            next_local_table_id: 0,
+            table_ids_map: HashMap::new(),
         }
         .generate_graph_inner(id_gen_manager, fragment_manager, stream_node, ctx)
         .await
@@ -190,29 +203,21 @@ impl StreamFragmenter {
                     .await? as _;
 
                 // Compute how many table ids should be allocated for all actors.
-                let mut table_ids_cnt = 0;
-                for (local_fragment_id, fragment) in fragment_graph.fragments() {
-                    let num_of_actors = fragment_actors
-                        .get(local_fragment_id)
-                        .expect("Fragment should have at least one actor")
-                        .len();
-                    // Total table ids number equals to table ids cnt in all actors.
-                    table_ids_cnt += num_of_actors * fragment.table_ids_cnt;
-                }
+                // Allocate all needed table ids for current MV.
+                let table_ids_len = self.next_local_table_id;
                 let start_table_id = id_gen_manager
                     .generate_interval::<{ IdCategory::Table }>(table_ids_cnt as i32)
                     .await? as _;
                 (actor_len, start_actor_id, table_ids_cnt, start_table_id)
             };
 
-            stream_graph_builder.build(
-                ctx,
-                start_actor_id,
-                actor_len,
-                start_table_id,
-                table_ids_cnt as u32,
-            )?
-        };
+        stream_graph_builder.build(
+            ctx,
+            start_actor_id,
+            actor_len,
+            &self.table_ids_map,
+            start_table_id,
+        )?};
 
         // Serialize the graph
         let stream_graph = stream_graph
@@ -363,7 +368,10 @@ impl StreamFragmenter {
         // For HashJoin nodes, attempting to rewrite to delta joins only on inner join
         // with only equal conditions
         if let Node::HashJoinNode(hash_join_node) = stream_node.get_node()? {
-            current_fragment.table_ids_cnt += 2;
+            self.table_ids_map
+                .entry(stream_node.operator_id)
+                .or_insert(self.next_local_table_id);
+            self.next_local_table_id += 2;
             if hash_join_node.is_delta_join {
                 if hash_join_node.get_join_type()? == JoinType::Inner
                     && hash_join_node.condition.is_none()

--- a/src/meta/src/stream/stream_manager.rs
+++ b/src/meta/src/stream/stream_manager.rs
@@ -61,8 +61,8 @@ pub struct CreateMaterializedViewContext {
     pub hash_mapping: Vec<ParallelUnitId>,
     /// Distribution key of materialize node in current mview.
     pub distribution_keys: Vec<i32>,
-    /// Used for allocating internal table ids.
-    pub next_local_table_id: u32,
+    /// Table id offset get from meta id generator. Used to calculate global unique table id.
+    pub table_id_offset: u32,
     /// TODO: remove this when we deprecate Java frontend.
     pub is_legacy_frontend: bool,
 }
@@ -266,7 +266,7 @@ where
             affiliated_source,
             hash_mapping,
             distribution_keys: _,
-            next_local_table_id: _,
+            table_id_offset: _,
             is_legacy_frontend,
         }: CreateMaterializedViewContext,
     ) -> Result<()> {


### PR DESCRIPTION
## What's changed and what's your intention?

Should resolve #2028  and #2032 . After this PR, different actors of same fragment should fix back to use same table id. And it do not introduce new round of StreamNode traverse.

<strike>

* Add a HashMap `table_ids_map` in fragmenter. (operator_id -> local table ids). It records the local table ids of each stateful operator. For cases that generate new operator
   *  Exchange -> Dispatcher/Merge. They do not need table ids so it's safe.
   * Delta Join rewrite. Might generate Arrange Executors, so if Delta Join needs table states it should update this map.

* When serialize StreamNode, get local table id from `table_ids_map` via operator id. Add the `start_table_id` and we get global table id.

</strike>

There will be a two-phase rewrite. First rewrite only write local table id into `StreamNode` (Build Fragment). Second rewrite will write local table id + offset (global table id) into `StreamNode` (Build actors). 

Note that I do not use a enum to wrap TableId (Like `LocalFragmentId`, `LocalActorId`) cuz i think it's a bit over-design. 

Welcome for suggestions.

## Checklist

- [x] I have written necessary docs and comments
- [x] I have added necessary unit tests and integration tests

## Refer to a related PR or issue link (optional)
