### PR TITLE
refactor(storage): use iter instead of scan in CellBasedTableRowIter

### DIFF
--- a/src/storage/src/keyspace.rs
+++ b/src/storage/src/keyspace.rs
@@ -168,10 +168,7 @@ impl<S: StateStore> Keyspace<S> {
         self.store.iter(range, epoch).await
     }
 
-    pub async fn iter(
-        &'_ self,
-        epoch: u64,
-    ) -> StorageResult<impl StateStoreIter<Item = (Bytes, Bytes)> + '_> {
+    pub async fn iter(&'_ self, epoch: u64) -> StorageResult<StripPrefixIterator<S::Iter>> {
         let iter = self.iter_inner(epoch).await?;
         let strip_prefix_iterator = StripPrefixIterator {
             iter,
@@ -186,7 +183,7 @@ impl<S: StateStore> Keyspace<S> {
     }
 }
 
-struct StripPrefixIterator<I: StateStoreIter<Item = (Bytes, Bytes)>> {
+pub struct StripPrefixIterator<I: StateStoreIter<Item = (Bytes, Bytes)>> {
     iter: I,
     prefix_len: usize,
 }


### PR DESCRIPTION
## What's changed and what's your intention?
As the title suggests, we should use iter in most cases unless we know for sure that we need to scan a number of kv pairs all at once.

## Refer to a related PR or issue link (optional)
#2221 