### PR TITLE
refactor: remove unused api in cluster manager

### DIFF
--- a/src/frontend/src/session.rs
+++ b/src/frontend/src/session.rs
@@ -392,38 +392,6 @@ impl Session for SessionImpl {
     }
 }
 
-// TODO: with a good MockMeta and then we can open the tests.
-// #[cfg(test)]
-// mod tests {
-
-//     #[tokio::test]
-//     async fn test_run_statement() {
-//         use std::ffi::OsString;
-
-//         use clap::StructOpt;
-//         use risingwave_meta::test_utils::LocalMeta;
-
-//         use super::*;
-
-//         let meta = LocalMeta::start(12008).await;
-//         let args: [OsString; 0] = []; // No argument.
-//         let mut opts = FrontendOpts::parse_from(args);
-//         opts.meta_addr = format!("http://{}", meta.meta_addr());
-//         let mgr = SessionManagerImpl::new(&opts).await.unwrap();
-//         // Check default database is created.
-//         assert!(mgr
-//             .env
-//             .catalog_manager
-//             .get_database(DEFAULT_DATABASE_NAME)
-//             .is_some());
-//         let session = mgr.connect();
-//         assert!(session.run_statement("select * from t").await.is_err());
-
-//         mgr.terminate();
-//         meta.stop().await;
-//     }
-// }
-
 #[cfg(test)]
 mod tests {
     use assert_impl::assert_impl;

--- a/src/meta/src/barrier/mod.rs
+++ b/src/meta/src/barrier/mod.rs
@@ -407,12 +407,7 @@ where
             .await;
         BarrierActorInfo::resolve(all_nodes, all_actor_infos)
     }
-}
 
-impl<S> GlobalBarrierManager<S>
-where
-    S: MetaStore,
-{
     async fn do_schedule(&self, command: Command, notifier: Notifier) -> Result<()> {
         self.scheduled_barriers
             .push((command, once(notifier).collect()))

--- a/src/meta/src/cluster/mod.rs
+++ b/src/meta/src/cluster/mod.rs
@@ -21,14 +21,13 @@ use std::sync::Arc;
 use std::time::{Duration, SystemTime};
 
 use itertools::Itertools;
-use risingwave_common::error::ErrorCode::InternalError;
-use risingwave_common::error::{Result, RwError};
+use risingwave_common::error::{internal_error, Result};
 use risingwave_common::try_match_expand;
 use risingwave_pb::common::worker_node::State;
 use risingwave_pb::common::{HostAddress, ParallelUnit, ParallelUnitType, WorkerNode, WorkerType};
 use risingwave_pb::meta::subscribe_response::{Info, Operation};
 use tokio::sync::mpsc::UnboundedSender;
-use tokio::sync::{RwLock, RwLockReadGuard};
+use tokio::sync::RwLock;
 use tokio::task::JoinHandle;
 
 use crate::manager::{
@@ -92,12 +91,6 @@ where
         })
     }
 
-    /// Used in `NotificationService::subscribe`.
-    /// Need to pay attention to the order of acquiring locks to prevent deadlock problems.
-    pub async fn get_cluster_core_guard(&self) -> RwLockReadGuard<'_, ClusterManagerCore> {
-        self.core.read().await
-    }
-
     pub async fn add_worker_node(
         &self,
         host_address: HostAddress,
@@ -151,94 +144,64 @@ where
         }
     }
 
