### PR TITLE
feat(meta): support rewrite join on index

### DIFF
--- a/.github/workflow-template/jobs/compute-node-test.yml
+++ b/.github/workflow-template/jobs/compute-node-test.yml
@@ -16,7 +16,7 @@ jobs:
       - name: Install Protoc
         uses: arduino/setup-protoc@v1
         with:
-          version: '3.x'
+          version: "3.x"
 
       - name: Install Rust toolchain
         uses: actions-rs/toolchain@v1
@@ -49,7 +49,7 @@ jobs:
 
       - name: Run rust test with coverage
         run: |
-          cargo llvm-cov nextest --lcov --output-path lcov.info --no-fail-fast
+          cargo llvm-cov nextest --lcov --output-path lcov.info -- --no-fail-fast
 
       - uses: codecov/codecov-action@v2
         with:

--- a/.github/workflows/main-cron.yml
+++ b/.github/workflows/main-cron.yml
@@ -526,7 +526,7 @@ jobs:
       - name: Install Protoc
         uses: arduino/setup-protoc@v1
         with:
-          version: '3.x'
+          version: "3.x"
       - name: Install Rust toolchain
         uses: actions-rs/toolchain@v1
         with:
@@ -553,7 +553,7 @@ jobs:
           cargo doc --document-private-items --no-deps
       - name: Run rust test with coverage
         run: |
-          cargo llvm-cov nextest --lcov --output-path lcov.info --no-fail-fast
+          cargo llvm-cov nextest --lcov --output-path lcov.info -- --no-fail-fast
       - uses: codecov/codecov-action@v2
         with:
           token: ${{ secrets.CODECOV_TOKEN }}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -719,7 +719,7 @@ jobs:
       - name: Install Protoc
         uses: arduino/setup-protoc@v1
         with:
-          version: '3.x'
+          version: "3.x"
       - name: Install Rust toolchain
         uses: actions-rs/toolchain@v1
         with:
@@ -746,7 +746,7 @@ jobs:
           cargo doc --document-private-items --no-deps
       - name: Run rust test with coverage
         run: |
-          cargo llvm-cov nextest --lcov --output-path lcov.info --no-fail-fast
+          cargo llvm-cov nextest --lcov --output-path lcov.info -- --no-fail-fast
       - uses: codecov/codecov-action@v2
         with:
           token: ${{ secrets.CODECOV_TOKEN }}

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -483,7 +483,7 @@ jobs:
       - name: Install Protoc
         uses: arduino/setup-protoc@v1
         with:
-          version: '3.x'
+          version: "3.x"
       - name: Install Rust toolchain
         uses: actions-rs/toolchain@v1
         with:
@@ -510,7 +510,7 @@ jobs:
           cargo doc --document-private-items --no-deps
       - name: Run rust test with coverage
         run: |
-          cargo llvm-cov nextest --lcov --output-path lcov.info --no-fail-fast
+          cargo llvm-cov nextest --lcov --output-path lcov.info -- --no-fail-fast
       - uses: codecov/codecov-action@v2
         with:
           token: ${{ secrets.CODECOV_TOKEN }}

--- a/e2e_test/v2/streaming/index.slt
+++ b/e2e_test/v2/streaming/index.slt
@@ -35,6 +35,34 @@ select v4, v1, v3, v5 from iii_index;
 4 3 3 3
 5 2 2 2
 
+# create MV using index
+
+# statement ok
+# create index iii_index_1 on iii_t1(v1);
+
+# statement ok
+# create index iii_index_2 on iii_t2(v3);
+
+# statement ok
+# create materialized view iii_mv2 as select * from iii_t1, iii_t2 where iii_t1.v1 = iii_t2.v3;
+
+# query IIII rowsort
+# select v1, v2, v3, v4 from iii_mv2;
+# ----
+# 2 0 2 5
+# 3 0 3 4
+# 0 0 0 3
+# 1 0 1 2
+
+# statement ok
+# drop materialized view iii_mv2
+
+# statement ok
+# drop materialized view iii_index_2
+
+# statement ok
+# drop materialized view iii_index_1
+
 # TODO: support drop index
 
 statement ok

