### PR TITLE
feat(storage): init compaction group

### DIFF
--- a/src/meta/src/hummock/compaction/compaction_picker.rs
+++ b/src/meta/src/hummock/compaction/compaction_picker.rs
@@ -1,0 +1,31 @@
+// Copyright 2022 Singularity Data
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use risingwave_pb::hummock::Level;
+
+use crate::hummock::compaction::SearchResult;
+use crate::hummock::level_handler::LevelHandler;
+
+pub trait CompactionPicker {
+    /// Decides if a compaction is needed after excluding files already in compaction. This method
+    /// is expected to be lightweight compared with `pick_compaction_task`.
+    fn need_compaction(&self, levels: Vec<Level>) -> bool;
+    /// Tries to pick a compaction task.
+    fn try_pick_compaction(
+        &self,
+        levels: Vec<Level>,
+        level_handlers: &mut [LevelHandler],
+        compact_task_id: u64,
+    ) -> Option<SearchResult>;
+}

--- a/src/meta/src/hummock/compaction_group/group_compaction_picker.rs
+++ b/src/meta/src/hummock/compaction_group/group_compaction_picker.rs
@@ -1,0 +1,39 @@
+// Copyright 2022 Singularity Data
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use risingwave_pb::hummock::Level;
+
+use crate::hummock::compaction::compaction_picker::CompactionPicker;
+use crate::hummock::compaction::SearchResult;
+use crate::hummock::level_handler::LevelHandler;
+
+/// Picks files from common level which will be assembled according to compaction groups later.
+// TODO: A dedicated picker for common level is not mandatory. We can remove this if any other
+// picker is qualified.
+pub struct GroupCompactionPicker {}
+
+impl CompactionPicker for GroupCompactionPicker {
+    fn need_compaction(&self, _levels: Vec<Level>) -> bool {
+        todo!()
+    }
+
+    fn try_pick_compaction(
+        &self,
+        _levels: Vec<Level>,
+        _level_handlers: &mut [LevelHandler],
+        _compact_task_id: u64,
+    ) -> Option<SearchResult> {
+        todo!()
+    }
+}

--- a/src/meta/src/hummock/compaction_group/mod.rs
+++ b/src/meta/src/hummock/compaction_group/mod.rs
@@ -12,19 +12,109 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+mod group_compaction_picker;
+
+use std::fmt::{Display, Formatter};
+
+use risingwave_pb::hummock::Level;
+
+use crate::hummock::compaction::compaction_picker::CompactionPicker;
+use crate::hummock::compaction::tier_compaction_picker::TierCompactionPicker;
+use crate::hummock::compaction::SearchResult;
+use crate::hummock::compaction_group::group_compaction_picker::GroupCompactionPicker;
+use crate::hummock::level_handler::LevelHandler;
+
 #[derive(Debug, Clone)]
+struct Prefix([u8; 4]);
+
+#[derive(Copy, Clone, Eq, Hash, PartialEq)]
 pub struct CompactionGroupId(u64);
 
