### PR TITLE
feat(frontend): record index in catalog

### DIFF
--- a/Makefile.toml
+++ b/Makefile.toml
@@ -114,6 +114,7 @@ fi
 [tasks.link-standalone-binaries]
 category = "RiseDev - Build"
 description = "Link standalone cmds to RiseDev bin"
+condition = { env_not_set = [ "ENABLE_ALL_IN_ONE" ] }
 script = '''
 #!@shell
 set -e

--- a/proto/catalog.proto
+++ b/proto/catalog.proto
@@ -58,6 +58,7 @@ message Table {
   oneof optional_associated_source_id {
     uint32 associated_source_id = 9;
   }
+  bool is_index = 10;
 }
 
 message Schema {

--- a/src/frontend/src/catalog/table_catalog.rs
+++ b/src/frontend/src/catalog/table_catalog.rs
@@ -32,6 +32,7 @@ pub struct TableCatalog {
     pub name: String,
     pub columns: Vec<ColumnCatalog>,
     pub pk_desc: Vec<OrderedColumnDesc>,
+    pub is_index: bool,
 }
 
 impl TableCatalog {
@@ -94,6 +95,7 @@ impl TableCatalog {
             optional_associated_source_id: self
                 .associated_source_id
                 .map(|source_id| OptionalAssociatedSourceId::AssociatedSourceId(source_id.into())),
+            is_index: self.is_index,
         }
     }
 }
@@ -139,6 +141,7 @@ impl From<ProstTable> for TableCatalog {
             name,
             pk_desc,
             columns,
+            is_index: tb.is_index,
         }
     }
 }
@@ -165,6 +168,7 @@ mod tests {
     #[test]
     fn test_into_table_catalog() {
         let table: TableCatalog = ProstTable {
+            is_index: false,
             id: 0,
             schema_id: 0,
             database_id: 0,
@@ -206,6 +210,7 @@ mod tests {
         assert_eq!(
             table,
             TableCatalog {
+                is_index: false,
                 id: TableId::new(0),
                 associated_source_id: Some(TableId::new(233)),
                 name: "test".to_string(),

--- a/src/frontend/src/optimizer/plan_node/stream_materialize.rs
+++ b/src/frontend/src/optimizer/plan_node/stream_materialize.rs
@@ -100,19 +100,19 @@ impl StreamMaterialize {
 
     /// Create a materialize node.
     ///
-    /// When creating index, `distribute_only_order_by` should be true. We should distribute keys
+    /// When creating index, `is_index` should be true. Then, materialize will distribute keys
     /// using order by columns, instead of pk.
     pub fn create(
         input: PlanRef,
         mv_name: String,
         user_order_by: Order,
         user_cols: FixedBitSet,
-        distribute_only_order_by: bool,
+        is_index: bool,
     ) -> Result<Self> {
         // ensure the same pk will not shuffle to different node
         let input = match input.distribution() {
             Distribution::Single => input,
-            _ => Distribution::HashShard(if distribute_only_order_by {
+            _ => Distribution::HashShard(if is_index {
                 user_order_by.field_order.iter().map(|x| x.index).collect()
             } else {
                 input.pk_indices().to_vec()
@@ -166,6 +166,7 @@ impl StreamMaterialize {
             name: mv_name,
             columns,
             pk_desc,
+            is_index,
         };
 
         Ok(Self { base, input, table })


### PR DESCRIPTION
Signed-off-by: Alex Chi <iskyzh@gmail.com>

## What's changed and what's your intention?

If `is_index` is true, then this table is actually an index.

I'm thinking of whether we need a separate `IndexCatalog` in the future. But for now, let's keep everything simple and just make it a special table.

## Checklist

- [x] I have written necessary docs and comments
- [x] I have added necessary unit tests and integration tests

## Refer to a related PR or issue link (optional)

close https://github.com/singularity-data/risingwave/issues/2015
close https://github.com/singularity-data/risingwave/issues/1908