### PR TITLE
chore(relational_layer): add value_meta in relational write interfaces

### DIFF
--- a/src/storage/src/table/state_table.rs
+++ b/src/storage/src/table/state_table.rs
@@ -94,6 +94,14 @@ impl<S: StateStore> StateTable<S> {
         Ok(())
     }
 
+    pub async fn commit_with_value_meta(&mut self, new_epoch: u64) -> StorageResult<()> {
+        let mem_table = std::mem::take(&mut self.mem_table).into_parts();
+        self.cell_based_table
+            .batch_write_rows_with_value_meta(mem_table, new_epoch)
+            .await?;
+        Ok(())
+    }
+
     pub async fn iter(&self, _pk: Row) -> StorageResult<StateTableRowIter<S>> {
         todo!()
     }

--- a/src/stream/src/executor_v2/mview/materialize.rs
+++ b/src/stream/src/executor_v2/mview/materialize.rs
@@ -121,7 +121,7 @@ impl<S: StateStore> MaterializeExecutor<S> {
                 Message::Barrier(b) => {
                     // FIXME(ZBW): use a better error type
                     self.state_table
-                        .commit(b.epoch.prev)
+                        .commit_with_value_meta(b.epoch.prev)
                         .await
                         .map_err(StreamExecutorError::executor_v1)?;
                     Message::Barrier(b)


### PR DESCRIPTION
## What's changed and what's your intention?

As title, relational layer provides hash and non-hash write interfaces.

## Checklist

- [x] I have written necessary docs and comments
- [x] I have added necessary unit tests and integration tests

## Refer to a related PR or issue link (optional)
