### PR TITLE
feat(frontend): generate delta join plan when index matches

### DIFF
--- a/proto/catalog.proto
+++ b/proto/catalog.proto
@@ -59,6 +59,7 @@ message Table {
     uint32 associated_source_id = 9;
   }
   bool is_index = 10;
+  uint32 index_on_id = 11;
 }
 
 message Schema {

--- a/src/frontend/src/binder/relation/table_or_source.rs
+++ b/src/frontend/src/binder/relation/table_or_source.rs
@@ -12,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use std::sync::Arc;
+
 use risingwave_common::catalog::ColumnDesc;
 use risingwave_common::error::{ErrorCode, Result, RwError};
 use risingwave_sqlparser::ast::{ObjectName, TableAlias};
@@ -26,16 +28,7 @@ pub struct BoundBaseTable {
     pub name: String, // explain-only
     pub table_id: TableId,
     pub table_catalog: TableCatalog,
-}
-
-impl From<&TableCatalog> for BoundBaseTable {
-    fn from(t: &TableCatalog) -> Self {
-        Self {
-            name: t.name.clone(),
-            table_id: t.id,
-            table_catalog: t.clone(),
-        }
-    }
+    pub table_indexes: Vec<Arc<TableCatalog>>,
 }
 
 /// `BoundTableSource` is used by DML statement on table source like insert, updata
@@ -83,23 +76,32 @@ impl Binder {
         let (ret, columns) = {
             let catalog = &self.catalog;
 
-            catalog
-                .get_table_by_name(&self.db_name, schema_name, table_name)
-                .map(|t| (Relation::BaseTable(Box::new(t.into())), t.columns.clone()))
-                .or_else(|_| {
-                    catalog
-                        .get_source_by_name(&self.db_name, schema_name, table_name)
-                        .map(|s| {
-                            let source = s.clone().flatten();
-                            (Relation::Source(Box::new((&source).into())), source.columns)
-                        })
-                })
-                .map_err(|_| {
-                    RwError::from(CatalogError::NotFound(
-                        "table or source",
-                        table_name.to_string(),
-                    ))
-                })?
+            if let Ok(table_catalog) =
+                catalog.get_table_by_name(&self.db_name, schema_name, table_name)
+            {
+                let table_id = table_catalog.id();
+                let table_catalog = table_catalog.clone();
+                let columns = table_catalog.columns.clone();
+                let table_indexes = self.resolve_table_indexes(schema_name, table_id)?;
+
+                let table = BoundBaseTable {
+                    name: table_name.to_string(),
+                    table_id,
+                    table_catalog,
+                    table_indexes,
+                };
+
+                (Relation::BaseTable(Box::new(table)), columns)
+            } else if let Ok(s) = catalog.get_source_by_name(&self.db_name, schema_name, table_name)
+            {
+                let source = s.clone().flatten();
+                (Relation::Source(Box::new((&source).into())), source.columns)
+            } else {
+                return Err(RwError::from(CatalogError::NotFound(
+                    "table or source",
+                    table_name.to_string(),
+                )));
+            }
         };
 
         self.bind_context(
@@ -113,6 +115,20 @@ impl Binder {
         Ok(ret)
     }
 
+    fn resolve_table_indexes(
+        &mut self,
+        schema_name: &str,
+        table_id: TableId,
+    ) -> Result<Vec<Arc<TableCatalog>>> {
+        Ok(self
+            .catalog
+            .get_schema_by_name(&self.db_name, schema_name)?
+            .iter_mv()
+            .filter(|x| x.is_index_on == Some(table_id))
+            .map(|table| table.clone().into())
+            .collect())
+    }
+
     pub(crate) fn bind_table(
         &mut self,
         schema_name: &str,
@@ -123,6 +139,10 @@ impl Binder {
             .catalog
             .get_table_by_name(&self.db_name, schema_name, table_name)?
             .clone();
+
+        let table_id = table_catalog.id();
+        let table_indexes = self.resolve_table_indexes(schema_name, table_id)?;
+
         let columns = table_catalog.columns.clone();
 
         self.bind_context(
@@ -134,11 +154,11 @@ impl Binder {
             alias,
         )?;
 
-        let table_id = table_catalog.id();
         Ok(BoundBaseTable {
             name: table_name.to_string(),
             table_id,
             table_catalog,
+            table_indexes,
         })
     }
 

--- a/src/frontend/src/catalog/table_catalog.rs
+++ b/src/frontend/src/catalog/table_catalog.rs
@@ -32,7 +32,7 @@ pub struct TableCatalog {
     pub name: String,
     pub columns: Vec<ColumnCatalog>,
     pub pk_desc: Vec<OrderedColumnDesc>,
-    pub is_index: bool,
+    pub is_index_on: Option<TableId>,
 }
 
 impl TableCatalog {
@@ -95,7 +95,8 @@ impl TableCatalog {
             optional_associated_source_id: self
                 .associated_source_id
                 .map(|source_id| OptionalAssociatedSourceId::AssociatedSourceId(source_id.into())),
-            is_index: self.is_index,
+            is_index: self.is_index_on.is_some(),
+            index_on_id: self.is_index_on.unwrap_or_default().table_id(),
         }
     }
 }
@@ -141,7 +142,11 @@ impl From<ProstTable> for TableCatalog {
             name,
             pk_desc,
             columns,
-            is_index: tb.is_index,
+            is_index_on: if tb.is_index {
+                Some(tb.index_on_id.into())
+            } else {
+                None
+            },
         }
     }
 }
@@ -169,6 +174,7 @@ mod tests {
     fn test_into_table_catalog() {
         let table: TableCatalog = ProstTable {
             is_index: false,
+            index_on_id: 0,
             id: 0,
             schema_id: 0,
             database_id: 0,
@@ -210,7 +216,7 @@ mod tests {
         assert_eq!(
             table,
             TableCatalog {
-                is_index: false,
+                is_index_on: None,
                 id: TableId::new(0),
                 associated_source_id: Some(TableId::new(233)),
                 name: "test".to_string(),

--- a/src/frontend/src/handler/create_index.rs
+++ b/src/frontend/src/handler/create_index.rs
@@ -97,6 +97,8 @@ pub(crate) fn gen_create_index_plan(
             table_name,
             (0..table_desc.columns.len()).into_iter().collect(),
             table_desc,
+            // indexes are only used by DeltaJoin rule, and we don't need to provide them here.
+            vec![],
             context,
         ));
         let mut required_cols = FixedBitSet::with_capacity(scan_node.schema().len());
@@ -114,7 +116,7 @@ pub(crate) fn gen_create_index_plan(
             ),
             required_cols,
         )
-        .gen_create_index_plan(index_name.to_string())?
+        .gen_create_index_plan(index_name.to_string(), table.id())?
     };
 
     let (index_schema_name, index_table_name) = Binder::resolve_table_name(index_name)?;

--- a/src/frontend/src/optimizer/plan_node/mod.rs
+++ b/src/frontend/src/optimizer/plan_node/mod.rs
@@ -236,6 +236,7 @@ mod logical_scan;
 mod logical_source;
 mod logical_topn;
 mod logical_values;
+mod stream_delta_join;
 mod stream_exchange;
 mod stream_filter;
 mod stream_hash_agg;
@@ -274,6 +275,7 @@ pub use logical_scan::LogicalScan;
 pub use logical_source::LogicalSource;
 pub use logical_topn::LogicalTopN;
 pub use logical_values::LogicalValues;
+pub use stream_delta_join::StreamDeltaJoin;
 pub use stream_exchange::StreamExchange;
 pub use stream_filter::StreamFilter;
 pub use stream_hash_agg::StreamHashAgg;
@@ -343,6 +345,7 @@ macro_rules! for_all_plan_nodes {
             ,{ Stream, Materialize }
             ,{ Stream, TopN }
             ,{ Stream, HopWindow }
+            ,{ Stream, DeltaJoin }
         }
     };
 }
@@ -412,6 +415,7 @@ macro_rules! for_stream_plan_nodes {
             ,{ Stream, Materialize }
             ,{ Stream, TopN }
             ,{ Stream, HopWindow }
+            ,{ Stream, DeltaJoin }
         }
     };
 }

--- a/src/frontend/src/optimizer/plan_node/stream_delta_join.rs
+++ b/src/frontend/src/optimizer/plan_node/stream_delta_join.rs
@@ -41,10 +41,10 @@ impl StreamDeltaJoin {
         // Inner join won't change the append-only behavior of the stream. The rest might.
         let append_only = match logical.join_type() {
             JoinType::Inner => logical.left().append_only() && logical.right().append_only(),
-            _ => panic!("delta join only supports inner join for now"),
+            _ => todo!("delta join only supports inner join for now"),
         };
         if eq_join_predicate.has_non_eq() {
-            panic!("non-eq condition not supported for delta join");
+            todo!("non-eq condition not supported for delta join");
         }
         let dist = StreamHashJoin::derive_dist(
             logical.left().distribution(),
@@ -79,7 +79,7 @@ impl fmt::Display for StreamDeltaJoin {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(
             f,
-            "StreamDeltaHashJoin {{ type: {:?}, predicate: {} }}",
+            "StreamDeltaJoin {{ type: {:?}, predicate: {} }}",
             self.logical.join_type(),
             self.eq_join_predicate()
         )

--- a/src/frontend/src/optimizer/plan_node/stream_delta_join.rs
+++ b/src/frontend/src/optimizer/plan_node/stream_delta_join.rs
@@ -19,52 +19,39 @@ use risingwave_pb::plan::JoinType;
 use risingwave_pb::stream_plan::stream_node::Node;
 use risingwave_pb::stream_plan::HashJoinNode;
 
-use super::{LogicalJoin, PlanBase, PlanRef, PlanTreeNodeBinary, StreamDeltaJoin, ToStreamProst};
+use super::{LogicalJoin, PlanBase, PlanRef, PlanTreeNodeBinary, StreamHashJoin, ToStreamProst};
 use crate::expr::Expr;
 use crate::optimizer::plan_node::EqJoinPredicate;
-use crate::optimizer::property::Distribution;
-use crate::utils::ColIndexMapping;
 
-/// [`StreamHashJoin`] implements [`super::LogicalJoin`] with hash table. It builds a hash table
-/// from inner (right-side) relation and probes with data from outer (left-side) relation to
-/// get output rows.
+/// [`StreamDeltaJoin`] implements [`super::LogicalJoin`] with delta join. It requires its two
+/// inputs to be indexes.
 #[derive(Debug, Clone)]
-pub struct StreamHashJoin {
+pub struct StreamDeltaJoin {
     pub base: PlanBase,
     logical: LogicalJoin,
 
     /// The join condition must be equivalent to `logical.on`, but separated into equal and
     /// non-equal parts to facilitate execution later
     eq_join_predicate: EqJoinPredicate,
-
-    /// Whether to force use delta join for this join node. If this is true, then indexes will
-    /// be create automatically when building the executors on meta service. For testing purpose
-    /// only. Will remove after we have fully support shared state and index.
-    is_delta: bool,
 }
 
-pub static DELTA_JOIN: &str = "RW_FORCE_DELTA_JOIN";
-
-impl StreamHashJoin {
+impl StreamDeltaJoin {
     pub fn new(logical: LogicalJoin, eq_join_predicate: EqJoinPredicate) -> Self {
         let ctx = logical.base.ctx.clone();
         // Inner join won't change the append-only behavior of the stream. The rest might.
         let append_only = match logical.join_type() {
             JoinType::Inner => logical.left().append_only() && logical.right().append_only(),
-            _ => false,
+            _ => panic!("delta join only supports inner join for now"),
         };
-        let dist = Self::derive_dist(
+        if eq_join_predicate.has_non_eq() {
+            panic!("non-eq condition not supported for delta join");
+        }
+        let dist = StreamHashJoin::derive_dist(
             logical.left().distribution(),
             logical.right().distribution(),
             &eq_join_predicate,
             &logical.l2o_col_mapping(),
         );
-
-        let force_delta = if let Some(config) = ctx.inner().session_ctx.get_config(DELTA_JOIN) {
-            config.is_set(false)
-        } else {
-            false
-        };
 
         // TODO: derive from input
         let base = PlanBase::new_stream(
@@ -79,60 +66,27 @@ impl StreamHashJoin {
             base,
             logical,
             eq_join_predicate,
-            is_delta: force_delta,
         }
-    }
-
-    /// Get join type
-    pub fn join_type(&self) -> JoinType {
-        self.logical.join_type()
     }
 
     /// Get a reference to the batch hash join's eq join predicate.
     pub fn eq_join_predicate(&self) -> &EqJoinPredicate {
         &self.eq_join_predicate
     }
-
-    pub(super) fn derive_dist(
-        left: &Distribution,
-        right: &Distribution,
-        predicate: &EqJoinPredicate,
-        l2o_mapping: &ColIndexMapping,
-    ) -> Distribution {
-        match (left, right) {
-            (Distribution::Single, Distribution::Single) => Distribution::Single,
-            (Distribution::HashShard(_), Distribution::HashShard(_)) => {
-                assert!(left.satisfies(&Distribution::HashShard(predicate.left_eq_indexes())));
-                assert!(right.satisfies(&Distribution::HashShard(predicate.right_eq_indexes())));
-                l2o_mapping.rewrite_provided_distribution(left)
-            }
-            (_, _) => panic!(),
-        }
-    }
-
-    /// Convert this hash join to a delta join plan
-    pub fn to_delta_join(&self) -> StreamDeltaJoin {
-        StreamDeltaJoin::new(self.logical.clone(), self.eq_join_predicate.clone())
-    }
 }
 
-impl fmt::Display for StreamHashJoin {
+impl fmt::Display for StreamDeltaJoin {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(
             f,
-            "{} {{ type: {:?}, predicate: {} }}",
-            if self.is_delta {
-                "StreamDeltaHashJoin"
-            } else {
-                "StreamHashJoin"
-            },
+            "StreamDeltaHashJoin {{ type: {:?}, predicate: {} }}",
             self.logical.join_type(),
             self.eq_join_predicate()
         )
     }
 }
 
-impl PlanTreeNodeBinary for StreamHashJoin {
+impl PlanTreeNodeBinary for StreamDeltaJoin {
     fn left(&self) -> PlanRef {
         self.logical.left()
     }
@@ -149,10 +103,12 @@ impl PlanTreeNodeBinary for StreamHashJoin {
     }
 }
 
-impl_plan_tree_node_for_binary! { StreamHashJoin }
+impl_plan_tree_node_for_binary! { StreamDeltaJoin }
 
-impl ToStreamProst for StreamHashJoin {
+impl ToStreamProst for StreamDeltaJoin {
     fn to_stream_prost_body(&self) -> Node {
+        // TODO: add a separate delta join node in proto, or move fragmenter to frontend so that we
+        // don't need an intermediate representation.
         Node::HashJoinNode(HashJoinNode {
             join_type: self.logical.join_type() as i32,
             left_key: self
@@ -179,7 +135,7 @@ impl ToStreamProst for StreamHashJoin {
                 .iter()
                 .map(|idx| *idx as i32)
                 .collect_vec(),
-            is_delta_join: self.is_delta,
+            is_delta_join: true,
             ..Default::default()
         })
     }

--- a/src/frontend/src/optimizer/plan_node/stream_materialize.rs
+++ b/src/frontend/src/optimizer/plan_node/stream_materialize.rs
@@ -107,12 +107,12 @@ impl StreamMaterialize {
         mv_name: String,
         user_order_by: Order,
         user_cols: FixedBitSet,
-        is_index: bool,
+        is_index_on: Option<TableId>,
     ) -> Result<Self> {
         // ensure the same pk will not shuffle to different node
         let input = match input.distribution() {
             Distribution::Single => input,
-            _ => Distribution::HashShard(if is_index {
+            _ => Distribution::HashShard(if is_index_on.is_some() {
                 user_order_by.field_order.iter().map(|x| x.index).collect()
             } else {
                 input.pk_indices().to_vec()
@@ -166,7 +166,7 @@ impl StreamMaterialize {
             name: mv_name,
             columns,
             pk_desc,
-            is_index,
+            is_index_on,
         };
 
         Ok(Self { base, input, table })

--- a/src/frontend/src/optimizer/plan_node/stream_table_scan.rs
+++ b/src/frontend/src/optimizer/plan_node/stream_table_scan.rs
@@ -55,7 +55,12 @@ impl StreamTableScan {
     pub fn table_name(&self) -> &str {
         self.logical.table_name()
     }
+
+    pub fn logical(&self) -> &LogicalScan {
+        &self.logical
+    }
 }
+
 impl_plan_tree_node_for_leaf! { StreamTableScan }
 
 impl fmt::Display for StreamTableScan {

--- a/src/frontend/src/optimizer/rule/index_delta_join.rs
+++ b/src/frontend/src/optimizer/rule/index_delta_join.rs
@@ -1,0 +1,101 @@
+// Copyright 2022 Singularity Data
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::collections::HashSet;
+use std::rc::Rc;
+
+use itertools::Itertools;
+use risingwave_pb::plan::JoinType;
+
+use super::super::plan_node::*;
+use super::{BoxedRule, Rule};
+
+/// Use index scan and delta joins for supported queries.
+pub struct IndexDeltaJoinRule {}
+
+impl Rule for IndexDeltaJoinRule {
+    fn apply(&self, plan: PlanRef) -> Option<PlanRef> {
+        let join = plan.as_stream_hash_join()?;
+        if join.eq_join_predicate().has_non_eq() || join.join_type() != JoinType::Inner {
+            return Some(plan);
+        }
+
+        fn match_through_exchange(plan: PlanRef) -> Option<PlanRef> {
+            if let Some(exchange) = plan.as_stream_exchange() {
+                match_through_exchange(exchange.input())
+            } else if plan.as_stream_table_scan().is_some() {
+                Some(plan)
+            } else {
+                None
+            }
+        }
+
+        let input_left_dyn = match_through_exchange(Rc::clone(&join.inputs()[0]))?;
+        let input_left = input_left_dyn.as_stream_table_scan()?;
+        let input_right_dyn = match_through_exchange(Rc::clone(&join.inputs()[1]))?;
+        let input_right = input_right_dyn.as_stream_table_scan()?;
+        let left_indices = join.eq_join_predicate().left_eq_indexes();
+        let right_indices = join.eq_join_predicate().right_eq_indexes();
+
+        fn match_indexes(join_indices: &[usize], table_scan: &StreamTableScan) -> bool {
+            if table_scan.logical().indexes().is_empty() {
+                return false;
+            }
+            let column_descs = table_scan.logical().column_descs();
+            // We assume column id of create index's MV is exactly the same as corresponding columns
+            // in the original table. We generate a list of column ids, and match them against
+            // prefixes of indexes.
+            let columns_to_match = join_indices
+                .iter()
+                .map(|idx| column_descs[*idx].column_id)
+                .collect_vec();
+            for index in table_scan.logical().indexes() {
+                // A HashSet containing remaining columns to match
+                let mut remaining_to_match =
+                    columns_to_match.iter().copied().collect::<HashSet<_>>();
+
+                // Begin match join columns with index prefix. e.g., if the join columns are `a, b,
+                // c`, and the index has `a, b, c` or `a, c, b` or any combination as prefix, then
+                // we can use this index.
+                for ordered_column in &index.pk {
+                    let column_id = ordered_column.column_desc.column_id;
+
+                    match remaining_to_match.remove(&column_id) {
+                        true => continue, // matched
+                        false => break,   // not matched
+                    }
+                }
+
+                if remaining_to_match.is_empty() {
+                    return true;
+                }
+            }
+
+            false
+        }
+
+        if match_indexes(&left_indices, input_left) && match_indexes(&right_indices, input_right) {
+            // TODO: rewrite child to stream index scan
+            Some(join.to_delta_join().into())
+        } else {
+            Some(plan)
+        }
+    }
+}
+
+impl IndexDeltaJoinRule {
+    pub fn create() -> BoxedRule {
+        Box::new(Self {})
+    }
+}

--- a/src/frontend/src/optimizer/rule/mod.rs
+++ b/src/frontend/src/optimizer/rule/mod.rs
@@ -18,7 +18,7 @@ use super::PlanRef;
 
 /// A one-to-one transform for the [`PlanNode`](super::plan_node::PlanNode), every [`Rule`] should
 /// downcast and check if the node matches the rule.
-pub trait Rule: Send + Sync + 'static {
+pub trait Rule: Send + Sync {
     /// return err(()) if not match
     fn apply(&self, plan: PlanRef) -> Option<PlanRef>;
 }
@@ -43,3 +43,5 @@ mod unnest_agg_for_loj;
 pub use unnest_agg_for_loj::*;
 mod pull_up_correlated_predicate;
 pub use pull_up_correlated_predicate::*;
+mod index_delta_join;
+pub use index_delta_join::*;

--- a/src/frontend/src/planner/relation.rs
+++ b/src/frontend/src/planner/relation.rs
@@ -44,6 +44,11 @@ impl Planner {
         LogicalScan::create(
             base_table.name,
             Rc::new(base_table.table_catalog.table_desc()),
+            base_table
+                .table_indexes
+                .iter()
+                .map(|x| Rc::new(x.table_desc()))
+                .collect(),
             self.ctx(),
         )
     }

--- a/src/frontend/src/scheduler/plan_fragmenter.rs
+++ b/src/frontend/src/scheduler/plan_fragmenter.rs
@@ -443,6 +443,7 @@ mod tests {
                     },
                 ],
             }),
+            vec![],
             ctx,
         ))
         .into();

--- a/src/frontend/test_runner/src/lib.rs
+++ b/src/frontend/test_runner/src/lib.rs
@@ -23,7 +23,9 @@ use std::sync::Arc;
 use anyhow::{anyhow, Result};
 pub use resolve_id::*;
 use risingwave_frontend::binder::Binder;
-use risingwave_frontend::handler::{create_mv, create_source, create_table, drop_table};
+use risingwave_frontend::handler::{
+    create_index, create_mv, create_source, create_table, drop_table,
+};
 use risingwave_frontend::optimizer::PlanRef;
 use risingwave_frontend::planner::Planner;
 use risingwave_frontend::session::{OptimizerContext, OptimizerContextRef, SessionImpl};
@@ -252,6 +254,15 @@ impl TestCase {
                     stmt,
                 } => {
                     create_source::handle_create_source(context, is_materialized, stmt).await?;
+                }
+                Statement::CreateIndex {
+                    name,
+                    table_name,
+                    columns,
+                    // TODO: support unique and if_not_exist in planner test
+                    ..
+                } => {
+                    create_index::handle_create_index(context, name, table_name, columns).await?;
                 }
                 Statement::CreateView {
                     materialized: true,

--- a/src/frontend/test_runner/tests/testdata/index.yaml
+++ b/src/frontend/test_runner/tests/testdata/index.yaml
@@ -1,0 +1,15 @@
+- sql: |
+    create table t1 (v1 int, v2 float);
+    create table t2 (v3 int, v4 numeric, v5 bigint);
+    create index t1_v1 on t1(v1);
+    create index t2_v3 on t2(v3);
+    /* should generate delta join plan, and stream index scan (not supported for now) */
+    select * from t1, t2 where t1.v1 = t2.v3;
+  stream_plan: |
+    StreamMaterialize { columns: [v1, v2, _row_id#0(hidden), v3, v4, v5, _row_id#1(hidden)], pk_columns: [_row_id#0, _row_id#1] }
+      StreamExchange { dist: HashShard([2, 6]) }
+        StreamDeltaHashJoin { type: Inner, predicate: $0 = $3 }
+          StreamExchange { dist: HashShard([0]) }
+            StreamTableScan { table: t1, columns: [v1, v2, _row_id#0], pk_indices: [2] }
+          StreamExchange { dist: HashShard([0]) }
+            StreamTableScan { table: t2, columns: [v3, v4, v5, _row_id#0], pk_indices: [3] }

--- a/src/frontend/test_runner/tests/testdata/index.yaml
+++ b/src/frontend/test_runner/tests/testdata/index.yaml
@@ -8,7 +8,7 @@
   stream_plan: |
     StreamMaterialize { columns: [v1, v2, _row_id#0(hidden), v3, v4, v5, _row_id#1(hidden)], pk_columns: [_row_id#0, _row_id#1] }
       StreamExchange { dist: HashShard([2, 6]) }
-        StreamDeltaHashJoin { type: Inner, predicate: $0 = $3 }
+        StreamDeltaJoin { type: Inner, predicate: $0 = $3 }
           StreamExchange { dist: HashShard([0]) }
             StreamTableScan { table: t1, columns: [v1, v2, _row_id#0], pk_indices: [2] }
           StreamExchange { dist: HashShard([0]) }


### PR DESCRIPTION
Signed-off-by: Alex Chi <iskyzh@gmail.com>

## What's changed and what's your intention?

In this PR, we added a rule. If both children of stream hash join are indexed by join key (join key is the prefix of mv order key), then we use `StreamDeltaJoin` for this plan.

Table indexes are added to `BoundTable` when binding. In the future, we should optimize this.

The PR only implements the rule. What's going on underlying is still creating "delta join + arrange" nodes, instead of re-using the index. The re-using index part will be introduce later after next week's meeting.

## Checklist

- [x] I have written necessary docs and comments
- [x] I have added necessary unit tests and integration tests

## Refer to a related PR or issue link (optional)

close https://github.com/singularity-data/risingwave/issues/885