### PR TITLE
refactor(fragmenter): split fileds into different structs -- lose weight!

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1216,6 +1216,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "eaa37046cc0f6c3cc6090fbdbf73ef0b8ef4cfcc37f6befc0020f63e8cf121e1"
 
 [[package]]
+name = "derivative"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fcc3dd5e9e9c0b295d6e1e4d811fb6f157d5ffd784b8d202fc62eac8035a770b"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "derive_utils"
 version = "0.11.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3623,6 +3634,7 @@ dependencies = [
  "chrono",
  "clap 3.1.9",
  "crc32fast",
+ "derivative",
  "either",
  "etcd-client",
  "futures",

--- a/src/meta/Cargo.toml
+++ b/src/meta/Cargo.toml
@@ -15,6 +15,7 @@ bytes = { version = "1", features = ["serde"] }
 chrono = "0.4"
 clap = { version = "3", features = ["derive"] }
 crc32fast = "1"
+derivative = "2"
 either = "1"
 etcd-client = "0.9"
 futures = { version = "0.3", default-features = false, features = ["alloc"] }

--- a/src/meta/src/stream/fragmenter/graph/fragment_graph.rs
+++ b/src/meta/src/stream/fragmenter/graph/fragment_graph.rs
@@ -101,6 +101,7 @@ impl StreamFragment {
 }
 
 /// [`StreamFragmentGraph`] stores a fragment graph (DAG).
