### PR TITLE
fix(optimizer): fix batch top_n with offset

### DIFF
--- a/e2e_test/v2/batch/order_by.slt
+++ b/e2e_test/v2/batch/order_by.slt
@@ -60,3 +60,6 @@ select * from t order by v2 desc, v1 limit 2
 ----
 1 4 2
 3 4 4
+
+statement ok
+drop table t;

--- a/e2e_test/v2/batch/order_by.slt
+++ b/e2e_test/v2/batch/order_by.slt
@@ -1,0 +1,62 @@
+statement ok
+SET RW_IMPLICIT_FLUSH TO true;
+
+statement ok
+create table t (v1 int not null, v2 int not null, v3 int not null)
+
+statement ok
+insert into t values (1,4,2), (2,3,3), (3,4,4), (4,3,5)
+
+query III rowsort
+select * from t
+----
+1 4 2
+2 3 3
+3 4 4
+4 3 5
+
+query III
+select * from t order by v1 desc
+----
+4 3 5
+3 4 4
+2 3 3
+1 4 2
+
+query III
+select * from t order by v1 desc limit 1
+----
+4 3 5
+
+query III
+select * from t order by v1 desc limit 1 offset 1
+----
+3 4 4
+
+query III
+select * from t order by v2, v1
+----
+2 3 3
+4 3 5
+1 4 2
+3 4 4
+
+query III
+select * from t order by v2, v1 limit 2
+----
+2 3 3
+4 3 5
+
+query III
+select * from t order by v2, v1 limit 10
+----
+2 3 3
+4 3 5
+1 4 2
+3 4 4
+
+query III
+select * from t order by v2 desc, v1 limit 2
+----
+1 4 2
+3 4 4

--- a/src/frontend/src/optimizer/plan_node/logical_limit.rs
+++ b/src/frontend/src/optimizer/plan_node/logical_limit.rs
@@ -31,7 +31,7 @@ pub struct LogicalLimit {
 }
 
 impl LogicalLimit {
-    fn new(input: PlanRef, limit: usize, offset: usize) -> Self {
+    pub fn new(input: PlanRef, limit: usize, offset: usize) -> Self {
         let ctx = input.ctx();
         let schema = input.schema().clone();
         let pk_indices = input.pk_indices().to_vec();

--- a/src/frontend/src/optimizer/plan_node/logical_topn.rs
+++ b/src/frontend/src/optimizer/plan_node/logical_topn.rs
@@ -172,7 +172,7 @@ impl ToBatch for LogicalTopN {
             }
         } else {
             let new_input = self.input().to_batch_with_order_required(self.topn_order());
-            let limit = LogicalLimit::new(new_input.into(), self.limit(), self.offset());
+            let limit = LogicalLimit::new(new_input, self.limit(), self.offset());
             BatchLimit::new(limit).into()
         };
 

--- a/src/frontend/test_runner/tests/testdata/order_by.yaml
+++ b/src/frontend/test_runner/tests/testdata/order_by.yaml
@@ -63,9 +63,10 @@
     create table t (v1 bigint, v2 double precision);
     select * from t order by v1 desc limit 5 offset 7;
   batch_plan: |
-    BatchTopN { order: [$0 DESC], limit: 5, offset: 7 }
-      BatchExchange { order: [], dist: Single }
-        BatchScan { table: t, columns: [v1, v2] }
+    BatchLimit { limit: 5, offset: 7 }
+      BatchTopN { order: [$0 DESC], limit: 12, offset: 0 }
+        BatchExchange { order: [], dist: Single }
+          BatchScan { table: t, columns: [v1, v2] }
   stream_plan: |
     StreamMaterialize { columns: [v1, v2, _row_id#0(hidden)], pk_columns: [v1, _row_id#0] }
       StreamTopN { order: [$0 DESC], limit: 5, offset: 7 }


### PR DESCRIPTION
## What's changed and what's your intention?

our batch top_n executor does not support `offset` now. so this pr will write it to `limit-sort` or `limit-topn`
## Checklist

- [x] I have written necessary docs and comments
- [x] I have added necessary unit tests and integration tests

## Refer to a related PR or issue link (optional)
#2128 