### PR TITLE
fix(frontend): fix a bug of is_correlated(has_correlated_input_ref)

### DIFF
--- a/src/frontend/src/expr/mod.rs
+++ b/src/frontend/src/expr/mod.rs
@@ -155,16 +155,20 @@ impl ExprImpl {
     pub fn has_correlated_input_ref(&self) -> bool {
         struct Has {
             has: bool,
+            depth: usize,
         }
 
         impl ExprVisitor for Has {
-            fn visit_correlated_input_ref(&mut self, _: &CorrelatedInputRef) {
-                self.has = true;
+            fn visit_correlated_input_ref(&mut self, correlated_input_ref: &CorrelatedInputRef) {
+                if correlated_input_ref.depth() >= self.depth {
+                    self.has = true;
+                }
             }
 
             fn visit_subquery(&mut self, subquery: &Subquery) {
                 use crate::binder::BoundSetExpr;
 
+                self.depth += 1;
                 match &subquery.query.body {
                     BoundSetExpr::Select(select) => select
                         .select_items
@@ -174,10 +178,11 @@ impl ExprImpl {
                         .for_each(|expr| self.visit_expr(expr)),
                     BoundSetExpr::Values(_) => {}
                 }
+                self.depth -= 1;
             }
         }
 
-        let mut visitor = Has { has: false };
+        let mut visitor = Has { has: false, depth: 1 };
         visitor.visit_expr(self);
         visitor.has
     }

--- a/src/frontend/src/expr/mod.rs
+++ b/src/frontend/src/expr/mod.rs
@@ -182,7 +182,10 @@ impl ExprImpl {
             }
         }
 
-        let mut visitor = Has { has: false, depth: 1 };
+        let mut visitor = Has {
+            has: false,
+            depth: 1,
+        };
         visitor.visit_expr(self);
         visitor.has
     }

--- a/src/frontend/test_runner/tests/testdata/subquery_expr_correlated.yaml
+++ b/src/frontend/test_runner/tests/testdata/subquery_expr_correlated.yaml
@@ -211,3 +211,50 @@
     create table t2(x int, y int);
     select x from t1 where y in (select y, x from t2 where t1.x > t2.x + 1000);
   binder_error: 'Bind error: Subquery must return only one column'
+- sql: |
+    create table t1(x int, y int);
+    create table t2(x int, y int);
+    create table t3(x int, y int);
+    select x from t1 where y in (select x from t2 where t2.y = t1.y and x > (select min(x) from t3));
+  logical_plan: |
+    LogicalProject { exprs: [$1], expr_alias: [x] }
+      LogicalApply { type: LeftSemi, on: ($2 = $3) }
+        LogicalScan { table: t1, columns: [_row_id#0, x, y] }
+        LogicalProject { exprs: [$1], expr_alias: [x] }
+          LogicalFilter { predicate: ($2 = CorrelatedInputRef { index: 2, depth: 1 }) AND ($1 > $3) }
+            LogicalJoin { type: LeftOuter, on: always }
+              LogicalScan { table: t2, columns: [_row_id#0, x, y] }
+              LogicalProject { exprs: [$0], expr_alias: [ ] }
+                LogicalAgg { group_keys: [], agg_calls: [min($0)] }
+                  LogicalProject { exprs: [$1], expr_alias: [ ] }
+                    LogicalScan { table: t3, columns: [_row_id#0, x, y] }
+- sql: |
+    create table t1(x int, y int);
+    create table t2(x int, y int);
+    create table t3(x int, y int);
+    select x from t1 where y in (select x from t2 where y in (select y from t3 where t1.y = t3.y));
+  logical_plan: |
+    LogicalProject { exprs: [$1], expr_alias: [x] }
+      LogicalApply { type: LeftSemi, on: ($2 = $3) }
+        LogicalScan { table: t1, columns: [_row_id#0, x, y] }
+        LogicalProject { exprs: [$1], expr_alias: [x] }
+          LogicalApply { type: LeftSemi, on: ($2 = $3) }
+            LogicalScan { table: t2, columns: [_row_id#0, x, y] }
+            LogicalProject { exprs: [$2], expr_alias: [y] }
+              LogicalFilter { predicate: (CorrelatedInputRef { index: 2, depth: 2 } = $2) }
+                LogicalScan { table: t3, columns: [_row_id#0, x, y] }
+- sql: |
+    create table t1(x int, y int);
+    create table t2(x int, y int);
+    create table t3(x int, y int);
+    select x from t1 where y in (select x from t2 where y in (select y from t3 where t2.y = t3.y));
+  logical_plan: |
+    LogicalProject { exprs: [$1], expr_alias: [x] }
+      LogicalJoin { type: LeftSemi, on: ($2 = $3) }
+        LogicalScan { table: t1, columns: [_row_id#0, x, y] }
+        LogicalProject { exprs: [$1], expr_alias: [x] }
+          LogicalApply { type: LeftSemi, on: ($2 = $3) }
+            LogicalScan { table: t2, columns: [_row_id#0, x, y] }
+            LogicalProject { exprs: [$2], expr_alias: [y] }
+              LogicalFilter { predicate: (CorrelatedInputRef { index: 2, depth: 1 } = $2) }
+                LogicalScan { table: t3, columns: [_row_id#0, x, y] }

--- a/src/frontend/test_runner/tests/testdata/subquery_expr_correlated.yaml
+++ b/src/frontend/test_runner/tests/testdata/subquery_expr_correlated.yaml
@@ -212,6 +212,7 @@
     select x from t1 where y in (select y, x from t2 where t1.x > t2.x + 1000);
   binder_error: 'Bind error: Subquery must return only one column'
 - sql: |
+    /* correlated outer subquery with an uncorrelated inner subquery */
     create table t1(x int, y int);
     create table t2(x int, y int);
     create table t3(x int, y int);
@@ -229,6 +230,7 @@
                   LogicalProject { exprs: [$1], expr_alias: [ ] }
                     LogicalScan { table: t3, columns: [_row_id#0, x, y] }
 - sql: |
+    /* correlated inner subquery with depth = 2 */
     create table t1(x int, y int);
     create table t2(x int, y int);
     create table t3(x int, y int);
@@ -244,6 +246,7 @@
               LogicalFilter { predicate: (CorrelatedInputRef { index: 2, depth: 2 } = $2) }
                 LogicalScan { table: t3, columns: [_row_id#0, x, y] }
 - sql: |
+    /* uncorrelated outer subquery with a correlated inner subquery */
     create table t1(x int, y int);
     create table t2(x int, y int);
     create table t3(x int, y int);

--- a/src/frontend/test_runner/tests/testdata/tpch.yaml
+++ b/src/frontend/test_runner/tests/testdata/tpch.yaml
@@ -1236,7 +1236,7 @@
   logical_plan: |
     LogicalProject { exprs: [$2, $3], expr_alias: [s_name, s_address] }
       LogicalFilter { predicate: ($4 = $9) AND ($10 = 'KENYA':Varchar) }
-        LogicalApply { type: LeftSemi, on: ($1 = $13) }
+        LogicalJoin { type: LeftSemi, on: ($1 = $13) }
           LogicalJoin { type: Inner, on: always }
             LogicalScan { table: supplier, columns: [_row_id#0, s_suppkey, s_name, s_address, s_nationkey, s_phone, s_acctbal, s_comment] }
             LogicalScan { table: nation, columns: [_row_id#0, n_nationkey, n_name, n_regionkey, n_comment] }


### PR DESCRIPTION
## What's changed and what's your intention?

***PLEASE DO NOT LEAVE THIS EMPTY !!!***

Please explain **IN DETAIL** what the changes are in this PR and why they are needed:

- Summarize your change (**mandatory**)
For multi-nested queries, if a subquery as a whole doesn't reference any columns out of it, then it should not be consisdered correlated. Assume we have a two-level nested query(use outer subquery and inner subquery to differeniate them), if the inner subquery only references columns in outer subquery and outer subquery doesn't reference any columns out of it, then outer subquery should not be considered correlated.

## Checklist

- [x] I have added necessary unit tests and integration tests

## Refer to a related PR or issue link (optional)
