### PR TITLE
feat(relational-states): use table id for hash agg states

### DIFF
--- a/proto/stream_plan.proto
+++ b/proto/stream_plan.proto
@@ -77,6 +77,7 @@ message SimpleAggNode {
 message HashAggNode {
   repeated int32 distribution_keys = 1;
   repeated expr.AggCall agg_calls = 2;
+  repeated uint32 table_ids = 3;
 }
 
 message TopNNode {

--- a/src/frontend/src/optimizer/plan_node/stream_hash_agg.rs
+++ b/src/frontend/src/optimizer/plan_node/stream_hash_agg.rs
@@ -105,6 +105,7 @@ impl ToStreamProst for StreamHashAgg {
                 .iter()
                 .map(PlanAggCall::to_protobuf)
                 .collect_vec(),
+            table_ids: vec![],
         })
     }
 }

--- a/src/meta/src/stream/fragmenter/mod.rs
+++ b/src/meta/src/stream/fragmenter/mod.rs
@@ -393,6 +393,13 @@ impl StreamFragmenter {
             }
         }
 
+        // Rewrite hash agg. One agg call -> one table id.
+        if let Node::HashAggNode(hash_agg_node) = stream_node.node.as_mut().unwrap() {
+            for _ in &hash_agg_node.agg_calls {
+                hash_agg_node.table_ids.push(state.gen_table_id());
+            }
+        }
+
         let inputs = std::mem::take(&mut stream_node.input);
         // Visit plan children.
         let inputs = inputs

--- a/src/stream/src/executor/hash_agg.rs
+++ b/src/stream/src/executor/hash_agg.rs
@@ -17,6 +17,7 @@
 use std::marker::PhantomData;
 
 use itertools::Itertools;
+use risingwave_common::catalog::TableId;
 use risingwave_common::error::Result;
 use risingwave_common::hash::{calc_hash_key_kind, HashKey, HashKeyDispatcher};
 use risingwave_common::try_match_expand;
