### PR TITLE
refactor(frontend,streaming): separate output pk and internal key in topNExecutor

### DIFF
--- a/legacy/planner/src/main/java/com/risingwave/planner/rel/streaming/PrimaryKeyDerivationVisitor.java
+++ b/legacy/planner/src/main/java/com/risingwave/planner/rel/streaming/PrimaryKeyDerivationVisitor.java
@@ -356,33 +356,18 @@ public class PrimaryKeyDerivationVisitor
     var p = input.accept(this);
     var positionMap = p.info.getPositionMap();
     var oldPrimaryKeyIndices = p.info.getPrimaryKeyIndices();
-    var newPrimaryKeyIndices = new ArrayList<Integer>();
 
     var newFieldCollations = new ArrayList<RelFieldCollation>();
     for (var collation : sort.collation.getFieldCollations()) {
       var index = collation.getFieldIndex();
       var newIndex = positionMap.getOrDefault(index, index);
-      newPrimaryKeyIndices.add(newIndex);
       var newCollation = collation.withFieldIndex(newIndex);
       newFieldCollations.add(newCollation);
-    }
-    for (var oldPrimaryKeyIndex : oldPrimaryKeyIndices) {
-      boolean exist = false;
-      for (var existPrimaryKeyIndex : newPrimaryKeyIndices) {
-        if (oldPrimaryKeyIndex.equals(existPrimaryKeyIndex)) {
-          exist = true;
-          break;
-        }
-      }
-      if (!exist) {
-        newPrimaryKeyIndices.add(oldPrimaryKeyIndex);
-      }
     }
     var newCollation = RelCollations.of(newFieldCollations);
     LOGGER.debug("old collation:" + sort.collation);
     LOGGER.debug("new collation:" + newCollation);
