### PR TITLE
refactor(test): refactor some unit tests by relational interfaces

### DIFF
--- a/src/storage/src/table/state_table.rs
+++ b/src/storage/src/table/state_table.rs
@@ -17,6 +17,7 @@ use std::sync::Arc;
 use risingwave_common::array::Row;
 use risingwave_common::catalog::ColumnDesc;
 use risingwave_common::error::RwError;
+use risingwave_common::util::ordered::OrderedRowSerializer;
 use risingwave_common::util::sort_util::OrderType;
 
 use super::cell_based_table::{CellBasedTable, CellBasedTableRowIter};
@@ -46,7 +47,12 @@ impl<S: StateStore> StateTable<S> {
         Self {
             order_types: order_types.clone(),
             mem_table: MemTable::new(),
-            cell_based_table: CellBasedTable::new_for_test(keyspace, column_descs, order_types),
+            cell_based_table: CellBasedTable::new(
+                keyspace,
+                column_descs,
+                Some(OrderedRowSerializer::new(order_types)),
+                Arc::new(StateStoreMetrics::unused()),
+            ),
         }
     }
 

--- a/src/stream/src/executor_v2/mview/materialize.rs
+++ b/src/stream/src/executor_v2/mview/materialize.rs
@@ -213,7 +213,10 @@ mod tests {
 
         let keyspace = Keyspace::table_root(memory_state_store.clone(), &table_id);
         let order_types = vec![OrderType::Ascending];
-        let column_descs = vec![ColumnDesc::unnamed(column_ids[1], DataType::Int32)];
+        let column_descs = vec![
+            ColumnDesc::unnamed(column_ids[0], DataType::Int32),
+            ColumnDesc::unnamed(column_ids[1], DataType::Int32),
+        ];
         let table = CellBasedTable::new_for_test(keyspace.clone(), column_descs, order_types);
         let mut materialize_executor = Box::new(MaterializeExecutor::new(
             Box::new(source),
@@ -233,7 +236,7 @@ mod tests {
                     .get_row(&Row(vec![Some(3_i32.into())]), u64::MAX)
                     .await
                     .unwrap();
-                assert_eq!(row, Some(Row(vec![Some(6_i32.into())])));
+                assert_eq!(row, Some(Row(vec![Some(3_i32.into()), Some(6_i32.into())])));
             }
             _ => unreachable!(),
         }
@@ -245,7 +248,7 @@ mod tests {
                     .get_row(&Row(vec![Some(7_i32.into())]), u64::MAX)
                     .await
                     .unwrap();
-                assert_eq!(row, Some(Row(vec![Some(8_i32.into())])));
+                assert_eq!(row, Some(Row(vec![Some(7_i32.into()), Some(8_i32.into())])));
             }
             _ => unreachable!(),
         }

--- a/src/stream/src/executor_v2/mview/test_utils.rs
+++ b/src/stream/src/executor_v2/mview/test_utils.rs
@@ -18,9 +18,8 @@ use risingwave_common::types::DataType;
 use risingwave_common::util::sort_util::OrderType;
 use risingwave_storage::memory::MemoryStateStore;
 use risingwave_storage::table::cell_based_table::CellBasedTable;
+use risingwave_storage::table::state_table::StateTable;
 use risingwave_storage::Keyspace;
-
-use super::ManagedMViewState;
 
 pub async fn gen_basic_table(row_count: usize) -> CellBasedTable<MemoryStateStore> {
     let state_store = MemoryStateStore::new();
@@ -28,26 +27,28 @@ pub async fn gen_basic_table(row_count: usize) -> CellBasedTable<MemoryStateStor
     let orderings = vec![OrderType::Ascending, OrderType::Descending];
     let keyspace = Keyspace::executor_root(state_store, 0x42);
     let column_ids = vec![0.into(), 1.into(), 2.into()];
-    let mut state = ManagedMViewState::new(
-        keyspace.clone(),
-        column_ids.clone(),
-        vec![OrderType::Ascending, OrderType::Descending],
-    );
     let column_descs = vec![
         ColumnDesc::unnamed(column_ids[0], DataType::Int32),
         ColumnDesc::unnamed(column_ids[1], DataType::Int32),
         ColumnDesc::unnamed(column_ids[2], DataType::Int32),
     ];
+    let mut state = StateTable::new(
+        keyspace.clone(),
+        column_descs.clone(),
+        vec![OrderType::Ascending, OrderType::Descending],
+    );
     let table = CellBasedTable::new_for_test(keyspace.clone(), column_descs, orderings);
     let epoch: u64 = 0;
 
     for idx in 0..row_count {
         let idx = idx as i32;
-        state.put(
-            Row(vec![Some(idx.into()), Some(idx.into())]),
-            Row(vec![Some(idx.into()), Some(idx.into()), Some(idx.into())]),
-        );
+        state
+            .insert(
+                Row(vec![Some(idx.into()), Some(idx.into())]),
+                Row(vec![Some(idx.into()), Some(idx.into()), Some(idx.into())]),
+            )
+            .unwrap();
     }
-    state.flush(epoch).await.unwrap();
+    state.commit(epoch).await.unwrap();
     table
 }


### PR DESCRIPTION
## What's changed and what's your intention?
As some relational interfaces has been implemented, `ManageMViewState` can be replaced by `StateTable`. This PR replaced `ManageMViewState` with `StateTable` in some unit tests.



## Checklist

- [x] I have written necessary docs and comments
- [x] I have added necessary unit tests and integration tests

## Refer to a related PR or issue link (optional)