@@ -35,7 +36,7 @@ struct HashAggExecutorDispatcherArgs<S: StateStore> {
     input: BoxedExecutor,
     agg_calls: Vec<AggCall>,
     key_indices: Vec<usize>,
-    keyspace: Keyspace<S>,
+    keyspace: Vec<Keyspace<S>>,
     pk_indices: PkIndices,
     executor_id: u64,
     op_info: String,
@@ -79,7 +80,13 @@ impl ExecutorBuilder for HashAggExecutorBuilder {
             .iter()
             .map(build_agg_call_from_prost)
             .try_collect()?;
-        let keyspace = Keyspace::shared_executor_root(store, params.operator_id);
+        // Build vector of keyspace via table ids.
+        // One keyspace for one agg call.
+        let keyspace = node
+            .get_table_ids()
+            .iter()
+            .map(|table_id| Keyspace::table_root(store.clone(), &TableId::new(*table_id)))
+            .collect();
         let input = params.input.remove(0);
         let keys = key_indices
             .iter()

--- a/src/stream/src/executor_v2/aggregation/mod.rs
+++ b/src/stream/src/executor_v2/aggregation/mod.rs
@@ -18,6 +18,7 @@ pub use agg_call::*;
 pub use agg_state::*;
 use dyn_clone::{self, DynClone};
 pub use foldable::*;
+use itertools::Itertools;
 use risingwave_common::array::column::Column;
 use risingwave_common::array::stream_chunk::Ops;
 use risingwave_common::array::{
@@ -353,6 +354,64 @@ pub async fn generate_agg_state<S: StateStore>(
             keyspace.append_u16(idx as u16).append(bytes)
         } else {
             keyspace.append_u16(idx as u16)
+        };
+
+        let mut managed_state = ManagedStateImpl::create_managed_state(
+            agg_call.clone(),
+            keyspace,
+            row_count,
+            pk_data_types.clone(),
+            idx == ROW_COUNT_COLUMN,
+            key_hash_code.clone(),
+        )
+        .await
+        .map_err(StreamExecutorError::agg_state_error)?;
+
+        if idx == ROW_COUNT_COLUMN {
+            // For the rowcount state, we should record the rowcount.
+            let output = managed_state
+                .get_output(epoch)
+                .await
+                .map_err(StreamExecutorError::agg_state_error)?;
+            row_count = Some(output.as_ref().map(|x| *x.as_int64() as usize).unwrap_or(0));
+        }
+
+        managed_states.push(managed_state);
+    }
+
+    Ok(AggState {
+        managed_states,
+        prev_states: None,
+    })
+}
+
+/// Generate initial [`AggState`] from `agg_calls`. For [`crate::executor_v2::HashAggExecutor`], the
+/// group key should be provided.
+/// FIXME: It's a fork of [`generate_hash_agg_state`]. Should merge this two when simple agg is
+/// using table ids.
+pub async fn generate_hash_agg_state<S: StateStore>(
+    key: Option<&Row>,
+    agg_calls: &[AggCall],
+    keyspace: &[Keyspace<S>],
+    pk_data_types: PkDataTypes,
+    epoch: u64,
+    key_hash_code: Option<HashCode>,
+) -> StreamExecutorResult<AggState<S>> {
+    let mut managed_states = vec![];
+
+    // Currently the loop here only works if `ROW_COUNT_COLUMN` is 0.
+    const_assert_eq!(ROW_COUNT_COLUMN, 0);
+    let mut row_count = None;
+
+    for ((idx, agg_call), keyspace) in agg_calls.iter().enumerate().zip_eq(keyspace) {
+        // TODO: in pure in-memory engine, we should not do this serialization.
+
+        // The prefix of the state is `table_id / [group_key]`
+        let keyspace = if let Some(key) = key {
+            let bytes = key.serialize().unwrap();
+            keyspace.append(bytes)
+        } else {
+            keyspace.clone()
         };
 
         let mut managed_state = ManagedStateImpl::create_managed_state(

--- a/src/stream/src/executor_v2/hash_agg.rs
+++ b/src/stream/src/executor_v2/hash_agg.rs
@@ -304,87 +304,85 @@ impl<K: HashKey, S: StateStore> HashAggExecutor<K, S> {
         state_map: &'a mut EvictableHashMap<K, Option<Box<AggState<S>>>>,
         epoch: u64,
     ) {
-        for k in keyspace {
-            // --- Flush states to the state store ---
-            // Some state will have the correct output only after their internal states have been
-            // fully flushed.
-            let (write_batch, dirty_cnt) = {
-                let mut write_batch = k.state_store().start_write_batch();
-                let mut dirty_cnt = 0;
+        // The state store of each keyspace is the same so just need the first.
+        let store = keyspace[0].state_store();
+        // --- Flush states to the state store ---
+        // Some state will have the correct output only after their internal states have been
+        // fully flushed.
+        let (write_batch, dirty_cnt) = {
+            let mut write_batch = store.start_write_batch();
+            let mut dirty_cnt = 0;
 
-                for states in state_map.values_mut() {
-                    if states.as_ref().unwrap().is_dirty() {
-                        dirty_cnt += 1;
-                        for state in &mut states.as_mut().unwrap().managed_states {
-                            state
-                                .flush(&mut write_batch)
-                                .map_err(StreamExecutorError::agg_state_error)?;
-                        }
-                    }
-                }
-                (write_batch, dirty_cnt)
-            };
-
-            if dirty_cnt == 0 {
-                // Nothing to flush.
-                assert!(write_batch.is_empty());
-                return Ok(());
-            } else {
-                write_batch
-                    .ingest(epoch)
-                    .await
-                    .map_err(StreamExecutorError::agg_state_error)?;
-
-                // --- Produce the stream chunk ---
-                let mut batches = IterChunks::chunks(state_map.iter_mut(), PROCESSING_WINDOW_SIZE);
-                while let Some(batch) = batches.next() {
-                    // --- Create array builders ---
-                    // As the datatype is retrieved from schema, it contains both group key and
-                    // aggregation state outputs.
-                    let mut builders = schema
-                        .create_array_builders(dirty_cnt * 2)
-                        .map_err(StreamExecutorError::eval_error)?;
-                    let mut new_ops = Vec::with_capacity(dirty_cnt);
-
-                    // --- Retrieve modified states and put the changes into the builders ---
-                    for (key, states) in batch {
-                        let appended = states
-                            .as_mut()
-                            .unwrap()
-                            .build_changes(&mut builders[key_indices.len()..], &mut new_ops, epoch)
-                            .await
+            for states in state_map.values_mut() {
+                if states.as_ref().unwrap().is_dirty() {
+                    dirty_cnt += 1;
+                    for state in &mut states.as_mut().unwrap().managed_states {
+                        state
+                            .flush(&mut write_batch)
                             .map_err(StreamExecutorError::agg_state_error)?;
-
-                        for _ in 0..appended {
-                            key.clone()
-                                .deserialize_to_builders(&mut builders[..key_indices.len()])
-                                .map_err(StreamExecutorError::eval_error)?;
-                        }
                     }
+                }
+            }
+            (write_batch, dirty_cnt)
+        };
 
-                    let columns: Vec<Column> = builders
-                        .into_iter()
-                        .map(|builder| -> Result<_> {
-                            Ok(Column::new(Arc::new(builder.finish()?)))
-                        })
-                        .try_collect()
-                        .map_err(StreamExecutorError::eval_error)?;
+        if dirty_cnt == 0 {
+            // Nothing to flush.
+            assert!(write_batch.is_empty());
+            return Ok(());
+        } else {
+            write_batch
+                .ingest(epoch)
+                .await
+                .map_err(StreamExecutorError::agg_state_error)?;
 
-                    let chunk = StreamChunk::new(new_ops, columns, None);
+            // --- Produce the stream chunk ---
+            let mut batches = IterChunks::chunks(state_map.iter_mut(), PROCESSING_WINDOW_SIZE);
+            while let Some(batch) = batches.next() {
+                // --- Create array builders ---
+                // As the datatype is retrieved from schema, it contains both group key and
+                // aggregation state outputs.
+                let mut builders = schema
+                    .create_array_builders(dirty_cnt * 2)
+                    .map_err(StreamExecutorError::eval_error)?;
+                let mut new_ops = Vec::with_capacity(dirty_cnt);
 
-                    trace!("output_chunk: {:?}", &chunk);
-                    yield chunk;
+                // --- Retrieve modified states and put the changes into the builders ---
+                for (key, states) in batch {
+                    let appended = states
+                        .as_mut()
+                        .unwrap()
+                        .build_changes(&mut builders[key_indices.len()..], &mut new_ops, epoch)
+                        .await
+                        .map_err(StreamExecutorError::agg_state_error)?;
+
+                    for _ in 0..appended {
+                        key.clone()
+                            .deserialize_to_builders(&mut builders[..key_indices.len()])
+                            .map_err(StreamExecutorError::eval_error)?;
+                    }
                 }
 
-                // evict cache to target capacity
-                // In current implementation, we need to fetch the RowCount from the state store
-                // once a key is deleted and added again. We should find a way to
-                // eliminate this extra fetch.
-                assert!(!state_map
-                    .values()
-                    .any(|state| state.as_ref().unwrap().is_dirty()));
-                state_map.evict_to_target_cap();
+                let columns: Vec<Column> = builders
+                    .into_iter()
+                    .map(|builder| -> Result<_> { Ok(Column::new(Arc::new(builder.finish()?))) })
+                    .try_collect()
+                    .map_err(StreamExecutorError::eval_error)?;
+
+                let chunk = StreamChunk::new(new_ops, columns, None);
+
+                trace!("output_chunk: {:?}", &chunk);
+                yield chunk;
             }
+
+            // evict cache to target capacity
+            // In current implementation, we need to fetch the RowCount from the state store
+            // once a key is deleted and added again. We should find a way to
+            // eliminate this extra fetch.
+            assert!(!state_map
+                .values()
+                .any(|state| state.as_ref().unwrap().is_dirty()));
+            state_map.evict_to_target_cap();
         }
     }
 

--- a/src/stream/src/executor_v2/v1_compat.rs
+++ b/src/stream/src/executor_v2/v1_compat.rs
@@ -304,7 +304,7 @@ impl<K: HashKey, S: StateStore> HashAggExecutor<K, S> {
         input: BoxedExecutor,
         agg_calls: Vec<AggCall>,
         key_indices: Vec<usize>,
-        keyspace: Keyspace<S>,
+        keyspace: Vec<Keyspace<S>>,
         pk_indices: PkIndices,
         executor_id: u64,
         _op_info: String,


### PR DESCRIPTION
## What's changed and what's your intention?

For HashAgg, previous the keyspace encoding is `operator_id/agg_idx/group_key ....`, now change to `table_id/group_key...`. Each agg call in hash agg corresponds to a table states. 

After some offline discusssion, the simple agg will also do similar refactoring. It might be helpful for relation table interface. In future, all internal states may be prefixed by table_id instead of operator_id.

Code
* Add table ids in proto `HashAgg` node.
* Count and assign table id in meta fragmenter.
* Tweak the hash agg in stream executor to use vector of keyspace. I add a new method `generate_hash_agg_states` (fork of `generate_agg_states`). It will only be used by hash agg for now and if we merge hash agg and simple agg, we can merge them into one.
* Tweak some unit tests. 

## Checklist

- [x] I have written necessary docs and comments
- [x] I have added necessary unit tests and integration tests

## Refer to a related PR or issue link (optional)
