### PR TITLE
test(batch): introduce DataChunk::from_pretty

### DIFF
--- a/src/batch/src/executor2/project.rs
+++ b/src/batch/src/executor2/project.rs
@@ -103,7 +103,7 @@ mod tests {
     use futures::stream::StreamExt;
     use risingwave_common::array::{Array, I32Array};
     use risingwave_common::catalog::{Field, Schema};
-    use risingwave_common::column_nonnull;
+    use risingwave_common::test_prelude::*;
     use risingwave_common::types::DataType;
     use risingwave_expr::expr::{InputRefExpression, LiteralExpression};
 
@@ -114,9 +114,16 @@ mod tests {
 
     #[tokio::test]
     async fn test_project_executor() -> Result<()> {
-        let col1 = column_nonnull! {I32Array, [1, 2, 33333, 4, 5]};
-        let col2 = column_nonnull! {I32Array, [7, 8, 66666, 4, 3]};
-        let chunk = DataChunk::builder().columns(vec![col1, col2]).build();
+        let chunk = DataChunk::from_pretty(
+            "
+            i     i
+            1     7
+            2     8
+            33333 66666
+            4     4
+            5     3
+        ",
+        );
 
         let expr1 = InputRefExpression::new(DataType::Int32, 0);
         let expr_vec = vec![Box::new(expr1) as BoxedExpression];

--- a/src/common/src/array/data_chunk.rs
+++ b/src/common/src/array/data_chunk.rs
@@ -26,7 +26,7 @@ use crate::array::{ArrayBuilderImpl, ArrayImpl};
 use crate::buffer::Bitmap;
 use crate::error::{Result, RwError};
 use crate::hash::HashCode;
-use crate::types::DataType;
+use crate::types::{DataType, NaiveDateTimeWrapper};
 use crate::util::hash_util::finalize_hashers;
 
 pub struct DataChunkBuilder {
@@ -452,6 +452,124 @@ impl TryFrom<Vec<Column>> for DataChunk {
 }
 
 pub type DataChunkRef = Arc<DataChunk>;
+
+/// Test utilities for [`DataChunk`].
+pub trait DataChunkTestExt {
+    fn from_pretty(s: &str) -> Self;
+}
+
+impl DataChunkTestExt for DataChunk {
+    /// Parse a chunk from string.
+    ///
+    /// # Format
+    ///
+    /// The first line is a header indicating the column types.
+    /// The following lines indicate rows within the chunk.
+    /// Each line starts with an operation followed by values.
+    /// NULL values are represented as `.`.
+    ///
+    /// # Example
+    /// ```
+    /// use risingwave_common::array::stream_chunk::DataChunkTestExt as _;
+    /// use risingwave_common::array::DataChunk;
+    /// let chunk = DataChunk::from_pretty(
+    ///     "I I I I      // type chars
+    ///      2 5 . .      // '.' means NULL
+    ///      2 5 2 6 D    // 'D' means deleted in visibility
+    ///      . . 4 8      // ^ comments are ignored
+    ///      . . 3 4",
+    /// );
+    ///
+    /// // type chars:
+    /// //     I: i64
+    /// //     i: i32
+    /// //     F: f64
+    /// //     f: f32
+    /// //     T: str
+    /// //    TS: Timestamp
+    /// ```
+    fn from_pretty(s: &str) -> Self {
+        use crate::types::ScalarImpl;
+
+        let mut lines = s.split('\n').filter(|l| !l.trim().is_empty());
+        // initialize array builders from the first line
+        let header = lines.next().unwrap().trim();
+        let mut array_builders = header
+            .split_ascii_whitespace()
+            .take_while(|c| *c != "//")
+            .map(|c| match c {
+                "I" => DataType::Int64,
+                "i" => DataType::Int32,
+                "F" => DataType::Float64,
+                "f" => DataType::Float32,
+                "TS" => DataType::Timestamp,
+                "T" => DataType::Varchar,
+                _ => todo!("unsupported type: {c:?}"),
+            })
+            .map(|ty| ty.create_array_builder(1))
+            .collect::<Result<Vec<_>>>()
+            .unwrap();
+        let mut visibility = vec![];
+        for mut line in lines {
+            line = line.trim();
+            let mut token = line.split_ascii_whitespace();
+            // allow `zip` since `token` may longer than `array_builders`
+            #[allow(clippy::disallowed_methods)]
+            for (builder, val_str) in array_builders.iter_mut().zip(&mut token) {
+                let datum = match val_str {
+                    "." => None,
+                    s if matches!(builder, ArrayBuilderImpl::Int32(_)) => Some(ScalarImpl::Int32(
+                        s.parse()
+                            .map_err(|_| panic!("invalid int32: {s:?}"))
+                            .unwrap(),
+                    )),
+                    s if matches!(builder, ArrayBuilderImpl::Int64(_)) => Some(ScalarImpl::Int64(
+                        s.parse()
+                            .map_err(|_| panic!("invalid int64: {s:?}"))
+                            .unwrap(),
+                    )),
+                    s if matches!(builder, ArrayBuilderImpl::Float64(_)) => {
+                        Some(ScalarImpl::Float64(
+                            s.parse()
+                                .map_err(|_| panic!("invalid float64: {s:?}"))
+                                .unwrap(),
+                        ))
+                    }
+                    s if matches!(builder, ArrayBuilderImpl::NaiveDateTime(_)) => {
+                        Some(ScalarImpl::NaiveDateTime(NaiveDateTimeWrapper(
+                            s.parse()
+                                .map_err(|_| panic!("invalid datetime: {s:?}"))
+                                .unwrap(),
+                        )))
+                    }
+                    s if matches!(builder, ArrayBuilderImpl::Utf8(_)) => {
+                        Some(ScalarImpl::Utf8(s.into()))
+                    }
+                    _ => panic!("invalid data type"),
+                };
+                builder
+                    .append_datum(&datum)
+                    .expect("failed to append datum");
+            }
+            let visible = match token.next() {
+                None | Some("//") => true,
+                Some("D") => false,
+                Some(t) => panic!("invalid token: {t:?}"),
+            };
+            visibility.push(visible);
+        }
+        let columns = array_builders
+            .into_iter()
+            .map(|builder| Column::new(Arc::new(builder.finish().unwrap())))
+            .collect();
+        let visibility = if visibility.iter().all(|b| *b) {
+            None
+        } else {
+            Some(Bitmap::try_from(visibility).unwrap())
+        };
+        DataChunk::new(columns, visibility)
+    }
+}
 
 #[cfg(test)]
 mod tests {

--- a/src/common/src/array/mod.rs
+++ b/src/common/src/array/mod.rs
@@ -42,7 +42,7 @@ pub use chrono_array::{
     NaiveTimeArray, NaiveTimeArrayBuilder,
 };
 pub use column_proto_readers::*;
-pub use data_chunk::{DataChunk, DataChunkRef};
+pub use data_chunk::{DataChunk, DataChunkRef, DataChunkTestExt};
 pub use data_chunk_iter::{Row, RowDeserializer, RowRef};
 pub use decimal_array::{DecimalArray, DecimalArrayBuilder};
 pub use interval_array::{IntervalArray, IntervalArrayBuilder};
@@ -51,7 +51,7 @@ pub use list_array::{ListArray, ListArrayBuilder, ListRef, ListValue};
 use paste::paste;
 pub use primitive_array::{PrimitiveArray, PrimitiveArrayBuilder, PrimitiveArrayItemType};
 use risingwave_pb::data::{Array as ProstArray, ArrayType as ProstArrayType};
-pub use stream_chunk::{Op, StreamChunk};
+pub use stream_chunk::{Op, StreamChunk, StreamChunkTestExt};
 pub use struct_array::{StructArray, StructArrayBuilder, StructRef, StructValue};
 pub use utf8_array::*;
 

--- a/src/common/src/array/stream_chunk.rs
+++ b/src/common/src/array/stream_chunk.rs
@@ -316,7 +316,7 @@ impl StreamChunkTestExt for StreamChunk {
     fn from_pretty(s: &str) -> Self {
         use crate::types::ScalarImpl;
 
-        let mut lines = s.split('\n');
+        let mut lines = s.split('\n').filter(|l| !l.trim().is_empty());
         let mut ops = vec![];
         // initialize array builders from the first line
         let header = lines.next().unwrap().trim();

--- a/src/common/src/lib.rs
+++ b/src/common/src/lib.rs
@@ -49,3 +49,7 @@ pub mod hash;
 #[cfg(test)]
 pub mod test_utils;
 pub mod types;
+
+pub mod test_prelude {
+    pub use super::array::{DataChunkTestExt, StreamChunkTestExt};
+}


### PR DESCRIPTION
Signed-off-by: TennyZhuang <zty0826@gmail.com>

## What's changed and what's your intention?

Similar to #2111 

Although it may not be the best solution, it's must friendly then before.

If we find a better solution such as `pretty_chunk!` macro, it's possible to write a simple script to migrate them all.

## Checklist

- [x] I have written necessary docs and comments
- [x] I have added necessary unit tests and integration tests

## Refer to a related PR or issue link (optional)
