### PR TITLE
fix(cmd_all): playground cannot start without risedev.yml

### DIFF
--- a/risedev.yml
+++ b/risedev.yml
@@ -67,7 +67,6 @@ risedev:
     - use: compute-node
     - use: frontend
 
-
   # TODO: Remove all legacy configs after java removed.
   # `dev-frontend` have the same settings as default except the the frontend-legacy node will be started by user.
   dev-frontend-legacy:

--- a/src/cmd_all/src/playground.rs
+++ b/src/cmd_all/src/playground.rs
@@ -102,7 +102,6 @@ pub async fn playground() -> Result<()> {
             RisingWaveService::Meta(vec!["--backend".into(), "mem".into()]),
             RisingWaveService::Compute(vec!["--state-store".into(), "hummock+memory".into()]),
             RisingWaveService::Frontend(vec![]),
-            RisingWaveService::Compactor(vec![]),
         ]
     };
 


### PR DESCRIPTION
Signed-off-by: Alex Chi <iskyzh@gmail.com>

## What's changed and what's your intention?

Compactor should not be part of the playground.

## Checklist

- [x] I have written necessary docs and comments
- [x] I have added necessary unit tests and integration tests

## Refer to a related PR or issue link (optional)

close https://github.com/singularity-data/risingwave/issues/2249