-    pub async fn deactivate_worker_node(&self, host_address: HostAddress) -> Result<()> {
-        let mut core = self.core.write().await;
-        match core.get_worker_by_host(host_address.clone()) {
-            Some(mut worker) => {
-                if worker.worker_node.state == State::Starting as i32 {
-                    return Ok(());
-                }
-                worker.worker_node.state = State::Starting as i32;
-                worker.insert(self.env.meta_store()).await?;
-
-                core.update_worker_node(worker);
-                Ok(())
-            }
-            None => Err(RwError::from(InternalError(
-                "Worker node does not exist!".to_string(),
-            ))),
-        }
-    }
-
     pub async fn activate_worker_node(&self, host_address: HostAddress) -> Result<()> {
         let mut core = self.core.write().await;
-        match core.get_worker_by_host(host_address.clone()) {
-            Some(mut worker) => {
-                if worker.worker_node.state == State::Running as i32 {
-                    return Ok(());
-                }
-                worker.worker_node.state = State::Running as i32;
-                worker.insert(self.env.meta_store()).await?;
-
-                core.update_worker_node(worker.clone());
-
-                // Notify frontends of new compute node.
-                if worker.worker_node.r#type == WorkerType::ComputeNode as i32 {
-                    self.env
-                        .notification_manager()
-                        .notify_frontend(Operation::Add, Info::Node(worker.worker_node))
-                        .await;
-                }
-
-                Ok(())
-            }
-            None => Err(RwError::from(InternalError(
-                "Worker node does not exist!".to_string(),
-            ))),
+        let mut worker = core.get_worker_by_host_checked(host_address.clone())?;
+        if worker.worker_node.state == State::Running as i32 {
+            return Ok(());
         }
+        worker.worker_node.state = State::Running as i32;
+        worker.insert(self.env.meta_store()).await?;
+
+        core.update_worker_node(worker.clone());
+
+        // Notify frontends of new compute node.
+        if worker.worker_node.r#type == WorkerType::ComputeNode as i32 {
+            self.env
+                .notification_manager()
+                .notify_frontend(Operation::Add, Info::Node(worker.worker_node))
+                .await;
+        }
+
+        Ok(())
     }
 
     pub async fn delete_worker_node(&self, host_address: HostAddress) -> Result<()> {
         let mut core = self.core.write().await;
-        match core.get_worker_by_host(host_address.clone()) {
-            Some(worker) => {
-                let worker_type = worker.worker_type();
-                let worker_node = worker.to_protobuf();
-                // Alter consistent hash mapping.
-                if worker_type == WorkerType::ComputeNode {
-                    self.hash_mapping_manager
-                        .delete_worker_node(&worker.worker_node)
-                        .await?;
-                }
-
-                // Persist deletion.
-                Worker::delete(self.env.meta_store(), &host_address).await?;
-
-                // Update core.
-                core.delete_worker_node(worker);
-
-                // Notify frontends to delete compute node.
-                if worker_type == WorkerType::ComputeNode {
-                    self.env
-                        .notification_manager()
-                        .notify_frontend(Operation::Delete, Info::Node(worker_node.clone()))
-                        .await;
-                }
-
-                // Notify local subscribers.
-                self.env
-                    .notification_manager()
-                    .notify_local_subscribers(LocalNotification::WorkerDeletion(worker_node))
-                    .await;
-
-                Ok(())
-            }
-            None => Err(RwError::from(InternalError(
-                "Worker node does not exist!".to_string(),
-            ))),
+        let worker = core.get_worker_by_host_checked(host_address.clone())?;
+        let worker_type = worker.worker_type();
+        let worker_node = worker.to_protobuf();
+        // Alter consistent hash mapping.
+        if worker_type == WorkerType::ComputeNode {
+            self.hash_mapping_manager
+                .delete_worker_node(&worker.worker_node)
+                .await?;
         }
+
+        // Persist deletion.
+        Worker::delete(self.env.meta_store(), &host_address).await?;
+
+        // Update core.
+        core.delete_worker_node(worker);
+
+        // Notify frontends to delete compute node.
+        if worker_type == WorkerType::ComputeNode {
+            self.env
+                .notification_manager()
+                .notify_frontend(Operation::Delete, Info::Node(worker_node.clone()))
+                .await;
+        }
+
+        // Notify local subscribers.
+        self.env
+            .notification_manager()
+            .notify_local_subscribers(LocalNotification::WorkerDeletion(worker_node))
+            .await;
+
+        Ok(())
     }
 
+    /// Invoked when it receives a heartbeat from a worker node.
     pub async fn heartbeat(&self, worker_id: WorkerId) -> Result<()> {
         tracing::trace!(target: "events::meta::server_heartbeat", worker_id = worker_id, "receive heartbeat");
         let mut core = self.core.write().await;
@@ -395,7 +358,7 @@ where
     }
 }
 
-pub struct ClusterManagerCore {
+struct ClusterManagerCore {
     /// Record for workers in the cluster.
     workers: HashMap<WorkerKey, Worker>,
 
@@ -433,6 +396,12 @@ impl ClusterManagerCore {
             single_parallel_units,
             hash_parallel_units,
         })
+    }
+
+    /// If no worker exists, return an error.
+    fn get_worker_by_host_checked(&self, host_address: HostAddress) -> Result<Worker> {
+        self.get_worker_by_host(host_address)
+            .ok_or_else(|| internal_error("Worker node does not exist!"))
     }
 
     fn get_worker_by_host(&self, host_address: HostAddress) -> Option<Worker> {

--- a/src/meta/src/rpc/service/ddl_service.rs
+++ b/src/meta/src/rpc/service/ddl_service.rs
@@ -12,7 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#![allow(dead_code)]
 use std::collections::HashSet;
 
 use risingwave_common::catalog::CatalogVersion;

--- a/src/meta/src/rpc/service/notification_service.rs
+++ b/src/meta/src/rpc/service/notification_service.rs
@@ -81,10 +81,8 @@ where
                     .await
                     .map_err(|e| e.to_grpc_status())?;
 
-                let nodes = self
-                    .cluster_manager
-                    .list_worker_node(WorkerType::ComputeNode, Some(Running))
-                    .await;
+                let cluster_guard = self.cluster_manager.get_cluster_core_guard().await;
+                let nodes = cluster_guard.list_worker_node(WorkerType::ComputeNode, Some(Running));
 
                 // Send the snapshot on subscription. After that we will send only updates.
                 let meta_snapshot = MetaSnapshot {

--- a/src/meta/src/rpc/service/notification_service.rs
+++ b/src/meta/src/rpc/service/notification_service.rs
@@ -81,8 +81,10 @@ where
                     .await
                     .map_err(|e| e.to_grpc_status())?;
 
-                let cluster_guard = self.cluster_manager.get_cluster_core_guard().await;
-                let nodes = cluster_guard.list_worker_node(WorkerType::ComputeNode, Some(Running));
+                let nodes = self
+                    .cluster_manager
+                    .list_worker_node(WorkerType::ComputeNode, Some(Running))
+                    .await;
 
                 // Send the snapshot on subscription. After that we will send only updates.
                 let meta_snapshot = MetaSnapshot {


### PR DESCRIPTION
## What's changed and what's your intention?

- Removed `deactivate_worker_node` in  ClusterManager.
