### PR TITLE
fix(binder): remove stale error about correlated subquery

### DIFF
--- a/src/frontend/src/binder/expr/subquery.rs
+++ b/src/frontend/src/binder/expr/subquery.rs
@@ -24,18 +24,12 @@ impl Binder {
         query: Query,
         kind: SubqueryKind,
     ) -> Result<ExprImpl> {
-        let r = self.bind_query(query);
-        if let Ok(query) = r {
-            // uncorrelated subquery
-            if kind == SubqueryKind::Scalar && query.data_types().len() != 1 {
-                return Err(ErrorCode::BindError(
-                    "subquery must return only one column".to_string(),
-                )
-                .into());
-            }
-            return Ok(Subquery::new(query, kind).into());
+        let query = self.bind_query(query)?;
+        if kind == SubqueryKind::Scalar && query.data_types().len() != 1 {
+            return Err(
+                ErrorCode::BindError("subquery must return only one column".to_string()).into(),
+            );
         }
-
-        Err(ErrorCode::NotImplemented("correlated subquery".to_string(), 1343.into()).into())
+        Ok(Subquery::new(query, kind).into())
     }
 }

--- a/src/frontend/test_runner/tests/testdata/subquery_expr.yaml
+++ b/src/frontend/test_runner/tests/testdata/subquery_expr.yaml
@@ -131,4 +131,4 @@
               LogicalValues { rows: [[1:Int32]], schema: Schema { fields: [:Int32] } }
 - sql: |
     select 1 + (select 2 from t);
-  binder_error: 'Feature is not yet implemented: correlated subquery, Tracking issue: https://github.com/singularity-data/risingwave/issues/1343'
+  binder_error: 'Catalog error: table or source not found: t'

--- a/src/frontend/test_runner/tests/testdata/subquery_expr.yaml
+++ b/src/frontend/test_runner/tests/testdata/subquery_expr.yaml
@@ -129,3 +129,6 @@
           LogicalProject { exprs: [($0 >= 1:Int32)], expr_alias: [ ] }
             LogicalAgg { group_keys: [], agg_calls: [count] }
               LogicalValues { rows: [[1:Int32]], schema: Schema { fields: [:Int32] } }
+- sql: |
+    select 1 + (select 2 from t);
+  binder_error: 'Feature is not yet implemented: correlated subquery, Tracking issue: https://github.com/singularity-data/risingwave/issues/1343'


### PR DESCRIPTION
## What's changed and what's your intention?

The binder was reporting "correlated subquery unsupported" on any error from subquery. As of now, presence of correlated subquery expr will not raise an error, and we should bubble the original error up.

## Checklist

- [x] I have written necessary docs and comments
- [x] I have added necessary unit tests and integration tests

## Refer to a related PR or issue link (optional)
