### PR TITLE
refactor(proto): replace TableRefId to uint32 for HashJoin

### DIFF
--- a/proto/stream_plan.proto
+++ b/proto/stream_plan.proto
@@ -97,8 +97,8 @@ message HashJoinNode {
   // TODO: remove this in the future when we have a separate DeltaHashJoin node.
   bool is_delta_join = 6;
   // Used for internal table states.
-  plan_common.TableRefId left_table_ref_id = 7;
-  plan_common.TableRefId right_table_ref_id = 8;
+  uint32 left_table_id = 7;
+  uint32 right_table_id = 8;
 }
 
 message HopWindowNode {

--- a/src/meta/src/stream/fragmenter/graph/stream_graph.rs
+++ b/src/meta/src/stream/fragmenter/graph/stream_graph.rs
@@ -21,7 +21,6 @@ use assert_matches::assert_matches;
 use itertools::Itertools;
 use risingwave_common::catalog::TableId;
 use risingwave_common::error::Result;
-use risingwave_pb::plan_common::TableRefId;
 use risingwave_pb::stream_plan::stream_node::Node;
 use risingwave_pb::stream_plan::{Dispatcher, DispatcherType, MergeNode, StreamActor, StreamNode};
 use risingwave_pb::ProstFieldNotFound;
@@ -454,17 +453,10 @@ impl StreamGraphBuilder {
                 {
                     // The operator id must be assigned with table ids. Otherwise it is a logic
                     // error.
-                    let left_table_id =
-                        node.left_table_ref_id.as_ref().unwrap().table_id + table_id_offset as i32;
+                    let left_table_id = node.left_table_id + table_id_offset;
                     let right_table_id = left_table_id + 1;
-                    node.left_table_ref_id = Some(TableRefId {
-                        table_id: left_table_id as i32,
-                        ..Default::default()
-                    });
-                    node.right_table_ref_id = Some(TableRefId {
-                        table_id: right_table_id as i32,
-                        ..Default::default()
-                    });
+                    node.left_table_id = left_table_id;
+                    node.right_table_id = right_table_id;
                 }
                 for (idx, input) in stream_node.input.iter().enumerate() {
                     match input.get_node()? {

--- a/src/meta/src/stream/fragmenter/mod.rs
+++ b/src/meta/src/stream/fragmenter/mod.rs
@@ -26,7 +26,7 @@ use risingwave_common::catalog::TableId;
 use risingwave_common::error::{ErrorCode, Result};
 use risingwave_pb::meta::table_fragments::fragment::{FragmentDistributionType, FragmentType};
 use risingwave_pb::meta::table_fragments::Fragment;
-use risingwave_pb::plan_common::{JoinType, TableRefId};
+use risingwave_pb::plan_common::JoinType;
 use risingwave_pb::stream_plan::stream_node::Node;
 use risingwave_pb::stream_plan::{
     DispatchStrategy, Dispatcher, DispatcherType, ExchangeNode, StreamNode,
@@ -368,14 +368,8 @@ impl StreamFragmenter {
         if let Node::HashJoinNode(hash_join_node) = stream_node.node.as_mut().unwrap() {
             // Allocate local table id. It will be rewrite to global table id after get table id
             // offset from id generator.
-            hash_join_node.left_table_ref_id = Some(TableRefId {
-                table_id: state.gen_table_id() as i32,
-                ..Default::default()
-            });
-            hash_join_node.right_table_ref_id = Some(TableRefId {
-                table_id: state.gen_table_id() as i32,
-                ..Default::default()
-            });
+            hash_join_node.left_table_id = state.gen_table_id();
+            hash_join_node.right_table_id = state.gen_table_id();
             if hash_join_node.is_delta_join {
                 if hash_join_node.get_join_type()? == JoinType::Inner
                     && hash_join_node.condition.is_none()

--- a/src/stream/src/executor/hash_join.rs
+++ b/src/stream/src/executor/hash_join.rs
@@ -233,8 +233,8 @@ impl ExecutorBuilder for HashJoinExecutorBuilder {
             .collect_vec();
         let kind = calc_hash_key_kind(&keys);
 
-        let left_table_id = TableId::from(&node.left_table_ref_id);
-        let right_table_id = TableId::from(&node.right_table_ref_id);
+        let left_table_id = TableId::from(node.left_table_id);
+        let right_table_id = TableId::from(node.right_table_id);
 
         let args = HashJoinExecutorDispatcherArgs {
             source_l,


### PR DESCRIPTION
## What's changed and what's your intention?
Previously I use TableRefId (wants to keep consistent with Materialize Executor), but it's too inconvenient to write code. 

Given that we wil remove `TableRefId` after Java frontend removed, replace it now. 


## Checklist

- [x] I have written necessary docs and comments
- [x] I have added necessary unit tests and integration tests

## Refer to a related PR or issue link (optional)
