### PR TITLE
chore(risedev): rust frontend debug is first citizen

### DIFF
--- a/risedev.yml
+++ b/risedev.yml
@@ -53,28 +53,35 @@ risedev:
     - use: meta-node
     - use: compute-node
       user-managed: true
-    - use: frontend-legacy
+    - use: frontend
 
-  # `dev-frontend` have the same settings as default except the the frontend-legacy node will be started by user.
   dev-frontend:
+    - use: meta-node
+    - use: compute-node
+    - use: frontend
+      user-managed: true
+
+  dev-meta:
+    - use: meta-node
+      user-managed: true
+    - use: compute-node
+    - use: frontend
+
+
+  # TODO: Remove all legacy configs after java removed.
+  # `dev-frontend` have the same settings as default except the the frontend-legacy node will be started by user.
+  dev-frontend-legacy:
     - use: meta-node
     - use: compute-node
     - use: frontend-legacy
       user-managed: true
 
   # `dev-meta-node` have the same settings as default except the the meta node will be started by user.
-  dev-meta-node:
+  dev-meta-node-legacy:
     - use: meta-node
       user-managed: true
     - use: compute-node
     - use: frontend-legacy
-
-  dev-frontend-v2:
-    - use: minio
-    - use: meta-node
-    - use: compute-node
-    - use: frontend
-      user-managed: true
 
   full:
     - use: minio


### PR DESCRIPTION
## What's changed and what's your intention?

Seems no one is using java frontend to debug. So add a `legcay` suffix to the command and make rust frontend a frist class citizen in risedev debug mode. 

Otherwise we have to change the yml every time to debug compute node with new fe.

## Checklist

- [x] I have written necessary docs and comments
- [x] I have added necessary unit tests and integration tests

## Refer to a related PR or issue link (optional)
