### PR TITLE
fix: fix mismatched configuration entry

### DIFF
--- a/src/config/risingwave.toml
+++ b/src/config/risingwave.toml
@@ -8,7 +8,7 @@ chunk_size = 1024
 chunk_size = 1024
 
 [storage]
-shared_buffer_threshold_size = 268435456
+shared_buffer_threshold = 268435456
 sstable_size = 268435456
 block_size = 4096
 bloom_false_positive = 0.1


### PR DESCRIPTION
## What's changed and what's your intention?
Fix a mismatched configuration entry which is originated from https://github.com/singularity-data/risingwave/pull/1928

in risingwave.toml, it's 
```toml
shared_buffer_threshold_size = 268435456
```
, while in config.rs it's 
```rust
    /// Size threshold to trigger shared buffer flush.
    #[serde(default = "default::shared_buffer_threshold")]
    pub shared_buffer_threshold: u32,
```

## Checklist

- [x] I have written necessary docs and comments
- [x] I have added necessary unit tests and integration tests

## Refer to a related PR or issue link (optional)
https://github.com/singularity-data/risingwave/pull/1928