### PR TITLE
fix(planner): report unsupported post-agg correlated subquery

### DIFF
--- a/src/frontend/src/optimizer/plan_node/logical_agg.rs
+++ b/src/frontend/src/optimizer/plan_node/logical_agg.rs
@@ -254,6 +254,16 @@ impl ExprRewriter for ExprHandler {
             expr
         }
     }
+
+    fn rewrite_subquery(&mut self, subquery: crate::expr::Subquery) -> ExprImpl {
+        if subquery.is_correlated() {
+            self.error = Some(ErrorCode::NotImplemented(
+                "correlated subquery in HAVING or SELECT with agg".into(),
+                1.into(),
+            ));
+        }
+        subquery.into()
+    }
 }
 
 impl LogicalAgg {

--- a/src/frontend/src/optimizer/plan_node/logical_agg.rs
+++ b/src/frontend/src/optimizer/plan_node/logical_agg.rs
@@ -259,7 +259,7 @@ impl ExprRewriter for ExprHandler {
         if subquery.is_correlated() {
             self.error = Some(ErrorCode::NotImplemented(
                 "correlated subquery in HAVING or SELECT with agg".into(),
-                1.into(),
+                2275.into(),
             ));
         }
         subquery.into()

--- a/src/frontend/test_runner/tests/testdata/subquery_expr_correlated.yaml
+++ b/src/frontend/test_runner/tests/testdata/subquery_expr_correlated.yaml
@@ -261,3 +261,82 @@
             LogicalProject { exprs: [$2], expr_alias: [y] }
               LogicalFilter { predicate: (CorrelatedInputRef { index: 2, depth: 1 } = $2) }
                 LogicalScan { table: t3, columns: [_row_id#0, x, y] }
+- sql: |
+    /* correlated agg column in SELECT */
+    create table t (v1 int, v2 int);
+    select min(v1), (select max(v2)) from t;
+  logical_plan: |
+    LogicalProject { exprs: [$0, $1], expr_alias: [ ,  ] }
+      LogicalApply { type: LeftOuter, on: always }
+        LogicalAgg { group_keys: [], agg_calls: [min($0)] }
+          LogicalProject { exprs: [$1], expr_alias: [ ] }
+            LogicalScan { table: t, columns: [_row_id#0, v1, v2] }
+        LogicalProject { exprs: [$0], expr_alias: [ ] }
+          LogicalAgg { group_keys: [], agg_calls: [max($0)] }
+            LogicalProject { exprs: [CorrelatedInputRef { index: 2, depth: 1 }], expr_alias: [ ] }
+              LogicalValues { rows: [[]], schema: Schema { fields: [] } }
+- sql: |
+    /* correlated group column in SELECT */
+    create table t (v1 int, v2 int);
+    select min(v1), (select v2) from t group by v2;
+  logical_plan: |
+    LogicalProject { exprs: [$1, $2], expr_alias: [ ,  ] }
+      LogicalApply { type: LeftOuter, on: always }
+        LogicalAgg { group_keys: [0], agg_calls: [min($1)] }
+          LogicalProject { exprs: [$2, $1], expr_alias: [ ,  ] }
+            LogicalScan { table: t, columns: [_row_id#0, v1, v2] }
+        LogicalProject { exprs: [CorrelatedInputRef { index: 2, depth: 1 }], expr_alias: [v2] }
+          LogicalValues { rows: [[]], schema: Schema { fields: [] } }
+- sql: |
+    /* correlated non-group column in SELECT */
+    create table t (v1 int, v2 int);
+    select min(v1), (select v2) from t;
+  logical_plan: |
+    LogicalProject { exprs: [$0, $1], expr_alias: [ ,  ] }
+      LogicalApply { type: LeftOuter, on: always }
+        LogicalAgg { group_keys: [], agg_calls: [min($0)] }
+          LogicalProject { exprs: [$1], expr_alias: [ ] }
+            LogicalScan { table: t, columns: [_row_id#0, v1, v2] }
+        LogicalProject { exprs: [CorrelatedInputRef { index: 2, depth: 1 }], expr_alias: [v2] }
+          LogicalValues { rows: [[]], schema: Schema { fields: [] } }
+- sql: |
+    /* correlated agg column in HAVING */
+    create table t (v1 int, v2 int);
+    select 1 from t having min(v1) > (select max(v2));
+  logical_plan: |
+    LogicalProject { exprs: [1:Int32], expr_alias: [ ] }
+      LogicalFilter { predicate: ($0 > $1) }
+        LogicalApply { type: LeftOuter, on: always }
+          LogicalAgg { group_keys: [], agg_calls: [min($0)] }
+            LogicalProject { exprs: [$1], expr_alias: [ ] }
+              LogicalScan { table: t, columns: [_row_id#0, v1, v2] }
+          LogicalProject { exprs: [$0], expr_alias: [ ] }
+            LogicalAgg { group_keys: [], agg_calls: [max($0)] }
+              LogicalProject { exprs: [CorrelatedInputRef { index: 2, depth: 1 }], expr_alias: [ ] }
+                LogicalValues { rows: [[]], schema: Schema { fields: [] } }
+- sql: |
+    /* correlated group column in HAVING */
+    create table t (v1 int, v2 int);
+    select 1 from t group by v2 having min(v1) > (select v2);
+  logical_plan: |
+    LogicalProject { exprs: [1:Int32], expr_alias: [ ] }
+      LogicalFilter { predicate: ($1 > $2) }
+        LogicalApply { type: LeftOuter, on: always }
+          LogicalAgg { group_keys: [0], agg_calls: [min($1)] }
+            LogicalProject { exprs: [$2, $1], expr_alias: [ ,  ] }
+              LogicalScan { table: t, columns: [_row_id#0, v1, v2] }
+          LogicalProject { exprs: [CorrelatedInputRef { index: 2, depth: 1 }], expr_alias: [v2] }
+            LogicalValues { rows: [[]], schema: Schema { fields: [] } }
+- sql: |
+    /* correlated non-group column in HAVING */
+    create table t (v1 int, v2 int);
+    select 1 from t having min(v1) > (select v2);
+  logical_plan: |
+    LogicalProject { exprs: [1:Int32], expr_alias: [ ] }
+      LogicalFilter { predicate: ($0 > $1) }
+        LogicalApply { type: LeftOuter, on: always }
+          LogicalAgg { group_keys: [], agg_calls: [min($0)] }
+            LogicalProject { exprs: [$1], expr_alias: [ ] }
+              LogicalScan { table: t, columns: [_row_id#0, v1, v2] }
+          LogicalProject { exprs: [CorrelatedInputRef { index: 2, depth: 1 }], expr_alias: [v2] }
+            LogicalValues { rows: [[]], schema: Schema { fields: [] } }

--- a/src/frontend/test_runner/tests/testdata/subquery_expr_correlated.yaml
+++ b/src/frontend/test_runner/tests/testdata/subquery_expr_correlated.yaml
@@ -265,29 +265,38 @@
     /* correlated agg column in SELECT */
     create table t (v1 int, v2 int);
     select min(v1), (select max(v2)) from t;
-  planner_error: 'Feature is not yet implemented: correlated subquery in HAVING or SELECT with agg, Tracking issue: https://github.com/singularity-data/risingwave/issues/1'
+  planner_error: 'Feature is not yet implemented: correlated subquery in HAVING or SELECT with agg, Tracking issue: https://github.com/singularity-data/risingwave/issues/2275'
 - sql: |
     /* correlated group column in SELECT */
     create table t (v1 int, v2 int);
     select min(v1), (select v2) from t group by v2;
-  planner_error: 'Feature is not yet implemented: correlated subquery in HAVING or SELECT with agg, Tracking issue: https://github.com/singularity-data/risingwave/issues/1'
+  planner_error: 'Feature is not yet implemented: correlated subquery in HAVING or SELECT with agg, Tracking issue: https://github.com/singularity-data/risingwave/issues/2275'
 - sql: |
     /* correlated non-group column in SELECT */
     create table t (v1 int, v2 int);
     select min(v1), (select v2) from t;
-  planner_error: 'Feature is not yet implemented: correlated subquery in HAVING or SELECT with agg, Tracking issue: https://github.com/singularity-data/risingwave/issues/1'
+  planner_error: 'Feature is not yet implemented: correlated subquery in HAVING or SELECT with agg, Tracking issue: https://github.com/singularity-data/risingwave/issues/2275'
 - sql: |
     /* correlated agg column in HAVING */
     create table t (v1 int, v2 int);
     select 1 from t having min(v1) > (select max(v2));
-  planner_error: 'Feature is not yet implemented: correlated subquery in HAVING or SELECT with agg, Tracking issue: https://github.com/singularity-data/risingwave/issues/1'
+  planner_error: 'Feature is not yet implemented: correlated subquery in HAVING or SELECT with agg, Tracking issue: https://github.com/singularity-data/risingwave/issues/2275'
 - sql: |
     /* correlated group column in HAVING */
     create table t (v1 int, v2 int);
     select 1 from t group by v2 having min(v1) > (select v2);
-  planner_error: 'Feature is not yet implemented: correlated subquery in HAVING or SELECT with agg, Tracking issue: https://github.com/singularity-data/risingwave/issues/1'
+  planner_error: 'Feature is not yet implemented: correlated subquery in HAVING or SELECT with agg, Tracking issue: https://github.com/singularity-data/risingwave/issues/2275'
 - sql: |
     /* correlated non-group column in HAVING */
     create table t (v1 int, v2 int);
     select 1 from t having min(v1) > (select v2);
-  planner_error: 'Feature is not yet implemented: correlated subquery in HAVING or SELECT with agg, Tracking issue: https://github.com/singularity-data/risingwave/issues/1'
+  planner_error: 'Feature is not yet implemented: correlated subquery in HAVING or SELECT with agg, Tracking issue: https://github.com/singularity-data/risingwave/issues/2275'
+- sql: |
+    /* correlated agg column belongs to outer query */
+    create table t (v1 int, v2 int);
+    create table t2 (v3 int, v4 int);
+    select
+      min(v1),
+      (select max(v2) + v3 from t2)  -- access to v3 is ok
+    from t;
+  planner_error: 'Feature is not yet implemented: correlated subquery in HAVING or SELECT with agg, Tracking issue: https://github.com/singularity-data/risingwave/issues/2275'

--- a/src/frontend/test_runner/tests/testdata/subquery_expr_correlated.yaml
+++ b/src/frontend/test_runner/tests/testdata/subquery_expr_correlated.yaml
@@ -265,78 +265,29 @@
     /* correlated agg column in SELECT */
     create table t (v1 int, v2 int);
     select min(v1), (select max(v2)) from t;
-  logical_plan: |
-    LogicalProject { exprs: [$0, $1], expr_alias: [ ,  ] }
-      LogicalApply { type: LeftOuter, on: always }
-        LogicalAgg { group_keys: [], agg_calls: [min($0)] }
-          LogicalProject { exprs: [$1], expr_alias: [ ] }
-            LogicalScan { table: t, columns: [_row_id#0, v1, v2] }
-        LogicalProject { exprs: [$0], expr_alias: [ ] }
-          LogicalAgg { group_keys: [], agg_calls: [max($0)] }
-            LogicalProject { exprs: [CorrelatedInputRef { index: 2, depth: 1 }], expr_alias: [ ] }
-              LogicalValues { rows: [[]], schema: Schema { fields: [] } }
+  planner_error: 'Feature is not yet implemented: correlated subquery in HAVING or SELECT with agg, Tracking issue: https://github.com/singularity-data/risingwave/issues/1'
 - sql: |
     /* correlated group column in SELECT */
     create table t (v1 int, v2 int);
     select min(v1), (select v2) from t group by v2;
-  logical_plan: |
-    LogicalProject { exprs: [$1, $2], expr_alias: [ ,  ] }
-      LogicalApply { type: LeftOuter, on: always }
-        LogicalAgg { group_keys: [0], agg_calls: [min($1)] }
-          LogicalProject { exprs: [$2, $1], expr_alias: [ ,  ] }
-            LogicalScan { table: t, columns: [_row_id#0, v1, v2] }
-        LogicalProject { exprs: [CorrelatedInputRef { index: 2, depth: 1 }], expr_alias: [v2] }
-          LogicalValues { rows: [[]], schema: Schema { fields: [] } }
+  planner_error: 'Feature is not yet implemented: correlated subquery in HAVING or SELECT with agg, Tracking issue: https://github.com/singularity-data/risingwave/issues/1'
 - sql: |
     /* correlated non-group column in SELECT */
     create table t (v1 int, v2 int);
     select min(v1), (select v2) from t;
-  logical_plan: |
-    LogicalProject { exprs: [$0, $1], expr_alias: [ ,  ] }
-      LogicalApply { type: LeftOuter, on: always }
-        LogicalAgg { group_keys: [], agg_calls: [min($0)] }
-          LogicalProject { exprs: [$1], expr_alias: [ ] }
-            LogicalScan { table: t, columns: [_row_id#0, v1, v2] }
-        LogicalProject { exprs: [CorrelatedInputRef { index: 2, depth: 1 }], expr_alias: [v2] }
-          LogicalValues { rows: [[]], schema: Schema { fields: [] } }
+  planner_error: 'Feature is not yet implemented: correlated subquery in HAVING or SELECT with agg, Tracking issue: https://github.com/singularity-data/risingwave/issues/1'
 - sql: |
     /* correlated agg column in HAVING */
     create table t (v1 int, v2 int);
     select 1 from t having min(v1) > (select max(v2));
-  logical_plan: |
-    LogicalProject { exprs: [1:Int32], expr_alias: [ ] }
-      LogicalFilter { predicate: ($0 > $1) }
-        LogicalApply { type: LeftOuter, on: always }
-          LogicalAgg { group_keys: [], agg_calls: [min($0)] }
-            LogicalProject { exprs: [$1], expr_alias: [ ] }
-              LogicalScan { table: t, columns: [_row_id#0, v1, v2] }
-          LogicalProject { exprs: [$0], expr_alias: [ ] }
-            LogicalAgg { group_keys: [], agg_calls: [max($0)] }
-              LogicalProject { exprs: [CorrelatedInputRef { index: 2, depth: 1 }], expr_alias: [ ] }
-                LogicalValues { rows: [[]], schema: Schema { fields: [] } }
+  planner_error: 'Feature is not yet implemented: correlated subquery in HAVING or SELECT with agg, Tracking issue: https://github.com/singularity-data/risingwave/issues/1'
 - sql: |
     /* correlated group column in HAVING */
     create table t (v1 int, v2 int);
     select 1 from t group by v2 having min(v1) > (select v2);
-  logical_plan: |
-    LogicalProject { exprs: [1:Int32], expr_alias: [ ] }
-      LogicalFilter { predicate: ($1 > $2) }
-        LogicalApply { type: LeftOuter, on: always }
-          LogicalAgg { group_keys: [0], agg_calls: [min($1)] }
-            LogicalProject { exprs: [$2, $1], expr_alias: [ ,  ] }
-              LogicalScan { table: t, columns: [_row_id#0, v1, v2] }
-          LogicalProject { exprs: [CorrelatedInputRef { index: 2, depth: 1 }], expr_alias: [v2] }
-            LogicalValues { rows: [[]], schema: Schema { fields: [] } }
+  planner_error: 'Feature is not yet implemented: correlated subquery in HAVING or SELECT with agg, Tracking issue: https://github.com/singularity-data/risingwave/issues/1'
 - sql: |
     /* correlated non-group column in HAVING */
     create table t (v1 int, v2 int);
     select 1 from t having min(v1) > (select v2);
-  logical_plan: |
-    LogicalProject { exprs: [1:Int32], expr_alias: [ ] }
-      LogicalFilter { predicate: ($0 > $1) }
-        LogicalApply { type: LeftOuter, on: always }
-          LogicalAgg { group_keys: [], agg_calls: [min($0)] }
-            LogicalProject { exprs: [$1], expr_alias: [ ] }
-              LogicalScan { table: t, columns: [_row_id#0, v1, v2] }
-          LogicalProject { exprs: [CorrelatedInputRef { index: 2, depth: 1 }], expr_alias: [v2] }
-            LogicalValues { rows: [[]], schema: Schema { fields: [] } }
+  planner_error: 'Feature is not yet implemented: correlated subquery in HAVING or SELECT with agg, Tracking issue: https://github.com/singularity-data/risingwave/issues/1'


### PR DESCRIPTION
## What's changed and what's your intention?

See #2275. Without the check in `rewrite_subquery`, the first test case (`select min(v1), (select max(v2)) from t`) would output the following plan (before decorrelation):
```
    LogicalProject { exprs: [$0, $1], expr_alias: [ ,  ] }
      LogicalApply { type: LeftOuter, on: always }
        LogicalAgg { group_keys: [], agg_calls: [min($0)] }
          LogicalProject { exprs: [$1], expr_alias: [ ] }
            LogicalScan { table: t, columns: [_row_id#0, v1, v2] }
        LogicalProject { exprs: [$0], expr_alias: [ ] }
          LogicalAgg { group_keys: [], agg_calls: [max($0)] }
            LogicalProject { exprs: [CorrelatedInputRef { index: 2, depth: 1 }], expr_alias: [ ] }
              LogicalValues { rows: [[]], schema: Schema { fields: [] } }
```
Note that 1st child of `LogicalApply` outputs 1 column but the 2nd child contains `CorrelatedInputRef { index: 2, depth: 1 }`, which would be an index-out-of-bound error.

The proper plan (before decorrelation) should be the following:
```
    LogicalProject { exprs: [$0, $2], expr_alias: [ ,  ] }
      LogicalApply { type: LeftOuter, on: always }
        LogicalAgg { group_keys: [], agg_calls: [min($0), max($1)] }
          LogicalProject { exprs: [$1, $2], expr_alias: [ ] }
            LogicalScan { table: t, columns: [_row_id#0, v1, v2] }
        LogicalProject { exprs: [CorrelatedInputRef { index: 1, depth: 1 }], expr_alias: [ ] }
          LogicalValues { rows: [[]], schema: Schema { fields: [] } }
```
It is not the interest of this PR to generate this proper plan. We just report an error that it is not supported.

## Checklist

- [x] I have written necessary docs and comments
- [x] I have added necessary unit tests and integration tests

## Refer to a related PR or issue link (optional)

#2275