### PR TITLE
fix(storage): incorrect key range overlap when picking compaction task

### DIFF
--- a/src/meta/src/hummock/compaction/tier_compaction_picker.rs
+++ b/src/meta/src/hummock/compaction/tier_compaction_picker.rs
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use std::borrow::{Borrow, BorrowMut};
 use std::collections::HashSet;
 
 use bytes::Bytes;
@@ -119,7 +120,7 @@ impl TierCompactionPicker {
 
     fn pick_target_level_overlap_files(
         &self,
-        select_table: &SstableInfo,
+        select_level_key_range: &KeyRange,
         level: &Level,
         level_handlers: &LevelHandler,
         input_ssts: &mut TargetFilesInfo,
@@ -130,7 +131,10 @@ impl TierCompactionPicker {
         let mut new_add_tables = vec![];
         // pick up files in L1 which are overlap with L0 to target level input.
         for table in &level.table_infos {
-            if !self.overlap_strategy.check_overlap(select_table, table) {
+            if !self.check_key_range_overlap(
+                &select_level_key_range.borrow().into(),
+                table.key_range.as_ref().unwrap(),
+            ) {
                 continue;
             }
             if level_handlers.is_pending_compact(&table.id) {
@@ -146,6 +150,25 @@ impl TierCompactionPicker {
             input_ssts.tables.push(table);
         }
         true
+    }
+
+    fn check_key_range_overlap(
+        &self,
+        left: &risingwave_pb::hummock::KeyRange,
+        right: &risingwave_pb::hummock::KeyRange,
+    ) -> bool {
+        // TODO: `SstableInfo` is to meet OverlapStrategy's signature. Refactor it.
+        // TODO #2259: remove `KeyRange` conversion
+        self.overlap_strategy.check_overlap(
+            &SstableInfo {
+                key_range: Some(left.clone()),
+                ..Default::default()
+            },
+            &SstableInfo {
+                key_range: Some(right.clone()),
+                ..Default::default()
+            },
+        )
     }
 
     fn pick_intra_l0_compaction(
@@ -207,21 +230,47 @@ impl TierCompactionPicker {
         select_level_handler: &LevelHandler,
         target_level_handler: &LevelHandler,
     ) -> (Vec<SstableInfo>, Vec<SstableInfo>) {
+        let mut compacting_key_range: Option<KeyRange> = None;
+        for table_info in select_level
+            .table_infos
+            .iter()
+            .filter(|t| select_level_handler.is_pending_compact(&t.id))
+        {
+            let kr = table_info.key_range.as_ref().unwrap().into();
+            match compacting_key_range.borrow_mut() {
+                None => {
+                    compacting_key_range = Some(kr);
+                }
+                Some(ref mut key_range) => {
+                    key_range.full_key_extend(&kr);
+                }
+            }
+        }
         for idx in 0..select_level.table_infos.len() {
             let select_table = select_level.table_infos[idx].clone();
             if select_level_handler.is_pending_compact(&select_table.id) {
                 continue;
             }
-            if select_level.table_infos[..idx]
-                .iter()
-                .any(|table| self.overlap_strategy.check_overlap(table, &select_table))
-            {
+            let mut selecting_key_range: KeyRange = select_table.key_range.as_ref().unwrap().into();
+            if select_level.table_infos[..idx].iter().any(|table| {
+                self.check_key_range_overlap(
+                    table.key_range.as_ref().unwrap(),
+                    &selecting_key_range.borrow().into(),
+                )
+            }) {
                 continue;
             }
-
+            if let Some(ref compacting_key_range) = compacting_key_range {
+                if self.check_key_range_overlap(
+                    &compacting_key_range.borrow().into(),
+                    &selecting_key_range.borrow().into(),
+                ) {
+                    continue;
+                }
+            }
             let mut target_level_ssts = TargetFilesInfo::default();
             if !self.pick_target_level_overlap_files(
-                &select_table,
+                &selecting_key_range,
                 target_level,
                 target_level_handler,
                 &mut target_level_ssts,
@@ -238,18 +287,30 @@ impl TierCompactionPicker {
                 {
                     break;
                 }
-                if select_level.table_infos[..idx]
-                    .iter()
-                    .any(|table| self.overlap_strategy.check_overlap(table, other))
-                {
+                selecting_key_range.full_key_extend(&other.key_range.as_ref().unwrap().into());
+                if select_level.table_infos[..idx].iter().any(|table| {
+                    self.check_key_range_overlap(
+                        table.key_range.as_ref().unwrap(),
+                        &selecting_key_range.borrow().into(),
+                    )
+                }) {
                     break;
                 }
+                if let Some(ref compacting_key_range) = compacting_key_range {
+                    if self.check_key_range_overlap(
+                        &compacting_key_range.borrow().into(),
+                        &selecting_key_range.borrow().into(),
+                    ) {
+                        break;
+                    }
+                }
                 if !self.pick_target_level_overlap_files(
-                    other,
+                    &selecting_key_range,
                     target_level,
                     target_level_handler,
                     &mut target_level_ssts,
                 ) {
+                    // select_key_range is now stale.
                     break;
                 }
                 select_compaction_bytes += other.file_size;

--- a/src/storage/hummock_sdk/src/key_range.rs
+++ b/src/storage/hummock_sdk/src/key_range.rs
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use std::borrow::Borrow;
 use std::cmp;
 
 use bytes::Bytes;
@@ -90,6 +91,12 @@ impl PartialOrd for KeyRange {
 
 impl From<KeyRange> for risingwave_pb::hummock::KeyRange {
     fn from(kr: KeyRange) -> Self {
+        kr.borrow().into()
+    }
+}
+
+impl From<&KeyRange> for risingwave_pb::hummock::KeyRange {
+    fn from(kr: &KeyRange) -> Self {
         risingwave_pb::hummock::KeyRange {
             left: kr.left.to_vec(),
             right: kr.right.to_vec(),


### PR DESCRIPTION
## What's changed and what's your intention?

Fix compaction picker bug found in https://github.com/singularity-data/risingwave/issues/2219

When calculating key range overlap, we should use these combined key ranges:
- combined key range of L0 files being selected (see `selecting_key_range`)
  - Otherwise, see https://github.com/singularity-data/risingwave/issues/2219#issuecomment-1113538546
- combined key range of L0 files being compacted (see `compacting_key_range`). 
  - Otherwise, consider L0: task#1 ([0,1], [19,20]), task#2 ([7,8],[9,10]). The two concurrent compaction tasks will create overlapped L1 files.

Added tests demonstrating when the original code will fail.

If this PR is inconsistent with the original algorithm design, feel free to close it. @Little-Wallace 

## Checklist

- [x] I have written necessary docs and comments
- [x] I have added necessary unit tests and integration tests

## Refer to a related PR or issue link (optional)
close https://github.com/singularity-data/risingwave/issues/2219
close https://github.com/singularity-data/risingwave/issues/2234
