### PR TITLE
fix(state-store): fix a dead lock in memory state store

### DIFF
--- a/src/storage/src/memory.rs
+++ b/src/storage/src/memory.rs
@@ -21,7 +21,7 @@ use std::sync::Arc;
 
 use bytes::Bytes;
 use lazy_static::lazy_static;
-use tokio::sync::RwLock;
+use parking_lot::RwLock;
 
 use crate::storage_value::StorageValue;
 use crate::store::*;
@@ -113,7 +113,7 @@ impl StateStore for MemoryStateStore {
             if limit == Some(0) {
                 return Ok(vec![]);
             }
-            let inner = self.inner.read().await;
+            let inner = self.inner.read();
 
             let mut last_key = None;
             for ((key, Reverse(key_epoch)), value) in inner.range(to_bytes_range(key_range)) {
@@ -153,7 +153,7 @@ impl StateStore for MemoryStateStore {
         epoch: u64,
     ) -> Self::IngestBatchFuture<'_> {
         async move {
-            let mut inner = self.inner.write().await;
+            let mut inner = self.inner.write();
             let mut size: usize = 0;
             for (key, value) in kv_pairs {
                 size += key.len() + value.size();

--- a/src/storage/src/memory.rs
+++ b/src/storage/src/memory.rs
@@ -21,7 +21,7 @@ use std::sync::Arc;
 
 use bytes::Bytes;
 use lazy_static::lazy_static;
-use tokio::sync::Mutex;
+use tokio::sync::RwLock;
 
 use crate::storage_value::StorageValue;
 use crate::store::*;
@@ -38,7 +38,7 @@ type KeyWithEpoch = (Bytes, Reverse<u64>);
 #[derive(Clone)]
 pub struct MemoryStateStore {
     /// Stores (key, epoch) -> user value. We currently don't consider value meta here.
-    inner: Arc<Mutex<BTreeMap<KeyWithEpoch, Option<Bytes>>>>,
+    inner: Arc<RwLock<BTreeMap<KeyWithEpoch, Option<Bytes>>>>,
 }
 
 impl Default for MemoryStateStore {
@@ -68,7 +68,7 @@ where
 impl MemoryStateStore {
     pub fn new() -> Self {
         Self {
-            inner: Arc::new(Mutex::new(BTreeMap::new())),
+            inner: Arc::new(RwLock::new(BTreeMap::new())),
         }
     }
 
@@ -113,7 +113,7 @@ impl StateStore for MemoryStateStore {
             if limit == Some(0) {
                 return Ok(vec![]);
             }
-            let inner = self.inner.lock().await;
+            let inner = self.inner.read().await;
 
             let mut last_key = None;
             for ((key, Reverse(key_epoch)), value) in inner.range(to_bytes_range(key_range)) {
@@ -153,7 +153,7 @@ impl StateStore for MemoryStateStore {
         epoch: u64,
     ) -> Self::IngestBatchFuture<'_> {
         async move {
-            let mut inner = self.inner.lock().await;
+            let mut inner = self.inner.write().await;
             let mut size: usize = 0;
             for (key, value) in kv_pairs {
                 size += key.len() + value.size();


### PR DESCRIPTION
## What's changed and what's your intention?

ref #2197 . e2e test will dead lock if runs in memory state backend.

parking_lot::Mutex can also solve it. 

Can not find the root cause. I guess different actors in different spawned tasks doing operations concurrently so we get a deadlock. 

Tested locally.

## Checklist

- [x] I have written necessary docs and comments
- [x] I have added necessary unit tests and integration tests

## Refer to a related PR or issue link (optional)
