### PR TITLE
refactor(storage): remove lifetime on Iter in StateStore

### DIFF
--- a/src/storage/src/hummock/state_store.rs
+++ b/src/storage/src/hummock/state_store.rs
@@ -180,7 +180,7 @@ impl HummockStorage {
 }
 
 impl StateStore for HummockStorage {
-    type Iter<'a> = HummockStateStoreIter;
+    type Iter = HummockStateStoreIter;
 
     define_state_store_associated_type!();
 

--- a/src/storage/src/keyspace.rs
+++ b/src/storage/src/keyspace.rs
@@ -163,7 +163,7 @@ impl<S: StateStore> Keyspace<S> {
 
     /// Gets an iterator with the prefix of this keyspace.
     /// The returned iterator will iterate data from a snapshot corresponding to the given `epoch`
-    async fn iter_inner(&'_ self, epoch: u64) -> StorageResult<S::Iter<'_>> {
+    async fn iter_inner(&'_ self, epoch: u64) -> StorageResult<S::Iter> {
         let range = self.prefix.to_owned()..next_key(self.prefix.as_slice());
         self.store.iter(range, epoch).await
     }

--- a/src/storage/src/memory.rs
+++ b/src/storage/src/memory.rs
@@ -81,7 +81,7 @@ impl MemoryStateStore {
 }
 
 impl StateStore for MemoryStateStore {
-    type Iter<'a> = MemoryStateStoreIter;
+    type Iter = MemoryStateStoreIter;
 
     define_state_store_associated_type!();
 

--- a/src/storage/src/monitor/monitored_store.rs
+++ b/src/storage/src/monitor/monitored_store.rs
@@ -49,9 +49,9 @@ where
     async fn monitored_iter<'a, I>(
         &self,
         iter: I,
-    ) -> StorageResult<<MonitoredStateStore<S> as StateStore>::Iter<'a>>
+    ) -> StorageResult<<MonitoredStateStore<S> as StateStore>::Iter>
     where
-        I: Future<Output = StorageResult<S::Iter<'a>>>,
+        I: Future<Output = StorageResult<S::Iter>>,
     {
         let iter = iter.await?;
 
@@ -68,7 +68,7 @@ impl<S> StateStore for MonitoredStateStore<S>
 where
     S: StateStore,
 {
-    type Iter<'a> = MonitoredStateStoreIter<S::Iter<'a>> where Self: 'a;
+    type Iter = MonitoredStateStoreIter<S::Iter>;
 
     define_state_store_associated_type!();
 

--- a/src/storage/src/panic_store.rs
+++ b/src/storage/src/panic_store.rs
@@ -27,7 +27,7 @@ use crate::{define_state_store_associated_type, StateStore, StateStoreIter};
 pub struct PanicStateStore;
 
 impl StateStore for PanicStateStore {
-    type Iter<'a> = PanicStateStoreIter;
+    type Iter = PanicStateStoreIter;
 
     define_state_store_associated_type!();
 

--- a/src/storage/src/rocksdb_local.rs
+++ b/src/storage/src/rocksdb_local.rs
@@ -49,7 +49,7 @@ impl RocksDBStateStore {
 }
 
 impl StateStore for RocksDBStateStore {
-    type Iter<'a> = RocksDBStateStoreIter;
+    type Iter = RocksDBStateStoreIter;
 
     define_state_store_associated_type!();
 

--- a/src/storage/src/rocksdb_local_mock.rs
+++ b/src/storage/src/rocksdb_local_mock.rs
@@ -35,7 +35,7 @@ impl RocksDBStateStore {
 }
 
 impl StateStore for RocksDBStateStore {
-    type Iter<'a> = RocksDBStateStoreIter;
+    type Iter = RocksDBStateStoreIter;
 
     define_state_store_associated_type!();
 

--- a/src/storage/src/store.rs
+++ b/src/storage/src/store.rs
@@ -37,15 +37,13 @@ macro_rules! define_state_store_associated_type {
         type ReplicateBatchFuture<'a> = impl EmptyFutureTrait<'a>;
         type WaitEpochFuture<'a> = impl EmptyFutureTrait<'a>;
         type SyncFuture<'a> = impl EmptyFutureTrait<'a>;
-        type IterFuture<'a, R, B> = impl Future<Output = $crate::error::StorageResult<Self::Iter<'a>>> + Send where R: 'static + Send, B: 'static + Send;
-        type ReverseIterFuture<'a, R, B> = impl Future<Output = $crate::error::StorageResult<Self::Iter<'a>>> + Send where R: 'static + Send, B: 'static + Send;
+        type IterFuture<'a, R, B> = impl Future<Output = $crate::error::StorageResult<Self::Iter>> + Send where R: 'static + Send, B: 'static + Send;
+        type ReverseIterFuture<'a, R, B> = impl Future<Output = $crate::error::StorageResult<Self::Iter>> + Send where R: 'static + Send, B: 'static + Send;
     }
 }
 
 pub trait StateStore: Send + Sync + 'static + Clone {
-    type Iter<'a>: StateStoreIter<Item = (Bytes, Bytes)>
-    where
-        Self: 'a;
+    type Iter: StateStoreIter<Item = (Bytes, Bytes)>;
 
     type GetFuture<'a>: GetFutureTrait<'a>;
 
@@ -67,12 +65,12 @@ pub trait StateStore: Send + Sync + 'static + Clone {
 
     type SyncFuture<'a>: EmptyFutureTrait<'a>;
 
-    type IterFuture<'a, R, B>: Future<Output = StorageResult<Self::Iter<'a>>> + Send
+    type IterFuture<'a, R, B>: Future<Output = StorageResult<Self::Iter>> + Send
     where
         R: 'static + Send,
         B: 'static + Send;
 
-    type ReverseIterFuture<'a, R, B>: Future<Output = StorageResult<Self::Iter<'a>>> + Send
+    type ReverseIterFuture<'a, R, B>: Future<Output = StorageResult<Self::Iter>> + Send
     where
         R: 'static + Send,
         B: 'static + Send;

--- a/src/storage/src/tikv.rs
+++ b/src/storage/src/tikv.rs
@@ -54,7 +54,7 @@ impl TikvStateStore {
 }
 
 impl StateStore for TikvStateStore {
-    type Iter<'a> = TikvStateStoreIter;
+    type Iter = TikvStateStoreIter;
 
     define_state_store_associated_type!();
 

--- a/src/storage/src/tikv_mock.rs
+++ b/src/storage/src/tikv_mock.rs
@@ -32,7 +32,7 @@ impl TikvStateStore {
 }
 
 impl StateStore for TikvStateStore {
-    type Iter<'a> = TikvStateStoreIter;
+    type Iter = TikvStateStoreIter;
 
     define_state_store_associated_type!();
 


### PR DESCRIPTION
## What's changed and what's your intention?
This is useless as we have removed all the lifetime on user iterators.

This is the first step for #2221 to replace `scan` with `iter`.