### PR TITLE
refactor(frontend): remove unused agg aliases

### DIFF
--- a/src/frontend/src/optimizer/plan_node/logical_agg.rs
+++ b/src/frontend/src/optimizer/plan_node/logical_agg.rs
@@ -249,11 +249,7 @@ impl ExprRewriter for ExprHandler {
 }
 
 impl LogicalAgg {
-    pub fn new(
-        agg_calls: Vec<PlanAggCall>,
-        group_keys: Vec<usize>,
-        input: PlanRef,
-    ) -> Self {
+    pub fn new(agg_calls: Vec<PlanAggCall>, group_keys: Vec<usize>, input: PlanRef) -> Self {
         let ctx = input.ctx();
         let schema = Self::derive_schema(
             input.schema(),
@@ -348,11 +344,7 @@ impl LogicalAgg {
         let logical_project = LogicalProject::create(input, expr_handler.project, expr_alias);
 
         // This LogicalAgg focuses on calculating the aggregates and grouping.
-        let logical_agg = LogicalAgg::new(
-            expr_handler.agg_calls,
-            group_keys,
-            logical_project,
-        );
+        let logical_agg = LogicalAgg::new(expr_handler.agg_calls, group_keys, logical_project);
 
         // This LogicalProject focus on transforming the aggregates and grouping columns to
         // InputRef.
@@ -374,11 +366,7 @@ impl LogicalAgg {
     }
 
     pub fn decompose(self) -> (Vec<PlanAggCall>, Vec<usize>, PlanRef) {
-        (
-            self.agg_calls,
-            self.group_keys,
-            self.input,
-        )
+        (self.agg_calls, self.group_keys, self.input)
     }
 }
 
@@ -388,11 +376,7 @@ impl PlanTreeNodeUnary for LogicalAgg {
     }
 
     fn clone_with_input(&self, input: PlanRef) -> Self {
-        Self::new(
-            self.agg_calls().to_vec(),
-            self.group_keys().to_vec(),
-            input,
-        )
+        Self::new(self.agg_calls().to_vec(), self.group_keys().to_vec(), input)
     }
 
     #[must_use]
@@ -718,11 +702,7 @@ mod tests {
             return_type: ty.clone(),
             inputs: vec![InputRef::new(2, ty.clone())],
         };
-        let agg = LogicalAgg::new(
-            vec![agg_call],
-            vec![1],
-            values.into(),
-        );
+        let agg = LogicalAgg::new(vec![agg_call], vec![1], values.into());
 
         // Perform the prune
         let mut required_cols = FixedBitSet::with_capacity(2);
@@ -775,11 +755,7 @@ mod tests {
             return_type: ty.clone(),
             inputs: vec![InputRef::new(2, ty.clone())],
         };
-        let agg = LogicalAgg::new(
-            vec![agg_call],
-            vec![1],
-            values.into(),
-        );
+        let agg = LogicalAgg::new(vec![agg_call], vec![1], values.into());
 
         // Perform the prune
         let mut required_cols = FixedBitSet::with_capacity(2);
@@ -847,11 +823,7 @@ mod tests {
                 inputs: vec![InputRef::new(1, ty.clone())],
             },
         ];
-        let agg = LogicalAgg::new(
-            agg_calls,
-            vec![1, 2],
-            values.into(),
-        );
+        let agg = LogicalAgg::new(agg_calls, vec![1, 2], values.into());
 
         // Perform the prune
         let mut required_cols = FixedBitSet::with_capacity(4);

--- a/src/frontend/src/optimizer/rule/unnest_agg_for_loj.rs
+++ b/src/frontend/src/optimizer/rule/unnest_agg_for_loj.rs
@@ -91,7 +91,7 @@ impl Rule for UnnestAggForLOJ {
                 input_ref.shift_with_offset(apply_left_len as isize);
             });
         });
-        let agg = LogicalAgg::new(agg_calls, vec![], group_keys, new_apply.into());
+        let agg = LogicalAgg::new(agg_calls, group_keys, new_apply.into());
 
         // Columns of old Apply's left child should be in the left.
         let mut exprs: Vec<ExprImpl> = apply

--- a/src/frontend/src/optimizer/rule/unnest_agg_for_loj.rs
+++ b/src/frontend/src/optimizer/rule/unnest_agg_for_loj.rs
@@ -66,7 +66,7 @@ impl Rule for UnnestAggForLOJ {
 
         // To pull LogicalAgg up on top of LogicalApply, we need to convert scalar agg to group agg
         // using pks of Apply.left as its group keys and convert count(*) to count(pk).
-        let (mut agg_calls, agg_call_alias, mut group_keys, _) = agg.clone().decompose();
+        let (mut agg_calls, mut group_keys, _) = agg.clone().decompose();
         // TODO: currently only scalar agg is supported in correlated subquery.
         if !group_keys.is_empty() {
             return None;
@@ -91,7 +91,7 @@ impl Rule for UnnestAggForLOJ {
                 input_ref.shift_with_offset(apply_left_len as isize);
             });
         });
-        let agg = LogicalAgg::new(agg_calls, agg_call_alias, group_keys, new_apply.into());
+        let agg = LogicalAgg::new(agg_calls, vec![], group_keys, new_apply.into());
 
         // Columns of old Apply's left child should be in the left.
         let mut exprs: Vec<ExprImpl> = apply

--- a/src/frontend/src/planner/select.rs
+++ b/src/frontend/src/planner/select.rs
@@ -72,7 +72,7 @@ impl Planner {
     /// It is represented by `Project([$0 >= 1]) - Agg(count(*)) - input`
     fn create_exists(&self, input: PlanRef) -> Result<PlanRef> {
         let count_star =
-            LogicalAgg::new(vec![PlanAggCall::count_star()], vec![None], vec![], input);
+            LogicalAgg::new(vec![PlanAggCall::count_star()], vec![], input);
         let ge = FunctionCall::new(
             ExprType::GreaterThanOrEqual,
             vec![

--- a/src/frontend/src/planner/select.rs
+++ b/src/frontend/src/planner/select.rs
@@ -71,8 +71,7 @@ impl Planner {
     /// Helper to create an `EXISTS` boolean operator with the given `input`.
     /// It is represented by `Project([$0 >= 1]) - Agg(count(*)) - input`
     fn create_exists(&self, input: PlanRef) -> Result<PlanRef> {
-        let count_star =
-            LogicalAgg::new(vec![PlanAggCall::count_star()], vec![], input);
+        let count_star = LogicalAgg::new(vec![PlanAggCall::count_star()], vec![], input);
         let ge = FunctionCall::new(
             ExprType::GreaterThanOrEqual,
             vec![


### PR DESCRIPTION
## What's changed and what's your intention?

This `aliases` field in `LogicalAgg` has always been `None` (except in unit tests) and will not be used in the future (#1433).

To reiterate: `aliases` will be user-facing and handled at bound sql level but not in plan nodes, while `field` names are for internal debugging only and can follow whatever rules, possibly not matching aliases.

## Checklist

~~- [ ] I have written necessary docs and comments~~
~~- [ ] I have added necessary unit tests and integration tests~~ (Refactor does not break existing tests.)

## Refer to a related PR or issue link (optional)