-    LOGGER.debug("old primaryKeyIndices:" + oldPrimaryKeyIndices);
-    LOGGER.debug("new primaryKeyIndices:" + newPrimaryKeyIndices);
+    LOGGER.debug("primaryKeyIndices:" + oldPrimaryKeyIndices);
     var newSort =
         (RwStreamSort)
             sort.copy(
@@ -394,7 +379,7 @@ public class PrimaryKeyDerivationVisitor
     return new Result<>(
         newSort,
         new PrimaryKeyIndicesAndPositionMap(
-            ImmutableList.copyOf(newPrimaryKeyIndices), positionMap));
+            ImmutableList.copyOf(oldPrimaryKeyIndices), positionMap));
   }
 
   /**

--- a/legacy/planner/src/main/java/com/risingwave/planner/rel/streaming/RwStreamSort.java
+++ b/legacy/planner/src/main/java/com/risingwave/planner/rel/streaming/RwStreamSort.java
@@ -2,13 +2,16 @@ package com.risingwave.planner.rel.streaming;
 
 import static com.risingwave.planner.rel.logical.RisingWaveLogicalRel.LOGICAL;
 
+import com.risingwave.common.datatype.RisingWaveDataType;
 import com.risingwave.planner.metadata.RisingWaveRelMetadataQuery;
 import com.risingwave.planner.rel.logical.RwLogicalSort;
+import com.risingwave.proto.data.DataType;
+import com.risingwave.proto.expr.InputRefExpr;
+import com.risingwave.proto.plan_common.ColumnOrder;
 import com.risingwave.proto.plan_common.OrderType;
 import com.risingwave.proto.streaming.plan.StreamNode;
 import com.risingwave.proto.streaming.plan.TopNNode;
 import java.util.ArrayList;
-import java.util.HashMap;
 import java.util.List;
 import org.apache.calcite.plan.RelOptCluster;
 import org.apache.calcite.plan.RelOptRule;
@@ -44,32 +47,35 @@ public class RwStreamSort extends Sort implements RisingWaveStreamingRel {
     var primaryKeyIndices =
         ((RisingWaveRelMetadataQuery) getCluster().getMetadataQuery()).getPrimaryKeyIndices(this);
 
-    var orderTypes = new ArrayList<OrderType>();
+    var columnOrders = new ArrayList<ColumnOrder>();
     List<RelFieldCollation> relFieldCollations = collation.getFieldCollations();
-    HashMap<Integer, RelFieldCollation> inputIndexToCollation = new HashMap<>();
     for (var relFieldCollation : relFieldCollations) {
-      inputIndexToCollation.put(relFieldCollation.getFieldIndex(), relFieldCollation);
-    }
-    for (var primaryKeyIndex : primaryKeyIndices) {
-      if (inputIndexToCollation.containsKey(primaryKeyIndex)) {
-        var relFieldCollation = inputIndexToCollation.get(primaryKeyIndex);
-        RelFieldCollation.Direction dir = relFieldCollation.getDirection();
-        OrderType orderType;
-        if (dir == RelFieldCollation.Direction.ASCENDING) {
-          orderType = OrderType.ASCENDING;
-        } else if (dir == RelFieldCollation.Direction.DESCENDING) {
-          orderType = OrderType.DESCENDING;
-        } else {
-          throw new SerializationException(String.format("%s direction not supported", dir));
-        }
-        orderTypes.add(orderType);
+      OrderType orderType;
+      RelFieldCollation.Direction dir = relFieldCollation.getDirection();
+      if (dir == RelFieldCollation.Direction.ASCENDING) {
+        orderType = OrderType.ASCENDING;
+      } else if (dir == RelFieldCollation.Direction.DESCENDING) {
+        orderType = OrderType.DESCENDING;
       } else {
-        orderTypes.add(OrderType.ASCENDING);
+        throw new SerializationException(String.format("%s direction not supported", dir));
       }
+
+      var inputRefIndex = relFieldCollation.getFieldIndex();
+      InputRefExpr inputRefExpr = InputRefExpr.newBuilder().setColumnIdx(inputRefIndex).build();
+      DataType returnType =
+          ((RisingWaveDataType) getRowType().getFieldList().get(inputRefIndex).getType())
+              .getProtobufType();
+      ColumnOrder columnOrder =
+          ColumnOrder.newBuilder()
+              .setOrderType(orderType)
+              .setInputRef(inputRefExpr)
+              .setReturnType(returnType)
+              .build();
+      columnOrders.add(columnOrder);
     }
 
     TopNNode.Builder topnBuilder = TopNNode.newBuilder();
-    topnBuilder.addAllOrderTypes(orderTypes);
+    topnBuilder.addAllColumnOrders(columnOrders);
     if (fetch != null) {
       topnBuilder.setLimit(RexLiteral.intValue(fetch));
     }

--- a/legacy/planner/src/test/resources/com/risingwave/planner/planner/streaming/PrimaryKeyDerivationTest.xml
+++ b/legacy/planner/src/test/resources/com/risingwave/planner/planner/streaming/PrimaryKeyDerivationTest.xml
@@ -313,7 +313,7 @@ RwStreamMaterialize(name=[t_changed_collation], collation=[[0 DESC, 6, 5]])
         </Resource>
         <Resource name="primaryKey">
             <![CDATA[
-[0, 6, 5, 3, 7]
+[3, 7]
 ]]>
         </Resource>
     </TestCase>

--- a/legacy/planner/src/test/resources/com/risingwave/planner/planner/streaming/StreamSortTest.xml
+++ b/legacy/planner/src/test/resources/com/risingwave/planner/planner/streaming/StreamSortTest.xml
@@ -15,7 +15,7 @@ RwStreamMaterialize(name=[t_select_all_order_v1], collation=[[0]])
         </Resource>
         <Resource name="primaryKey">
             <![CDATA[
-[0, 3]
+[3]
 ]]>
         </Resource>
     </TestCase>
@@ -35,7 +35,7 @@ RwStreamMaterialize(name=[t_select_all_order_v2_v1], collation=[[1, 0 DESC]])
         </Resource>
         <Resource name="primaryKey">
             <![CDATA[
-[1, 0, 3]
+[3]
 ]]>
         </Resource>
     </TestCase>
@@ -55,7 +55,7 @@ RwStreamMaterialize(name=[t_select_v1_order_v2], collation=[[1 DESC]])
         </Resource>
         <Resource name="primaryKey">
             <![CDATA[
-[1, 2]
+[2]
 ]]>
         </Resource>
     </TestCase>
@@ -78,7 +78,7 @@ RwStreamMaterialize(name=[t_order_after_aggregation], collation=[[1 DESC]])
         </Resource>
         <Resource name="primaryKey">
             <![CDATA[
-[1, 0, 2]
+[0, 2]
 ]]>
         </Resource>
     </TestCase>
@@ -100,7 +100,7 @@ RwStreamMaterialize(name=[t_order_limit], collation=[[0]])
         </Resource>
         <Resource name="primaryKey">
             <![CDATA[
-[0, 3]
+[3]
 ]]>
         </Resource>
     </TestCase>

--- a/proto/stream_plan.proto
+++ b/proto/stream_plan.proto
@@ -81,7 +81,7 @@ message HashAggNode {
 }
 
 message TopNNode {
-  repeated plan_common.OrderType order_types = 1;
+  repeated plan_common.ColumnOrder column_orders = 1;
   // 0 means no limit as limit of 0 means this node should be optimized away
   uint64 limit = 2;
   uint64 offset = 3;

--- a/src/frontend/src/optimizer/plan_node/stream_topn.rs
+++ b/src/frontend/src/optimizer/plan_node/stream_topn.rs
@@ -14,10 +14,12 @@
 
 use std::fmt;
 
+use risingwave_pb::expr::InputRefExpr;
+use risingwave_pb::plan_common::ColumnOrder;
 use risingwave_pb::stream_plan::stream_node::NodeBody as ProstStreamNode;
 
 use super::{LogicalTopN, PlanBase, PlanRef, PlanTreeNodeUnary, ToStreamProst};
-use crate::optimizer::property::{Distribution, FieldOrder, Order};
+use crate::optimizer::property::{Distribution, Order};
 
 /// `StreamTopN` implements [`super::LogicalTopN`] to find the top N elements with a heap
 #[derive(Debug, Clone)]
@@ -35,7 +37,6 @@ impl StreamTopN {
             _ => panic!(),
         };
 
-        // TODO: This is ported from the legacy Java code. Refactor to use input's PK as TopN's PK
         let (pk_indices, extended_order) =
             Self::derive_pk_and_order(logical.input().pk_indices(), logical.topn_order());
         let logical = LogicalTopN::new(
@@ -49,19 +50,7 @@ impl StreamTopN {
     }
 
     fn derive_pk_and_order(input_pk: &[usize], order: &Order) -> (Vec<usize>, Order) {
-        let mut output_pk = vec![];
-        let mut extended_order = vec![];
-        for field_order in &order.field_order {
-            output_pk.push(field_order.index);
-            extended_order.push(field_order.clone());
-        }
-        for col_index in input_pk {
-            if !output_pk.contains(col_index) {
-                output_pk.push(*col_index);
-                extended_order.push(FieldOrder::ascending(*col_index));
-            }
-        }
-        (output_pk, Order::new(extended_order))
+        (input_pk.to_vec(), order.clone())
     }
 }
 
@@ -92,15 +81,21 @@ impl_plan_tree_node_for_unary! { StreamTopN }
 impl ToStreamProst for StreamTopN {
     fn to_stream_prost_body(&self) -> ProstStreamNode {
         use risingwave_pb::stream_plan::*;
-        let order_types = self
+        let column_orders = self
             .logical
             .topn_order()
             .field_order
             .iter()
-            .map(|f| f.direct.to_protobuf() as i32)
+            .map(|f| ColumnOrder {
+                order_type: f.direct.to_protobuf() as i32,
+                input_ref: Some(InputRefExpr {
+                    column_idx: f.index as i32,
+                }),
+                return_type: Some(self.input().schema()[f.index].data_type().to_protobuf()),
+            })
             .collect();
         ProstStreamNode::TopN(TopNNode {
-            order_types,
+            column_orders,
             limit: self.logical.limit() as u64,
             offset: self.logical.offset() as u64,
             distribution_keys: vec![], // TODO: seems unnecessary

--- a/src/frontend/test_runner/tests/testdata/order_by.yaml
+++ b/src/frontend/test_runner/tests/testdata/order_by.yaml
@@ -54,8 +54,8 @@
       BatchExchange { order: [], dist: Single }
         BatchScan { table: t, columns: [v1, v2] }
   stream_plan: |
-    StreamMaterialize { columns: [v1, v2, _row_id#0(hidden)], pk_columns: [v1, _row_id#0] }
-      StreamTopN { order: [$0 DESC, $2 ASC], limit: 5, offset: 0 }
+    StreamMaterialize { columns: [v1, v2, _row_id#0(hidden)], pk_columns: [_row_id#0], order_descs: [v1, _row_id#0] }
+      StreamTopN { order: [$0 DESC], limit: 5, offset: 0 }
         StreamExchange { dist: Single }
           StreamTableScan { table: t, columns: [v1, v2, _row_id#0], pk_indices: [2] }
 - sql: |
@@ -66,7 +66,7 @@
       BatchExchange { order: [], dist: Single }
         BatchScan { table: t, columns: [v1, v2] }
   stream_plan: |
-    StreamMaterialize { columns: [v1, v2, _row_id#0(hidden)], pk_columns: [v1, _row_id#0] }
-      StreamTopN { order: [$0 DESC, $2 ASC], limit: 5, offset: 7 }
+    StreamMaterialize { columns: [v1, v2, _row_id#0(hidden)], pk_columns: [_row_id#0], order_descs: [v1, _row_id#0] }
+      StreamTopN { order: [$0 DESC], limit: 5, offset: 7 }
         StreamExchange { dist: Single }
           StreamTableScan { table: t, columns: [v1, v2, _row_id#0], pk_indices: [2] }

--- a/src/frontend/test_runner/tests/testdata/tpch.yaml
+++ b/src/frontend/test_runner/tests/testdata/tpch.yaml
@@ -750,8 +750,8 @@
                   BatchExchange { order: [], dist: HashShard([0]) }
                     BatchScan { table: nation, columns: [n_nationkey, n_name] }
   stream_plan: |
-    StreamMaterialize { columns: [c_custkey, c_name, revenue, c_acctbal, n_name, c_address, c_phone, c_comment], pk_columns: [revenue, c_custkey, c_name, c_acctbal, c_phone, n_name, c_address, c_comment] }
-      StreamTopN { order: [$2 DESC, $0 ASC, $1 ASC, $3 ASC, $6 ASC, $4 ASC, $5 ASC, $7 ASC], limit: 20, offset: 0 }
+    StreamMaterialize { columns: [c_custkey, c_name, revenue, c_acctbal, n_name, c_address, c_phone, c_comment], pk_columns: [c_custkey, c_name, c_acctbal, c_phone, n_name, c_address, c_comment], order_descs: [revenue, c_custkey, c_name, c_acctbal, c_phone, n_name, c_address, c_comment] }
+      StreamTopN { order: [$2 DESC], limit: 20, offset: 0 }
         StreamExchange { dist: Single }
           StreamProject { exprs: [$0, $1, $8, $2, $4, $5, $3, $6], expr_alias: [c_custkey, c_name, revenue, c_acctbal, n_name, c_address, c_phone, c_comment] }
             StreamHashAgg { group_keys: [$0, $1, $2, $3, $4, $5, $6], aggs: [count, sum($7)] }

--- a/src/stream/src/executor/top_n.rs
+++ b/src/stream/src/executor/top_n.rs
@@ -14,8 +14,7 @@
 
 use risingwave_common::error::Result;
 use risingwave_common::try_match_expand;
-use risingwave_common::util::sort_util::OrderType;
-use risingwave_pb::plan_common::OrderType as ProstOrderType;
+use risingwave_common::util::sort_util::OrderPair;
 use risingwave_pb::stream_plan;
 use risingwave_pb::stream_plan::stream_node::NodeBody;
 use risingwave_storage::{Keyspace, StateStore};
@@ -34,13 +33,11 @@ impl ExecutorBuilder for TopNExecutorBuilder {
         _stream: &mut LocalStreamManagerCore,
     ) -> Result<BoxedExecutor> {
         let node = try_match_expand!(node.get_node_body().unwrap(), NodeBody::TopN)?;
-        let order_types: Vec<_> = node
-            .get_order_types()
+        let order_pairs: Vec<_> = node
+            .get_column_orders()
             .iter()
-            .map(|v| ProstOrderType::from_i32(*v).unwrap())
-            .map(|v| OrderType::from_prost(&v))
+            .map(OrderPair::from_prost)
             .collect();
-        assert_eq!(order_types.len(), params.pk_indices.len());
         let limit = if node.limit == 0 {
             None
         } else {
@@ -57,7 +54,7 @@ impl ExecutorBuilder for TopNExecutorBuilder {
 
         Ok(TopNExecutor::new(
             params.input.remove(0),
-            order_types,
+            order_pairs,
             (node.offset as usize, limit),
             params.pk_indices,
             keyspace,

--- a/src/stream/src/executor/top_n_appendonly.rs
+++ b/src/stream/src/executor/top_n_appendonly.rs
@@ -14,8 +14,7 @@
 
 use risingwave_common::error::Result;
 use risingwave_common::try_match_expand;
-use risingwave_common::util::sort_util::OrderType;
-use risingwave_pb::plan_common::OrderType as ProstOrderType;
+use risingwave_common::util::sort_util::OrderPair;
 use risingwave_pb::stream_plan;
 use risingwave_pb::stream_plan::stream_node::NodeBody;
 use risingwave_storage::{Keyspace, StateStore};
@@ -34,13 +33,11 @@ impl ExecutorBuilder for AppendOnlyTopNExecutorBuilder {
         _stream: &mut LocalStreamManagerCore,
     ) -> Result<BoxedExecutor> {
         let node = try_match_expand!(node.get_node_body().unwrap(), NodeBody::AppendOnlyTopN)?;
-        let order_types: Vec<_> = node
-            .get_order_types()
+        let order_pairs: Vec<_> = node
+            .get_column_orders()
             .iter()
-            .map(|v| ProstOrderType::from_i32(*v).unwrap())
-            .map(|v| OrderType::from_prost(&v))
+            .map(OrderPair::from_prost)
             .collect();
-        assert_eq!(order_types.len(), params.pk_indices.len());
         let limit = if node.limit == 0 {
             None
         } else {
@@ -57,7 +54,7 @@ impl ExecutorBuilder for AppendOnlyTopNExecutorBuilder {
 
         Ok(AppendOnlyTopNExecutor::new(
             params.input.remove(0),
-            order_types,
+            order_pairs,
             (node.offset as usize, limit),
             params.pk_indices,
             keyspace,

--- a/src/stream/src/executor_v2/hash_join.rs
+++ b/src/stream/src/executor_v2/hash_join.rs
@@ -471,7 +471,7 @@ impl<K: HashKey, S: StateStore, const T: JoinTypePrimitive> HashJoinExecutor<K, 
     /// the data the hash table and match the coming
     /// data chunk with the executor state
     async fn hash_eq_match<'a>(
-        key: &K,
+        key: &'a K,
         ht: &'a mut JoinHashMap<K, S>,
     ) -> Option<&'a mut HashValueType<S>> {
         if key.has_null() {

--- a/src/stream/src/executor_v2/top_n.rs
+++ b/src/stream/src/executor_v2/top_n.rs
@@ -12,12 +12,15 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use std::collections::HashSet;
+
 use async_trait::async_trait;
 use risingwave_common::array::{Op, StreamChunk};
 use risingwave_common::catalog::{ColumnDesc, ColumnId, Schema};
 use risingwave_common::error::Result;
+use risingwave_common::types::DataType;
 use risingwave_common::util::ordered::{OrderedRow, OrderedRowDeserializer};
-use risingwave_common::util::sort_util::OrderType;
+use risingwave_common::util::sort_util::{OrderPair, OrderType};
 use risingwave_storage::cell_based_row_deserializer::CellBasedRowDeserializer;
 use risingwave_storage::{Keyspace, StateStore};
 
@@ -35,7 +38,7 @@ impl<S: StateStore> TopNExecutor<S> {
     #[allow(clippy::too_many_arguments)]
     pub fn new(
         input: Box<dyn Executor>,
-        pk_order_types: Vec<OrderType>,
+        order_pairs: Vec<OrderPair>,
         offset_and_limit: (usize, Option<usize>),
         pk_indices: PkIndices,
         keyspace: Keyspace<S>,
@@ -52,7 +55,7 @@ impl<S: StateStore> TopNExecutor<S> {
             inner: InnerTopNExecutor::new(
                 info,
                 schema,
-                pk_order_types,
+                order_pairs,
                 offset_and_limit,
                 pk_indices,
                 keyspace,
@@ -71,8 +74,6 @@ pub struct InnerTopNExecutor<S: StateStore> {
     /// Schema of the executor.
     schema: Schema,
 
-    /// The ordering
-    pk_order_types: Vec<OrderType>,
     /// `LIMIT XXX`. `None` means no limit.
     limit: Option<usize>,
     /// `OFFSET XXX`. `0` means no offset.
@@ -80,6 +81,12 @@ pub struct InnerTopNExecutor<S: StateStore> {
 
     /// The primary key indices of the `TopNExecutor`
     pk_indices: PkIndices,
+
+    /// The internal key indices of the `TopNExecutor`
+    internal_key_indices: PkIndices,
+
+    /// The order of internal keys of the `TopNExecutor`
+    internal_key_order_types: Vec<OrderType>,
 
     /// We are interested in which element is in the range of [offset, offset+limit). But we
     /// still need to record elements in the other two ranges.
@@ -96,12 +103,42 @@ pub struct InnerTopNExecutor<S: StateStore> {
     key_indices: Vec<usize>,
 }
 
+pub fn generate_internal_key(
+    order_pairs: &[OrderPair],
+    pk_indices: PkIndicesRef,
+    schema: &Schema,
+) -> (PkIndices, Vec<DataType>, Vec<OrderType>) {
+    let mut exists_key_index = HashSet::new();
+    let mut internal_key_indices = vec![];
+    let mut internal_order_types = vec![];
+    for order_pair in order_pairs {
+        exists_key_index.insert(order_pair.column_idx);
+        internal_key_indices.push(order_pair.column_idx);
+        internal_order_types.push(order_pair.order_type);
+    }
+    for pk_index in pk_indices {
+        if !internal_key_indices.contains(pk_index) {
+            internal_key_indices.push(*pk_index);
+            internal_order_types.push(OrderType::Ascending);
+        }
+    }
+    let internal_data_types = internal_key_indices
+        .iter()
+        .map(|idx| schema.fields()[*idx].data_type())
+        .collect();
+    (
+        internal_key_indices,
+        internal_data_types,
+        internal_order_types,
+    )
+}
+
 impl<S: StateStore> InnerTopNExecutor<S> {
     #[allow(clippy::too_many_arguments)]
     pub fn new(
         input_info: ExecutorInfo,
         schema: Schema,
-        pk_order_types: Vec<OrderType>,
+        order_pairs: Vec<OrderPair>,
         offset_and_limit: (usize, Option<usize>),
         pk_indices: PkIndices,
         keyspace: Keyspace<S>,
@@ -110,17 +147,17 @@ impl<S: StateStore> InnerTopNExecutor<S> {
         executor_id: u64,
         key_indices: Vec<usize>,
     ) -> Result<Self> {
-        let pk_data_types = pk_indices
-            .iter()
-            .map(|idx| schema.fields[*idx].data_type())
-            .collect::<Vec<_>>();
+        let (internal_key_indices, internal_key_data_types, internal_key_order_types) =
+            generate_internal_key(&order_pairs, &pk_indices, &schema);
+
+        let ordered_row_deserializer =
+            OrderedRowDeserializer::new(internal_key_data_types, internal_key_order_types.clone());
+
         let row_data_types = schema
             .fields
             .iter()
             .map(|field| field.data_type.clone())
             .collect::<Vec<_>>();
-        let ordered_row_deserializer =
-            OrderedRowDeserializer::new(pk_data_types, pk_order_types.clone());
         let table_column_descs = row_data_types
             .iter()
             .enumerate()
@@ -163,13 +200,14 @@ impl<S: StateStore> InnerTopNExecutor<S> {
                 identity: format!("TopNExecutor {:X}", executor_id),
             },
             schema,
-            pk_order_types,
             offset: offset_and_limit.0,
             limit: offset_and_limit.1,
             managed_lowest_state,
             managed_middle_state,
             managed_highest_state,
             pk_indices,
+            internal_key_indices,
+            internal_key_order_types,
             first_execution: true,
             key_indices,
         })
@@ -237,8 +275,8 @@ impl<S: StateStore> TopNExecutorBase for InnerTopNExecutor<S> {
         let mut new_rows = vec![];
 
         for (op, row_ref) in chunk.rows() {
-            let pk_row = row_ref.row_by_indices(&self.pk_indices);
-            let ordered_pk_row = OrderedRow::new(pk_row, &self.pk_order_types);
+            let pk_row = row_ref.row_by_indices(&self.internal_key_indices);
+            let ordered_pk_row = OrderedRow::new(pk_row, &self.internal_key_order_types);
             let row = row_ref.to_owned_row();
 
             match op {
@@ -492,8 +530,11 @@ mod tests {
         }
     }
 
-    fn create_order_types() -> Vec<OrderType> {
-        vec![OrderType::Ascending, OrderType::Ascending]
+    fn create_order_pairs() -> Vec<OrderPair> {
+        vec![
+            OrderPair::new(0, OrderType::Ascending),
+            OrderPair::new(1, OrderType::Ascending),
+        ]
     }
 
     fn create_source() -> Box<MockSource> {
@@ -518,7 +559,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_top_n_executor_with_offset() {
-        let order_types = create_order_types();
+        let order_types = create_order_pairs();
         let source = create_source();
         let keyspace = create_in_memory_keyspace();
         let top_n_executor = Box::new(
@@ -614,7 +655,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_top_n_executor_with_limit() {
-        let order_types = create_order_types();
+        let order_types = create_order_pairs();
         let source = create_source();
         let keyspace = create_in_memory_keyspace();
         let top_n_executor = Box::new(
@@ -719,7 +760,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_top_n_executor_with_offset_and_limit() {
-        let order_types = create_order_types();
+        let order_types = create_order_pairs();
         let source = create_source();
         let keyspace = create_in_memory_keyspace();
         let top_n_executor = Box::new(

--- a/src/stream/src/executor_v2/top_n_appendonly.rs
+++ b/src/stream/src/executor_v2/top_n_appendonly.rs
@@ -17,7 +17,7 @@ use risingwave_common::array::{Op, StreamChunk};
 use risingwave_common::catalog::{ColumnDesc, ColumnId, Schema};
 use risingwave_common::error::Result;
 use risingwave_common::util::ordered::{OrderedRow, OrderedRowDeserializer};
-use risingwave_common::util::sort_util::OrderType;
+use risingwave_common::util::sort_util::{OrderPair, OrderType};
 use risingwave_storage::cell_based_row_deserializer::CellBasedRowDeserializer;
 use risingwave_storage::{Keyspace, StateStore};
 
@@ -26,6 +26,7 @@ use super::managed_state::top_n::variants::TOP_N_MAX;
 use super::managed_state::top_n::ManagedTopNState;
 use super::top_n_executor::{generate_output, TopNExecutorBase, TopNExecutorWrapper};
 use super::{Executor, ExecutorInfo, PkIndices, PkIndicesRef};
+use crate::executor_v2::top_n::generate_internal_key;
 
 /// If the input contains only append, `AppendOnlyTopNExecutor` does not need
 /// to keep all the data records/rows that have been seen. As long as a record
@@ -38,7 +39,7 @@ impl<S: StateStore> AppendOnlyTopNExecutor<S> {
     #[allow(clippy::too_many_arguments)]
     pub fn new(
         input: Box<dyn Executor>,
-        pk_order_types: Vec<OrderType>,
+        order_pairs: Vec<OrderPair>,
         offset_and_limit: (usize, Option<usize>),
         pk_indices: PkIndices,
         keyspace: Keyspace<S>,
@@ -55,7 +56,7 @@ impl<S: StateStore> AppendOnlyTopNExecutor<S> {
             inner: InnerAppendOnlyTopNExecutor::new(
                 info,
                 schema,
-                pk_order_types,
+                order_pairs,
                 offset_and_limit,
                 pk_indices,
                 keyspace,
@@ -74,14 +75,21 @@ pub struct InnerAppendOnlyTopNExecutor<S: StateStore> {
     /// Schema of the executor.
     schema: Schema,
 
-    /// The ordering
-    pk_order_types: Vec<OrderType>,
     /// `LIMIT XXX`. `None` means no limit.
     limit: Option<usize>,
+
     /// `OFFSET XXX`. `0` means no offset.
     offset: usize,
+
     /// The primary key indices of the `AppendOnlyTopNExecutor`
     pk_indices: PkIndices,
+
+    /// The internal key indices of the `TopNExecutor`
+    internal_key_indices: PkIndices,
+
+    /// The order of internal keys of the `TopNExecutor`
+    internal_key_order_types: Vec<OrderType>,
+
     /// We are only interested in which element is in the range of `[offset, offset+limit)`(right
     /// open interval) but not the rank of such element
     ///
@@ -89,6 +97,7 @@ pub struct InnerAppendOnlyTopNExecutor<S: StateStore> {
     /// another set stores the elements in the range of `[offset, offset+limit)`.
     managed_lower_state: ManagedTopNState<S, TOP_N_MAX>,
     managed_higher_state: ManagedTopNState<S, TOP_N_MAX>,
+
     /// Marks whether this is first-time execution. If yes, we need to fill in the cache from
     /// storage.
     first_execution: bool,
@@ -103,7 +112,7 @@ impl<S: StateStore> InnerAppendOnlyTopNExecutor<S> {
     pub fn new(
         input_info: ExecutorInfo,
         schema: Schema,
-        pk_order_types: Vec<OrderType>,
+        order_pairs: Vec<OrderPair>,
         offset_and_limit: (usize, Option<usize>),
         pk_indices: PkIndices,
         keyspace: Keyspace<S>,
@@ -112,10 +121,9 @@ impl<S: StateStore> InnerAppendOnlyTopNExecutor<S> {
         executor_id: u64,
         key_indices: Vec<usize>,
     ) -> Result<Self> {
-        let pk_data_types = pk_indices
-            .iter()
-            .map(|idx| schema.fields[*idx].data_type())
-            .collect::<Vec<_>>();
+        let (internal_key_indices, internal_key_data_types, internal_key_order_types) =
+            generate_internal_key(&order_pairs, &pk_indices, &schema);
+
         let row_data_types = schema
             .fields
             .iter()
@@ -124,7 +132,7 @@ impl<S: StateStore> InnerAppendOnlyTopNExecutor<S> {
         let lower_sub_keyspace = keyspace.append_u8(b'l');
         let higher_sub_keyspace = keyspace.append_u8(b'h');
         let ordered_row_deserializer =
-            OrderedRowDeserializer::new(pk_data_types, pk_order_types.clone());
+            OrderedRowDeserializer::new(internal_key_data_types, internal_key_order_types.clone());
         let table_column_descs = row_data_types
             .iter()
             .enumerate()
@@ -140,7 +148,6 @@ impl<S: StateStore> InnerAppendOnlyTopNExecutor<S> {
                 identity: format!("AppendOnlyTopNExecutor {:X}", executor_id),
             },
             schema,
-            pk_order_types,
             offset: offset_and_limit.0,
             limit: offset_and_limit.1,
             managed_lower_state: ManagedTopNState::<S, TOP_N_MAX>::new(
@@ -160,6 +167,8 @@ impl<S: StateStore> InnerAppendOnlyTopNExecutor<S> {
                 cell_based_row_deserializer,
             ),
             pk_indices,
+            internal_key_indices,
+            internal_key_order_types,
             first_execution: true,
             key_indices,
         })
@@ -203,8 +212,8 @@ impl<S: StateStore> TopNExecutorBase for InnerAppendOnlyTopNExecutor<S> {
         for (op, row_ref) in chunk.rows() {
             assert_eq!(op, Op::Insert);
 
-            let pk_row = row_ref.row_by_indices(&self.pk_indices);
-            let ordered_pk_row = OrderedRow::new(pk_row, &self.pk_order_types);
+            let pk_row = row_ref.row_by_indices(&self.internal_key_indices);
+            let ordered_pk_row = OrderedRow::new(pk_row, &self.internal_key_order_types);
             let row = row_ref.to_owned_row();
 
             if self.managed_lower_state.total_count() < self.offset {
@@ -305,7 +314,7 @@ mod tests {
     use risingwave_common::array::StreamChunk;
     use risingwave_common::catalog::{Field, Schema};
     use risingwave_common::types::DataType;
-    use risingwave_common::util::sort_util::OrderType;
+    use risingwave_common::util::sort_util::{OrderPair, OrderType};
 
     use crate::executor_v2::test_utils::{create_in_memory_keyspace, MockSource};
     use crate::executor_v2::top_n_appendonly::AppendOnlyTopNExecutor;
@@ -347,8 +356,11 @@ mod tests {
         }
     }
 
-    fn create_order_types() -> Vec<OrderType> {
-        vec![OrderType::Ascending, OrderType::Ascending]
+    fn create_order_pairs() -> Vec<OrderPair> {
+        vec![
+            OrderPair::new(0, OrderType::Ascending),
+            OrderPair::new(1, OrderType::Ascending),
+        ]
     }
 
     fn create_source() -> Box<MockSource> {
@@ -379,14 +391,14 @@ mod tests {
 
     #[tokio::test]
     async fn test_append_only_top_n_executor_with_offset() {
-        let order_types = create_order_types();
+        let order_pairs = create_order_pairs();
         let source = create_source();
 
         let keyspace = create_in_memory_keyspace();
         let top_n_executor = Box::new(
             AppendOnlyTopNExecutor::new(
                 source as Box<dyn Executor>,
-                order_types,
+                order_pairs,
                 (3, None),
                 vec![0, 1],
                 keyspace,
@@ -453,14 +465,14 @@ mod tests {
 
     #[tokio::test]
     async fn test_append_only_top_n_executor_with_limit() {
-        let order_types = create_order_types();
+        let order_pairs = create_order_pairs();
         let source = create_source();
 
         let keyspace = create_in_memory_keyspace();
         let top_n_executor = Box::new(
             AppendOnlyTopNExecutor::new(
                 source as Box<dyn Executor>,
-                order_types,
+                order_pairs,
                 (0, Some(5)),
                 vec![0, 1],
                 keyspace,
@@ -533,14 +545,14 @@ mod tests {
 
     #[tokio::test]
     async fn test_append_only_top_n_executor_with_offset_and_limit() {
-        let order_types = create_order_types();
+        let order_pairs = create_order_pairs();
         let source = create_source();
 
         let keyspace = create_in_memory_keyspace();
         let top_n_executor = Box::new(
             AppendOnlyTopNExecutor::new(
                 source as Box<dyn Executor>,
-                order_types,
+                order_pairs,
                 (3, Some(4)),
                 vec![0, 1],
                 keyspace,


### PR DESCRIPTION
## What's changed and what's your intention?
As #2130 suggests, the internal key used in `TopNExecutor` is different from the output primary key of `TopNExecutor`. 

This PR separates these two concepts.

Notice that as previously, the column used in both `order by` and primary keys will be deduplicated when used as the internal key. Only the backend, not the frontend, is now aware of this optimization.


## Checklist

- [x] I have written necessary docs and comments

## Refer to a related PR or issue link (optional)
closes #2130 
closes #2022 