-impl CompactionGroupId {
-    pub fn new(cg_id: u64) -> CompactionGroupId {
+pub const DEFAULT_COMPACTION_GROUP_ID: CompactionGroupId = CompactionGroupId(0);
+
+pub enum CompactionPickerImpl {
+    Group(GroupCompactionPicker),
+    Tiered(TierCompactionPicker),
+}
+
+pub struct CompactionGroup {
+    group_id: CompactionGroupId,
+    #[allow(dead_code)]
+    prefixes: Vec<Prefix>,
+    compaction_picker: CompactionPickerImpl,
+    /// If `is_scheduled`, no need to notify scheduler again. Scheduler will reschedule it if
+    /// necessary, e.g. more compaction task available.
+    is_scheduled: bool,
+}
+
+impl CompactionGroup {
+    pub fn group_id(&self) -> &CompactionGroupId {
+        &self.group_id
+    }
+
+    pub fn compaction_picker(&self) -> &CompactionPickerImpl {
+        &self.compaction_picker
+    }
+
+    pub fn is_scheduled(&self) -> bool {
+        self.is_scheduled
+    }
+
+    pub fn set_is_scheduled(&mut self, is_scheduled: bool) {
+        self.is_scheduled = is_scheduled;
+    }
+}
+
+impl From<u64> for CompactionGroupId {
+    fn from(cg_id: u64) -> Self {
         Self(cg_id)
     }
 }
 
-#[allow(dead_code)]
-struct CompactionGroup {
-    group_id: CompactionGroupId,
-    /// If `is_scheduled`, no need to notify scheduler again. Scheduler will reschedule it if
-    /// necessary, e.g. more compaction task available.
-    is_scheduled: bool,
+impl From<&CompactionGroupId> for u64 {
+    fn from(cg_id: &CompactionGroupId) -> Self {
+        cg_id.0
+    }
+}
+
+impl Display for CompactionGroupId {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}", self.0)
+    }
+}
+
+impl CompactionGroup {
+    pub fn new(cg_id: CompactionGroupId, compaction_picker: CompactionPickerImpl) -> Self {
+        CompactionGroup {
+            group_id: cg_id,
+            prefixes: vec![],
+            compaction_picker,
+            is_scheduled: false,
+        }
+    }
+}
+
+impl CompactionPicker for CompactionPickerImpl {
+    fn need_compaction(&self, levels: Vec<Level>) -> bool {
+        match self {
+            CompactionPickerImpl::Group(picker) => picker.need_compaction(levels),
+            CompactionPickerImpl::Tiered(picker) => picker.need_compaction(levels),
+        }
+    }
+
+    fn try_pick_compaction(
+        &self,
+        levels: Vec<Level>,
+        level_handlers: &mut [LevelHandler],
+        compact_task_id: u64,
+    ) -> Option<SearchResult> {
+        match self {
+            CompactionPickerImpl::Group(picker) => {
+                picker.try_pick_compaction(levels, level_handlers, compact_task_id)
+            }
+            CompactionPickerImpl::Tiered(picker) => {
+                picker.pick_compaction(levels, level_handlers, compact_task_id)
+            }
+        }
+    }
 }

--- a/src/meta/src/hummock/compactor_manager.rs
+++ b/src/meta/src/hummock/compactor_manager.rs
@@ -29,6 +29,7 @@ pub struct Compactor {
 }
 
 impl Compactor {
+    // TODO: use try_send to indicate whether it's busy
     pub async fn send_task(
         &self,
         compact_task: Option<CompactTask>,

--- a/src/meta/src/hummock/error.rs
+++ b/src/meta/src/hummock/error.rs
@@ -1,0 +1,85 @@
+// Copyright 2022 Singularity Data
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use risingwave_common::error::{ErrorCode, RwError, ToErrorStr};
+use risingwave_hummock_sdk::HummockContextId;
+use thiserror::Error;
+
+use crate::storage::meta_store;
+
+pub type Result<T> = std::result::Result<T, Error>;
+
+#[derive(Error, Debug)]
+pub enum Error {
+    #[error("invalid hummock context {0}")]
+    InvalidContext(HummockContextId),
+    #[error(transparent)]
+    MetaStoreError(anyhow::Error),
+    #[error("internal error: {0}")]
+    InternalError(String),
+}
+
+impl Error {
+    pub fn retryable(&self) -> bool {
+        match self {
+            Error::InvalidContext(_) => false,
+            Error::MetaStoreError(_) => true,
+            Error::InternalError(_) => false,
+        }
+    }
+}
+
+impl From<meta_store::Error> for Error {
+    fn from(error: meta_store::Error) -> Self {
+        match error {
+            meta_store::Error::ItemNotFound(err) => Error::InternalError(err),
+            meta_store::Error::TransactionAbort() => {
+                // TODO: need more concrete error from meta store.
+                Error::InvalidContext(0)
+            }
+            meta_store::Error::Internal(err) => Error::MetaStoreError(err),
+        }
+    }
+}
+
+impl From<Error> for ErrorCode {
+    fn from(error: Error) -> Self {
+        match error {
+            Error::InvalidContext(err) => {
+                ErrorCode::InternalError(format!("invalid hummock context {}", err))
+            }
+            Error::MetaStoreError(err) => ErrorCode::MetaError(err.to_error_str()),
+            Error::InternalError(err) => ErrorCode::InternalError(err),
+        }
+    }
+}
+
+impl From<Error> for risingwave_common::error::RwError {
+    fn from(error: Error) -> Self {
+        ErrorCode::from(error).into()
+    }
+}
+
+// TODO: as a workaround before refactoring `MetadataModel` error
+impl From<risingwave_common::error::RwError> for Error {
+    fn from(error: RwError) -> Self {
+        match error.inner() {
+            ErrorCode::InternalError(err) => Error::InternalError(err.to_owned()),
+            ErrorCode::ItemNotFound(err) => Error::InternalError(err.to_owned()),
+            _ => {
+                panic!("convertion not supported");
+            }
+        }
+    }
+}

--- a/src/meta/src/hummock/hummock_manager_tests.rs
+++ b/src/meta/src/hummock/hummock_manager_tests.rs
@@ -16,7 +16,6 @@ use std::cmp::Ordering;
 use std::time::Duration;
 
 use itertools::Itertools;
-use risingwave_common::error::{ErrorCode, Result};
 use risingwave_common::util::epoch::INVALID_EPOCH;
 use risingwave_hummock_sdk::compact::compact_task_to_string;
 use risingwave_hummock_sdk::{
@@ -28,6 +27,7 @@ use risingwave_pb::hummock::{
     HummockVersionRefId,
 };
 
+use crate::hummock::error::Error;
 use crate::hummock::model::CurrentHummockVersionId;
 use crate::hummock::test_utils::*;
 use crate::model::MetadataModel;
@@ -41,14 +41,15 @@ fn pin_snapshots_sum(pin_snapshots: &[HummockPinnedSnapshot]) -> usize {
 }
 
 #[tokio::test]
-async fn test_hummock_pin_unpin() -> Result<()> {
+async fn test_hummock_pin_unpin() {
     let (env, hummock_manager, _cluster_manager, worker_node) = setup_compute_env(80).await;
     let context_id = worker_node.id;
     let version_id = FIRST_VERSION_ID;
     let epoch = INVALID_EPOCH;
 
     assert!(HummockPinnedVersion::list(env.meta_store())
-        .await?
+        .await
+        .unwrap()
         .is_empty());
     for _ in 0..2 {
         let hummock_version = hummock_manager
@@ -60,7 +61,7 @@ async fn test_hummock_pin_unpin() -> Result<()> {
         assert_eq!(0, hummock_version.levels[0].table_infos.len());
         assert_eq!(0, hummock_version.levels[1].table_infos.len());
 
-        let pinned_versions = HummockPinnedVersion::list(env.meta_store()).await?;
+        let pinned_versions = HummockPinnedVersion::list(env.meta_store()).await.unwrap();
         assert_eq!(pin_versions_sum(&pinned_versions), 1);
         assert_eq!(pinned_versions[0].context_id, context_id);
         assert_eq!(pinned_versions[0].version_id.len(), 1);
@@ -74,13 +75,13 @@ async fn test_hummock_pin_unpin() -> Result<()> {
             .await
             .unwrap();
         assert_eq!(
-            pin_versions_sum(&HummockPinnedVersion::list(env.meta_store()).await?),
+            pin_versions_sum(&HummockPinnedVersion::list(env.meta_store()).await.unwrap()),
             0
         );
     }
 
     assert_eq!(
-        pin_snapshots_sum(&HummockPinnedSnapshot::list(env.meta_store()).await?),
+        pin_snapshots_sum(&HummockPinnedSnapshot::list(env.meta_store()).await.unwrap()),
         0
     );
     for _ in 0..2 {
@@ -89,7 +90,7 @@ async fn test_hummock_pin_unpin() -> Result<()> {
             .await
             .unwrap();
         assert_eq!(pin_result.epoch, epoch);
-        let pinned_snapshots = HummockPinnedSnapshot::list(env.meta_store()).await?;
+        let pinned_snapshots = HummockPinnedSnapshot::list(env.meta_store()).await.unwrap();
         assert_eq!(pin_snapshots_sum(&pinned_snapshots), 1);
         assert_eq!(pinned_snapshots[0].context_id, context_id);
         assert_eq!(pinned_snapshots[0].snapshot_id.len(), 1);
@@ -102,21 +103,19 @@ async fn test_hummock_pin_unpin() -> Result<()> {
             .await
             .unwrap();
         assert_eq!(
-            pin_snapshots_sum(&HummockPinnedSnapshot::list(env.meta_store()).await?),
+            pin_snapshots_sum(&HummockPinnedSnapshot::list(env.meta_store()).await.unwrap()),
             0
         );
     }
-
-    Ok(())
 }
 
 #[tokio::test]
-async fn test_hummock_compaction_task() -> Result<()> {
+async fn test_hummock_compaction_task() {
     let (env, hummock_manager, _cluster_manager, worker_node) = setup_compute_env(80).await;
     let context_id = worker_node.id;
 
     // No compaction task available.
-    let task = hummock_manager.get_compact_task(context_id).await?;
+    let task = hummock_manager.get_compact_task(context_id).await.unwrap();
     assert_eq!(task, None);
 
     // Add some sstables and commit.
@@ -128,14 +127,15 @@ async fn test_hummock_compaction_task() -> Result<()> {
         .unwrap();
 
     // No compaction task available. Uncommitted sst won't be compacted.
-    let task = hummock_manager.get_compact_task(context_id).await?;
+    let task = hummock_manager.get_compact_task(context_id).await.unwrap();
     assert_eq!(task, None);
 
     hummock_manager.commit_epoch(epoch).await.unwrap();
 
     // check safe epoch in hummock version
     let version_id1 = CurrentHummockVersionId::get(env.meta_store())
-        .await?
+        .await
+        .unwrap()
         .unwrap();
     let hummock_version1 = HummockVersion::select(
         env.meta_store(),
@@ -143,7 +143,8 @@ async fn test_hummock_compaction_task() -> Result<()> {
             id: version_id1.id(),
         },
     )
-    .await?
+    .await
+    .unwrap()
     .unwrap();
 
     // safe epoch should be INVALID before success compaction
@@ -168,18 +169,19 @@ async fn test_hummock_compaction_task() -> Result<()> {
     // Cancel the task and succeed.
     compact_task.task_status = false;
     assert!(hummock_manager
-        .report_compact_task(compact_task.clone())
+        .report_compact_task(&compact_task)
         .await
         .unwrap());
     // Cancel the task and told the task is not found, which may have been processed previously.
     assert!(!hummock_manager
-        .report_compact_task(compact_task.clone())
+        .report_compact_task(&compact_task)
         .await
         .unwrap());
 
     // check safe epoch in hummock version
     let version_id2 = CurrentHummockVersionId::get(env.meta_store())
-        .await?
+        .await
+        .unwrap()
         .unwrap();
 
     let hummock_version2 = HummockVersion::select(
@@ -188,7 +190,8 @@ async fn test_hummock_compaction_task() -> Result<()> {
             id: version_id2.id(),
         },
     )
-    .await?
+    .await
+    .unwrap()
     .unwrap();
 
     // safe epoch should still be INVALID since comapction task is canceled
@@ -205,18 +208,19 @@ async fn test_hummock_compaction_task() -> Result<()> {
     compact_task.task_status = true;
 
     assert!(hummock_manager
-        .report_compact_task(compact_task.clone())
+        .report_compact_task(&compact_task)
         .await
         .unwrap());
     // Finish the task and told the task is not found, which may have been processed previously.
     assert!(!hummock_manager
-        .report_compact_task(compact_task.clone())
+        .report_compact_task(&compact_task)
         .await
         .unwrap());
 
     // check safe epoch in hummock version after success compaction
     let version_id3 = CurrentHummockVersionId::get(env.meta_store())
-        .await?
+        .await
+        .unwrap()
         .unwrap();
 
     let hummock_version3 = HummockVersion::select(
@@ -225,17 +229,16 @@ async fn test_hummock_compaction_task() -> Result<()> {
             id: version_id3.id(),
         },
     )
-    .await?
+    .await
+    .unwrap()
     .unwrap();
 
     // Since there is no pinned epochs, the safe epoch in version should be max_committed_epoch
     assert_eq!(epoch, hummock_version3.safe_epoch);
-
-    Ok(())
 }
 
 #[tokio::test]
-async fn test_hummock_table() -> Result<()> {
+async fn test_hummock_table() {
     let (_env, hummock_manager, _cluster_manager, worker_node) = setup_compute_env(80).await;
     let context_id = worker_node.id;
 
@@ -247,7 +250,10 @@ async fn test_hummock_table() -> Result<()> {
         .unwrap();
     hummock_manager.commit_epoch(epoch).await.unwrap();
 
-    let pinned_version = hummock_manager.pin_version(context_id, u64::MAX).await?;
+    let pinned_version = hummock_manager
+        .pin_version(context_id, u64::MAX)
+        .await
+        .unwrap();
     assert_eq!(
         Ordering::Equal,
         pinned_version
@@ -264,12 +270,10 @@ async fn test_hummock_table() -> Result<()> {
         get_sorted_sstable_ids(&original_tables),
         get_sorted_committed_sstable_ids(&pinned_version)
     );
-
-    Ok(())
 }
 
 #[tokio::test]
-async fn test_hummock_transaction() -> Result<()> {
+async fn test_hummock_transaction() {
     let (_env, hummock_manager, _cluster_manager, worker_node) = setup_compute_env(80).await;
     let context_id = worker_node.id;
     let mut committed_tables = vec![];
@@ -288,7 +292,10 @@ async fn test_hummock_transaction() -> Result<()> {
             .unwrap();
 
         // Get tables before committing epoch1. No tables should be returned.
-        let mut pinned_version = hummock_manager.pin_version(context_id, u64::MAX).await?;
+        let mut pinned_version = hummock_manager
+            .pin_version(context_id, u64::MAX)
+            .await
+            .unwrap();
         let uncommitted_epoch = pinned_version.uncommitted_epochs.first_mut().unwrap();
         assert_eq!(epoch1, uncommitted_epoch.epoch);
         assert_eq!(pinned_version.max_committed_epoch, INVALID_EPOCH);
@@ -298,14 +305,18 @@ async fn test_hummock_transaction() -> Result<()> {
 
         hummock_manager
             .unpin_version(context_id, vec![pinned_version.id])
-            .await?;
+            .await
+            .unwrap();
 
         // Commit epoch1
         hummock_manager.commit_epoch(epoch1).await.unwrap();
         committed_tables.extend(tables_in_epoch1.clone());
 
         // Get tables after committing epoch1. All tables committed in epoch1 should be returned
-        let pinned_version = hummock_manager.pin_version(context_id, u64::MAX).await?;
+        let pinned_version = hummock_manager
+            .pin_version(context_id, u64::MAX)
+            .await
+            .unwrap();
         assert!(pinned_version.uncommitted_epochs.is_empty());
         assert_eq!(pinned_version.max_committed_epoch, epoch1);
         assert_eq!(
@@ -315,7 +326,8 @@ async fn test_hummock_transaction() -> Result<()> {
 
         hummock_manager
             .unpin_version(context_id, vec![pinned_version.id])
-            .await?;
+            .await
+            .unwrap();
     }
 
     // Add and commit tables in epoch2.
@@ -333,7 +345,10 @@ async fn test_hummock_transaction() -> Result<()> {
 
         // Get tables before committing epoch2. tables_in_epoch1 should be returned and
         // tables_in_epoch2 should be invisible.
-        let mut pinned_version = hummock_manager.pin_version(context_id, u64::MAX).await?;
+        let mut pinned_version = hummock_manager
+            .pin_version(context_id, u64::MAX)
+            .await
+            .unwrap();
         let uncommitted_epoch = pinned_version.uncommitted_epochs.first_mut().unwrap();
         assert_eq!(epoch2, uncommitted_epoch.epoch);
         uncommitted_epoch.tables.sort_unstable_by_key(|e| e.id);
@@ -345,7 +360,8 @@ async fn test_hummock_transaction() -> Result<()> {
         );
         hummock_manager
             .unpin_version(context_id, vec![pinned_version.id])
-            .await?;
+            .await
+            .unwrap();
 
         // Commit epoch2
         hummock_manager.commit_epoch(epoch2).await.unwrap();
@@ -353,7 +369,10 @@ async fn test_hummock_transaction() -> Result<()> {
 
         // Get tables after committing epoch2. tables_in_epoch1 and tables_in_epoch2 should be
         // returned
-        let pinned_version = hummock_manager.pin_version(context_id, u64::MAX).await?;
+        let pinned_version = hummock_manager
+            .pin_version(context_id, u64::MAX)
+            .await
+            .unwrap();
         assert!(pinned_version.uncommitted_epochs.is_empty());
         assert_eq!(pinned_version.max_committed_epoch, epoch2);
         assert_eq!(
@@ -362,7 +381,8 @@ async fn test_hummock_transaction() -> Result<()> {
         );
         hummock_manager
             .unpin_version(context_id, vec![pinned_version.id])
-            .await?;
+            .await
+            .unwrap();
     }
 
     // Add tables in epoch3 and epoch4. Abort epoch3, commit epoch4.
@@ -386,7 +406,10 @@ async fn test_hummock_transaction() -> Result<()> {
 
         // Get tables before committing epoch3 and epoch4. tables_in_epoch1 and tables_in_epoch2
         // should be returned
-        let mut pinned_version = hummock_manager.pin_version(context_id, u64::MAX).await?;
+        let mut pinned_version = hummock_manager
+            .pin_version(context_id, u64::MAX)
+            .await
+            .unwrap();
         let uncommitted_epoch3 = pinned_version
             .uncommitted_epochs
             .iter_mut()
@@ -423,11 +446,15 @@ async fn test_hummock_transaction() -> Result<()> {
         );
         hummock_manager
             .unpin_version(context_id, vec![pinned_version.id])
-            .await?;
+            .await
+            .unwrap();
 
         // Get tables after aborting epoch3. tables_in_epoch1 and tables_in_epoch2 should be
         // returned
-        let mut pinned_version = hummock_manager.pin_version(context_id, u64::MAX).await?;
+        let mut pinned_version = hummock_manager
+            .pin_version(context_id, u64::MAX)
+            .await
+            .unwrap();
         assert!(pinned_version
             .uncommitted_epochs
             .iter_mut()
@@ -446,7 +473,8 @@ async fn test_hummock_transaction() -> Result<()> {
         );
         hummock_manager
             .unpin_version(context_id, vec![pinned_version.id])
-            .await?;
+            .await
+            .unwrap();
 
         // Commit epoch4
         hummock_manager.commit_epoch(epoch4).await.unwrap();
@@ -454,7 +482,10 @@ async fn test_hummock_transaction() -> Result<()> {
 
         // Get tables after committing epoch4. tables_in_epoch1, tables_in_epoch2, tables_in_epoch4
         // should be returned.
-        let pinned_version = hummock_manager.pin_version(context_id, u64::MAX).await?;
+        let pinned_version = hummock_manager
+            .pin_version(context_id, u64::MAX)
+            .await
+            .unwrap();
         assert!(pinned_version.uncommitted_epochs.is_empty());
         assert_eq!(pinned_version.max_committed_epoch, epoch4);
         assert_eq!(
@@ -463,13 +494,13 @@ async fn test_hummock_transaction() -> Result<()> {
         );
         hummock_manager
             .unpin_version(context_id, vec![pinned_version.id])
-            .await?;
+            .await
+            .unwrap();
     }
-    Ok(())
 }
 
 #[tokio::test]
-async fn test_release_context_resource() -> Result<()> {
+async fn test_release_context_resource() {
     let (env, hummock_manager, cluster_manager, worker_node) = setup_compute_env(1).await;
     let context_id_1 = worker_node.id;
 
@@ -542,7 +573,6 @@ async fn test_release_context_resource() -> Result<()> {
         pin_snapshots_sum(&HummockPinnedSnapshot::list(env.meta_store()).await.unwrap()),
         0
     );
-    Ok(())
 }
 
 #[tokio::test]
@@ -558,8 +588,7 @@ async fn test_context_id_validation() {
         .add_tables(invalid_context_id, original_tables.clone(), epoch)
         .await
         .unwrap_err();
-    assert!(matches!(error.inner(), ErrorCode::InternalError(_)));
-    assert_eq!(error.to_string(), "internal error: transaction aborted");
+    assert!(matches!(error, Error::InvalidContext(_)));
 
     // Valid context id is accepted.
     hummock_manager
@@ -587,8 +616,7 @@ async fn test_context_id_validation() {
         .pin_version(context_id, u64::MAX)
         .await
         .unwrap_err();
-    assert!(matches!(error.inner(), ErrorCode::InternalError(_)));
-    assert_eq!(error.to_string(), "internal error: transaction aborted");
+    assert!(matches!(error, Error::InvalidContext(_)));
 }
 
 #[tokio::test]
@@ -902,7 +930,7 @@ async fn test_pin_snapshot_response_lost() {
 }
 
 #[tokio::test]
-async fn test_print_compact_task() -> Result<()> {
+async fn test_print_compact_task() {
     let (_, hummock_manager, _cluster_manager, worker_node) = setup_compute_env(80).await;
     let context_id = worker_node.id;
 
@@ -932,8 +960,6 @@ async fn test_print_compact_task() -> Result<()> {
 
     let s = compact_task_to_string(&compact_task);
     assert!(s.contains("Compaction task id: 1, target level: 1"));
-
-    Ok(())
 }
 
 #[tokio::test]
@@ -946,14 +972,7 @@ async fn test_invalid_sst_id() {
         .add_tables(context_id, ssts.clone(), epoch)
         .await
         .unwrap_err();
-    assert!(matches!(error.inner(), ErrorCode::MetaError(_)));
-    assert_eq!(
-        error.to_string(),
-        format!(
-            "Error while interact with meta service: Invalid SST id {}, may have been vacuumed",
-            ssts.first().unwrap().id
-        )
-    );
+    assert!(matches!(error, Error::InternalError(_)));
 }
 
 #[tokio::test]
@@ -996,12 +1015,5 @@ async fn test_mark_orphan_ssts() {
         .add_tables(context_id, ssts.clone(), epoch)
         .await
         .unwrap_err();
-    assert!(matches!(error.inner(), ErrorCode::MetaError(_)));
-    assert_eq!(
-        error.to_string(),
-        format!(
-            "Error while interact with meta service: SST id {} has been marked for vacuum",
-            ssts.first().unwrap().id
-        )
-    );
+    assert!(matches!(error, Error::InternalError(_)));
 }

--- a/src/meta/src/hummock/manager/compaction.rs
+++ b/src/meta/src/hummock/manager/compaction.rs
@@ -1,0 +1,71 @@
+// Copyright 2022 Singularity Data
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::collections::{BTreeMap, HashMap};
+use std::sync::Arc;
+
+use risingwave_common::error::Result;
+use risingwave_pb::hummock::CompactTaskAssignment;
+
+use crate::hummock::compaction::overlap_strategy::RangeOverlapStrategy;
+use crate::hummock::compaction::tier_compaction_picker::TierCompactionPicker;
+use crate::hummock::compaction::CompactStatus;
+use crate::hummock::compaction_group::{
+    CompactionGroup, CompactionGroupId, CompactionPickerImpl, DEFAULT_COMPACTION_GROUP_ID,
+};
+use crate::model::MetadataModel;
+use crate::storage::MetaStore;
+
+pub type CompactionGroupRef = Arc<parking_lot::RwLock<CompactionGroup>>;
+
+#[derive(Default)]
+pub struct Compaction {
+    pub(crate) compact_status: CompactStatus,
+    pub(crate) compaction_groups: HashMap<CompactionGroupId, CompactionGroupRef>,
+    pub(crate) compact_task_assignment: BTreeMap<u64, CompactTaskAssignment>,
+}
+
+impl Compaction {
+    pub async fn init(&mut self, meta_store: &impl MetaStore) -> Result<()> {
+        self.compact_status = CompactStatus::get(meta_store)
+            .await?
+            .unwrap_or_else(CompactStatus::new);
+
+        self.compact_task_assignment = CompactTaskAssignment::list(meta_store)
+            .await?
+            .into_iter()
+            .map(|assigned| (assigned.key().unwrap().id, assigned))
+            .collect();
+
+        // TODO: load groups from meta_store
+        // TODO: init groups. DEFAULT_COMPACTION_GROUP_ID should be the common level of all groups.
+        let picker = CompactionPickerImpl::Tiered(TierCompactionPicker::new(Box::new(
+            RangeOverlapStrategy::default(),
+        )));
+        let default_group = CompactionGroup::new(DEFAULT_COMPACTION_GROUP_ID, picker);
+        self.compaction_groups = HashMap::new();
+        self.compaction_groups.insert(
+            default_group.group_id().to_owned(),
+            Arc::new(parking_lot::RwLock::new(default_group)),
+        );
+        Ok(())
+    }
+
+    pub fn get_default_compaction_group(&self) -> CompactionGroupRef {
+        self.compaction_groups
+            .get(&DEFAULT_COMPACTION_GROUP_ID)
+            .expect("default compaction group not found")
+            .clone()
+    }
+}

--- a/src/meta/src/hummock/manager/mod.rs
+++ b/src/meta/src/hummock/manager/mod.rs
@@ -12,18 +12,5 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-mod etcd_meta_store;
-mod mem_meta_store;
-pub mod meta_store;
-#[cfg(test)]
-mod tests;
-mod transaction;
-
-pub type ColumnFamily = String;
-pub type Key = Vec<u8>;
-pub type Value = Vec<u8>;
-
-pub use etcd_meta_store::*;
-pub use mem_meta_store::*;
-pub use meta_store::*;
-pub use transaction::*;
+pub mod compaction;
+pub mod versioning;

--- a/src/meta/src/hummock/manager/versioning.rs
+++ b/src/meta/src/hummock/manager/versioning.rs
@@ -1,0 +1,110 @@
+// Copyright 2022 Singularity Data
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::collections::BTreeMap;
+
+use risingwave_common::error::Result;
+use risingwave_common::util::epoch::INVALID_EPOCH;
+use risingwave_hummock_sdk::{HummockContextId, HummockSSTableId, HummockVersionId};
+use risingwave_pb::hummock::{
+    HummockPinnedSnapshot, HummockPinnedVersion, HummockStaleSstables, HummockVersion, Level,
+    LevelType, SstableIdInfo,
+};
+
+use crate::hummock::model::CurrentHummockVersionId;
+use crate::model::MetadataModel;
+use crate::storage::MetaStore;
+
+#[derive(Default)]
+pub struct Versioning {
+    pub(crate) current_version_id: CurrentHummockVersionId,
+    pub(crate) hummock_versions: BTreeMap<HummockVersionId, HummockVersion>,
+    pub(crate) pinned_versions: BTreeMap<HummockContextId, HummockPinnedVersion>,
+    pub(crate) pinned_snapshots: BTreeMap<HummockContextId, HummockPinnedSnapshot>,
+    pub(crate) stale_sstables: BTreeMap<HummockVersionId, HummockStaleSstables>,
+    pub(crate) sstable_id_infos: BTreeMap<HummockSSTableId, SstableIdInfo>,
+}
+
+impl Versioning {
+    pub async fn init(&mut self, meta_store: &impl MetaStore) -> Result<()> {
+        self.current_version_id = CurrentHummockVersionId::get(meta_store)
+            .await?
+            .unwrap_or_else(CurrentHummockVersionId::new);
+
+        self.hummock_versions = HummockVersion::list(meta_store)
+            .await?
+            .into_iter()
+            .map(|version| (version.id, version))
+            .collect();
+
+        // Insert the initial version.
+        if self.hummock_versions.is_empty() {
+            let init_version = HummockVersion {
+                id: self.current_version_id.id(),
+                levels: vec![
+                    Level {
+                        level_idx: 0,
+                        level_type: LevelType::Overlapping as i32,
+                        table_infos: vec![],
+                    },
+                    Level {
+                        level_idx: 1,
+                        level_type: LevelType::Nonoverlapping as i32,
+                        table_infos: vec![],
+                    },
+                ],
+                uncommitted_epochs: vec![],
+                max_committed_epoch: INVALID_EPOCH,
+                safe_epoch: INVALID_EPOCH,
+            };
+            init_version.insert(meta_store).await?;
+            self.hummock_versions.insert(init_version.id, init_version);
+        }
+
+        self.pinned_versions = HummockPinnedVersion::list(meta_store)
+            .await?
+            .into_iter()
+            .map(|p| (p.context_id, p))
+            .collect();
+        self.pinned_snapshots = HummockPinnedSnapshot::list(meta_store)
+            .await?
+            .into_iter()
+            .map(|p| (p.context_id, p))
+            .collect();
+
+        self.stale_sstables = HummockStaleSstables::list(meta_store)
+            .await?
+            .into_iter()
+            .map(|s| (s.version_id, s))
+            .collect();
+
+        self.sstable_id_infos = SstableIdInfo::list(meta_store)
+            .await?
+            .into_iter()
+            .map(|s| (s.id, s))
+            .collect();
+
+        Ok(())
+    }
+
+    pub fn current_version_ref(&self) -> &HummockVersion {
+        self.hummock_versions
+            .get(&self.current_version_id.id())
+            .expect("current version should always be available.")
+    }
+
+    pub fn current_version(&self) -> HummockVersion {
+        self.current_version_ref().clone()
+    }
+}

--- a/src/meta/src/hummock/mock_hummock_meta_client.rs
+++ b/src/meta/src/hummock/mock_hummock_meta_client.rs
@@ -57,12 +57,14 @@ impl HummockMetaClient for MockHummockMetaClient {
         self.hummock_manager
             .pin_version(self.context_id, last_pinned)
             .await
+            .map_err(|e| e.into())
     }
 
     async fn unpin_version(&self, pinned_version_id: &[HummockVersionId]) -> Result<()> {
         self.hummock_manager
             .unpin_version(self.context_id, pinned_version_id)
             .await
+            .map_err(|e| e.into())
     }
 
     async fn pin_snapshot(&self, last_pinned: HummockEpoch) -> Result<HummockEpoch> {
@@ -70,6 +72,7 @@ impl HummockMetaClient for MockHummockMetaClient {
             .pin_snapshot(self.context_id, last_pinned)
             .await
             .map(|e| e.epoch)
+            .map_err(|e| e.into())
     }
 
     async fn unpin_snapshot(&self, pinned_epochs: &[HummockEpoch]) -> Result<()> {
@@ -82,10 +85,14 @@ impl HummockMetaClient for MockHummockMetaClient {
         self.hummock_manager
             .unpin_snapshot(self.context_id, snapshots)
             .await
+            .map_err(|e| e.into())
     }
 
     async fn get_new_table_id(&self) -> Result<HummockSSTableId> {
-        self.hummock_manager.get_new_table_id().await
+        self.hummock_manager
+            .get_new_table_id()
+            .await
+            .map_err(|e| e.into())
     }
 
     async fn add_tables(
@@ -96,21 +103,29 @@ impl HummockMetaClient for MockHummockMetaClient {
         self.hummock_manager
             .add_tables(self.context_id, sstables, epoch)
             .await
+            .map_err(|e| e.into())
     }
 
     async fn report_compaction_task(&self, compact_task: CompactTask) -> Result<()> {
         self.hummock_manager
-            .report_compact_task(compact_task)
+            .report_compact_task(&compact_task)
             .await
             .map(|_| ())
+            .map_err(|e| e.into())
     }
 
     async fn commit_epoch(&self, epoch: HummockEpoch) -> Result<()> {
-        self.hummock_manager.commit_epoch(epoch).await
+        self.hummock_manager
+            .commit_epoch(epoch)
+            .await
+            .map_err(|e| e.into())
     }
 
     async fn abort_epoch(&self, epoch: HummockEpoch) -> Result<()> {
-        self.hummock_manager.abort_epoch(epoch).await
+        self.hummock_manager
+            .abort_epoch(epoch)
+            .await
+            .map_err(|e| e.into())
     }
 
     async fn subscribe_compact_tasks(&self) -> Result<Streaming<SubscribeCompactTasksResponse>> {

--- a/src/meta/src/hummock/mod.rs
+++ b/src/meta/src/hummock/mod.rs
@@ -16,16 +16,19 @@ mod compaction;
 mod compaction_group;
 mod compaction_scheduler;
 mod compactor_manager;
+pub mod error;
 mod hummock_manager;
 #[cfg(test)]
 mod hummock_manager_tests;
 mod level_handler;
+mod manager;
 mod metrics_utils;
 #[cfg(any(test, feature = "test"))]
 pub mod mock_hummock_meta_client;
 mod model;
 #[cfg(any(test, feature = "test"))]
 pub mod test_utils;
+mod utils;
 mod vacuum;
 
 use std::sync::Arc;
@@ -41,8 +44,8 @@ use tokio::task::JoinHandle;
 use tokio_retry::strategy::{jitter, ExponentialBackoff};
 pub use vacuum::*;
 
-use crate::hummock::compaction_group::CompactionGroupId;
 use crate::hummock::compaction_scheduler::CompactionSchedulerRef;
+use crate::hummock::utils::RetryableError;
 use crate::manager::{LocalNotification, NotificationManagerRef};
 use crate::storage::MetaStore;
 
@@ -97,18 +100,24 @@ where
                 }
             };
             compactor_manager.remove_compactor(worker_node.id);
+
+            // Retry only happens when meta store is undergoing failure.
             let retry_strategy = ExponentialBackoff::from_millis(10)
                 .max_delay(Duration::from_secs(60))
                 .map(jitter);
-            tokio_retry::Retry::spawn(retry_strategy, || async {
-                if let Err(err) = hummock_manager.release_contexts(vec![worker_node.id]).await {
-                    tracing::warn!("Failed to release_contexts {}. Will retry.", err);
-                    return Err(err);
-                }
-                Ok(())
-            })
+            tokio_retry::RetryIf::spawn(
+                retry_strategy,
+                || async {
+                    if let Err(err) = hummock_manager.release_contexts(vec![worker_node.id]).await {
+                        tracing::warn!("Failed to release_contexts {:?}. Will retry.", err);
+                        return Err(err);
+                    }
+                    Ok(())
+                },
+                RetryableError::default(),
+            )
             .await
-            .expect("Should retry until release_contexts succeeds");
+            .expect("release_contexts should always be retryable and eventually succeed.")
         }
     });
     (join_handle, shutdown_tx)
@@ -121,19 +130,6 @@ fn start_compaction_scheduler<S>(
 where
     S: MetaStore,
 {
-    // TODO: remove this periodic trigger after #2121
-    let request_sender = compaction_scheduler.request_sender();
-    tokio::spawn(async move {
-        let mut min_interval = tokio::time::interval(Duration::from_secs(10));
-        loop {
-            min_interval.tick().await;
-            if request_sender.send(CompactionGroupId::new(0)).is_err() {
-                tracing::info!("Stop periodic compaction trigger");
-                return;
-            }
-        }
-    });
-
     // Start compaction scheduler
     let shutdown_sender = compaction_scheduler.shutdown_sender();
     let join_handle = tokio::spawn(async move {

--- a/src/meta/src/hummock/model/current_version_id.rs
+++ b/src/meta/src/hummock/model/current_version_id.rs
@@ -73,3 +73,9 @@ impl CurrentHummockVersionId {
         self.id
     }
 }
+
+impl Default for CurrentHummockVersionId {
+    fn default() -> Self {
+        CurrentHummockVersionId::new()
+    }
+}

--- a/src/meta/src/hummock/test_utils.rs
+++ b/src/meta/src/hummock/test_utils.rs
@@ -62,7 +62,7 @@ where
     compact_task.sorted_output_ssts = test_tables_2.clone();
     compact_task.task_status = true;
     hummock_manager
-        .report_compact_task(compact_task)
+        .report_compact_task(&compact_task)
         .await
         .unwrap();
     // Current state: {v0: [], v1: [test_tables uncommitted], v2: [test_tables], v3: [test_tables_2,

--- a/src/meta/src/hummock/utils.rs
+++ b/src/meta/src/hummock/utils.rs
@@ -12,18 +12,15 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-mod etcd_meta_store;
-mod mem_meta_store;
-pub mod meta_store;
-#[cfg(test)]
-mod tests;
-mod transaction;
+use tokio_retry::Condition;
 
-pub type ColumnFamily = String;
-pub type Key = Vec<u8>;
-pub type Value = Vec<u8>;
+use crate::hummock::error::Error;
 
-pub use etcd_meta_store::*;
-pub use mem_meta_store::*;
-pub use meta_store::*;
-pub use transaction::*;
+#[derive(Default)]
+pub struct RetryableError {}
+
+impl Condition<Error> for RetryableError {
+    fn should_retry(&mut self, error: &Error) -> bool {
+        error.retryable()
+    }
+}

--- a/src/meta/src/rpc/service/hummock_service.rs
+++ b/src/meta/src/rpc/service/hummock_service.rs
@@ -70,7 +70,7 @@ where
                 status: None,
                 pinned_version: Some(pinned_version),
             })),
-            Err(e) => Err(e.to_grpc_status()),
+            Err(e) => Err(tonic_err(e)),
         }
     }
 
@@ -85,7 +85,7 @@ where
             .await;
         match result {
             Ok(_) => Ok(Response::new(UnpinVersionResponse { status: None })),
-            Err(e) => Err(e.to_grpc_status()),
+            Err(e) => Err(tonic_err(e)),
         }
     }
 
@@ -103,7 +103,7 @@ where
                 status: None,
                 version: Some(version),
             })),
-            Err(e) => Err(e.to_grpc_status()),
+            Err(e) => Err(tonic_err(e)),
         }
     }
 
@@ -117,12 +117,15 @@ where
                 status: None,
             })),
             Some(compact_task) => {
-                let result = self.hummock_manager.report_compact_task(compact_task).await;
+                let result = self
+                    .hummock_manager
+                    .report_compact_task(&compact_task)
+                    .await;
                 match result {
                     Ok(_) => Ok(Response::new(ReportCompactionTasksResponse {
                         status: None,
                     })),
-                    Err(e) => Err(e.to_grpc_status()),
+                    Err(e) => Err(tonic_err(e)),
                 }
             }
         }
@@ -142,7 +145,7 @@ where
                 status: None,
                 snapshot: Some(hummock_snapshot),
             })),
-            Err(e) => Err(e.to_grpc_status()),
+            Err(e) => Err(tonic_err(e)),
         }
     }
 
@@ -156,7 +159,7 @@ where
             .unpin_snapshot(req.context_id, req.snapshots)
             .await
         {
-            return Err(e.to_grpc_status());
+            return Err(tonic_err(e));
         }
         Ok(Response::new(UnpinSnapshotResponse { status: None }))
     }
@@ -169,7 +172,7 @@ where
         let result = self.hummock_manager.commit_epoch(req.epoch).await;
         match result {
             Ok(_) => Ok(Response::new(CommitEpochResponse { status: None })),
-            Err(e) => Err(e.to_grpc_status()),
+            Err(e) => Err(tonic_err(e)),
         }
     }
 
@@ -181,7 +184,7 @@ where
         let result = self.hummock_manager.abort_epoch(req.epoch).await;
         match result {
             Ok(_) => Ok(Response::new(AbortEpochResponse { status: None })),
-            Err(e) => Err(e.to_grpc_status()),
+            Err(e) => Err(tonic_err(e)),
         }
     }
 
@@ -195,7 +198,7 @@ where
                 status: None,
                 table_id,
             })),
-            Err(e) => Err(e.to_grpc_status()),
+            Err(e) => Err(tonic_err(e)),
         }
     }
 
@@ -224,7 +227,7 @@ where
             self.vacuum_trigger
                 .report_vacuum_task(vacuum_task)
                 .await
-                .map_err(|e| e.to_grpc_status())?;
+                .map_err(tonic_err)?;
         }
         Ok(Response::new(ReportVacuumTaskResponse { status: None }))
     }

--- a/src/meta/src/storage/meta_store.rs
+++ b/src/meta/src/storage/meta_store.rs
@@ -12,10 +12,12 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use std::fmt::{Display, Formatter};
 use std::str;
 
 use async_trait::async_trait;
 use risingwave_common::error::{ErrorCode, RwError};
+use thiserror::Error;
 
 use crate::storage::transaction::Transaction;
 use crate::storage::{Key, Value};
@@ -49,7 +51,7 @@ pub trait MetaStore: Clone + Sync + Send + 'static {
 }
 
 // Error of metastore
