### PR TITLE
feat(frontend): bind & plan having

### DIFF
--- a/src/frontend/src/optimizer/plan_node/logical_agg.rs
+++ b/src/frontend/src/optimizer/plan_node/logical_agg.rs
@@ -228,8 +228,8 @@ impl ExprRewriter for ExprHandler {
     /// When there is an `FunctionCall` (outside of agg call), it must refers to a group column.
     /// Or all `InputRef`s appears in it must refer to a group column.
     fn rewrite_function_call(&mut self, func_call: FunctionCall) -> ExprImpl {
-        let expr = func_call.into();
-        if let Some(index) = self.expr_index.get(&expr) && *index < self.group_key_len {
+        let expr: ExprImpl = func_call.into();
+        if !expr.has_subquery() && let Some(index) = self.expr_index.get(&expr) && *index < self.group_key_len {
             InputRef::new(*index, expr.return_type()).into()
         } else {
             let (func_type, inputs, ret) = expr.into_function_call().unwrap().decompose();

--- a/src/frontend/src/optimizer/plan_node/logical_agg.rs
+++ b/src/frontend/src/optimizer/plan_node/logical_agg.rs
@@ -322,13 +322,14 @@ impl LogicalAgg {
         Schema { fields }
     }
 
-    /// `create` will analyze the select exprs and group exprs, and construct a plan like
+    /// `create` will analyze select exprs, group exprs and having, and construct a plan like
     ///
     /// ```text
     /// LogicalAgg -> LogicalProject -> input
     /// ```
     ///
-    /// It also returns the rewritten select exprs that reference into the aggregated results.
+    /// It also returns the rewritten select exprs and having that reference into the aggregated
+    /// results.
     pub fn create(
         select_exprs: Vec<ExprImpl>,
         group_exprs: Vec<ExprImpl>,

--- a/src/frontend/src/planner/select.rs
+++ b/src/frontend/src/planner/select.rs
@@ -36,6 +36,7 @@ impl Planner {
             where_clause,
             mut select_items,
             group_by,
+            mut having,
             aliases,
             ..
         }: BoundSelect,
@@ -52,8 +53,13 @@ impl Planner {
         // Plan the SELECT clause.
         // TODO: select-agg, group-by, having can also contain subquery exprs.
         let has_agg_call = select_items.iter().any(|expr| expr.has_agg_call());
-        if !group_by.is_empty() || has_agg_call {
-            (root, select_items) = LogicalAgg::create(select_items, group_by, root)?;
+        if !group_by.is_empty() || having.is_some() || has_agg_call {
+            (root, select_items, having) =
+                LogicalAgg::create(select_items, group_by, having, root)?;
+        }
+
+        if let Some(having) = having {
+            root = self.plan_where(root, having)?;
         }
 
         if select_items.iter().any(|e| e.has_subquery()) {

--- a/src/frontend/test_runner/tests/testdata/agg.yaml
+++ b/src/frontend/test_runner/tests/testdata/agg.yaml
@@ -160,3 +160,28 @@
     BatchSimpleAgg { aggs: [count] }
       BatchExchange { order: [], dist: Single }
         BatchScan { table: t, columns: [] }
+- sql: |
+    /* having with agg call */
+    create table t (v1 real not null);
+    select 1 from t having sum(v1) > 5;
+  batch_plan: |
+    BatchProject { exprs: [1:Int32], expr_alias: [ ] }
+      BatchFilter { predicate: ($0 > 5:Int32) }
+        BatchSimpleAgg { aggs: [sum($0)] }
+          BatchExchange { order: [], dist: Single }
+            BatchScan { table: t, columns: [v1] }
+- sql: |
+    /* having with group column */
+    create table t (v1 real not null);
+    select 1 from t group by v1 having v1 > 5;
+  logical_plan: |
+    LogicalProject { exprs: [1:Int32], expr_alias: [ ] }
+      LogicalFilter { predicate: ($0 > 5:Int32) }
+        LogicalAgg { group_keys: [0], agg_calls: [] }
+          LogicalProject { exprs: [$1], expr_alias: [ ] }
+            LogicalScan { table: t, columns: [_row_id#0, v1] }
+- sql: |
+    /* having with non-group column */
+    create table t (v1 real not null, v2 int);
+    select 1 from t group by v1 having v2 > 5;
+  planner_error: 'Invalid input syntax: column must appear in the GROUP BY clause or be used in an aggregate function'

--- a/src/frontend/test_runner/tests/testdata/tpch.yaml
+++ b/src/frontend/test_runner/tests/testdata/tpch.yaml
@@ -776,6 +776,84 @@
                                 StreamTableScan { table: lineitem, columns: [l_orderkey, l_extendedprice, l_discount, l_returnflag, _row_id#0], pk_indices: [4] }
                     StreamExchange { dist: HashShard([0]) }
                       StreamTableScan { table: nation, columns: [n_nationkey, n_name, _row_id#0], pk_indices: [2] }
+- id: tpch_q11
+  before:
+    - create_tables
+  sql: |
+    select
+      ps_partkey,
+      sum(ps_supplycost * ps_availqty) as value
+    from
+      partsupp,
+      supplier,
+      nation
+    where
+      ps_suppkey = s_suppkey
+      and s_nationkey = n_nationkey
+      and n_name = 'ARGENTINA'
+    group by
+      ps_partkey
+    having
+      sum(ps_supplycost * ps_availqty) > (
+        select
+          sum(ps_supplycost * ps_availqty) * 0.0001000000
+        from
+          partsupp,
+          supplier,
+          nation
+        where
+          ps_suppkey = s_suppkey
+          and s_nationkey = n_nationkey
+          and n_name = 'ARGENTINA'
+      )
+    order by
+      value desc;
+  logical_plan: |
+    LogicalProject { exprs: [$0, $1], expr_alias: [ps_partkey, value] }
+      LogicalFilter { predicate: ($2 > $3) }
+        LogicalJoin { type: LeftOuter, on: always }
+          LogicalAgg { group_keys: [0], agg_calls: [sum($1), sum($1)] }
+            LogicalProject { exprs: [$1, ($4 * $3)], expr_alias: [ ,  ] }
+              LogicalFilter { predicate: ($2 = $7) AND ($10 = $15) AND ($16 = 'ARGENTINA':Varchar) }
+                LogicalJoin { type: Inner, on: always }
+                  LogicalJoin { type: Inner, on: always }
+                    LogicalScan { table: partsupp, columns: [_row_id#0, ps_partkey, ps_suppkey, ps_availqty, ps_supplycost, ps_comment] }
+                    LogicalScan { table: supplier, columns: [_row_id#0, s_suppkey, s_name, s_address, s_nationkey, s_phone, s_acctbal, s_comment] }
+                  LogicalScan { table: nation, columns: [_row_id#0, n_nationkey, n_name, n_regionkey, n_comment] }
+          LogicalProject { exprs: [($0 * 0.0001000000:Decimal)], expr_alias: [ ] }
+            LogicalAgg { group_keys: [], agg_calls: [sum($0)] }
+              LogicalProject { exprs: [($4 * $3)], expr_alias: [ ] }
+                LogicalFilter { predicate: ($2 = $7) AND ($10 = $15) AND ($16 = 'ARGENTINA':Varchar) }
+                  LogicalJoin { type: Inner, on: always }
+                    LogicalJoin { type: Inner, on: always }
+                      LogicalScan { table: partsupp, columns: [_row_id#0, ps_partkey, ps_suppkey, ps_availqty, ps_supplycost, ps_comment] }
+                      LogicalScan { table: supplier, columns: [_row_id#0, s_suppkey, s_name, s_address, s_nationkey, s_phone, s_acctbal, s_comment] }
+                    LogicalScan { table: nation, columns: [_row_id#0, n_nationkey, n_name, n_regionkey, n_comment] }
+  optimized_logical_plan: |
+    LogicalProject { exprs: [$0, $1], expr_alias: [ps_partkey, value] }
+      LogicalFilter { predicate: ($2 > $3) }
+        LogicalJoin { type: LeftOuter, on: always }
+          LogicalAgg { group_keys: [0], agg_calls: [sum($1), sum($1)] }
+            LogicalProject { exprs: [$0, ($2 * $1)], expr_alias: [ ,  ] }
+              LogicalJoin { type: Inner, on: ($3 = $4) }
+                LogicalProject { exprs: [$0, $2, $3, $5], expr_alias: [ ,  ,  ,  ] }
+                  LogicalJoin { type: Inner, on: ($1 = $4) }
+                    LogicalScan { table: partsupp, columns: [ps_partkey, ps_suppkey, ps_availqty, ps_supplycost] }
+                    LogicalScan { table: supplier, columns: [s_suppkey, s_nationkey] }
+                LogicalProject { exprs: [$0], expr_alias: [ ] }
+                  LogicalFilter { predicate: ($1 = 'ARGENTINA':Varchar) }
+                    LogicalScan { table: nation, columns: [n_nationkey, n_name] }
+          LogicalProject { exprs: [($0 * 0.0001000000:Decimal)], expr_alias: [ ] }
+            LogicalAgg { group_keys: [], agg_calls: [sum($0)] }
+              LogicalProject { exprs: [($1 * $0)], expr_alias: [ ] }
+                LogicalJoin { type: Inner, on: ($2 = $3) }
+                  LogicalProject { exprs: [$1, $2, $4], expr_alias: [ ,  ,  ] }
+                    LogicalJoin { type: Inner, on: ($0 = $3) }
+                      LogicalScan { table: partsupp, columns: [ps_suppkey, ps_availqty, ps_supplycost] }
+                      LogicalScan { table: supplier, columns: [s_suppkey, s_nationkey] }
+                  LogicalProject { exprs: [$0], expr_alias: [ ] }
+                    LogicalFilter { predicate: ($1 = 'ARGENTINA':Varchar) }
+                      LogicalScan { table: nation, columns: [n_nationkey, n_name] }
 - id: tpch_q12
   before:
     - create_tables

--- a/src/frontend/test_runner/tests/testdata/tpch.yaml
+++ b/src/frontend/test_runner/tests/testdata/tpch.yaml
@@ -1078,8 +1078,9 @@
         from
           lineitem
         group by
-          l_orderkey having
-            sum(l_quantity) > 1
+          l_orderkey
+        having
+          sum(l_quantity) > 1
       )
       and c_custkey = o_custkey
       and o_orderkey = l_orderkey
@@ -1112,9 +1113,11 @@
                               BatchScan { table: orders, columns: [o_orderkey, o_custkey, o_totalprice, o_orderdate] }
                       BatchExchange { order: [], dist: HashShard([0]) }
                         BatchScan { table: lineitem, columns: [l_orderkey, l_quantity] }
-                  BatchHashAgg { group_keys: [$0], aggs: [] }
-                    BatchExchange { order: [], dist: HashShard([0]) }
-                      BatchScan { table: lineitem, columns: [l_orderkey] }
+                  BatchProject { exprs: [$0], expr_alias: [l_orderkey] }
+                    BatchFilter { predicate: ($1 > 1:Int32) }
+                      BatchHashAgg { group_keys: [$0], aggs: [sum($1)] }
+                        BatchExchange { order: [], dist: HashShard([0]) }
+                          BatchScan { table: lineitem, columns: [l_orderkey, l_quantity] }
   stream_plan: |
     StreamMaterialize { columns: [c_name, c_custkey, o_orderkey, o_orderdate, o_totalprice, quantity], pk_columns: [c_name, c_custkey, o_orderkey, o_orderdate, o_totalprice], order_descs: [o_totalprice, o_orderdate, c_name, c_custkey, o_orderkey] }
       StreamTopN { order: [$4 DESC, $3 ASC], limit: 100, offset: 0 }
@@ -1135,9 +1138,11 @@
                                 StreamTableScan { table: orders, columns: [o_orderkey, o_custkey, o_totalprice, o_orderdate, _row_id#0], pk_indices: [4] }
                         StreamExchange { dist: HashShard([0]) }
                           StreamTableScan { table: lineitem, columns: [l_orderkey, l_quantity, _row_id#0], pk_indices: [2] }
-                    StreamHashAgg { group_keys: [$0], aggs: [count] }
-                      StreamExchange { dist: HashShard([0]) }
-                        StreamTableScan { table: lineitem, columns: [l_orderkey, _row_id#0], pk_indices: [1] }
+                    StreamProject { exprs: [$0], expr_alias: [l_orderkey] }
+                      StreamFilter { predicate: ($2 > 1:Int32) }
+                        StreamHashAgg { group_keys: [$0], aggs: [count, sum($1)] }
+                          StreamExchange { dist: HashShard([0]) }
+                            StreamTableScan { table: lineitem, columns: [l_orderkey, l_quantity, _row_id#0], pk_indices: [2] }
 - id: tpch_q19
   before:
     - create_tables


### PR DESCRIPTION
## What's changed and what's your intention?

Bind and plan `having`. Mostly reusing logic handling `where` for filtering and logical handling `select_items` for post-agg rewriting.

Limitations:
- Q11 still requires nested loop join for `having sum(...) > uncorrelated-subquery` as there are no equality conditions.
- Post-agg correlated subqueries are not handled by the rewriter yet. For example:

```
create table t (v1 int, v2 int);

select min(v1), (select max(v2)) from t;
select min(v1), (select v2) from t group by v2;
select min(v1), (select v2) from t;  -- expected error: subquery uses ungrouped column "t.v2" from outer query

select 1 from t having min(v1) > (select max(v2));
select 1 from t group by v2 having min(v1) > (select v2);
select 1 from t having min(v1) > (select v2);  -- expected error: subquery uses ungrouped column "t.v2" from outer query
```

## Checklist

- [x] I have written necessary docs and comments
- [x] I have added necessary unit tests and integration tests

## Refer to a related PR or issue link (optional)

Closes #2166