+#[derive(Default)]
 pub struct StreamFragmentGraph {
     /// stores all the fragments in the graph.
     fragments: HashMap<LocalFragmentId, StreamFragment>,
@@ -116,15 +117,6 @@ pub struct StreamFragmentGraph {
 }
 
 impl StreamFragmentGraph {
-    pub fn new() -> Self {
-        Self {
-            fragments: HashMap::new(),
-            downstreams: HashMap::new(),
-            upstreams: HashMap::new(),
-            sealed: false,
-        }
-    }
-
     pub fn fragments(&self) -> &HashMap<LocalFragmentId, StreamFragment> {
         &self.fragments
     }

--- a/src/meta/src/stream/fragmenter/graph/stream_graph.rs
+++ b/src/meta/src/stream/fragmenter/graph/stream_graph.rs
@@ -390,7 +390,7 @@ impl StreamGraphBuilder {
 
     /// Build final stream DAG with dependencies with current actor builders.
     pub fn build(
-        &mut self,
+        mut self,
         ctx: &mut CreateMaterializedViewContext,
         actor_id_offset: u32,
         actor_id_len: u32,

--- a/src/meta/src/stream/fragmenter/rewrite/delta_join.rs
+++ b/src/meta/src/stream/fragmenter/rewrite/delta_join.rs
@@ -21,17 +21,18 @@ use risingwave_pb::stream_plan::{
 };
 
 use super::super::{StreamFragment, StreamFragmentEdge};
-use crate::storage::MetaStore;
+use crate::stream::fragmenter::BuildFragmentGraphState;
 use crate::stream::StreamFragmenter;
 
-impl<S> StreamFragmenter<S>
-where
-    S: MetaStore,
-{
+impl StreamFragmenter {
     /// All exchanges inside delta join is one-to-one exchange.
-    fn build_exchange_for_delta_join(&mut self, upstream: &StreamNode) -> StreamNode {
+    fn build_exchange_for_delta_join(
+        &self,
+        state: &mut BuildFragmentGraphState,
+        upstream: &StreamNode,
+    ) -> StreamNode {
         StreamNode {
-            operator_id: self.gen_operator_id() as u64,
+            operator_id: state.gen_operator_id() as u64,
             identity: "Exchange (Lookup and Merge)".into(),
             fields: upstream.fields.clone(),
             pk_indices: upstream.pk_indices.clone(),
@@ -48,7 +49,8 @@ where
     /// We should shuffle upstream data to make sure it meets the distribution requirement of hash
     /// join.
     fn build_input_with_exchange(
-        &mut self,
+        &self,
+        state: &mut BuildFragmentGraphState,
         mut upstream: StreamNode,
     ) -> Result<(StreamFragmentEdge, StreamFragment, StreamNode)> {
         match &upstream.node {
@@ -57,7 +59,7 @@ where
                 let exchange_node = exchange_node.clone();
                 assert_eq!(upstream.input.len(), 1);
                 let child_node = upstream.input.remove(0);
-                let child_fragment = self.build_and_add_fragment(child_node)?;
+                let child_fragment = self.build_and_add_fragment(state, child_node)?;
                 Ok((
                     StreamFragmentEdge {
                         dispatch_strategy: exchange_node.get_strategy()?.clone(),
@@ -74,7 +76,7 @@ where
             // Otherwise, use 1-to-1 exchange
             _ => {
                 let strategy = Self::dispatch_no_shuffle();
-                let operator_id = self.gen_operator_id() as u64;
+                let operator_id = state.gen_operator_id() as u64;
                 let node = StreamNode {
                     input: vec![],
                     identity: "Exchange (Arrange)".into(),
@@ -87,7 +89,7 @@ where
                     append_only: upstream.append_only,
                 };
 
-                let child_fragment = self.build_and_add_fragment(upstream)?;
+                let child_fragment = self.build_and_add_fragment(state, upstream)?;
 
                 Ok((
                     StreamFragmentEdge {
@@ -103,12 +105,14 @@ where
     }
 
     fn build_arrange_for_delta_join(
-        &mut self,
+        &self,
+        state: &mut BuildFragmentGraphState,
+
         exchange_node: &StreamNode,
         arrange_key_indexes: Vec<i32>,
     ) -> StreamNode {
         StreamNode {
-            operator_id: self.gen_operator_id() as u64,
+            operator_id: state.gen_operator_id() as u64,
             identity: "Arrange".into(),
             fields: exchange_node.fields.clone(),
             pk_indices: exchange_node.pk_indices.clone(),
@@ -128,13 +132,14 @@ where
     }
 
     fn build_lookup_for_delta_join(
-        &mut self,
+        &self,
+        state: &mut BuildFragmentGraphState,
         (exchange_node_arrangement, exchange_node_stream): (&StreamNode, &StreamNode),
         (output_fields, output_pk_indices): (Vec<Field>, Vec<u32>),
         lookup_node: LookupNode,
     ) -> StreamNode {
         StreamNode {
-            operator_id: self.gen_operator_id() as u64,
+            operator_id: state.gen_operator_id() as u64,
             identity: "Lookup".into(),
             fields: output_fields,
             pk_indices: output_pk_indices,
@@ -147,8 +152,9 @@ where
         }
     }
 
-    pub fn build_delta_join(
-        &mut self,
+    pub(in super::super) fn build_delta_join(
+        &self,
+        state: &mut BuildFragmentGraphState,
         current_fragment: &mut StreamFragment,
         mut node: StreamNode,
     ) -> Result<StreamNode> {
@@ -180,41 +186,48 @@ where
         //
         // TODO: support multi-way join.
 
-        let exchange_a0l0 = self.build_exchange_for_delta_join(&node.input[0]);
-        let exchange_a0l1 = self.build_exchange_for_delta_join(&node.input[0]);
-        let exchange_a1l0 = self.build_exchange_for_delta_join(&node.input[1]);
-        let exchange_a1l1 = self.build_exchange_for_delta_join(&node.input[1]);
+        let exchange_a0l0 = self.build_exchange_for_delta_join(state, &node.input[0]);
+        let exchange_a0l1 = self.build_exchange_for_delta_join(state, &node.input[0]);
+        let exchange_a1l0 = self.build_exchange_for_delta_join(state, &node.input[1]);
+        let exchange_a1l1 = self.build_exchange_for_delta_join(state, &node.input[1]);
 
         let i0_length = node.input[0].fields.len();
         let i1_length = node.input[1].fields.len();
 
         let (link_i1a1, input_1_frag, exchange_i1a1) =
-            self.build_input_with_exchange(node.input.remove(1))?;
+            self.build_input_with_exchange(state, node.input.remove(1))?;
 
         let (link_i0a0, input_0_frag, exchange_i0a0) =
-            self.build_input_with_exchange(node.input.remove(0))?;
+            self.build_input_with_exchange(state, node.input.remove(0))?;
 
-        let arrange_0 =
-            self.build_arrange_for_delta_join(&exchange_i0a0, hash_join_node.left_key.clone());
-        let arrange_1 =
-            self.build_arrange_for_delta_join(&exchange_i1a1, hash_join_node.right_key.clone());
+        let arrange_0 = self.build_arrange_for_delta_join(
+            state,
+            &exchange_i0a0,
+            hash_join_node.left_key.clone(),
+        );
+        let arrange_1 = self.build_arrange_for_delta_join(
+            state,
+            &exchange_i1a1,
+            hash_join_node.right_key.clone(),
+        );
 
-        let arrange_0_frag = self.build_and_add_fragment(arrange_0)?;
-        let arrange_1_frag = self.build_and_add_fragment(arrange_1)?;
+        let arrange_0_frag = self.build_and_add_fragment(state, arrange_0)?;
+        let arrange_1_frag = self.build_and_add_fragment(state, arrange_1)?;
 
-        self.fragment_graph.add_edge(
+        state.fragment_graph.add_edge(
             input_0_frag.fragment_id,
             arrange_0_frag.fragment_id,
             link_i0a0,
         );
 
-        self.fragment_graph.add_edge(
+        state.fragment_graph.add_edge(
             input_1_frag.fragment_id,
             arrange_1_frag.fragment_id,
             link_i1a1,
         );
 
         let lookup_0 = self.build_lookup_for_delta_join(
+            state,
             (&exchange_a1l0, &exchange_a0l0),
             (node.fields.clone(), node.pk_indices.clone()),
             LookupNode {
@@ -233,6 +246,7 @@ where
         );
 
         let lookup_1 = self.build_lookup_for_delta_join(
+            state,
             (&exchange_a0l1, &exchange_a1l1),
             (node.fields.clone(), node.pk_indices.clone()),
             LookupNode {
@@ -247,10 +261,10 @@ where
             },
         );
 
-        let lookup_0_frag = self.build_and_add_fragment(lookup_0)?;
-        let lookup_1_frag = self.build_and_add_fragment(lookup_1)?;
+        let lookup_0_frag = self.build_and_add_fragment(state, lookup_0)?;
+        let lookup_1_frag = self.build_and_add_fragment(state, lookup_1)?;
 
-        self.fragment_graph.add_edge(
+        state.fragment_graph.add_edge(
             arrange_0_frag.fragment_id,
             lookup_0_frag.fragment_id,
             StreamFragmentEdge {
@@ -260,7 +274,7 @@ where
             },
         );
 
-        self.fragment_graph.add_edge(
+        state.fragment_graph.add_edge(
             arrange_0_frag.fragment_id,
             lookup_1_frag.fragment_id,
             StreamFragmentEdge {
@@ -270,7 +284,7 @@ where
             },
         );
 
-        self.fragment_graph.add_edge(
+        state.fragment_graph.add_edge(
             arrange_1_frag.fragment_id,
             lookup_0_frag.fragment_id,
             StreamFragmentEdge {
@@ -280,7 +294,7 @@ where
             },
         );
 
-        self.fragment_graph.add_edge(
+        state.fragment_graph.add_edge(
             arrange_1_frag.fragment_id,
             lookup_1_frag.fragment_id,
             StreamFragmentEdge {
@@ -290,11 +304,11 @@ where
             },
         );
 
-        let exchange_l0m = self.build_exchange_for_delta_join(&node);
-        let exchange_l1m = self.build_exchange_for_delta_join(&node);
+        let exchange_l0m = self.build_exchange_for_delta_join(state, &node);
+        let exchange_l1m = self.build_exchange_for_delta_join(state, &node);
 
         let union = StreamNode {
-            operator_id: self.gen_operator_id() as u64,
+            operator_id: state.gen_operator_id() as u64,
             identity: "Union".into(),
             fields: node.fields.clone(),
             pk_indices: node.pk_indices.clone(),
@@ -303,7 +317,7 @@ where
             append_only: node.append_only,
         };
 
-        self.fragment_graph.add_edge(
+        state.fragment_graph.add_edge(
             lookup_0_frag.fragment_id,
             current_fragment.fragment_id,
             StreamFragmentEdge {
@@ -313,7 +327,7 @@ where
             },
         );
 
-        self.fragment_graph.add_edge(
+        state.fragment_graph.add_edge(
             lookup_1_frag.fragment_id,
             current_fragment.fragment_id,
             StreamFragmentEdge {

--- a/src/meta/src/stream/fragmenter/rewrite/delta_join.rs
+++ b/src/meta/src/stream/fragmenter/rewrite/delta_join.rs
@@ -20,8 +20,7 @@ use risingwave_pb::stream_plan::{
     ArrangeNode, DispatchStrategy, DispatcherType, ExchangeNode, LookupNode, StreamNode, UnionNode,
 };
 
-use super::super::{StreamFragment, StreamFragmentEdge};
-use crate::stream::fragmenter::BuildFragmentGraphState;
+use crate::stream::fragmenter::{BuildFragmentGraphState, StreamFragment, StreamFragmentEdge};
 use crate::stream::StreamFragmenter;
 
 impl StreamFragmenter {


### PR DESCRIPTION
## What's changed and what's your intention?

- Mutable states are split into `BuildFragmentGraphState` and `BuildActorGraphState`
  
  The two stage of fragmenter is orthogonal, after splitting the mutable states into two places, what variables are mutated/referenced become more clear, and only `&self` is used for `StreamFragmenter`

- For the remaining fields, `XxManagerRef` can be used directly thus removed. `parallel_degree` and `is_legacy_frontend` are kept for simplicity



## Checklist

- ~~[ ] I have written necessary docs and comments~~
- ~~[ ] I have added necessary unit tests and integration tests~~

## Refer to a related PR or issue link (optional)
