### PR TITLE
ci: reopen kafka basic tests

### DIFF
--- a/e2e_test/source/basic_test.slt
+++ b/e2e_test/source/basic_test.slt
@@ -37,6 +37,7 @@ select * from s6;
 statement ok
 flush;
 
+# Wait enough time to ensure SourceExecutor consumes all Kafka data.
 sleep 1s
 
 query IT rowsort

--- a/e2e_test/source/basic_test.slt
+++ b/e2e_test/source/basic_test.slt
@@ -2,7 +2,42 @@ statement ok
 create materialized source s1 (v1 int, v2 varchar) with ( 'connector' = 'kafka', 'kafka.topic' = 'kafka_1_partition_topic', 'kafka.brokers' = '127.0.0.1:29092', 'kafka.scan.startup.mode'='earliest' ) row format json
 
 statement ok
+select * from s1;
+
+statement ok
+create materialized source s2 (v1 int, v2 varchar) with ( 'connector' = 'kafka', 'kafka.topic' = 'kafka_2_partition_topic', 'kafka.brokers' = '127.0.0.1:29092', 'kafka.scan.startup.mode'='earliest'  ) row format json
+
+statement ok
+select * from s2;
+
+statement ok
+create materialized source s3 (v1 int, v2 varchar) with ( 'connector' = 'kafka', 'kafka.topic' = 'kafka_3_partition_topic', 'kafka.brokers' = '127.0.0.1:29092', 'kafka.scan.startup.mode'='earliest'  ) row format json
+
+statement ok
+select * from s3;
+
+statement ok
+create materialized source s4 (v1 int, v2 varchar) with ( 'connector' = 'kafka', 'kafka.topic' = 'kafka_4_partition_topic', 'kafka.brokers' = '127.0.0.1:29092', 'kafka.scan.startup.mode'='earliest'  ) row format json
+
+statement ok
+select * from s4;
+
+statement ok
+create materialized source s5 (v1 int, v2 varchar) with ( 'connector' = 'kafka', 'kafka.topic' = 'kafka_4_partition_topic_with_100_message', 'kafka.brokers' = '127.0.0.1:29092', 'kafka.scan.startup.mode'='earliest'  ) row format json
+
+statement ok
+select * from s5;
+
+statement ok
+create materialized source s6 (v1 int, v2 varchar) with ( 'connector' = 'kafka', 'kafka.topic' = 'kafka_1_partition_mv_topic', 'kafka.brokers' = '127.0.0.1:29092', 'kafka.scan.startup.mode'='earliest'  ) row format json
+
+statement ok
+select * from s6;
+
+statement ok
 flush;
+
+sleep 1s
 
 query IT rowsort
 select * from s1
@@ -15,12 +50,6 @@ select * from s1
 statement ok
 drop source s1
 
-statement ok
-create materialized source s2 (v1 int, v2 varchar) with ( 'connector' = 'kafka', 'kafka.topic' = 'kafka_2_partition_topic', 'kafka.brokers' = '127.0.0.1:29092', 'kafka.scan.startup.mode'='earliest'  ) row format json
-
-statement ok
-flush;
-
 query IT rowsort
 select * from s2
 ----
@@ -31,12 +60,6 @@ select * from s2
 
 statement ok
 drop source s2
-
-statement ok
-create materialized source s3 (v1 int, v2 varchar) with ( 'connector' = 'kafka', 'kafka.topic' = 'kafka_3_partition_topic', 'kafka.brokers' = '127.0.0.1:29092', 'kafka.scan.startup.mode'='earliest'  ) row format json
-
-statement ok
-flush;
 
 query IT rowsort
 select * from s3
@@ -49,12 +72,6 @@ select * from s3
 statement ok
 drop source s3
 
-statement ok
-create materialized source s4 (v1 int, v2 varchar) with ( 'connector' = 'kafka', 'kafka.topic' = 'kafka_4_partition_topic', 'kafka.brokers' = '127.0.0.1:29092', 'kafka.scan.startup.mode'='earliest'  ) row format json
-
-statement ok
-flush;
-
 query IT rowsort
 select * from s4
 ----
@@ -66,12 +83,6 @@ select * from s4
 statement ok
 drop source s4
 
-statement ok
-create materialized source s5 (v1 int, v2 varchar) with ( 'connector' = 'kafka', 'kafka.topic' = 'kafka_4_partition_topic_with_100_message', 'kafka.brokers' = '127.0.0.1:29092', 'kafka.scan.startup.mode'='earliest'  ) row format json
-
-statement ok
-flush;
-
 query I
 select count(*) from s5
 ----
@@ -79,12 +90,6 @@ select count(*) from s5
 
 statement ok
 drop source s5
-
-statement ok
-create materialized source s6 (v1 int, v2 varchar) with ( 'connector' = 'kafka', 'kafka.topic' = 'kafka_1_partition_mv_topic', 'kafka.brokers' = '127.0.0.1:29092', 'kafka.scan.startup.mode'='earliest'  ) row format json
-
-statement ok
-flush;
 
 query I
 select count(*) from s6


### PR DESCRIPTION
Signed-off-by: tabVersion <tabvision@bupt.icu>

## What's changed and what's your intention?

***PLEASE DO NOT LEAVE THIS EMPTY !!!***

Please explain **IN DETAIL** what the changes are in this PR and why they are needed:

as title, use select * from s twice:

1. trigger connector reader to fetch from kafka
2. query from materialized source

- Summarize your change (**mandatory**)
- How does this PR work? Need a brief introduction for the changed logic (optional)
- Describe clearly one logical change and avoid lazy messages (optional)
- Describe any limitations of the current code (optional)
  - the test may last for 30s (on my local machine)
  - sleep 1s may not long enough for all reader to fetch data and it may cause unexpected failure

## Checklist

- [x] I have written necessary docs and comments
- [x] I have added necessary unit tests and integration tests

## Refer to a related PR or issue link (optional)
