### PR TITLE
fix(doc): fix doc cargo test fail

### DIFF
--- a/src/common/src/array/data_chunk.rs
+++ b/src/common/src/array/data_chunk.rs
@@ -468,8 +468,7 @@ impl DataChunkTestExt for DataChunk {
     ///
     /// # Example
     /// ```
-    /// use risingwave_common::array::stream_chunk::DataChunkTestExt as _;
-    /// use risingwave_common::array::DataChunk;
+    /// use risingwave_common::array::{DataChunk, DataChunkTestExt};
     /// let chunk = DataChunk::from_pretty(
     ///     "I I I I      // type chars
     ///      2 5 . .      // '.' means NULL


### PR DESCRIPTION
## What's changed and what's your intention?

`cargo test` will fail due to this error. Not sure why this pass CI 
```
---- src/array/data_chunk.rs - array::data_chunk::DataChunk::from_pretty (line 470) stdout ----
error[E0432]: unresolved import `risingwave_common::array::stream_chunk::DataChunkTestExt`
 --> src/array/data_chunk.rs:471:5
  |
4 | use risingwave_common::array::stream_chunk::DataChunkTestExt as _;
  |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^----------------^^^^^
  |     |                                       |
  |     |                                       help: a similar name exists in the module: `StreamChunkTestExt`
  |     no `DataChunkTestExt` in `array::stream_chunk`

error[E0599]: no function or associated item named `from_pretty` found for struct `DataChunk` in the current scope
 --> src/array/data_chunk.rs:473:24
  |
6 | let chunk = DataChunk::from_pretty(
  |                        ^^^^^^^^^^^ function or associated item not found in `DataChunk`
  |
  = help: items from traits can only be used if the trait is in scope
help: the following trait is implemented but not in scope; perhaps add a `use` for it:
  |
3 | use crate::risingwave_common::array::DataChunkTestExt;

```

## Checklist

- [x] I have written necessary docs and comments
- [x] I have added necessary unit tests and integration tests

## Refer to a related PR or issue link (optional)
