### PR TITLE
fix: panic when starting with dashboard v2

### DIFF
--- a/src/risedevtool/src/task/meta_node_service.rs
+++ b/src/risedevtool/src/task/meta_node_service.rs
@@ -74,7 +74,8 @@ impl MetaNodeService {
         }
 
         if config.enable_dashboard_v2 {
-            cmd.arg("--dashboard-ui-path").arg(env::var("PREFIX_UI")?);
+            cmd.arg("--dashboard-ui-path")
+                .arg(env::var("PREFIX_UI").unwrap_or(".risingwave/ui".to_owned()));
         }
 
         if config.unsafe_disable_recovery {

--- a/src/risedevtool/src/task/meta_node_service.rs
+++ b/src/risedevtool/src/task/meta_node_service.rs
@@ -75,7 +75,7 @@ impl MetaNodeService {
 
         if config.enable_dashboard_v2 {
             cmd.arg("--dashboard-ui-path")
-                .arg(env::var("PREFIX_UI").unwrap_or(".risingwave/ui".to_owned()));
+                .arg(env::var("PREFIX_UI").unwrap_or_else(|_| ".risingwave/ui".to_owned()));
         }
 
         if config.unsafe_disable_recovery {


### PR DESCRIPTION
## What's changed and what's your intention?

If you start risingwave playground via `cargo run --bin risingwave -- playground` with `enable-dashboard-v2: true`, it will panic and complain "environment variable not found". This PR fixes this.

## Checklist

N/A
## Refer to a related PR or issue link (optional)

None