### PR TITLE
chore(relational-table): store zero bytes for sentinel columns

### DIFF
--- a/src/common/src/util/ordered/serde.rs
+++ b/src/common/src/util/ordered/serde.rs
@@ -183,7 +183,7 @@ pub fn serialize_pk_and_row(
         result.push((key, None));
     } else {
         // Store zero bytes for the sentinel value.
-        result.push((key, Some("".to_string().into_bytes())));
+        result.push((key, Some(vec![])));
     }
 
     Ok(result)

--- a/src/common/src/util/ordered/serde.rs
+++ b/src/common/src/util/ordered/serde.rs
@@ -182,8 +182,8 @@ pub fn serialize_pk_and_row(
     if row.is_none() {
         result.push((key, None));
     } else {
-        let value = serialize_cell(&None)?;
-        result.push((key, Some(value)));
+        // Store zero bytes for the sentinel value.
+        result.push((key, Some("".to_string().into_bytes())));
     }
 
     Ok(result)

--- a/src/stream/src/executor/lookup/tests.rs
+++ b/src/stream/src/executor/lookup/tests.rs
@@ -18,9 +18,10 @@ use itertools::Itertools;
 use risingwave_common::array::stream_chunk::StreamChunkTestExt;
 use risingwave_common::array::StreamChunk;
 use risingwave_common::catalog::{ColumnDesc, ColumnId, Field, Schema, TableId};
-use risingwave_common::types::{deserialize_datum_from, DataType};
+use risingwave_common::types::DataType;
 use risingwave_common::util::ordered::{deserialize_column_id, SENTINEL_CELL_ID};
 use risingwave_common::util::sort_util::{OrderPair, OrderType};
+use risingwave_common::util::value_encoding::deserialize_cell;
 use risingwave_storage::memory::MemoryStateStore;
 use risingwave_storage::{Keyspace, StateStore};
 
@@ -239,13 +240,13 @@ async fn test_lookup_this_epoch() {
     next_msg(&mut msgs, &mut lookup_executor).await;
 
     for (k, v) in store.scan::<_, Vec<u8>>(.., None, u64::MAX).await.unwrap() {
-        let mut deserializer = memcomparable::Deserializer::new(v);
+        let mut deserializer = value_encoding::Deserializer::new(v);
         // Do not deserialize datum for SENTINEL_CELL_ID cuz the value length is 0.
         if deserialize_column_id(&k[k.len() - 4..]).unwrap() != SENTINEL_CELL_ID {
             println!(
                 "{:?} => {:?}",
                 k,
-                deserialize_datum_from(&DataType::Int64, &mut deserializer).unwrap()
+                deserialize_cell(&mut deserializer, &DataType::Int64).unwrap()
             );
         }
     }


### PR DESCRIPTION
## What's changed and what's your intention?

Store zero bytes for sentinel cell value. 

## Checklist

- [x] I have written necessary docs and comments
- [x] I have added necessary unit tests and integration tests

## Refer to a related PR or issue link (optional)
