### PR TITLE
feat(relational_layer): use relational layer for materialize executor

### DIFF
--- a/src/stream/src/executor_v2/mview/materialize.rs
+++ b/src/stream/src/executor_v2/mview/materialize.rs
@@ -15,11 +15,12 @@
 use futures::StreamExt;
 use futures_async_stream::try_stream;
 use itertools::Itertools;
-use risingwave_common::{array::Op::*, catalog::ColumnDesc};
+use risingwave_common::array::Op::*;
 use risingwave_common::array::Row;
-use risingwave_common::catalog::{ColumnId, Schema};
+use risingwave_common::catalog::{ColumnDesc, ColumnId, Schema};
 use risingwave_common::util::sort_util::OrderPair;
-use risingwave_storage::{Keyspace, StateStore, table::state_table::StateTable};
+use risingwave_storage::table::state_table::StateTable;
+use risingwave_storage::{Keyspace, StateStore};
 
 use crate::executor_v2::error::StreamExecutorError;
 use crate::executor_v2::{
@@ -50,16 +51,16 @@ impl<S: StateStore> MaterializeExecutor<S> {
         let arrange_order_types = keys.iter().map(|k| k.order_type).collect();
         let schema = input.schema().clone();
         let column_descs = column_ids
-        .into_iter()
-        .zip_eq(schema.fields.iter().cloned())
-        .map(|(column_id, field)| ColumnDesc {
-            data_type: field.data_type,
-            column_id,
-            name: field.name,
-            field_descs: vec![],
-            type_name: "".to_string(),
-        })
-        .collect_vec();
+            .into_iter()
+            .zip_eq(schema.fields.iter().cloned())
+            .map(|(column_id, field)| ColumnDesc {
+                data_type: field.data_type,
+                column_id,
+                name: field.name,
+                field_descs: vec![],
+                type_name: "".to_string(),
+            })
+            .collect_vec();
         Self {
             input,
             state_table: StateTable::new(keyspace, column_descs, arrange_order_types),

--- a/src/stream/src/executor_v2/mview/materialize.rs
+++ b/src/stream/src/executor_v2/mview/materialize.rs
@@ -15,14 +15,13 @@
 use futures::StreamExt;
 use futures_async_stream::try_stream;
 use itertools::Itertools;
-use risingwave_common::array::Op::*;
+use risingwave_common::{array::Op::*, catalog::ColumnDesc};
 use risingwave_common::array::Row;
 use risingwave_common::catalog::{ColumnId, Schema};
 use risingwave_common::util::sort_util::OrderPair;
-use risingwave_storage::{Keyspace, StateStore};
+use risingwave_storage::{Keyspace, StateStore, table::state_table::StateTable};
 
 use crate::executor_v2::error::StreamExecutorError;
-use crate::executor_v2::mview::ManagedMViewState;
 use crate::executor_v2::{
     BoxedExecutor, BoxedMessageStream, Executor, ExecutorInfo, Message, PkIndicesRef,
 };
@@ -31,7 +30,7 @@ use crate::executor_v2::{
 pub struct MaterializeExecutor<S: StateStore> {
     input: BoxedExecutor,
 
-    local_state: ManagedMViewState<S>,
+    state_table: StateTable<S>,
 
     /// Columns of arrange keys (including pk, group keys, join keys, etc.)
     arrange_columns: Vec<usize>,
@@ -50,9 +49,20 @@ impl<S: StateStore> MaterializeExecutor<S> {
         let arrange_columns: Vec<usize> = keys.iter().map(|k| k.column_idx).collect();
         let arrange_order_types = keys.iter().map(|k| k.order_type).collect();
         let schema = input.schema().clone();
+        let column_descs = column_ids
+        .into_iter()
+        .zip_eq(schema.fields.iter().cloned())
+        .map(|(column_id, field)| ColumnDesc {
+            data_type: field.data_type,
+            column_id,
+            name: field.name,
+            field_descs: vec![],
+            type_name: "".to_string(),
+        })
+        .collect_vec();
         Self {
             input,
-            local_state: ManagedMViewState::new(keyspace, column_ids, arrange_order_types),
+            state_table: StateTable::new(keyspace, column_descs, arrange_order_types),
             arrange_columns: arrange_columns.clone(),
             info: ExecutorInfo {
                 schema,
@@ -97,10 +107,10 @@ impl<S: StateStore> MaterializeExecutor<S> {
 
                         match op {
                             Insert | UpdateInsert => {
-                                self.local_state.put(arrange_row, row);
+                                self.state_table.insert(arrange_row, row)?;
                             }
                             Delete | UpdateDelete => {
-                                self.local_state.delete(arrange_row);
+                                self.state_table.delete(arrange_row, row)?;
                             }
                         }
                     }
@@ -109,8 +119,8 @@ impl<S: StateStore> MaterializeExecutor<S> {
                 }
                 Message::Barrier(b) => {
                     // FIXME(ZBW): use a better error type
-                    self.local_state
-                        .flush(b.epoch.prev)
+                    self.state_table
+                        .commit(b.epoch.prev)
                         .await
                         .map_err(StreamExecutorError::executor_v1)?;
                     Message::Barrier(b)


### PR DESCRIPTION
## What's changed and what's your intention?

This PR uses relational interfaces for materialize executor.

## Checklist

- [x] I have written necessary docs and comments
- [x] I have added necessary unit tests and integration tests

## Refer to a related PR or issue link (optional)
close https://github.com/singularity-data/risingwave/issues/1201