### PR TITLE
refactor(frontend): separate post-agg Project from LogicalAgg::create

### DIFF
--- a/src/frontend/src/optimizer/plan_node/logical_agg.rs
+++ b/src/frontend/src/optimizer/plan_node/logical_agg.rs
@@ -317,8 +317,10 @@ impl LogicalAgg {
     /// `create` will analyze the select exprs and group exprs, and construct a plan like
     ///
     /// ```text
-    /// LogicalProject -> LogicalAgg -> LogicalProject -> input
+    /// LogicalAgg -> LogicalProject -> input
     /// ```
+    ///
+    /// It also returns the rewritten select exprs that reference into the aggregated results.
     pub fn create(
         select_exprs: Vec<ExprImpl>,
         group_exprs: Vec<ExprImpl>,

--- a/src/frontend/src/optimizer/plan_node/logical_agg.rs
+++ b/src/frontend/src/optimizer/plan_node/logical_agg.rs
@@ -321,10 +321,9 @@ impl LogicalAgg {
     /// ```
     pub fn create(
         select_exprs: Vec<ExprImpl>,
-        select_alias: Vec<Option<String>>,
         group_exprs: Vec<ExprImpl>,
         input: PlanRef,
-    ) -> Result<PlanRef> {
+    ) -> Result<(PlanRef, Vec<ExprImpl>)> {
         let group_keys = (0..group_exprs.len()).collect();
         let mut expr_handler = ExprHandler::new(group_exprs)?;
 
@@ -346,13 +345,7 @@ impl LogicalAgg {
         // This LogicalAgg focuses on calculating the aggregates and grouping.
         let logical_agg = LogicalAgg::new(expr_handler.agg_calls, group_keys, logical_project);
 
-        // This LogicalProject focus on transforming the aggregates and grouping columns to
-        // InputRef.
-        Ok(LogicalProject::create(
-            logical_agg.into(),
-            rewritten_select_exprs,
-            select_alias,
-        ))
+        Ok((logical_agg.into(), rewritten_select_exprs))
     }
 
     /// Get a reference to the logical agg's agg calls.
@@ -574,18 +567,14 @@ mod tests {
         let gen_internal_value = |select_exprs: Vec<ExprImpl>,
                                   group_exprs|
          -> (Vec<ExprImpl>, Vec<PlanAggCall>, Vec<usize>) {
-            let select_alias = vec![None; select_exprs.len()];
-            let plan =
-                LogicalAgg::create(select_exprs, select_alias, group_exprs, input.clone()).unwrap();
-            let logical_project = plan.as_logical_project().unwrap();
-            let exprs = logical_project.exprs();
+            let (plan, exprs) =
+                LogicalAgg::create(select_exprs, group_exprs, input.clone()).unwrap();
 
-            let plan = logical_project.input();
             let logical_agg = plan.as_logical_agg().unwrap();
             let agg_calls = logical_agg.agg_calls().to_vec();
             let group_keys = logical_agg.group_keys().to_vec();
 
-            (exprs.clone(), agg_calls, group_keys)
+            (exprs, agg_calls, group_keys)
         };
 
         // Test case: select v1 from test group by v1;

--- a/src/frontend/src/planner/select.rs
+++ b/src/frontend/src/planner/select.rs
@@ -53,13 +53,13 @@ impl Planner {
         // TODO: select-agg, group-by, having can also contain subquery exprs.
         let has_agg_call = select_items.iter().any(|expr| expr.has_agg_call());
         if !group_by.is_empty() || has_agg_call {
-            LogicalAgg::create(select_items, aliases, group_by, root)
-        } else {
-            if select_items.iter().any(|e| e.has_subquery()) {
-                (root, select_items) = self.substitute_subqueries(root, select_items)?;
-            }
-            Ok(LogicalProject::create(root, select_items, aliases))
+            (root, select_items) = LogicalAgg::create(select_items, group_by, root)?;
         }
+
+        if select_items.iter().any(|e| e.has_subquery()) {
+            (root, select_items) = self.substitute_subqueries(root, select_items)?;
+        }
+        Ok(LogicalProject::create(root, select_items, aliases))
     }
 
     /// Helper to create a dummy node as child of [`LogicalProject`].


### PR DESCRIPTION
## What's changed and what's your intention?

Post-agg Project from `select_items` (and post-agg Filter from `having`) will not be planned inside `LogicalAgg::create`. This allows reusing the subquery expr handling logic in `plan_select`. It will only create `LogicalAgg` with `agg_calls` extract from `select_items` (and `having`) and return the rewritten `select_items` (and `having`).

Also reverts the unnecessary separation of `bind_select` and `BoundSelect::create` in https://github.com/singularity-data/risingwave/pull/2220#discussion_r861436057

## Checklist

- [x] I have written necessary docs and comments
~~- [ ] I have added necessary unit tests and integration tests~~ (Refactor does not break existing tests.)

## Refer to a related PR or issue link (optional)