--- a/src/frontend/src/optimizer/plan_node/stream_index_scan.rs
+++ b/src/frontend/src/optimizer/plan_node/stream_index_scan.rs
@@ -116,7 +116,7 @@ impl StreamIndexScan {
         let pk_indices = self.base.pk_indices.iter().map(|x| *x as u32).collect_vec();
 
         ProstStreamPlan {
-            fields: vec![], // TODO: fill this later
+            fields: self.schema().to_prost(),
             input: vec![
                 // The merge node should be empty
                 ProstStreamPlan {

--- a/src/frontend/src/optimizer/plan_node/stream_table_scan.rs
+++ b/src/frontend/src/optimizer/plan_node/stream_table_scan.rs
@@ -121,7 +121,7 @@ impl StreamTableScan {
         let pk_indices = self.base.pk_indices.iter().map(|x| *x as u32).collect_vec();
 
         ProstStreamPlan {
-            fields: vec![], // TODO: fill this later
+            fields: self.schema().to_prost(),
             input: vec![
                 // The merge node should be empty
                 ProstStreamPlan {

--- a/src/frontend/test_runner/tests/testdata/stream_proto.yaml
+++ b/src/frontend/test_runner/tests/testdata/stream_proto.yaml
@@ -27,6 +27,15 @@
                           name: "_row_id#0"
                 pkIndices:
                   - 1
+                fields:
+                  - dataType:
+                      typeName: INT32
+                      isNullable: true
+                    name: v1
+                  - dataType:
+                      typeName: INT64
+                      isNullable: true
+                    name: "_row_id#0"
                 chainNode:
                   tableRefId:
                     tableId: 1
@@ -160,6 +169,15 @@
                       name: "_row_id#0"
             pkIndices:
               - 1
+            fields:
+              - dataType:
+                  typeName: INT32
+                  isNullable: true
+                name: v1
+              - dataType:
+                  typeName: INT64
+                  isNullable: true
+                name: "_row_id#0"
             chainNode:
               tableRefId:
                 tableId: 1
@@ -263,6 +281,15 @@
                       name: "_row_id#0"
             pkIndices:
               - 1
+            fields:
+              - dataType:
+                  typeName: INT32
+                  isNullable: true
+                name: v1
+              - dataType:
+                  typeName: INT64
+                  isNullable: true
+                name: "_row_id#0"
             chainNode:
               tableRefId:
                 tableId: 1
@@ -371,6 +398,15 @@
                           name: "_row_id#0"
                 pkIndices:
                   - 1
+                fields:
+                  - dataType:
+                      typeName: INT32
+                      isNullable: true
+                    name: v1
+                  - dataType:
+                      typeName: INT64
+                      isNullable: true
+                    name: "_row_id#0"
                 chainNode:
                   tableRefId:
                     tableId: 1
@@ -513,6 +549,19 @@
                                   name: "_row_id#0"
                         pkIndices:
                           - 2
+                        fields:
+                          - dataType:
+                              typeName: INT32
+                              isNullable: true
+                            name: v1
+                          - dataType:
+                              typeName: INT32
+                              isNullable: true
+                            name: v2
+                          - dataType:
+                              typeName: INT64
+                              isNullable: true
+                            name: "_row_id#0"
                         chainNode:
                           tableRefId:
                             tableId: 1

--- a/src/meta/src/stream/fragmenter/mod.rs
+++ b/src/meta/src/stream/fragmenter/mod.rs
@@ -263,7 +263,7 @@ impl StreamFragmenter {
             let input = match child_node.get_node()? {
                 // For stateful operators, set `exchange_flag = true`. If it's already true, force
                 // add an exchange.
-                Node::HashAggNode(_) | Node::HashJoinNode(_) => {
+                Node::HashAggNode(_) | Node::HashJoinNode(_) | Node::DeltaIndexJoin(_) => {
                     // We didn't make `fields` available on Java frontend yet, so we check if schema
                     // is available (by `child_node.fields.is_empty()`) before deciding to do the
                     // rewrite.
@@ -380,6 +380,16 @@ impl StreamFragmenter {
                         "only inner join without non-equal condition is supported for delta joins"
                     );
                 }
+            }
+        }
+
+        if let Node::DeltaIndexJoin(delta_index_join) = stream_node.node.as_mut().unwrap() {
+            if delta_index_join.get_join_type()? == JoinType::Inner
+                && delta_index_join.condition.is_none()
+            {
+                return self.build_delta_join_without_arrange(state, current_fragment, stream_node);
+            } else {
+                panic!("only inner join without non-equal condition is supported for delta joins");
             }
         }
 

--- a/src/meta/src/stream/fragmenter/rewrite/delta_join.rs
+++ b/src/meta/src/stream/fragmenter/rewrite/delta_join.rs
@@ -17,7 +17,8 @@ use risingwave_common::error::Result;
 use risingwave_pb::plan_common::Field;
 use risingwave_pb::stream_plan::stream_node::Node;
 use risingwave_pb::stream_plan::{
-    ArrangeNode, DispatchStrategy, DispatcherType, ExchangeNode, LookupNode, StreamNode, UnionNode,
+    ArrangeNode, DeltaIndexJoinNode, DispatchStrategy, DispatcherType, ExchangeNode, LookupNode,
+    StreamNode, UnionNode,
 };
 
 use crate::stream::fragmenter::{BuildFragmentGraphState, StreamFragment, StreamFragmentEdge};
@@ -151,6 +152,182 @@ impl StreamFragmenter {
         }
     }
 
+    fn build_delta_join_inner(
+        &self,
+        state: &mut BuildFragmentGraphState,
+        current_fragment: &mut StreamFragment,
+        arrange_0_frag: StreamFragment,
+        arrange_1_frag: StreamFragment,
+        node: &StreamNode,
+    ) -> Result<StreamNode> {
+        let delta_join_node = match &node.node {
+            Some(Node::DeltaIndexJoin(node)) => node,
+            _ => unreachable!(),
+        };
+
+        let arrange_0 = arrange_0_frag.node.as_ref().unwrap();
+        let arrange_1 = arrange_1_frag.node.as_ref().unwrap();
+        let exchange_a0l0 = self.build_exchange_for_delta_join(state, arrange_0);
+        let exchange_a0l1 = self.build_exchange_for_delta_join(state, arrange_0);
+        let exchange_a1l0 = self.build_exchange_for_delta_join(state, arrange_1);
+        let exchange_a1l1 = self.build_exchange_for_delta_join(state, arrange_1);
+
+        let i0_length = arrange_0.fields.len();
+        let i1_length = arrange_1.fields.len();
+
+        let lookup_0 = self.build_lookup_for_delta_join(
+            state,
+            (&exchange_a1l0, &exchange_a0l0),
+            (node.fields.clone(), node.pk_indices.clone()),
+            LookupNode {
+                stream_key: delta_join_node.right_key.clone(),
+                arrange_key: delta_join_node.left_key.clone(),
+                use_current_epoch: false,
+                // will be filled later in StreamFragment::seal
+                arrange_fragment_id: u32::MAX,
+                arrange_local_fragment_id: arrange_0_frag.fragment_id.as_local_id(),
+                arrange_operator_id: arrange_0_frag.node.unwrap().operator_id,
+                column_mapping: (i1_length..i1_length + i0_length)
+                    .chain(0..i1_length)
+                    .map(|x| x as _)
+                    .collect_vec(),
+            },
+        );
+
+        let lookup_1 = self.build_lookup_for_delta_join(
+            state,
+            (&exchange_a0l1, &exchange_a1l1),
+            (node.fields.clone(), node.pk_indices.clone()),
+            LookupNode {
+                stream_key: delta_join_node.left_key.clone(),
+                arrange_key: delta_join_node.right_key.clone(),
+                use_current_epoch: true,
+                // will be filled later in StreamFragment::seal
+                arrange_fragment_id: u32::MAX,
+                arrange_local_fragment_id: arrange_1_frag.fragment_id.as_local_id(),
+                arrange_operator_id: arrange_1_frag.node.unwrap().operator_id,
+                column_mapping: (0..i0_length + i1_length).map(|x| x as _).collect_vec(),
+            },
+        );
+
+        let lookup_0_frag = self.build_and_add_fragment(state, lookup_0)?;
+        let lookup_1_frag = self.build_and_add_fragment(state, lookup_1)?;
+
+        state.fragment_graph.add_edge(
+            arrange_0_frag.fragment_id,
+            lookup_0_frag.fragment_id,
+            StreamFragmentEdge {
+                dispatch_strategy: Self::dispatch_no_shuffle(),
+                same_worker_node: true,
+                link_id: exchange_a0l0.operator_id,
+            },
+        );
+
+        state.fragment_graph.add_edge(
+            arrange_0_frag.fragment_id,
+            lookup_1_frag.fragment_id,
+            StreamFragmentEdge {
+                dispatch_strategy: Self::dispatch_no_shuffle(),
+                same_worker_node: true,
+                link_id: exchange_a0l1.operator_id,
+            },
+        );
+
+        state.fragment_graph.add_edge(
+            arrange_1_frag.fragment_id,
+            lookup_0_frag.fragment_id,
+            StreamFragmentEdge {
+                dispatch_strategy: Self::dispatch_no_shuffle(),
+                same_worker_node: true,
+                link_id: exchange_a1l0.operator_id,
+            },
+        );
+
+        state.fragment_graph.add_edge(
+            arrange_1_frag.fragment_id,
+            lookup_1_frag.fragment_id,
+            StreamFragmentEdge {
+                dispatch_strategy: Self::dispatch_no_shuffle(),
+                same_worker_node: true,
+                link_id: exchange_a1l1.operator_id,
+            },
+        );
+
+        let exchange_l0m = self.build_exchange_for_delta_join(state, node);
+        let exchange_l1m = self.build_exchange_for_delta_join(state, node);
+
+        let union = StreamNode {
+            operator_id: state.gen_operator_id() as u64,
+            identity: "Union".into(),
+            fields: node.fields.clone(),
+            pk_indices: node.pk_indices.clone(),
+            node: Some(Node::UnionNode(UnionNode {})),
+            input: vec![exchange_l0m.clone(), exchange_l1m.clone()],
+            append_only: node.append_only,
+        };
+
+        state.fragment_graph.add_edge(
+            lookup_0_frag.fragment_id,
+            current_fragment.fragment_id,
+            StreamFragmentEdge {
+                dispatch_strategy: Self::dispatch_no_shuffle(),
+                same_worker_node: false,
+                link_id: exchange_l0m.operator_id,
+            },
+        );
+
+        state.fragment_graph.add_edge(
+            lookup_1_frag.fragment_id,
+            current_fragment.fragment_id,
+            StreamFragmentEdge {
+                dispatch_strategy: Self::dispatch_no_shuffle(),
+                same_worker_node: false,
+                link_id: exchange_l1m.operator_id,
+            },
+        );
+
+        Ok(union)
+    }
+
+    pub(in super::super) fn build_delta_join_without_arrange(
+        &self,
+        state: &mut BuildFragmentGraphState,
+        current_fragment: &mut StreamFragment,
+        mut node: StreamNode,
+    ) -> Result<StreamNode> {
+        match &node.node {
+            Some(Node::DeltaIndexJoin(node)) => node,
+            _ => unreachable!(),
+        };
+
+        let arrange_1 = node.input.remove(1);
+        let arrange_0 = node.input.remove(0);
+
+        // TODO: when distribution key is added to catalog, chain and delta join won't have any
+        // exchange in-between. Then we can safely remove this function.
+        fn check_no_exchange(node: &StreamNode) {
+            if let Node::ExchangeNode(_) = node.get_node().unwrap() {
+                panic!("exchange not allowed between delta join and arrange");
+            }
+        }
+
+        check_no_exchange(&arrange_0);
+        check_no_exchange(&arrange_1);
+
+        let arrange_0_frag = self.build_and_add_fragment(state, arrange_0)?;
+        let arrange_1_frag = self.build_and_add_fragment(state, arrange_1)?;
+
+        let union = self.build_delta_join_inner(
+            state,
+            current_fragment,
+            arrange_0_frag,
+            arrange_1_frag,
+            &node,
+        )?;
+
+        Ok(union)
+    }
+
     pub(in super::super) fn build_delta_join(
         &self,
         state: &mut BuildFragmentGraphState,
@@ -185,14 +362,6 @@ impl StreamFragmenter {
         //
         // TODO: support multi-way join.
 
-        let exchange_a0l0 = self.build_exchange_for_delta_join(state, &node.input[0]);
-        let exchange_a0l1 = self.build_exchange_for_delta_join(state, &node.input[0]);
-        let exchange_a1l0 = self.build_exchange_for_delta_join(state, &node.input[1]);
-        let exchange_a1l1 = self.build_exchange_for_delta_join(state, &node.input[1]);
-
-        let i0_length = node.input[0].fields.len();
-        let i1_length = node.input[1].fields.len();
-
         let (link_i1a1, input_1_frag, exchange_i1a1) =
             self.build_input_with_exchange(state, node.input.remove(1))?;
 
@@ -225,116 +394,25 @@ impl StreamFragmenter {
             link_i1a1,
         );
 
-        let lookup_0 = self.build_lookup_for_delta_join(
-            state,
-            (&exchange_a1l0, &exchange_a0l0),
-            (node.fields.clone(), node.pk_indices.clone()),
-            LookupNode {
-                stream_key: hash_join_node.right_key.clone(),
-                arrange_key: hash_join_node.left_key.clone(),
-                use_current_epoch: false,
-                // will be filled later in StreamFragment::seal
-                arrange_fragment_id: u32::MAX,
-                arrange_local_fragment_id: arrange_0_frag.fragment_id.as_local_id(),
-                arrange_operator_id: arrange_0_frag.node.unwrap().operator_id,
-                column_mapping: (i1_length..i1_length + i0_length)
-                    .chain(0..i1_length)
-                    .map(|x| x as _)
-                    .collect_vec(),
-            },
-        );
-
-        let lookup_1 = self.build_lookup_for_delta_join(
-            state,
-            (&exchange_a0l1, &exchange_a1l1),
-            (node.fields.clone(), node.pk_indices.clone()),
-            LookupNode {
-                stream_key: hash_join_node.left_key.clone(),
-                arrange_key: hash_join_node.right_key.clone(),
-                use_current_epoch: true,
-                // will be filled later in StreamFragment::seal
-                arrange_fragment_id: u32::MAX,
-                arrange_local_fragment_id: arrange_1_frag.fragment_id.as_local_id(),
-                arrange_operator_id: arrange_1_frag.node.unwrap().operator_id,
-                column_mapping: (0..i0_length + i1_length).map(|x| x as _).collect_vec(),
-            },
-        );
-
-        let lookup_0_frag = self.build_and_add_fragment(state, lookup_0)?;
-        let lookup_1_frag = self.build_and_add_fragment(state, lookup_1)?;
-
-        state.fragment_graph.add_edge(
-            arrange_0_frag.fragment_id,
-            lookup_0_frag.fragment_id,
-            StreamFragmentEdge {
-                dispatch_strategy: Self::dispatch_no_shuffle(),
-                same_worker_node: false,
-                link_id: exchange_a0l0.operator_id,
-            },
-        );
-
-        state.fragment_graph.add_edge(
-            arrange_0_frag.fragment_id,
-            lookup_1_frag.fragment_id,
-            StreamFragmentEdge {
-                dispatch_strategy: Self::dispatch_no_shuffle(),
-                same_worker_node: false,
-                link_id: exchange_a0l1.operator_id,
-            },
-        );
-
-        state.fragment_graph.add_edge(
-            arrange_1_frag.fragment_id,
-            lookup_0_frag.fragment_id,
-            StreamFragmentEdge {
-                dispatch_strategy: Self::dispatch_no_shuffle(),
-                same_worker_node: false,
-                link_id: exchange_a1l0.operator_id,
-            },
-        );
-
-        state.fragment_graph.add_edge(
-            arrange_1_frag.fragment_id,
-            lookup_1_frag.fragment_id,
-            StreamFragmentEdge {
-                dispatch_strategy: Self::dispatch_no_shuffle(),
-                same_worker_node: false,
-                link_id: exchange_a1l1.operator_id,
-            },
-        );
-
-        let exchange_l0m = self.build_exchange_for_delta_join(state, &node);
-        let exchange_l1m = self.build_exchange_for_delta_join(state, &node);
-
-        let union = StreamNode {
-            operator_id: state.gen_operator_id() as u64,
-            identity: "Union".into(),
-            fields: node.fields.clone(),
-            pk_indices: node.pk_indices.clone(),
-            node: Some(Node::UnionNode(UnionNode {})),
-            input: vec![exchange_l0m.clone(), exchange_l1m.clone()],
-            append_only: node.append_only,
+        let delta_join_node = StreamNode {
+            node: Some(Node::DeltaIndexJoin(DeltaIndexJoinNode {
+                join_type: hash_join_node.join_type,
+                left_key: hash_join_node.left_key.clone(),
+                right_key: hash_join_node.right_key.clone(),
+                left_table_id: hash_join_node.left_table_id,
+                right_table_id: hash_join_node.right_table_id,
+                condition: hash_join_node.condition.clone(),
+            })),
+            ..node
         };
 
-        state.fragment_graph.add_edge(
-            lookup_0_frag.fragment_id,
-            current_fragment.fragment_id,
-            StreamFragmentEdge {
-                dispatch_strategy: Self::dispatch_no_shuffle(),
-                same_worker_node: false,
-                link_id: exchange_l0m.operator_id,
-            },
-        );
-
-        state.fragment_graph.add_edge(
-            lookup_1_frag.fragment_id,
-            current_fragment.fragment_id,
-            StreamFragmentEdge {
-                dispatch_strategy: Self::dispatch_no_shuffle(),
-                same_worker_node: false,
-                link_id: exchange_l1m.operator_id,
-            },
-        );
+        let union = self.build_delta_join_inner(
+            state,
+            current_fragment,
+            arrange_0_frag,
+            arrange_1_frag,
+            &delta_join_node,
+        )?;
 
         Ok(union)
     }


### PR DESCRIPTION
Signed-off-by: Alex Chi <iskyzh@gmail.com>

## What's changed and what's your intention?

This PR adds support for rewriting `DeltaIndexJoin` to lookups on meta node. If we have created index beforehand, we will create `DeltaIndexJoin` plan, and we will join using index directly.

The MV can be created, but the result will be empty if we remove the force exchange check. Things will only work when we have added distribution key and pk of MV to catalog, so that the exchange can be eliminated.

## Checklist

- [x] I have written necessary docs and comments
- [x] I have added necessary unit tests and integration tests

## Refer to a related PR or issue link (optional)

ref https://github.com/singularity-data/risingwave/issues/2076