### PR TITLE
fix(streaming): lookup barrier is not aligned

### DIFF
--- a/e2e_test/v2/streaming/index.slt
+++ b/e2e_test/v2/streaming/index.slt
@@ -54,9 +54,6 @@ select v1, v2, v3, v4 from iii_mv2;
 0 0 0 3
 1 0 1 2
 
-# TODO: support drop lookup mv
-halt
-
 statement ok
 drop materialized view iii_mv2
 
@@ -65,8 +62,6 @@ drop materialized view iii_index_2
 
 statement ok
 drop materialized view iii_index_1
-
-# TODO: support drop index
 
 statement ok
 drop materialized view iii_index;

--- a/e2e_test/v2/streaming_delta_join/join-3way.slt
+++ b/e2e_test/v2/streaming_delta_join/join-3way.slt
@@ -33,18 +33,14 @@ select v1, v3, v5 from mv1;
 2 2 2
 3 3 3
 
-halt
-
-# TODO: drop MV is not supported yet for delta joins
-
 statement ok
 drop materialized view mv1;
 
 statement ok
-drop ttable tt1;
+drop table tt1;
 
 statement ok
-drop ttable tt2;
+drop table tt2;
 
 statement ok
-drop ttable tt3;
+drop table tt3;

--- a/e2e_test/v2/streaming_delta_join/tpch_snapshot.slt
+++ b/e2e_test/v2/streaming_delta_join/tpch_snapshot.slt
@@ -36,10 +36,6 @@ include ../../streaming/tpch/q12.slt.part
 include ../../streaming/tpch/q14.slt.part
 include ../../streaming/tpch/q19.slt.part
 
-halt
-
-# TODO: drop MV is not supported yet for delta joins
-
 statement ok
 drop materialized view tpch_q1;
 

--- a/e2e_test/v2/streaming_delta_join/tpch_snapshot.slt
+++ b/e2e_test/v2/streaming_delta_join/tpch_snapshot.slt
@@ -40,6 +40,9 @@ statement ok
 drop materialized view tpch_q1;
 
 statement ok
+drop materialized view tpch_q3;
+
+statement ok
 drop materialized view tpch_q5;
 
 statement ok
@@ -61,13 +64,7 @@ statement ok
 drop materialized view tpch_q12;
 
 statement ok
-drop materialized view tpch_q13;
-
-statement ok
 drop materialized view tpch_q14;
-
-statement ok
-drop materialized view tpch_q17;
 
 statement ok
 drop materialized view tpch_q19;

--- a/src/stream/src/executor/actor.rs
+++ b/src/stream/src/executor/actor.rs
@@ -68,7 +68,7 @@ where
             let to_stop = barrier.is_to_stop_actor(self.id);
             if to_stop {
                 tracing::trace!(actor_id = self.id, "actor exit");
-                break;
+                return Ok(());
             }
 
             // Tracing related work
@@ -94,6 +94,8 @@ where
                 );
             }
         }
+
+        tracing::error!(actor_id = self.id, "actor exit without stop barrier");
 
         Ok(())
     }

--- a/src/stream/src/executor/dispatch.rs
+++ b/src/stream/src/executor/dispatch.rs
@@ -23,6 +23,7 @@ use futures::{SinkExt, Stream};
 use futures_async_stream::try_stream;
 use itertools::Itertools;
 use risingwave_common::array::Op;
+use risingwave_common::error::internal_error;
 use risingwave_common::hash::VIRTUAL_NODE_COUNT;
 use risingwave_common::util::addr::{is_local_address, HostAddr};
 use risingwave_common::util::hash_util::CRC32FastBuilder;