-#[derive(Debug)]
+#[derive(Debug, Error)]
 pub enum Error {
     ItemNotFound(String),
     TransactionAbort(),
@@ -69,6 +71,23 @@ impl From<Error> for RwError {
                 "meta internal error: {}",
                 e
             ))),
+        }
+    }
+}
+
+impl Display for Error {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Error::ItemNotFound(s) => {
+                write!(f, "{}", s)
+            }
+            Error::TransactionAbort() => {
+                // TODO: refine it
+                write!(f, "TransactionAbort")
+            }
+            Error::Internal(err) => {
+                write!(f, "{}", err)
+            }
         }
     }
 }

--- a/src/storage/hummock_sdk/src/key_range.rs
+++ b/src/storage/hummock_sdk/src/key_range.rs
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use std::borrow::Borrow;
 use std::cmp;
 
 use bytes::Bytes;
@@ -90,6 +91,12 @@ impl PartialOrd for KeyRange {
 
 impl From<KeyRange> for risingwave_pb::hummock::KeyRange {
     fn from(kr: KeyRange) -> Self {
+        kr.borrow().into()
+    }
+}
+
+impl From<&KeyRange> for risingwave_pb::hummock::KeyRange {
+    fn from(kr: &KeyRange) -> Self {
         risingwave_pb::hummock::KeyRange {
             left: kr.left.to_vec(),
             right: kr.right.to_vec(),


### PR DESCRIPTION
## What's changed and what's your intention?
This PR initializes compaction group. To be compatible with current code, we temporarily create one default compaction group and use the existent tiered compaction picker for it. All files are added to the default compaction group, so the whole write path remains the same.

Changes
- Send compaction request to compaction scheduler when `HummockManager::commit_epoch`, instead of previous periodic compaction trigger. **The compaction frequency are expected to be very different from before.**
- Define dedicated error types for hummock meta module, to distinguish retryable errors from unretryable ones.
- Move some code from hummock_manager.rs to versioning.rs and compaction.rs, to reduce hummock_manager.rs size.

TODO
- Add the real default compaction group which is responsible for dispatching KVs to their targeted compaction group.
- After multiple level enabled, also send compaction request to compaction scheduler when `HummockManager::report_compact_task`.

## Checklist

- [ ] I have written necessary docs and comments
- [ ] I have added necessary unit tests and integration tests

## Refer to a related PR or issue link (optional)
