### PR TITLE
feat(simple-agg): use table ids for simple agg

### DIFF
--- a/proto/stream_plan.proto
+++ b/proto/stream_plan.proto
@@ -72,6 +72,7 @@ message MaterializeNode {
 message SimpleAggNode {
   repeated expr.AggCall agg_calls = 1;
   repeated int32 distribution_keys = 2;
+  repeated uint32 table_ids = 3;
 }
 
 message HashAggNode {

--- a/src/frontend/src/optimizer/plan_node/stream_simple_agg.rs
+++ b/src/frontend/src/optimizer/plan_node/stream_simple_agg.rs
@@ -86,6 +86,7 @@ impl ToStreamProst for StreamSimpleAgg {
                 .iter()
                 .map(|idx| *idx as i32)
                 .collect_vec(),
+            table_ids: vec![],
         })
     }
 }

--- a/src/meta/src/stream/fragmenter/graph/stream_graph.rs
+++ b/src/meta/src/stream/fragmenter/graph/stream_graph.rs
@@ -479,6 +479,17 @@ impl StreamGraphBuilder {
                     }
                 }
 
+                match new_stream_node.node_body.as_mut().unwrap() {
+                    NodeBody::GlobalSimpleAgg(node) | NodeBody::LocalSimpleAgg(node) => {
+                        assert_eq!(node.table_ids.len(), node.agg_calls.len());
+                        // In-place update the table id. Convert from local to global.
+                        for table_id in &mut node.table_ids {
+                            *table_id += table_id_offset;
+                        }
+                    }
+                    _ => {}
+                }
+
                 for (idx, input) in stream_node.input.iter().enumerate() {
                     match input.get_node_body()? {
                         NodeBody::Exchange(_) => {

--- a/src/meta/src/stream/fragmenter/mod.rs
+++ b/src/meta/src/stream/fragmenter/mod.rs
@@ -392,6 +392,15 @@ impl StreamFragmenter {
             }
         }
 
+        match stream_node.node_body.as_mut().unwrap() {
+            NodeBody::GlobalSimpleAgg(node) | NodeBody::LocalSimpleAgg(node) => {
+                for _ in &node.agg_calls {
+                    node.table_ids.push(state.gen_table_id());
+                }
+            }
+            _ => {}
+        }
+
         let inputs = std::mem::take(&mut stream_node.input);
         // Visit plan children.
         let inputs = inputs

--- a/src/meta/src/stream/test_fragmenter.rs
+++ b/src/meta/src/stream/test_fragmenter.rs
@@ -178,6 +178,7 @@ fn make_stream_node() -> StreamNode {
         node_body: Some(NodeBody::GlobalSimpleAgg(SimpleAggNode {
             agg_calls: vec![make_sum_aggcall(0), make_sum_aggcall(1)],
             distribution_keys: Default::default(),
+            table_ids: vec![],
         })),
         input: vec![filter_node],
         fields: vec![], // TODO: fill this later
@@ -208,6 +209,7 @@ fn make_stream_node() -> StreamNode {
         node_body: Some(NodeBody::GlobalSimpleAgg(SimpleAggNode {
             agg_calls: vec![make_sum_aggcall(0), make_sum_aggcall(1)],
             distribution_keys: Default::default(),
+            table_ids: vec![],
         })),
         fields: vec![], // TODO: fill this later
         input: vec![exchange_node_1],

--- a/src/stream/src/executor_v2/aggregation/mod.rs
+++ b/src/stream/src/executor_v2/aggregation/mod.rs
@@ -333,64 +333,6 @@ pub fn generate_agg_schema(
 pub async fn generate_agg_state<S: StateStore>(
     key: Option<&Row>,
     agg_calls: &[AggCall],
-    keyspace: &Keyspace<S>,
-    pk_data_types: PkDataTypes,
-    epoch: u64,
-    key_hash_code: Option<HashCode>,
-) -> StreamExecutorResult<AggState<S>> {
-    let mut managed_states = vec![];
-
-    // Currently the loop here only works if `ROW_COUNT_COLUMN` is 0.
-    const_assert_eq!(ROW_COUNT_COLUMN, 0);
-    let mut row_count = None;
-
-    for (idx, agg_call) in agg_calls.iter().enumerate() {
-        // TODO: in pure in-memory engine, we should not do this serialization.
-
-        // The prefix of the state is `agg_call_idx / [group_key]`
-        let keyspace = if let Some(key) = key {
-            let bytes = key.serialize().unwrap();
-            keyspace.append_u16(idx as u16).append(bytes)
-        } else {
-            keyspace.append_u16(idx as u16)
-        };
-
-        let mut managed_state = ManagedStateImpl::create_managed_state(
-            agg_call.clone(),
-            keyspace,
-            row_count,
-            pk_data_types.clone(),
-            idx == ROW_COUNT_COLUMN,
-            key_hash_code.clone(),
-        )
-        .await
-        .map_err(StreamExecutorError::agg_state_error)?;
-
-        if idx == ROW_COUNT_COLUMN {
-            // For the rowcount state, we should record the rowcount.
-            let output = managed_state
-                .get_output(epoch)
-                .await
-                .map_err(StreamExecutorError::agg_state_error)?;
-            row_count = Some(output.as_ref().map(|x| *x.as_int64() as usize).unwrap_or(0));
-        }
-
-        managed_states.push(managed_state);
-    }
-
-    Ok(AggState {
-        managed_states,
-        prev_states: None,
-    })
-}
-
-/// Generate initial [`AggState`] from `agg_calls`. For [`crate::executor_v2::HashAggExecutor`], the
-/// group key should be provided.
-/// FIXME: It's a fork of [`generate_hash_agg_state`]. Should merge this two when simple agg is
-/// using table ids.
-pub async fn generate_hash_agg_state<S: StateStore>(
-    key: Option<&Row>,
-    agg_calls: &[AggCall],
     keyspace: &[Keyspace<S>],
     pk_data_types: PkDataTypes,
     epoch: u64,
@@ -405,7 +347,7 @@ pub async fn generate_hash_agg_state<S: StateStore>(
     for ((idx, agg_call), keyspace) in agg_calls.iter().enumerate().zip_eq(keyspace) {
         // TODO: in pure in-memory engine, we should not do this serialization.
 
-        // The prefix of the state is `table_id / [group_key]`
+        // The prefix of the state is `table_id/[group_key]`
         let keyspace = if let Some(key) = key {
             let bytes = key.serialize().unwrap();
             keyspace.append(bytes)

--- a/src/stream/src/executor_v2/hash_agg.rs
+++ b/src/stream/src/executor_v2/hash_agg.rs
@@ -32,7 +32,7 @@ use risingwave_storage::{Keyspace, StateStore};
 
 use super::{pk_input_arrays, Executor, PkDataTypes, PkIndicesRef, StreamExecutorResult};
 use crate::executor_v2::aggregation::{
-    agg_input_arrays, generate_agg_schema, generate_hash_agg_state, AggCall, AggState,
+    agg_input_arrays, generate_agg_schema, generate_agg_state, AggCall, AggState,
 };
 use crate::executor_v2::error::StreamExecutorError;
 use crate::executor_v2::{BoxedMessageStream, Message, PkIndices, PROCESSING_WINDOW_SIZE};
@@ -245,7 +245,7 @@ impl<K: HashKey, S: StateStore> HashAggExecutor<K, S> {
                     match states {
                         Some(s) => s.unwrap(),
                         None => Box::new(
-                            generate_hash_agg_state(
+                            generate_agg_state(
                                 Some(
                                     &key.clone()
                                         .deserialize(key_data_types.iter())
@@ -434,12 +434,11 @@ mod tests {
     use risingwave_common::array::data_chunk_iter::Row;
     use risingwave_common::array::stream_chunk::StreamChunkTestExt;
     use risingwave_common::array::{Op, StreamChunk};
-    use risingwave_common::catalog::{Field, Schema, TableId};
+    use risingwave_common::catalog::{Field, Schema};
     use risingwave_common::error::Result;
     use risingwave_common::hash::{calc_hash_key_kind, HashKey, HashKeyDispatcher};
     use risingwave_common::types::DataType;
     use risingwave_expr::expr::*;
-    use risingwave_storage::memory::MemoryStateStore;
     use risingwave_storage::{Keyspace, StateStore};
 
     use crate::executor_v2::aggregation::{AggArgs, AggCall};
@@ -512,19 +511,6 @@ mod tests {
     #[tokio::test]
     async fn test_local_hash_aggregation_max_in_memory() {
         test_local_hash_aggregation_max(create_in_memory_keyspace_agg(2)).await
-    }
-
-    /// Create a vector of memory keyspace with len `num_ks`.
-    fn create_in_memory_keyspace_agg(num_ks: usize) -> Vec<Keyspace<MemoryStateStore>> {
-        let mut returned_vec = vec![];
-        let mem_state = MemoryStateStore::new();
-        for idx in 0..num_ks {
-            returned_vec.push(Keyspace::table_root(
-                mem_state.clone(),
-                &TableId::new(idx as u32),
-            ));
-        }
-        returned_vec
     }
 
     async fn test_local_hash_aggregation_count(keyspace: Vec<Keyspace<impl StateStore>>) {

--- a/src/stream/src/executor_v2/integration_tests.rs
+++ b/src/stream/src/executor_v2/integration_tests.rs
@@ -27,7 +27,7 @@ use super::*;
 use crate::executor_v2::aggregation::{AggArgs, AggCall};
 use crate::executor_v2::dispatch::*;
 use crate::executor_v2::receiver::ReceiverExecutor;
-use crate::executor_v2::test_utils::create_in_memory_keyspace;
+use crate::executor_v2::test_utils::create_in_memory_keyspace_agg;
 use crate::executor_v2::{
     Executor, LocalSimpleAggExecutor, MergeExecutor, ProjectExecutor, SimpleAggExecutor,
 };
@@ -127,7 +127,7 @@ async fn test_merger_sum_aggr() {
                 return_type: DataType::Int64,
             },
         ],
-        create_in_memory_keyspace(),
+        create_in_memory_keyspace_agg(2),
         vec![],
         2,
         vec![],

--- a/src/stream/src/executor_v2/test_utils.rs
+++ b/src/stream/src/executor_v2/test_utils.rs
@@ -14,7 +14,7 @@
 
 use futures::StreamExt;
 use futures_async_stream::try_stream;
-use risingwave_common::catalog::Schema;
+use risingwave_common::catalog::{Schema, TableId};
 use risingwave_storage::memory::MemoryStateStore;
 use risingwave_storage::Keyspace;
 use tokio::sync::mpsc;
@@ -146,4 +146,17 @@ macro_rules! row_nonnull {
             Row(vec![$(Some($value.to_scalar_value()), )*])
         }
     };
+}
+
+/// Create a vector of memory keyspace with len `num_ks`.
+pub fn create_in_memory_keyspace_agg(num_ks: usize) -> Vec<Keyspace<MemoryStateStore>> {
+    let mut returned_vec = vec![];
+    let mem_state = MemoryStateStore::new();
+    for idx in 0..num_ks {
+        returned_vec.push(Keyspace::table_root(
+            mem_state.clone(),
+            &TableId::new(idx as u32),
+        ));
+    }
+    returned_vec
 }


### PR DESCRIPTION
## What's changed and what's your intention?

Prevoius the keyspace encoding is `executor_id/agg_call_idx` (9 + 4), now `table_id` (5). 

Code:
* Count and assign table id in meta fragmenter. 
* use table id to create agg states

## Checklist

- [x] I have written necessary docs and comments
- [x] I have added necessary unit tests and integration tests

## Refer to a related PR or issue link (optional)
