### PR TITLE
fix(metrics): correct compaction metrics

### DIFF
--- a/src/meta/src/hummock/compaction.rs
+++ b/src/meta/src/hummock/compaction.rs
@@ -23,7 +23,7 @@ use rand::thread_rng;
 use risingwave_common::error::Result;
 use risingwave_hummock_sdk::key::{user_key, FullKey};
 use risingwave_hummock_sdk::key_range::KeyRange;
-use risingwave_hummock_sdk::{HummockEpoch, HummockVersionId};
+use risingwave_hummock_sdk::HummockEpoch;
 use risingwave_pb::hummock::{
     CompactMetrics, CompactTask, HummockVersion, Level, LevelEntry, LevelType, SstableInfo,
     TableSetStatistics,
@@ -415,10 +415,8 @@ impl CompactStatus {
     pub fn apply_compact_result(
         compact_task: &CompactTask,
         based_hummock_version: HummockVersion,
-        new_version_id: HummockVersionId,
     ) -> HummockVersion {
         let mut new_version = based_hummock_version;
-        new_version.id = new_version_id;
         new_version.safe_epoch = std::cmp::max(new_version.safe_epoch, compact_task.watermark);
         for (idx, input_level) in compact_task.input_ssts.iter().enumerate() {
             new_version.levels[idx].table_infos.retain(|sst| {

--- a/src/meta/src/hummock/hummock_manager_tests.rs
+++ b/src/meta/src/hummock/hummock_manager_tests.rs
@@ -930,7 +930,7 @@ async fn test_print_compact_task() -> Result<()> {
         0
     );
 
-    let s = compact_task_to_string(compact_task);
+    let s = compact_task_to_string(&compact_task);
     assert!(s.contains("Compaction task id: 1, target level: 1"));
 
     Ok(())

--- a/src/storage/hummock_sdk/src/compact.rs
+++ b/src/storage/hummock_sdk/src/compact.rs
@@ -14,7 +14,7 @@
 
 use risingwave_pb::hummock::CompactTask;
 
-pub fn compact_task_to_string(compact_task: CompactTask) -> String {
+pub fn compact_task_to_string(compact_task: &CompactTask) -> String {
     let mut s = String::new();
     s.push_str(&format!(
         "Compaction task id: {:?}, target level: {:?}\n",

--- a/src/storage/src/hummock/compactor.rs
+++ b/src/storage/src/hummock/compactor.rs
@@ -181,7 +181,7 @@ impl Compactor {
     pub async fn compact(context: Arc<CompactorContext>, compact_task: CompactTask) {
         tracing::debug!(
             "Ready to handle compaction task: \n{}",
-            compact_task_to_string(compact_task.clone())
+            compact_task_to_string(&compact_task)
         );
 
         // Number of splits (key ranges) is equal to number of compaction tasks


### PR DESCRIPTION
## What's changed and what's your intention?

Fix incorrect compaction metrics due to changes in https://github.com/singularity-data/risingwave/pull/2062.

- `trigger_sst_stat` should read number of SSTs should from `HummockVersion` now.

## Checklist

## Refer to a related PR or issue link (optional)
