### PR TITLE
refactor(stream): migrate SourceExecutor to ExecutorV2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3762,7 +3762,6 @@ dependencies = [
  "bytes",
  "chrono",
  "crc32fast",
- "either",
  "enum-as-inner",
  "farmhash",
  "futures",

--- a/src/compute/tests/table_v2_materialize.rs
+++ b/src/compute/tests/table_v2_materialize.rs
@@ -38,10 +38,8 @@ use risingwave_storage::monitor::StateStoreMetrics;
 use risingwave_storage::table::cell_based_table::CellBasedTable;
 // use risingwave_storage::table::mview::MViewTable;
 use risingwave_storage::{Keyspace, StateStore, StateStoreImpl};
-use risingwave_stream::executor::{
-    Barrier, ExecutorV1, Message, PkIndices, SourceExecutor, StreamingMetrics,
-};
-use risingwave_stream::executor_v2::{Executor, MaterializeExecutor};
+use risingwave_stream::executor::{Barrier, ExecutorV1, Message, PkIndices, StreamingMetrics};
+use risingwave_stream::executor_v2::{Executor, MaterializeExecutor, SourceExecutor};
 use tokio::sync::mpsc::unbounded_channel;
 
 struct SingleChunkExecutor {
@@ -167,9 +165,7 @@ async fn test_table_v2_materialize() -> Result<()> {
     // Create a `Materialize` to write the changes to storage
     let keyspace = Keyspace::table_root(memory_state_store.clone(), &source_table_id);
     let mut materialize = MaterializeExecutor::new_from_v1(
-        (Box::new(stream_source) as Box<dyn ExecutorV1>)
-            .v2()
-            .boxed(),
+        Box::new(stream_source),
         keyspace.clone(),
         vec![OrderPair::new(1, OrderType::Ascending)],
         all_column_ids.clone(),
@@ -236,7 +232,7 @@ async fn test_table_v2_materialize() -> Result<()> {
     // Send a barrier to start materialized view
     let curr_epoch = 1919;
     barrier_tx
-        .send(Message::Barrier(Barrier::new_test_barrier(curr_epoch)))
+        .send(Barrier::new_test_barrier(curr_epoch))
         .unwrap();
 
     assert!(matches!(
@@ -266,7 +262,7 @@ async fn test_table_v2_materialize() -> Result<()> {
     // Send a barrier and poll again, should write changes to storage
     let curr_epoch = 1919;
     barrier_tx
-        .send(Message::Barrier(Barrier::new_test_barrier(curr_epoch)))
+        .send(Barrier::new_test_barrier(curr_epoch))
         .unwrap();
 
     assert!(matches!(
@@ -333,7 +329,7 @@ async fn test_table_v2_materialize() -> Result<()> {
 
     // Send a barrier and poll again, should write changes to storage
     barrier_tx
-        .send(Message::Barrier(Barrier::new_test_barrier(curr_epoch + 1)))
+        .send(Barrier::new_test_barrier(curr_epoch + 1))
         .unwrap();
 
     assert!(matches!(

--- a/src/source/Cargo.toml
+++ b/src/source/Cargo.toml
@@ -11,7 +11,6 @@ byteorder = "1"
 bytes = "1"
 chrono = "0.4"
 crc32fast = "1"
-either = "1"
 enum-as-inner = "0.4"
 farmhash = "1"
 futures = { version = "0.3", default-features = false, features = ["alloc"] }

--- a/src/stream/src/executor/mod.rs
+++ b/src/stream/src/executor/mod.rs
@@ -30,13 +30,12 @@ pub use merge::*;
 pub use monitor::*;
 pub use mview::*;
 pub use project::*;
-pub use source::*;
 pub use top_n::*;
 pub use top_n_appendonly::*;
 
 use crate::executor_v2::{
     BoxedExecutor, Executor, HashJoinExecutorBuilder, HopWindowExecutorBuilder,
-    LookupExecutorBuilder, UnionExecutorBuilder,
+    LookupExecutorBuilder, SourceExecutorBuilder, UnionExecutorBuilder,
 };
 use crate::task::{ActorId, ExecutorParams, LocalStreamManagerCore, ENABLE_BARRIER_AGGREGATION};
 
@@ -54,7 +53,6 @@ mod merge;
 pub mod monitor;
 mod mview;
 mod project;
-mod source;
 mod top_n;
 mod top_n_appendonly;
 

--- a/src/stream/src/executor_v2/error.rs
+++ b/src/stream/src/executor_v2/error.rs
@@ -50,6 +50,9 @@ enum StreamExecutorErrorInner {
     #[error("Hash join error: {0}")]
     HashJoinError(RwError),
 
+    #[error("Source error: {0}")]
+    SourceError(RwError),
+
     #[error("Channel `{0}` closed")]
     ChannelClosed(String),
 
@@ -84,6 +87,10 @@ impl StreamExecutorError {
 
     pub fn hash_join_error(error: impl Into<RwError>) -> Self {
         StreamExecutorErrorInner::HashJoinError(error.into()).into()
+    }
+
+    pub fn source_error(error: impl Into<RwError>) -> Self {
+        StreamExecutorErrorInner::SourceError(error.into()).into()
     }
 
     pub fn channel_closed(name: impl Into<String>) -> Self {

--- a/src/stream/src/executor_v2/mod.rs
+++ b/src/stream/src/executor_v2/mod.rs
@@ -39,6 +39,7 @@ mod project;
 mod rearranged_chain;
 pub mod receiver;
 mod simple;
+mod source;
 #[cfg(test)]
 mod test_utils;
 mod top_n;
@@ -62,6 +63,7 @@ pub use mview::*;
 pub use project::ProjectExecutor;
 pub use rearranged_chain::RearrangedChainExecutor;
 pub(crate) use simple::{SimpleExecutor, SimpleExecutorWrapper};
+pub use source::*;
 pub use top_n::TopNExecutor;
 pub use top_n_appendonly::AppendOnlyTopNExecutor;
 pub use union::{UnionExecutor, UnionExecutorBuilder};

--- a/src/stream/src/task/barrier_manager.rs
+++ b/src/stream/src/task/barrier_manager.rs
@@ -97,7 +97,7 @@ enum BarrierState {
 /// barriers to and collect them from all actors, and finally report the progress.
 pub struct LocalBarrierManager {
     /// Stores all materialized view source sender.
-    senders: HashMap<ActorId, UnboundedSender<Message>>,
+    senders: HashMap<ActorId, UnboundedSender<Barrier>>,
 
     /// Span of the current epoch.
     #[allow(dead_code)]
@@ -128,7 +128,7 @@ impl LocalBarrierManager {
     }
 
     /// Register sender for source actors, used to send barriers.
-    pub fn register_sender(&mut self, actor_id: ActorId, sender: UnboundedSender<Message>) {
+    pub fn register_sender(&mut self, actor_id: ActorId, sender: UnboundedSender<Barrier>) {
         tracing::trace!(actor_id = actor_id, "register sender");
         self.senders.insert(actor_id, sender);
     }
@@ -181,7 +181,7 @@ impl LocalBarrierManager {
                 .senders
                 .get(&actor_id)
                 .unwrap_or_else(|| panic!("sender for actor {} does not exist", actor_id));
-            sender.send(Message::Barrier(barrier.clone())).unwrap();
+            sender.send(barrier.clone()).unwrap();
         }
 
         // Actors to stop should still accept this barrier, but won't get sent to in next times.

--- a/src/stream/src/task/barrier_manager/tests.rs
+++ b/src/stream/src/task/barrier_manager/tests.rs
@@ -51,14 +51,8 @@ async fn test_managed_barrier_collection() -> Result<()> {
     let collected_barriers = rxs
         .iter_mut()
         .map(|(actor_id, rx)| {
-            let msg = rx.try_recv().unwrap();
-            let barrier = match msg {
-                Message::Barrier(b) => {
-                    assert_eq!(b.epoch.curr, epoch);
-                    b
-                }
-                _ => unreachable!(),
-            };
+            let barrier = rx.try_recv().unwrap();
+            assert_eq!(barrier.epoch.curr, epoch);
             (*actor_id, barrier)
         })
         .collect_vec();
@@ -117,14 +111,8 @@ async fn test_managed_barrier_collection_before_send_request() -> Result<()> {
     let collected_barriers = rxs
         .iter_mut()
         .map(|(actor_id, rx)| {
-            let msg = rx.try_recv().unwrap();
-            let barrier = match msg {
-                Message::Barrier(b) => {
-                    assert_eq!(b.epoch.curr, epoch);
-                    b
-                }
-                _ => unreachable!(),
-            };
+            let barrier = rx.try_recv().unwrap();
+            assert_eq!(barrier.epoch.curr, epoch);
             (*actor_id, barrier)
         })
         .collect_vec();


### PR DESCRIPTION
Signed-off-by: Runji Wang <wangrunji0408@163.com>

## What's changed and what's your intention?

***PLEASE DO NOT LEAVE THIS EMPTY !!!***

As title. This PR also changes the channel element type in `BarrierManager` from `Message` to `Barrier`.

## Checklist

- [x] I have written necessary docs and comments
- [x] I have added necessary unit tests and integration tests

## Refer to a related PR or issue link (optional)

resolve #1476