### PR TITLE
refactor(storage): issue upload task to uploader to avoid buffering batches in uploader

### DIFF
--- a/src/bench/ss_bench/operations/write_batch.rs
+++ b/src/bench/ss_bench/operations/write_batch.rs
@@ -104,7 +104,7 @@ impl Operations {
                     // the assumption required by LocalVersionManager. It may result in some pinned
                     // versions never get unpinned. This can be fixed after
                     // LocalVersionManager::start_workers is modified into push-based.
-                    let last_pinned_id = local_version_manager.get_pinned_version().unwrap().id();
+                    let last_pinned_id = local_version_manager.get_pinned_version().id();
                     let version = self.meta_client.pin_version(last_pinned_id).await.unwrap();
                     local_version_manager.try_update_pinned_version(version);
                 }

--- a/src/storage/benches/bench_merge_iter.rs
+++ b/src/storage/benches/bench_merge_iter.rs
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 use std::cell::RefCell;
+use std::sync::atomic::AtomicUsize;
 use std::sync::Arc;
 
 use bytes::Bytes;
@@ -30,6 +31,7 @@ fn gen_interleave_shared_buffer_batch_iter(
     batch_count: usize,
 ) -> Vec<BoxedForwardHummockIterator> {
     let mut iterators = Vec::new();
+    let buffer_tracker = Arc::new(AtomicUsize::new(0));
     for i in 0..batch_count {
         let mut batch_data = vec![];
         for j in 0..batch_size {
@@ -38,7 +40,7 @@ fn gen_interleave_shared_buffer_batch_iter(
                 HummockValue::put(Bytes::copy_from_slice("value".as_bytes())),
             ));
         }
-        let batch = SharedBufferBatch::new(batch_data, 2333);
+        let batch = SharedBufferBatch::new(batch_data, 2333, buffer_tracker.clone());
         iterators.push(Box::new(batch.into_forward_iter()) as BoxedForwardHummockIterator);
     }
     iterators