@@ -67,7 +68,10 @@ impl LocalOutput {
 impl Output for LocalOutput {
     async fn send(&mut self, message: Message) -> Result<()> {
         // local channel should never fail
-        self.ch.send(message).await.unwrap();
+        self.ch
+            .send(message)
+            .await
+            .map_err(|_| internal_error("failed to send"))?;
         Ok(())
     }
 
@@ -105,7 +109,10 @@ impl Output for RemoteOutput {
             _ => message,
         };
         // local channel should never fail
-        self.ch.send(message).await.unwrap();
+        self.ch
+            .send(message)
+            .await
+            .map_err(|_| internal_error("failed to send"))?;
         Ok(())
     }
 

--- a/src/stream/src/executor_v2/lookup/sides.rs
+++ b/src/stream/src/executor_v2/lookup/sides.rs
@@ -91,7 +91,7 @@ pub enum ArrangeMessage {
     /// Arrangement sides' update in this epoch. There will be only one arrange batch message
     /// within epoch. Once the executor receives an arrange batch message, it can start doing
     /// joins.
-    ArrangeReady(Vec<StreamChunk>),
+    ArrangeReady(Vec<StreamChunk>, Barrier),
 
     /// There's a message from stream side.
     Stream(StreamChunk),
@@ -195,6 +195,7 @@ pub async fn align_barrier(left: impl MessageStream, right: impl MessageStream) 
 /// * `[Do`] lookup `b` in arrangement of epoch `[1`] (prev epoch)
 /// * `[Do`] update cache with epoch `[2`]
 /// * Barrier (prev = `[2`], current = `[3`])
+/// * `[Msg`] Arrangement (batch)
 #[try_stream(ok = ArrangeMessage, error = StreamExecutorError)]
 pub async fn stream_lookup_arrange_prev_epoch(
     stream: Box<dyn Executor>,
@@ -205,6 +206,8 @@ pub async fn stream_lookup_arrange_prev_epoch(
     let mut stream_side_end = false;
 
     loop {
+        let mut arrange_barrier = None;
+
         while let Some(item) = input.next().await {
             match item? {
                 Either::Left(Message::Chunk(msg)) => {
@@ -220,11 +223,15 @@ pub async fn stream_lookup_arrange_prev_epoch(
                     yield ArrangeMessage::Barrier(barrier);
                     stream_side_end = true;
                 }
-                Either::Right(Message::Barrier(_)) => {
+                Either::Right(Message::Barrier(barrier)) => {
                     if stream_side_end {
-                        yield ArrangeMessage::ArrangeReady(std::mem::take(&mut arrange_buf));
+                        yield ArrangeMessage::ArrangeReady(
+                            std::mem::take(&mut arrange_buf),
+                            barrier,
+                        );
                         stream_side_end = false;
                     } else {
+                        arrange_barrier = Some(barrier);
                         break;
                     }
                 }
@@ -246,7 +253,10 @@ pub async fn stream_lookup_arrange_prev_epoch(
             }
         }
 
-        yield ArrangeMessage::ArrangeReady(std::mem::take(&mut arrange_buf));
+        yield ArrangeMessage::ArrangeReady(
+            std::mem::take(&mut arrange_buf),
+            arrange_barrier.take().unwrap(),
+        );
     }
 }
 
@@ -293,8 +303,8 @@ pub async fn stream_lookup_arrange_this_epoch(
                 Either::Left(Message::Barrier(barrier)) => {
                     break 'inner Status::StreamReady(barrier);
                 }
-                Either::Right(Message::Barrier(_)) => {
-                    yield ArrangeMessage::ArrangeReady(std::mem::take(&mut arrange_buf));
+                Either::Right(Message::Barrier(barrier)) => {
+                    yield ArrangeMessage::ArrangeReady(std::mem::take(&mut arrange_buf), barrier);
                     for msg in std::mem::take(&mut stream_buf) {
                         yield ArrangeMessage::Stream(msg);
                     }
@@ -331,8 +341,11 @@ pub async fn stream_lookup_arrange_this_epoch(
                     Either::Right(Message::Chunk(chunk)) => {
                         arrange_buf.push(chunk);
                     }
-                    Either::Right(Message::Barrier(_)) => {
-                        yield ArrangeMessage::ArrangeReady(std::mem::take(&mut arrange_buf));
+                    Either::Right(Message::Barrier(barrier)) => {
+                        yield ArrangeMessage::ArrangeReady(
+                            std::mem::take(&mut arrange_buf),
+                            barrier,
+                        );
                         for msg in std::mem::take(&mut stream_buf) {
                             yield ArrangeMessage::Stream(msg);
                         }


### PR DESCRIPTION
Signed-off-by: Alex Chi <iskyzh@gmail.com>

## What's changed and what's your intention?

Lookup should forward barrier only when two sides are both ready.

## Checklist

- [x] I have written necessary docs and comments
- [x] I have added necessary unit tests and integration tests

## Refer to a related PR or issue link (optional)

close https://github.com/singularity-data/risingwave/issues/2243
