### PR TITLE
chore(docker): replace host network mode to docker network

### DIFF
--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -53,6 +53,6 @@ services:
   redpanda:
     container_name: redpanda_container
     image: docker.vectorized.io/vectorized/redpanda:latest
-    command: redpanda start --smp 1 --reserve-memory 0M --overprovisioned --node-id 0 --kafka-addr PLAINTEXT://0.0.0.0:9092 --advertise-kafka-addr PLAINTEXT://0.0.0.0:9092
+    command: redpanda start --smp 1 --reserve-memory 0M --overprovisioned --node-id 0 --kafka-addr PLAINTEXT://0.0.0.0:29092,OUTSIDE://0.0.0.0:9092 --advertise-kafka-addr PLAINTEXT://redpanda:29092,OUTSIDE://localhost:9092
     ports:
       - "9092:9092"

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -56,3 +56,4 @@ services:
     command: redpanda start --smp 1 --reserve-memory 0M --overprovisioned --node-id 0 --kafka-addr PLAINTEXT://0.0.0.0:29092,OUTSIDE://0.0.0.0:9092 --advertise-kafka-addr PLAINTEXT://redpanda:29092,OUTSIDE://localhost:9092
     ports:
       - "9092:9092"
+      - "29092:29092"

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -2,20 +2,21 @@ version: "3"
 services:
   minio:
     container_name: minio_container
-    network_mode: host
     image: quay.io/minio/minio
     command: server /data --console-address ":9001"
+    expose:
+      - "9000"
+      - "9001"
     environment:
       - "MINIO_ROOT_USER=AKIAIOSFODNN7EXAMPLE"
       - "MINIO_ROOT_PASSWORD=wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY"
   miniocreatebuckets:
     image: minio/mc
-    network_mode: host
     depends_on:
       - minio
     entrypoint: >
       /bin/sh -c "
-      until (mc alias set hummock-minio http://127.0.0.1:9000 AKIAIOSFODNN7EXAMPLE wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY) do echo '...waiting...' && sleep 1; done;
+      until (mc alias set hummock-minio http://minio:9000 AKIAIOSFODNN7EXAMPLE wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY) do echo '...waiting...' && sleep 1; done;
       mc admin user add hummock-minio/ hummock 12345678;
       mc admin policy set hummock-minio/ readwrite user=hummock;
       mc mb hummock-minio/hummock001;
@@ -23,28 +24,35 @@ services:
       "
   metanode:
     container_name: metanode_container
-    network_mode: host
     image: ghcr.io/singularity-data/risingwave:latest
-    command: /risingwave/bin/meta-node --host 127.0.0.1:5690 --dashboard-host 127.0.0.1:5691 --prometheus-host 127.0.0.1:1250
+    command: /risingwave/bin/meta-node --host 0.0.0.0:5690 --dashboard-host 0.0.0.0:5691 --prometheus-host 0.0.0.0:1250
+    expose:
+      - "5690"
+      - "5691"
+      - "1250"
   computenode:
     container_name: computenode_container
-    network_mode: host
     image: ghcr.io/singularity-data/risingwave:latest
-    command: /risingwave/bin/compute-node --config-path /risingwave/config/risingwave.toml --host 127.0.0.1:5688 --prometheus-listener-addr 127.0.0.1:1222 --metrics-level 1 --state-store hummock+minio://hummock:12345678@127.0.0.1:9000/hummock001 --meta-address http://127.0.0.1:5690
+    command: /risingwave/bin/compute-node --config-path /risingwave/config/risingwave.toml --client-address computenode:5688 --host 0.0.0.0:5688 --prometheus-listener-addr 0.0.0.0:1222 --metrics-level 1 --state-store hummock+minio://hummock:12345678@minio:9000/hummock001 --meta-address http://metanode:5690
+    expose:
+      - "5688"
+      - "1222"
     volumes:
       - ./src/config:/risingwave/config
     depends_on:
       - metanode
   frontend:
     container_name: frontend_container
-    network_mode: host
     image: ghcr.io/singularity-data/risingwave:latest
-    command: /risingwave/bin/frontend-v2 --host 127.0.0.1:4566 --meta-addr http://127.0.0.1:5690
+    command: /risingwave/bin/frontend-v2 --client-address frontend:4566 --host 0.0.0.0:4566 --meta-addr http://metanode:5690
+    ports:
+      - "4566:4566"
     depends_on:
       - metanode
       - computenode
   redpanda:
     container_name: redpanda_container
-    network_mode: host
     image: docker.vectorized.io/vectorized/redpanda:latest
-    command: redpanda start --smp 1 --reserve-memory 0M --overprovisioned --node-id 0 --kafka-addr PLAINTEXT://0.0.0.0:9092 --advertise-kafka-addr PLAINTEXT://127.0.0.1:9092
+    command: redpanda start --smp 1 --reserve-memory 0M --overprovisioned --node-id 0 --kafka-addr PLAINTEXT://0.0.0.0:9092 --advertise-kafka-addr PLAINTEXT://0.0.0.0:9092
+    ports:
+      - "9092:9092"


### PR DESCRIPTION
## What's changed and what's your intention?

Replace host network mode to docker network.
Notice that kafka-addr is set to port 29092 in docer network, and map 9092 to host.

## Checklist

- [x] I have written necessary docs and comments
- [x] I have added necessary unit tests and integration tests

## Refer to a related PR or issue link (optional)