--- a/src/storage/src/hummock/compactor.rs
+++ b/src/storage/src/hummock/compactor.rs
@@ -86,7 +86,7 @@ impl Compactor {
     /// For compaction from shared buffer to level 0, this is the only function gets called.
     pub async fn compact_shared_buffer(
         context: Arc<CompactorContext>,
-        buffers: Vec<SharedBufferBatch>,
+        buffers: &[SharedBufferBatch],
         stats: Arc<StateStoreMetrics>,
     ) -> HummockResult<Vec<Sstable>> {
         let mut start_user_keys: Vec<_> = buffers.iter().map(|m| m.start_user_key()).collect();

--- a/src/storage/src/hummock/local_version_manager.rs
+++ b/src/storage/src/hummock/local_version_manager.rs
@@ -12,12 +12,18 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use std::collections::BTreeMap;
+use std::mem::swap;
+use std::sync::atomic::AtomicUsize;
+use std::sync::atomic::Ordering::Relaxed;
 use std::sync::{Arc, Weak};
 use std::time::Duration;
 
-use parking_lot::{Mutex, RwLock};
-use prometheus::core::{Atomic, AtomicU64};
+use bytes::Bytes;
+use itertools::Itertools;
+use parking_lot::RwLock;
 use risingwave_common::config::StorageConfig;
+use risingwave_hummock_sdk::key::FullKey;
 use risingwave_pb::hummock::{HummockVersion, SstableInfo};
 use risingwave_rpc_client::HummockMetaClient;
 use tokio::sync::mpsc::error::TryRecvError;
@@ -25,50 +31,47 @@ use tokio::sync::mpsc::{UnboundedReceiver, UnboundedSender};
 use tokio::sync::oneshot;
 use tokio_retry::strategy::jitter;
 
-use super::local_version::{LocalVerion, PinnedVersion, ReadVersion};
+use super::local_version::{LocalVersion, PinnedVersion, ReadVersion};
 use super::shared_buffer::shared_buffer_batch::SharedBufferBatch;
 use super::shared_buffer::shared_buffer_uploader::{SharedBufferUploader, UploadItem};
 use super::SstableStoreRef;
+use crate::hummock::conflict_detector::ConflictDetector;
+use crate::hummock::shared_buffer::shared_buffer_batch::SharedBufferItem;
+use crate::hummock::shared_buffer::shared_buffer_uploader::UploadTask;
+use crate::hummock::shared_buffer::SharedBuffer;
 use crate::hummock::utils::validate_table_key_range;
 use crate::hummock::{
     HummockEpoch, HummockError, HummockResult, HummockVersionId, INVALID_VERSION_ID,
 };
 use crate::monitor::StateStoreMetrics;
+use crate::storage_value::StorageValue;
+
 struct WorkerContext {
     version_update_notifier_tx: tokio::sync::watch::Sender<HummockVersionId>,
-    version_unpin_worker_tx: UnboundedSender<HummockVersionId>,
     shared_buffer_uploader_tx: UnboundedSender<UploadItem>,
-
-    /// (version_unpin_worker_rx, shared_buffer_uploader_rx)
-    /// Become none after the worker is started.
-    worker_rx: Mutex<
-        Option<(
-            UnboundedReceiver<HummockVersionId>,
-            UnboundedReceiver<UploadItem>,
-        )>,
-    >,
 }
 
 struct BufferTracker {
-    capacity: u64,
-    size: AtomicU64,
+    capacity: usize,
+    upload_size: Arc<AtomicUsize>,
+    replicate_size: Arc<AtomicUsize>,
 }
 
 impl BufferTracker {
     pub fn is_empty(&self) -> bool {
-        self.size.get() == 0
+        self.upload_size.load(Relaxed) == 0
     }
 
-    pub fn can_write(&self, batch_size: u64) -> bool {
-        self.size.get() + batch_size <= self.capacity
+    pub fn get_upload_size(&self) -> usize {
+        self.upload_size.load(Relaxed)
     }
 
-    pub fn inc(&self, delta: u64) {
-        self.size.inc_by(delta)
+    pub fn get_replicate_size(&self) -> usize {
+        self.replicate_size.load(Relaxed)
     }
 
-    pub fn dec(&self, delta: u64) {
-        self.size.dec_by(delta)
+    pub fn can_write(&self, batch_size: usize) -> bool {
+        self.get_upload_size() + self.get_replicate_size() + batch_size <= self.capacity
     }
 }
 
@@ -77,67 +80,78 @@ impl BufferTracker {
 /// during the lifetime of `ScopedLocalVersion`. Internally `LocalVersionManager` will pin/unpin the
 /// versions in storage service.
 pub struct LocalVersionManager {
-    local_version: RwLock<Option<LocalVerion>>,
+    local_version: RwLock<LocalVersion>,
     worker_context: WorkerContext,
     buffer_tracker: BufferTracker,
+    write_conflict_detector: Option<Arc<ConflictDetector>>,
 }
 
 impl LocalVersionManager {
-    pub fn new(options: Arc<StorageConfig>) -> LocalVersionManager {
-        let (version_update_notifier_tx, _) = tokio::sync::watch::channel(INVALID_VERSION_ID);
+    pub async fn new(
+        options: Arc<StorageConfig>,
+        sstable_store: SstableStoreRef,
+        stats: Arc<StateStoreMetrics>,
+        hummock_meta_client: Arc<dyn HummockMetaClient>,
+        write_conflict_detector: Option<Arc<ConflictDetector>>,
+    ) -> Arc<LocalVersionManager> {
         let (shared_buffer_uploader_tx, shared_buffer_uploader_rx) =
             tokio::sync::mpsc::unbounded_channel();
         let (version_unpin_worker_tx, version_unpin_worker_rx) =
             tokio::sync::mpsc::unbounded_channel();
+        let (version_update_notifier_tx, _) = tokio::sync::watch::channel(INVALID_VERSION_ID);
 
-        LocalVersionManager {
-            local_version: RwLock::new(None),
+        let pinned_version = Self::pin_version_with_retry(
+            hummock_meta_client.clone(),
+            INVALID_VERSION_ID,
+            10,
+            // never break until max retry
+            || false,
+        )
+        .await
+        .expect("should be `Some` is `break_condition` is always false")
+        .expect("should be able to pinned the first version");
+
+        let global_upload_batches_size = Arc::new(AtomicUsize::new(0));
+        let global_replicate_batches_size = Arc::new(AtomicUsize::new(0));
+
+        let local_version_manager = Arc::new(LocalVersionManager {
+            local_version: RwLock::new(LocalVersion::new(pinned_version, version_unpin_worker_tx)),
             worker_context: WorkerContext {
                 version_update_notifier_tx,
-                version_unpin_worker_tx,
                 shared_buffer_uploader_tx,
-                worker_rx: Mutex::new(Some((version_unpin_worker_rx, shared_buffer_uploader_rx))),
             },
             buffer_tracker: BufferTracker {
-                capacity: options.shared_buffer_capacity as u64,
-                size: AtomicU64::new(0),
+                capacity: options.shared_buffer_capacity as usize,
+                upload_size: global_upload_batches_size,
+                replicate_size: global_replicate_batches_size,
             },
-        }
-    }
+            write_conflict_detector: write_conflict_detector.clone(),
+        });
 
-    pub fn start_workers(
-        options: Arc<StorageConfig>,
-        sstable_store: SstableStoreRef,
-        local_version_manager: Arc<LocalVersionManager>,
-        stats: Arc<StateStoreMetrics>,
-        hummock_meta_client: Arc<dyn HummockMetaClient>,
-    ) {
-        let local_version_manager_for_uploader = local_version_manager.clone();
-        if let Some((version_unpin_worker_rx, shared_buffer_uploader_rx)) =
-            local_version_manager.worker_context.worker_rx.lock().take()
-        {
-            // Pin and get the latest version.
-            tokio::spawn(LocalVersionManager::start_pin_worker(
-                Arc::downgrade(&local_version_manager),
-                hummock_meta_client.clone(),
-            ));
-            // Unpin unused version.
-            tokio::spawn(LocalVersionManager::start_unpin_worker(
-                version_unpin_worker_rx,
-                hummock_meta_client.clone(),
-            ));
-            // Uploader shared buffer to S3.
-            let mut uploader = SharedBufferUploader::new(
-                options.clone(),
-                options.shared_buffer_threshold as usize,
-                sstable_store,
-                local_version_manager_for_uploader,
-                hummock_meta_client,
-                shared_buffer_uploader_rx,
-                stats,
-            );
-            tokio::spawn(async move { uploader.run().await });
-        }
+        // Pin and get the latest version.
+        tokio::spawn(LocalVersionManager::start_pin_worker(
+            Arc::downgrade(&local_version_manager),
+            hummock_meta_client.clone(),
+        ));
+
+        // Unpin unused version.
+        tokio::spawn(LocalVersionManager::start_unpin_worker(
+            version_unpin_worker_rx,
+            hummock_meta_client.clone(),
+        ));
+
+        // Uploader shared buffer to S3.
+        let mut uploader = SharedBufferUploader::new(
+            options.clone(),
+            sstable_store,
+            hummock_meta_client,
+            shared_buffer_uploader_rx,
+            stats,
+            write_conflict_detector,
+        );
+        tokio::spawn(async move { uploader.run().await });
+
+        local_version_manager
     }
 
     /// Updates cached version if the new version is of greater id.
@@ -150,22 +164,11 @@ impl LocalVersionManager {
         }
         let mut guard = self.local_version.write();
 
-        if let Some(cached_version) = guard.as_mut() {
-            if cached_version.pinned_version().id() >= new_version_id {
-                return false;
-            }
-
-            let buffer_to_release = cached_version.set_pinned_version(newly_pinned_version);
-            let removed_size = buffer_to_release
-                .iter()
-                .fold(0, |acc, x| acc + x.1.read().size());
-            self.buffer_tracker.dec(removed_size);
-        } else {
-            *guard = Some(LocalVerion::new(
-                newly_pinned_version,
-                self.worker_context.version_unpin_worker_tx.clone(),
-            ));
+        if guard.pinned_version().id() >= new_version_id {
+            return false;
         }
+
+        guard.set_pinned_version(newly_pinned_version);
 
         self.worker_context
             .version_update_notifier_tx
@@ -183,20 +186,11 @@ impl LocalVersionManager {
         let mut guard = self.local_version.write();
 
         // Record uploaded but uncommitted SSTs and delete batches from shared buffer.
-        if let Some(cached_version) = guard.as_mut() {
-            cached_version.add_uncommitted_ssts(epoch, sst_info);
+        guard.add_uncommitted_ssts(epoch, sst_info);
 
-            if let Some(shared_buffer) = cached_version.get_shared_buffer(epoch) {
-                let mut guard = shared_buffer.write();
-                // TODO memory
-                let mut removed_size = 0;
-                for batch in shared_buffer_batches {
-                    if let Some(removed_batch) = guard.delete_batch(batch) {
-                        removed_size += removed_batch.size();
-                    }
-                }
-                self.buffer_tracker.dec(removed_size);
-            }
+        if let Some(shared_buffer) = guard.get_shared_buffer(epoch) {
+            let mut guard = shared_buffer.write();
+            guard.delete_batch(shared_buffer_batches.as_slice());
         }
     }
 
@@ -209,10 +203,8 @@ impl LocalVersionManager {
         loop {
             {
                 let current_version = self.local_version.read();
-                if let Some(version) = current_version.as_ref() {
-                    if version.pinned_version().max_committed_epoch() >= epoch {
-                        return Ok(());
-                    }
+                if current_version.pinned_version().max_committed_epoch() >= epoch {
+                    return Ok(());
                 }
             }
             match tokio::time::timeout(Duration::from_secs(10), receiver.changed()).await {
@@ -227,51 +219,62 @@ impl LocalVersionManager {
         }
     }
 
+    pub fn build_shared_buffer_item_batches(
+        kv_pairs: Vec<(Bytes, StorageValue)>,
+        epoch: HummockEpoch,
+    ) -> Vec<SharedBufferItem> {
+        kv_pairs
+            .into_iter()
+            .map(|(key, value)| {
+                (
+                    Bytes::from(FullKey::from_user_key(key.to_vec(), epoch).into_inner()),
+                    value.into(),
+                )
+            })
+            .collect_vec()
+    }
+
     pub async fn write_shared_buffer(
         &self,
         epoch: HummockEpoch,
-        batch: SharedBufferBatch,
+        kv_pairs: Vec<(Bytes, StorageValue)>,
         is_remote_batch: bool,
-    ) -> HummockResult<()> {
-        let batch_size = batch.size();
+    ) -> HummockResult<usize> {
+        let sorted_items = Self::build_shared_buffer_item_batches(kv_pairs, epoch);
+
+        let batch_size = SharedBufferBatch::measure_batch_size(&sorted_items);
         while !self.buffer_tracker.can_write(batch_size) {
             self.sync_shared_buffer(None).await?;
         }
 
+        let batch = SharedBufferBatch::new(
+            sorted_items,
+            epoch,
+            if is_remote_batch {
+                self.buffer_tracker.replicate_size.clone()
+            } else {
+                self.buffer_tracker.upload_size.clone()
+            },
+        );
+
         // Try get shared buffer with version read lock
-        let read_guard = self.local_version.read();
-        let shared_buffer = match read_guard.as_ref() {
-            None => return Err(HummockError::meta_error("No version found.")),
-            Some(current_version) => current_version.get_shared_buffer(epoch).cloned(),
-        };
-        drop(read_guard);
+        let shared_buffer = self.local_version.read().get_shared_buffer(epoch).cloned();
 
         // New a shared buffer with version write lock if shared buffer of the corresponding epoch
         // does not exist before
-        let shared_buffer = shared_buffer.unwrap_or_else(|| {
-            self.local_version
-                .write()
-                .as_mut()
-                .unwrap()
-                .new_shared_buffer(epoch)
-        });
+        let shared_buffer =
+            shared_buffer.unwrap_or_else(|| self.local_version.write().new_shared_buffer(epoch));
 
         // Write into shared buffer
         if is_remote_batch {
             // The batch won't be synced to S3 asynchronously if it is a remote batch
-            shared_buffer.write().write_batch(batch);
+            shared_buffer.write().replicate_batch(batch);
         } else {
             // The batch will be synced to S3 asynchronously if it is a local batch
-            shared_buffer.write().write_batch(batch.clone());
-            self.worker_context
-                .shared_buffer_uploader_tx
-                .send(UploadItem::Batch(batch))
-                .map_err(HummockError::shared_buffer_error)?;
+            shared_buffer.write().write_batch(batch);
         }
 
-        self.buffer_tracker.inc(batch_size);
-
-        Ok(())
+        Ok(batch_size)
     }
 
     pub async fn sync_shared_buffer(&self, epoch: Option<HummockEpoch>) -> HummockResult<()> {
@@ -279,65 +282,132 @@ impl LocalVersionManager {
             return Ok(());
         }
 
+        let mut tasks = vec![];
+
+        let mut handle_epoch = |epoch: &HummockEpoch, shared_buffer: &Arc<RwLock<SharedBuffer>>| {
+            let mut guard = shared_buffer.write();
+            let (task_id, task_data) = guard.new_upload_task(|batches| {
+                // Take all batches of an epoch out.
+                let mut ret = BTreeMap::default();
+                swap(&mut ret, batches);
+                ret
+            });
+            tasks.push(UploadTask::new(task_id, *epoch, task_data));
+        };
+
+        {
+            let guard = self.local_version.read();
+            match epoch {
+                Some(epoch) => match guard.get_shared_buffer(epoch) {
+                    None => return Ok(()),
+                    Some(shared_buffer) => {
+                        handle_epoch(&epoch, shared_buffer);
+                    }
+                },
+                None => {
+                    for (epoch, shared_buffer) in guard.iter_shared_buffer() {
+                        handle_epoch(epoch, shared_buffer);
+                    }
+                }
+            }
+        }
+
+        if tasks.is_empty() {
+            return Ok(());
+        }
+
         let (tx, rx) = oneshot::channel();
         self.worker_context
             .shared_buffer_uploader_tx
-            .send(UploadItem::Sync {
-                epoch,
-                notifier: tx,
-            })
+            .send(UploadItem::new(tasks, tx))
             .map_err(HummockError::shared_buffer_error)?;
-        rx.await.map_err(HummockError::shared_buffer_error)?;
-        Ok(())
-    }
+        let upload_result = rx.await.map_err(HummockError::shared_buffer_error)?;
 
-    pub fn read_version(
-        self: &Arc<LocalVersionManager>,
-        read_epoch: HummockEpoch,
-    ) -> HummockResult<ReadVersion> {
-        match self.local_version.read().as_ref() {
-            None => Err(HummockError::meta_error("No version found.")),
-            Some(current_version) => Ok(current_version.read_version(read_epoch)),
-        }
-    }
+        let failed_epoch = upload_result
+            .iter()
+            .filter_map(
+                |((epoch, _), result)| {
+                    if result.is_err() {
+                        Some(*epoch)
+                    } else {
+                        None
+                    }
+                },
+            )
+            .collect_vec();
 
-    pub fn get_pinned_version(&self) -> HummockResult<Arc<PinnedVersion>> {
-        match self.local_version.read().as_ref() {
-            None => Err(HummockError::meta_error("No version found.")),
-            Some(current_version) => Ok(current_version.pinned_version().clone()),
-        }
-    }
-
-    async fn start_pin_worker(
-        local_version_manager: Weak<LocalVersionManager>,
-        hummock_meta_client: Arc<dyn HummockMetaClient>,
-    ) {
-        let max_retry_interval = Duration::from_secs(10);
-        let min_execute_interval = Duration::from_millis(100);
-        let get_backoff_strategy = || {
-            tokio_retry::strategy::ExponentialBackoff::from_millis(10)
-                .max_delay(max_retry_interval)
-                .map(jitter)
-        };
-        let mut retry_backoff = get_backoff_strategy();
-        let mut min_execute_interval_tick = tokio::time::interval(min_execute_interval);
-        loop {
-            min_execute_interval_tick.tick().await;
-            let local_version_manager = match local_version_manager.upgrade() {
-                None => {
-                    tracing::info!("Shutdown hummock pin worker");
-                    return;
+        if failed_epoch.len() < upload_result.len() {
+            // only acquire the lock when any of the upload task succeed.
+            let mut guard = self.local_version.write();
+            for ((epoch, task_id), result) in upload_result {
+                match result {
+                    Ok(ssts) => {
+                        guard.add_uncommitted_ssts(epoch, ssts);
+                        if let Some(shared_buffer) = guard.get_shared_buffer(epoch) {
+                            shared_buffer.write().success_upload_task(task_id);
+                        }
+                        if let Some(conflict_detector) = self.write_conflict_detector.as_ref() {
+                            conflict_detector.archive_epoch(epoch);
+                        }
+                    }
+                    Err(_) => {
+                        if let Some(shared_buffer) = guard.get_shared_buffer(epoch) {
+                            shared_buffer.write().fail_upload_task(task_id);
+                        }
+                    }
                 }
-                Some(local_version_manager) => local_version_manager,
-            };
-            let last_pinned = match local_version_manager.local_version.read().as_ref() {
-                None => INVALID_VERSION_ID,
-                Some(v) => v.pinned_version().id(),
-            };
+            }
+        };
+
+        if failed_epoch.is_empty() {
+            Ok(())
+        } else {
+            Err(HummockError::shared_buffer_error(format!(
+                "Failed to sync epochs: {:?}",
+                failed_epoch
+            )))
+        }
+    }
+
+    pub fn read_version(self: &Arc<LocalVersionManager>, read_epoch: HummockEpoch) -> ReadVersion {
+        self.local_version.read().read_version(read_epoch)
+    }
+
+    pub fn get_pinned_version(&self) -> Arc<PinnedVersion> {
+        self.local_version.read().pinned_version().clone()
+    }
+
+    /// Pin a version with retry.
+    ///
+    /// Return:
+    ///   - `Some(Ok(pinned_version))` if success
+    ///   - `Some(Err(err))` if exceed the retry limit
+    ///   - `None` if meet the break condition
+    async fn pin_version_with_retry(
+        hummock_meta_client: Arc<dyn HummockMetaClient>,
+        last_pinned: HummockVersionId,
+        max_retry: usize,
+        break_condition: impl Fn() -> bool,
+    ) -> Option<HummockResult<HummockVersion>> {
+        let max_retry_interval = Duration::from_secs(10);
+        let mut retry_backoff = tokio_retry::strategy::ExponentialBackoff::from_millis(10)
+            .max_delay(max_retry_interval)
+            .map(jitter);
+
+        let mut retry_count = 0;
+        loop {
+            if retry_count > max_retry {
+                break Some(Err(HummockError::meta_error(format!(
+                    "pin_version max retry reached: {}.",
+                    max_retry
+                ))));
+            }
+            if break_condition() {
+                break None;
+            }
             match hummock_meta_client.pin_version(last_pinned).await {
                 Ok(version) => {
-                    local_version_manager.try_update_pinned_version(version);
-                    retry_backoff = get_backoff_strategy();
+                    break Some(Ok(version));
                 }
                 Err(err) => {
                     let retry_after = retry_backoff.next().unwrap_or(max_retry_interval);
@@ -349,6 +419,55 @@ impl LocalVersionManager {
                     tokio::time::sleep(retry_after).await;
                 }
             }
+            retry_count += 1;
+        }
+    }
+
+    async fn start_pin_worker(
+        local_version_manager_weak: Weak<LocalVersionManager>,
+        hummock_meta_client: Arc<dyn HummockMetaClient>,
+    ) {
+        let min_execute_interval = Duration::from_millis(100);
+        let mut min_execute_interval_tick = tokio::time::interval(min_execute_interval);
+        loop {
+            min_execute_interval_tick.tick().await;
+            let local_version_manager = match local_version_manager_weak.upgrade() {
+                None => {
+                    tracing::info!("Shutdown hummock pin worker");
+                    return;
+                }
+                Some(local_version_manager) => local_version_manager,
+            };
+
+            let last_pinned = local_version_manager
+                .local_version
+                .read()
+                .pinned_version()
+                .id();
+
+            match Self::pin_version_with_retry(
+                hummock_meta_client.clone(),
+                last_pinned,
+                usize::MAX,
+                || {
+                    // Should stop when the `local_version_manager` in this thread is the only
+                    // strong reference to the object.
+                    local_version_manager_weak.strong_count() == 1
+                },
+            )
+            .await
+            {
+                Some(Ok(pinned_version)) => {
+                    local_version_manager.try_update_pinned_version(pinned_version);
+                }
+                Some(Err(_)) => {
+                    unreachable!("since the max_retry is `usize::MAX`, this should return `Err`");
+                }
+                None => {
+                    tracing::info!("Shutdown hummock pin worker");
+                    return;
+                }
+            };
         }
     }
 
@@ -410,42 +529,45 @@ impl LocalVersionManager {
 
     #[cfg(test)]
     pub async fn refresh_version(&self, hummock_meta_client: &dyn HummockMetaClient) -> bool {
-        let last_pinned = self.get_pinned_version().unwrap().id();
+        let last_pinned = self.get_pinned_version().id();
         let version = hummock_meta_client.pin_version(last_pinned).await.unwrap();
         self.try_update_pinned_version(version)
     }
 
     #[cfg(test)]
-    pub fn get_local_version(&self) -> LocalVerion {
-        self.local_version.read().as_ref().unwrap().clone()
+    pub fn get_local_version(&self) -> LocalVersion {
+        self.local_version.read().clone()
     }
 
     #[cfg(test)]
-    pub fn get_shared_buffer_size(&self) -> u64 {
-        self.buffer_tracker.size.get()
+    pub fn get_shared_buffer_size(&self) -> usize {
+        self.buffer_tracker.get_replicate_size() + self.buffer_tracker.get_upload_size()
     }
 }
 
 #[cfg(test)]
 mod tests {
+    use std::sync::atomic::AtomicUsize;
     use std::sync::Arc;
 
+    use bytes::Bytes;
+    use risingwave_meta::hummock::test_utils::setup_compute_env;
+    use risingwave_meta::hummock::MockHummockMetaClient;
     use risingwave_pb::hummock::{HummockVersion, KeyRange, SstableInfo};
 
     use super::LocalVersionManager;
-    use crate::hummock::iterator::test_utils::iterator_test_key_of_epoch;
+    use crate::hummock::conflict_detector::ConflictDetector;
+    use crate::hummock::iterator::test_utils::{iterator_test_key_of_epoch, mock_sstable_store};
     use crate::hummock::shared_buffer::shared_buffer_batch::SharedBufferBatch;
     use crate::hummock::test_utils::default_config_for_test;
-    use crate::hummock::value::HummockValue;
+    use crate::monitor::StateStoreMetrics;
+    use crate::storage_value::{StorageValue, ValueMeta};
 
-    fn gen_dummy_batch(epoch: u64) -> SharedBufferBatch {
-        SharedBufferBatch::new(
-            vec![(
-                iterator_test_key_of_epoch(0, epoch).into(),
-                HummockValue::put(b"value1".to_vec()).into(),
-            )],
-            epoch,
-        )
+    fn gen_dummy_batch(epoch: u64) -> Vec<(Bytes, StorageValue)> {
+        vec![(
+            iterator_test_key_of_epoch(0, epoch).into(),
+            StorageValue::new_put(ValueMeta::default(), b"value1".to_vec()),
+        )]
     }
 
     fn gen_dummy_sst_info(id: u64, batches: Vec<SharedBufferBatch>) -> SstableInfo {
@@ -471,18 +593,32 @@ mod tests {
 
     #[tokio::test]
     async fn test_update_pinned_version() {
-        let local_version_manager = Arc::new(LocalVersionManager::new(Arc::new(
-            default_config_for_test(),
-        )));
-        let version = HummockVersion {
-            id: 0,
-            max_committed_epoch: 0,
-            ..Default::default()
-        };
-        local_version_manager.try_update_pinned_version(version);
+        let opt = Arc::new(default_config_for_test());
+        let (_, hummock_manager_ref, _, worker_node) = setup_compute_env(8080).await;
+        let local_version_manager = LocalVersionManager::new(
+            opt.clone(),
+            mock_sstable_store(),
+            Arc::new(StateStoreMetrics::unused()),
+            Arc::new(MockHummockMetaClient::new(
+                hummock_manager_ref.clone(),
+                worker_node.id,
+            )),
+            ConflictDetector::new_from_config(opt),
+        )
+        .await;
 
-        let epochs: Vec<u64> = vec![1, 2, 3, 4];
-        let batches: Vec<SharedBufferBatch> = epochs.iter().map(|e| gen_dummy_batch(*e)).collect();
+        let pinned_version = local_version_manager.get_pinned_version();
+        let initial_version_id = pinned_version.id();
+        let initial_max_commit_epoch = pinned_version.max_committed_epoch();
+
+        let epochs: Vec<u64> = vec![
+            initial_max_commit_epoch + 1,
+            initial_max_commit_epoch + 2,
+            initial_max_commit_epoch + 3,
+            initial_max_commit_epoch + 4,
+        ];
+        let batches: Vec<Vec<(Bytes, StorageValue)>> =
+            epochs.iter().map(|e| gen_dummy_batch(*e)).collect();
 
         // Fill shared buffer with a dummy empty batch in epochs[0] and epochs[1]
         for i in 0..2 {
@@ -497,13 +633,18 @@ mod tests {
                     .unwrap()
                     .read()
                     .size(),
-                batches[i].size()
+                SharedBufferBatch::measure_batch_size(
+                    &LocalVersionManager::build_shared_buffer_item_batches(
+                        batches[i].clone(),
+                        epochs[i]
+                    )
+                )
             );
         }
 
         // Update version for epochs[0]
         let version = HummockVersion {
-            id: 1,
+            id: initial_version_id + 1,
             max_committed_epoch: epochs[0],
             ..Default::default()
         };
@@ -516,12 +657,17 @@ mod tests {
                 .unwrap()
                 .read()
                 .size(),
-            batches[1].size()
+            SharedBufferBatch::measure_batch_size(
+                &LocalVersionManager::build_shared_buffer_item_batches(
+                    batches[1].clone(),
+                    epochs[1]
+                )
+            )
         );
 
         // Update version for epochs[1]
         let version = HummockVersion {
-            id: 2,
+            id: initial_version_id + 2,
             max_committed_epoch: epochs[1],
             ..Default::default()
         };
@@ -533,18 +679,29 @@ mod tests {
 
     #[tokio::test]
     async fn test_update_uncommitted_ssts() {
-        let local_version_manager = Arc::new(LocalVersionManager::new(Arc::new(
-            default_config_for_test(),
-        )));
-        let version = HummockVersion {
-            id: 0,
-            max_committed_epoch: 0,
-            ..Default::default()
-        };
-        local_version_manager.try_update_pinned_version(version.clone());
+        let opt = Arc::new(default_config_for_test());
+        let (_, hummock_manager_ref, _, worker_node) = setup_compute_env(8080).await;
+        let local_version_manager = LocalVersionManager::new(
+            opt.clone(),
+            mock_sstable_store(),
+            Arc::new(StateStoreMetrics::unused()),
+            Arc::new(MockHummockMetaClient::new(
+                hummock_manager_ref.clone(),
+                worker_node.id,
+            )),
+            ConflictDetector::new_from_config(opt),
+        )
+        .await;
 
-        let epochs: Vec<u64> = vec![1, 2];
-        let batches: Vec<SharedBufferBatch> = epochs.iter().map(|e| gen_dummy_batch(*e)).collect();
+        let pinned_version = local_version_manager.get_pinned_version();
+        let max_commit_epoch = pinned_version.max_committed_epoch();
+        let initial_id = pinned_version.id();
+        let version = pinned_version.version();
+
+        let epochs: Vec<u64> = vec![max_commit_epoch + 1, max_commit_epoch + 2];
+        let buffer_tracker = Arc::new(AtomicUsize::new(0));
+        let batches: Vec<Vec<(Bytes, StorageValue)>> =
+            epochs.iter().map(|e| gen_dummy_batch(*e)).collect();
 
         // Fill shared buffer with dummy batches
         for i in 0..2 {
@@ -559,12 +716,21 @@ mod tests {
                     .unwrap()
                     .read()
                     .size(),
-                batches[i].size()
+                SharedBufferBatch::measure_batch_size(
+                    &LocalVersionManager::build_shared_buffer_item_batches(
+                        batches[i].clone(),
+                        epochs[i]
+                    )
+                )
             );
         }
 
         // Update uncommitted sst for epochs[0]
-        let uploaded_batches: Vec<SharedBufferBatch> = vec![batches[0].clone()];
+        let uploaded_batches: Vec<SharedBufferBatch> = vec![SharedBufferBatch::new(
+            LocalVersionManager::build_shared_buffer_item_batches(batches[0].clone(), epochs[0]),
+            epochs[0],
+            buffer_tracker.clone(),
+        )];
         let sst1 = gen_dummy_sst_info(1, uploaded_batches.clone());
         local_version_manager.update_uncommitted_ssts(
             epochs[0],
@@ -587,8 +753,14 @@ mod tests {
                 .unwrap()
                 .read()
                 .size(),
-            batches[1].size()
+            SharedBufferBatch::measure_batch_size(
+                &LocalVersionManager::build_shared_buffer_item_batches(
+                    batches[1].clone(),
+                    epochs[1]
+                )
+            )
         );
+
         // Check pinned version
         assert_eq!(local_version.pinned_version().version(), version);
         // Check uncommitted ssts
@@ -599,7 +771,11 @@ mod tests {
         assert_eq!(*epoch_uncommitted_ssts.first().unwrap(), sst1);
 
         // Update uncommitted sst for epochs[1]
-        let uploaded_batches: Vec<SharedBufferBatch> = vec![batches[1].clone()];
+        let uploaded_batches: Vec<SharedBufferBatch> = vec![SharedBufferBatch::new(
+            LocalVersionManager::build_shared_buffer_item_batches(batches[1].clone(), epochs[1]),
+            epochs[1],
+            buffer_tracker.clone(),
+        )];
         let sst2 = gen_dummy_sst_info(2, uploaded_batches.clone());
         local_version_manager.update_uncommitted_ssts(
             epochs[1],
@@ -629,7 +805,7 @@ mod tests {
 
         // Update version for epochs[0]
         let version = HummockVersion {
-            id: 1,
+            id: initial_id + 1,
             max_committed_epoch: epochs[0],
             ..Default::default()
         };
@@ -656,7 +832,7 @@ mod tests {
 
         // Update version for epochs[1]
         let version = HummockVersion {
-            id: 2,
+            id: initial_id + 2,
             max_committed_epoch: epochs[1],
             ..Default::default()
         };

--- a/src/storage/src/hummock/shared_buffer/mod.rs
+++ b/src/storage/src/hummock/shared_buffer/mod.rs
@@ -17,24 +17,40 @@ pub mod shared_buffer_batch;
 #[allow(dead_code)]
 pub mod shared_buffer_uploader;
 
-use std::collections::BTreeMap;
+use std::collections::HashMap;
 use std::ops::RangeBounds;
 
+use itertools::Itertools;
+
 use self::shared_buffer_batch::SharedBufferBatch;
+use crate::hummock::shared_buffer::shared_buffer_batch::IndexedSharedBufferBatches;
+use crate::hummock::shared_buffer::shared_buffer_uploader::{UploadTaskData, UploadTaskId};
 use crate::hummock::utils::range_overlap;
 
 #[derive(Default, Debug)]
 pub struct SharedBuffer {
     /// `{ end key -> batch }`
-    inner: BTreeMap<Vec<u8>, SharedBufferBatch>,
-    size: u64,
+    non_upload_batches: IndexedSharedBufferBatches,
+    replicate_batches: IndexedSharedBufferBatches,
+    uploading_batches: HashMap<UploadTaskId, IndexedSharedBufferBatches>,
+
+    upload_batches_size: usize,
+    replicate_batches_size: usize,
+
+    next_upload_task_id: UploadTaskId,
 }
 
 impl SharedBuffer {
     pub fn write_batch(&mut self, batch: SharedBufferBatch) {
-        self.inner
-            .insert(batch.end_user_key().to_vec(), batch.clone());
-        self.size += batch.size;
+        self.upload_batches_size += batch.size();
+        self.non_upload_batches
+            .insert(batch.end_user_key().to_vec(), batch);
+    }
+
+    pub fn replicate_batch(&mut self, batch: SharedBufferBatch) {
+        self.replicate_batches_size += batch.size();
+        self.replicate_batches
+            .insert(batch.end_user_key().to_vec(), batch);
     }
 
     // Gets batches from shared buffer that overlap with the given key range.
@@ -47,15 +63,22 @@ impl SharedBuffer {
         R: RangeBounds<B>,
         B: AsRef<[u8]>,
     {
-        self.inner
-            .range((
-                if reversed_range {
-                    key_range.end_bound().map(|b| b.as_ref().to_vec())
-                } else {
-                    key_range.start_bound().map(|b| b.as_ref().to_vec())
-                },
-                std::ops::Bound::Unbounded,
-            ))
+        let range = (
+            if reversed_range {
+                key_range.end_bound().map(|b| b.as_ref().to_vec())
+            } else {
+                key_range.start_bound().map(|b| b.as_ref().to_vec())
+            },
+            std::ops::Bound::Unbounded,
+        );
+        self.non_upload_batches
+            .range(range.clone())
+            .chain(self.replicate_batches.range(range.clone()))
+            .chain(
+                self.uploading_batches
+                    .values()
+                    .flat_map(|batches| batches.range(range.clone())),
+            )
             .filter(|m| {
                 range_overlap(
                     key_range,
@@ -68,27 +91,61 @@ impl SharedBuffer {
             .collect()
     }
 
-    pub fn delete_batch(&mut self, batch: SharedBufferBatch) -> Option<SharedBufferBatch> {
-        let deleted_batch = self.inner.remove(batch.end_user_key());
-        if let Some(batch) = &deleted_batch {
-            self.size -= batch.size();
+    pub fn delete_batch(&mut self, batches: &[SharedBufferBatch]) {
+        for batch in batches {
+            if let Some(batch) = &self.non_upload_batches.remove(batch.end_user_key()) {
+                self.upload_batches_size -= batch.size();
+            }
         }
-        deleted_batch
     }
 
-    pub fn size(&self) -> u64 {
-        self.size
+    pub fn clear_replicate_batch(&mut self) {
+        self.replicate_batches.clear();
+        self.replicate_batches_size = 0;
+    }
+
+    pub fn new_upload_task(
+        &mut self,
+        task_gen: impl Fn(&mut IndexedSharedBufferBatches) -> IndexedSharedBufferBatches,
+    ) -> (UploadTaskId, UploadTaskData) {
+        let task_id = self.next_upload_task_id;
+        self.next_upload_task_id += 1;
+        let indexed_batches = task_gen(&mut self.non_upload_batches);
+        let batches = indexed_batches.values().cloned().collect_vec();
+        self.uploading_batches.insert(task_id, indexed_batches);
+        (task_id, batches)
+    }
+
+    pub fn fail_upload_task(&mut self, upload_task_id: UploadTaskId) {
+        debug_assert!(self.uploading_batches.contains_key(&upload_task_id));
+        let task_batches = self.uploading_batches.remove(&upload_task_id).unwrap();
+        self.non_upload_batches.extend(task_batches);
+    }
+
+    pub fn success_upload_task(&mut self, upload_task_id: UploadTaskId) {
+        debug_assert!(self.uploading_batches.contains_key(&upload_task_id));
+        let task_batches = self.uploading_batches.remove(&upload_task_id).unwrap();
+        for batch in task_batches.into_values() {
+            self.upload_batches_size -= batch.size();
+        }
+    }
+
+    pub fn size(&self) -> usize {
+        self.upload_batches_size + self.replicate_batches_size
     }
 }
 
 #[cfg(test)]
 mod tests {
+    use std::sync::atomic::AtomicUsize;
+    use std::sync::Arc;
+
     use bytes::Bytes;
     use risingwave_hummock_sdk::key::{key_with_epoch, user_key};
 
     use super::*;
     use crate::hummock::iterator::test_utils::iterator_test_value_of;
-    use crate::hummock::value::HummockValue;
+    use crate::hummock::HummockValue;
 
     async fn generate_and_write_batch(
         put_keys: &[Vec<u8>],
@@ -96,6 +153,7 @@ mod tests {
         epoch: u64,
         idx: &mut usize,
         shared_buffer: &mut SharedBuffer,
+        is_replicate: bool,
     ) -> SharedBufferBatch {
         let mut shared_buffer_items = Vec::new();
         for key in put_keys {
@@ -112,8 +170,13 @@ mod tests {
             ));
         }
         shared_buffer_items.sort_by(|l, r| user_key(&l.0).cmp(&r.0));
-        let batch = SharedBufferBatch::new(shared_buffer_items, epoch);
-        shared_buffer.write_batch(batch.clone());
+        let batch =
+            SharedBufferBatch::new(shared_buffer_items, epoch, Arc::new(AtomicUsize::new(0)));
+        if is_replicate {
+            shared_buffer.replicate_batch(batch.clone());
+        } else {
+            shared_buffer.write_batch(batch.clone());
+        }
         batch
     }
 
@@ -127,30 +190,47 @@ mod tests {
         let large_key = format!("key_test_{:05}", 9).as_bytes().to_vec();
         let mut idx = 0;
 
-        // Write a batch in epoch1
+        // Write two batches in epoch1
         let epoch1 = 1;
-        let shared_buffer_batch1 =
-            generate_and_write_batch(&keys[0..3], &[], epoch1, &mut idx, &mut shared_buffer).await;
+
+        // Write to upload buffer
+        let shared_buffer_batch1 = generate_and_write_batch(
+            &keys[0..3],
+            &[],
+            epoch1,
+            &mut idx,
+            &mut shared_buffer,
+            false,
+        )
+        .await;
+
+        // Write to replicate buffer
+        let shared_buffer_batch2 =
+            generate_and_write_batch(&keys[0..3], &[], epoch1, &mut idx, &mut shared_buffer, true)
+                .await;
 
         // Get overlap batches and verify
         for key in &keys[0..3] {
             // Single key
             let overlap_batches =
                 shared_buffer.get_overlap_batches(&(key.clone()..=key.clone()), false);
-            assert_eq!(overlap_batches.len(), 1);
+            assert_eq!(overlap_batches.len(), 2);
             assert_eq!(overlap_batches[0], shared_buffer_batch1);
+            assert_eq!(overlap_batches[1], shared_buffer_batch2);
 
             // Forward key range
             let overlap_batches =
                 shared_buffer.get_overlap_batches(&(key.clone()..=keys[3].clone()), false);
-            assert_eq!(overlap_batches.len(), 1);
+            assert_eq!(overlap_batches.len(), 2);
             assert_eq!(overlap_batches[0], shared_buffer_batch1);
+            assert_eq!(overlap_batches[1], shared_buffer_batch2);
 
             // Backward key range
             let overlap_batches =
                 shared_buffer.get_overlap_batches(&(keys[3].clone()..=key.clone()), true);
-            assert_eq!(overlap_batches.len(), 1);
+            assert_eq!(overlap_batches.len(), 2);
             assert_eq!(overlap_batches[0], shared_buffer_batch1);
+            assert_eq!(overlap_batches[1], shared_buffer_batch2);
         }
         // Non-existent key
         let overlap_batches =

--- a/src/storage/src/hummock/shared_buffer/shared_buffer_uploader.rs
+++ b/src/storage/src/hummock/shared_buffer/shared_buffer_uploader.rs
@@ -15,7 +15,6 @@
 use std::collections::BTreeMap;
 use std::sync::Arc;
 
-use itertools::Itertools;
 use risingwave_common::config::StorageConfig;
 use risingwave_hummock_sdk::HummockEpoch;
 use risingwave_pb::hummock::SstableInfo;
@@ -26,37 +25,45 @@ use tracing::error;
 use super::shared_buffer_batch::SharedBufferBatch;
 use crate::hummock::compactor::{Compactor, CompactorContext};
 use crate::hummock::conflict_detector::ConflictDetector;
-use crate::hummock::local_version_manager::LocalVersionManager;
 use crate::hummock::{HummockError, HummockResult, SstableStoreRef};
 use crate::monitor::StateStoreMetrics;
 
+pub(crate) type UploadTaskId = u64;
+pub(crate) type UploadTaskData = Vec<SharedBufferBatch>;
+pub(crate) type UploadTaskResult =
+    BTreeMap<(HummockEpoch, UploadTaskId), HummockResult<Vec<SstableInfo>>>;
+
 #[derive(Debug)]
-pub enum UploadItem {
-    Batch(SharedBufferBatch),
-    Flush,
-    Sync {
-        epoch: Option<HummockEpoch>,
-        notifier: oneshot::Sender<()>,
-    },
+pub struct UploadTask {
+    pub(crate) id: UploadTaskId,
+    pub(crate) epoch: HummockEpoch,
+    pub(crate) data: UploadTaskData,
+}
+
+impl UploadTask {
+    pub fn new(id: UploadTaskId, epoch: HummockEpoch, data: UploadTaskData) -> Self {
+        Self { id, epoch, data }
+    }
+}
+
+pub struct UploadItem {
+    pub(crate) tasks: Vec<UploadTask>,
+    pub(crate) notifier: oneshot::Sender<UploadTaskResult>,
+}
+
+impl UploadItem {
+    pub fn new(tasks: Vec<UploadTask>, notifier: oneshot::Sender<UploadTaskResult>) -> Self {
+        Self { tasks, notifier }
+    }
 }
 
 pub struct SharedBufferUploader {
     options: Arc<StorageConfig>,
-
-    size: usize,
-    threshold: usize,
-
-    /// Serve as for not-uploaded batches.
-    batches: BTreeMap<HummockEpoch, Vec<SharedBufferBatch>>,
-
-    /// For conflict key detection. Enabled by setting `write_conflict_detection_enabled` to true
-    /// in `StorageConfig`
     write_conflict_detector: Option<Arc<ConflictDetector>>,
 
     uploader_rx: mpsc::UnboundedReceiver<UploadItem>,
 
     sstable_store: SstableStoreRef,
-    local_version_manager: Arc<LocalVersionManager>,
     hummock_meta_client: Arc<dyn HummockMetaClient>,
     stats: Arc<StateStoreMetrics>,
 }
@@ -65,28 +72,19 @@ impl SharedBufferUploader {
     #[allow(clippy::too_many_arguments)]
     pub fn new(
         options: Arc<StorageConfig>,
-        threshold: usize,
         sstable_store: SstableStoreRef,
-        local_version_manager: Arc<LocalVersionManager>,
         hummock_meta_client: Arc<dyn HummockMetaClient>,
         uploader_rx: mpsc::UnboundedReceiver<UploadItem>,
         stats: Arc<StateStoreMetrics>,
+        write_conflict_detector: Option<Arc<ConflictDetector>>,
     ) -> Self {
         Self {
-            threshold,
-            write_conflict_detector: if options.write_conflict_detection_enabled {
-                Some(Arc::new(ConflictDetector::new()))
-            } else {
-                None
-            },
+            options,
+            write_conflict_detector,
             uploader_rx,
-            batches: BTreeMap::default(),
-            size: 0,
             sstable_store,
-            local_version_manager,
             hummock_meta_client,
             stats,
-            options,
         }
     }
 
@@ -94,7 +92,7 @@ impl SharedBufferUploader {
         loop {
             match self.run_inner().await {
                 Ok(()) => return Ok(()),
-                Err(e) => error!("error raised in shared buffer uploader: {}", e),
+                Err(e) => error!("error raised in shared buffer uploader: {:?}", e),
             }
         }
     }
@@ -103,58 +101,55 @@ impl SharedBufferUploader {
 impl SharedBufferUploader {
     async fn run_inner(&mut self) -> HummockResult<()> {
         while let Some(item) = self.uploader_rx.recv().await {
-            match item {
-                UploadItem::Batch(batch) => {
-                    if let Some(detector) = &self.write_conflict_detector {
-                        detector.check_conflict_and_track_write_batch(&batch.inner, batch.epoch);
+            let mut task_results = BTreeMap::new();
+            let mut failed = false;
+            for UploadTask {
+                id: task_id,
+                epoch,
+                data,
+            } in item.tasks
+            {
+                // If a previous task failed, this task will also fail
+                if failed {
+                    task_results.insert(
+                        (epoch, task_id),
+                        Err(HummockError::shared_buffer_error(
+                            "failed due to previous failure",
+                        )),
+                    );
+                } else {
+                    match self.flush(epoch, &data).await {
+                        Ok(tables) => {
+                            task_results.insert((epoch, task_id), Ok(tables));
+                        }
+                        Err(e) => {
+                            failed = true;
+                            task_results.insert((epoch, task_id), Err(e));
+                        }
                     }
+                };
+            }
+            item.notifier
+                .send(task_results)
+                .map_err(|_| HummockError::shared_buffer_error("failed to send result"))?;
+        }
+        Ok(())
+    }
 
-                    self.size += batch.size as usize;
-                    self.batches
-                        .entry(batch.epoch)
-                        .or_insert(vec![])
-                        .push(batch);
-                    if self.size > self.threshold {
-                        self.flush().await?;
-                    }
-                }
-                UploadItem::Flush => self.flush().await?,
-                UploadItem::Sync { epoch, notifier } => {
-                    match epoch {
-                        Some(epoch) => self.flush_epoch(epoch).await?,
-                        None => self.flush().await?,
-                    }
-                    notifier.send(()).map_err(|_| {
-                        HummockError::shared_buffer_error(format!(
-                            "error raised when noitfy sync epoch {:?}",
-                            epoch
-                        ))
-                    })?;
-                }
+    async fn flush(
+        &mut self,
+        epoch: HummockEpoch,
+        batches: &Vec<SharedBufferBatch>,
+    ) -> HummockResult<Vec<SstableInfo>> {
+        if batches.is_empty() {
+            return Ok(vec![]);
+        }
+
+        if let Some(detector) = &self.write_conflict_detector {
+            for batch in batches {
+                detector.check_conflict_and_track_write_batch(batch.get_data(), epoch);
             }
         }
-        Ok(())
-    }
-
-    async fn flush(&mut self) -> HummockResult<()> {
-        let epochs = self.batches.keys().copied().collect_vec();
-        for epoch in epochs {
-            self.flush_epoch(epoch).await?;
-        }
-        Ok(())
-    }
-
-    async fn flush_epoch(&mut self, epoch: HummockEpoch) -> HummockResult<()> {
-        if let Some(detector) = &self.write_conflict_detector {
-            detector.archive_epoch(epoch);
-        }
-
-        let batches = match self.batches.remove(&epoch) {
-            Some(batches) => batches,
-            None => return Ok(()),
-        };
-
-        let flush_size: usize = batches.iter().map(|batch| batch.size as usize).sum();
 
         // Compact buffers into SSTs
         let mem_compactor_ctx = CompactorContext {
@@ -167,7 +162,7 @@ impl SharedBufferUploader {
 
         let tables = Compactor::compact_shared_buffer(
             Arc::new(mem_compactor_ctx),
-            batches.clone(),
+            batches,
             self.stats.clone(),
         )
         .await?;
@@ -190,12 +185,6 @@ impl SharedBufferUploader {
             .await
             .map_err(HummockError::meta_error)?;
 
-        // Ensure the added data is available locally
-        self.local_version_manager
-            .update_uncommitted_ssts(epoch, uploaded_sst_info, batches);
-
-        self.size -= flush_size;
-
-        Ok(())
+        Ok(uploaded_sst_info)
     }
 }

--- a/src/storage/src/hummock/state_store.rs
+++ b/src/storage/src/hummock/state_store.rs
@@ -17,8 +17,7 @@ use std::future::Future;
 use std::ops::RangeBounds;
 
 use bytes::Bytes;
-use itertools::Itertools;
-use risingwave_hummock_sdk::key::{key_with_epoch, user_key, FullKey};
+use risingwave_hummock_sdk::key::{key_with_epoch, user_key};
 use risingwave_hummock_sdk::VersionedComparator;
 use risingwave_pb::hummock::LevelType;
 
@@ -26,7 +25,6 @@ use super::iterator::{
     BoxedForwardHummockIterator, ConcatIterator, DirectedUserIterator, MergeIterator,
     ReverseConcatIterator, ReverseMergeIterator, ReverseUserIterator, UserIterator,
 };
-use super::shared_buffer::shared_buffer_batch::SharedBufferBatch;
 use super::utils::{validate_epoch, validate_table_key_range};
 use super::{HummockStorage, ReverseSSTableIterator, SSTableIterator};
 use crate::error::StorageResult;
@@ -53,7 +51,7 @@ impl HummockStorage {
         let mut overlapped_backward_iters = vec![];
 
         let (uncommitted_ssts, pinned_version) = {
-            let read_version = self.local_version_manager.read_version(epoch)?;
+            let read_version = self.local_version_manager.read_version(epoch);
 
             // Check epoch validity
             validate_epoch(read_version.pinned_version.safe_epoch(), epoch)?;
@@ -193,7 +191,7 @@ impl StateStore for HummockStorage {
     fn get<'a>(&'a self, key: &'a [u8], epoch: u64) -> Self::GetFuture<'_> {
         async move {
             let (uncommitted_ssts, pinned_version) = {
-                let read_version = self.local_version_manager.read_version(epoch)?;
+                let read_version = self.local_version_manager.read_version(epoch);
 
                 // check epoch validity
                 validate_epoch(read_version.pinned_version.safe_epoch(), epoch)?;
@@ -321,22 +319,9 @@ impl StateStore for HummockStorage {
         epoch: u64,
     ) -> Self::IngestBatchFuture<'_> {
         async move {
-            let batch = SharedBufferBatch::new(
-                kv_pairs
-                    .into_iter()
-                    .map(|(key, value)| {
-                        (
-                            Bytes::from(FullKey::from_user_key(key.to_vec(), epoch).into_inner()),
-                            value.into(),
-                        )
-                    })
-                    .collect_vec(),
-                epoch,
-            );
-            let size = batch.size();
-
-            self.local_version_manager
-                .write_shared_buffer(epoch, batch, false)
+            let size = self
+                .local_version_manager
+                .write_shared_buffer(epoch, kv_pairs, false)
                 .await?;
 
             if !self.options.async_checkpoint_enabled {
@@ -355,21 +340,8 @@ impl StateStore for HummockStorage {
         epoch: u64,
     ) -> Self::ReplicateBatchFuture<'_> {
         async move {
-            let batch = SharedBufferBatch::new(
-                kv_pairs
-                    .into_iter()
-                    .map(|(key, value)| {
-                        (
-                            Bytes::from(FullKey::from_user_key(key.to_vec(), epoch).into_inner()),
-                            value.into(),
-                        )
-                    })
-                    .collect_vec(),
-                epoch,
-            );
-
             self.local_version_manager
-                .write_shared_buffer(epoch, batch, true)
+                .write_shared_buffer(epoch, kv_pairs, true)
                 .await?;
 
             Ok(())

--- a/src/storage/src/memory.rs
+++ b/src/storage/src/memory.rs
@@ -154,9 +154,9 @@ impl StateStore for MemoryStateStore {
     ) -> Self::IngestBatchFuture<'_> {
         async move {
             let mut inner = self.inner.lock().await;
-            let mut size: u64 = 0;
+            let mut size: usize = 0;
             for (key, value) in kv_pairs {
-                size += (key.len() + value.size()) as u64;
+                size += key.len() + value.size();
                 inner.insert((key, Reverse(epoch)), value.user_value);
             }
             Ok(size)

--- a/src/storage/src/store.rs
+++ b/src/storage/src/store.rs
@@ -25,7 +25,7 @@ use crate::write_batch::WriteBatch;
 pub trait GetFutureTrait<'a> = Future<Output = StorageResult<Option<Bytes>>> + Send;
 pub trait ScanFutureTrait<'a, R, B> = Future<Output = StorageResult<Vec<(Bytes, Bytes)>>> + Send;
 pub trait EmptyFutureTrait<'a> = Future<Output = StorageResult<()>> + Send;
-pub trait IngestBatchFutureTrait<'a> = Future<Output = StorageResult<u64>> + Send;
+pub trait IngestBatchFutureTrait<'a> = Future<Output = StorageResult<usize>> + Send;
 
 #[macro_export]
 macro_rules! define_state_store_associated_type {


### PR DESCRIPTION
## What's changed and what's your intention?

Currently, when we want to upload the shared buffer batches to S3, we need to first send `Arc` to the write batches to the shared buffer uploader, and then issue  `Upload` commands to tell the uploader to compact the batches and upload the SSTs to S3. Therefore, besides shared buffer, we also store the shared buffer batches in the shared buffer uploader, and this leads to extra work to keep track of the memory usage, and this PR will remove this two-step upload logic, and instead only issue upload tasks, which include the write batches to upload, to the uploader, so that the uploader will not buffer any write batches.

In this PR, we mainly introduce the following change:
* Change the upload logic to issue upload tasks to the uploader and avoid buffering batches in uploader.
* Implement `SharedBufferBatchInner`, which acts as a guard to the shared buffer batch payload. Whenever the payload is being dropped, it will decrement a global memory usage counter by the batch size. In this way, the memory usage tracking gets easier.
* During initialization of `LocalVersionManager`, we will pin a hummock version as the initial version, so that we can avoid using `Option<LocalVersion>` in `LocalVersionManager`.

## Checklist

- [x] I have written necessary docs and comments
- [x] I have added necessary unit tests and integration tests

## Refer to a related PR or issue link (optional)
