### PR TITLE
fix: compaction picker intra L0

### DIFF
--- a/src/meta/src/hummock/compaction/tier_compaction_picker.rs
+++ b/src/meta/src/hummock/compaction/tier_compaction_picker.rs
@@ -196,7 +196,7 @@ impl TierCompactionPicker {
                 level_type: LevelType::Overlapping as i32,
                 table_infos: vec![],
             },
-            split_ranges: vec![],
+            split_ranges: vec![KeyRange::inf()],
         })
     }
 


### PR DESCRIPTION
## What's changed and what's your intention?

CompactTask::splits shouldn't be empty. Otherwise `parallelism` == 0 and compactor is stuck. See `Compactor::compact` `let parallelism = compact_task.splits.len();` (found in e2e when intra L0 compaction happens)

Also `TierCompactionPicker::pick_compaction` uses `splits.push(KeyRange::new(Bytes::new(), Bytes::new()));`. Should it use `KeyRange::inf()` is `splits.len() == 1` ?

## Checklist

## Refer to a related PR or issue link (optional)
