### PR TITLE
fix(test): `StreamChunk::from_str` -> `from_pretty`

### DIFF
--- a/src/common/src/array/stream_chunk.rs
+++ b/src/common/src/array/stream_chunk.rs
@@ -290,8 +290,9 @@ impl StreamChunkTestExt for StreamChunk {
     ///
     /// # Example
     /// ```
+    /// use risingwave_common::array::stream_chunk::StreamChunkTestExt as _;
     /// use risingwave_common::array::StreamChunk;
-    /// let chunk = StreamChunk::from_str(
+    /// let chunk = StreamChunk::from_pretty(
     ///     "  I I I I      // type chars
     ///     U- 2 5 . .      // '.' means NULL
     ///     U+ 2 5 2 6 D    // 'D' means deleted in visibility


### PR DESCRIPTION
## What's changed and what's your intention?

The doctests of `cargo test` fail to compile because the rename did not update comments.

## Checklist

~~- [ ] I have written necessary docs and comments~~
~~- [ ] I have added necessary unit tests and integration tests~~

## Refer to a related PR or issue link (optional)

#2089