### PR TITLE
chore(cmd): sets the default start up mode of compute node to `hu…

### DIFF
--- a/src/compute/src/lib.rs
+++ b/src/compute/src/lib.rs
@@ -51,7 +51,7 @@ pub struct ComputeNodeOpts {
     #[clap(long)]
     pub port: Option<u16>,
 
-    #[clap(long, default_value = "in-memory")]
+    #[clap(long, default_value = "hummock+memory")]
     pub state_store: String,
 
     #[clap(long, default_value = "127.0.0.1:1222")]


### PR DESCRIPTION
…mmock+memory`

## What's changed and what's your intention?

It is tested locally with `./risedev dev dev-compute-node`.

## Checklist

- [x] I have written necessary docs and comments
- [x] I have added necessary unit tests and integration tests

## Refer to a related PR or issue link (optional)
