### PR TITLE
feat(docker): add compactor in compose file

### DIFF
--- a/docker/README.md
+++ b/docker/README.md
@@ -13,16 +13,22 @@ in the project root.
 To start a RisingWave playground, run
 
 ```
+# Ensure risingwave image is of latest version
+docker pull ghcr.io/singularity-data/risingwave:latest
+# Start playground
 docker run -it ghcr.io/singularity-data/risingwave:latest
 ```
 
 To start a RisingWave cluster, run
 
 ```
+# Ensure risingwave image is of latest version
+docker pull ghcr.io/singularity-data/risingwave:latest
+# Start all components
 docker-compose up
 ```
 
-It will start a minio, a meta node, a compute node, a frontend and a redpanda instance.
+It will start a minio, a meta node, a compute node, a frontend, a compactor and a redpanda instance.
 
 To clean all data, run:
 

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -1,6 +1,28 @@
 ---
 version: "3"
 services:
+  compactor-0:
+    image: "ghcr.io/singularity-data/compactor-node:latest"
+    command:
+      - "--host"
+      - "0.0.0.0:6660"
+      - "--prometheus-listener-addr"
+      - "0.0.0.0:1260"
+      - "--metrics-level"
+      - "1"
+      - "--state-store"
+      - "hummock+minio://hummockadmin:hummockadmin@minio-0:9301/hummock001"
+      - "--meta-address"
+      - "http://meta-node-0:5690"
+    expose:
+      - "6660"
+    ports: []
+    depends_on:
+      - meta-node-0
+      - minio-0
+    volumes: []
+    environment: []
+    container_name: compactor-0
   compute-node-0:
     image: "ghcr.io/singularity-data/compute-node:latest"
     command:
@@ -80,17 +102,7 @@ services:
     depends_on: []
     volumes:
       - "minio-0:/data"
-    entrypoint: "
-
-      /bin/sh -c '
-
-      set -e
-
-      mkdir -p \"/data/hummock001\"
-
-      /usr/bin/docker-entrypoint.sh \"$$0\" \"$$@\"
-
-      '"
+    entrypoint: "\n/bin/sh -c '\nset -e\nmkdir -p \"/data/hummock001\"\n/usr/bin/docker-entrypoint.sh \"$$0\" \"$$@\"\n'"
     environment:
       - MINIO_PROMETHEUS_AUTH_TYPE=public
       - MINIO_ROOT_PASSWORD=hummockadmin

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -2,8 +2,9 @@
 version: "3"
 services:
   compactor-0:
-    image: "ghcr.io/singularity-data/compactor-node:latest"
+    image: "ghcr.io/singularity-data/risingwave:latest"
     command:
+      - compactor-node
       - "--host"
       - "0.0.0.0:6660"
       - "--prometheus-listener-addr"
@@ -24,8 +25,9 @@ services:
     environment: []
     container_name: compactor-0
   compute-node-0:
-    image: "ghcr.io/singularity-data/compute-node:latest"
+    image: "ghcr.io/singularity-data/risingwave:latest"
     command:
+      - compute-node
       - "--host"
       - "0.0.0.0:5688"
       - "--prometheus-listener-addr"
@@ -49,8 +51,9 @@ services:
     environment: []
     container_name: compute-node-0
   frontend-node-0:
-    image: "ghcr.io/singularity-data/frontend-node:latest"
+    image: "ghcr.io/singularity-data/risingwave:latest"
     command:
+      - frontend-node
       - "--host"
       - "0.0.0.0:4566"
       - "--meta-addr"
@@ -65,8 +68,9 @@ services:
     environment: []
     container_name: frontend-node-0
   meta-node-0:
-    image: "ghcr.io/singularity-data/meta-node:latest"
+    image: "ghcr.io/singularity-data/risingwave:latest"
     command:
+      - meta-node
       - "--host"
       - "0.0.0.0:5690"
       - "--dashboard-host"

--- a/src/risedevtool/src/compose.rs
+++ b/src/risedevtool/src/compose.rs
@@ -14,10 +14,11 @@
 
 //! Generate docker compose yaml files for risedev components.
 
-const DOCKER_COMPUTE_NODE_IMAGE: &str = "ghcr.io/singularity-data/compute-node:latest";
-const DOCKER_META_NODE_IMAGE: &str = "ghcr.io/singularity-data/meta-node:latest";
-const DOCKER_COMPACTOR_NODE_IMAGE: &str = "ghcr.io/singularity-data/compactor-node:latest";
-const DOCKER_FRONTEND_NODE_IMAGE: &str = "ghcr.io/singularity-data/frontend-node:latest";
+// const DOCKER_COMPUTE_NODE_IMAGE: &str = "ghcr.io/singularity-data/compute-node:latest";
+// const DOCKER_META_NODE_IMAGE: &str = "ghcr.io/singularity-data/meta-node:latest";
+// const DOCKER_COMPACTOR_NODE_IMAGE: &str = "ghcr.io/singularity-data/compactor-node:latest";
+// const DOCKER_FRONTEND_NODE_IMAGE: &str = "ghcr.io/singularity-data/frontend-node:latest";
+const DOCKER_ALL_NODE_IMAGE: &str = "ghcr.io/singularity-data/risingwave:latest";
 
 use std::collections::BTreeMap;
 use std::process::Command;
@@ -107,13 +108,13 @@ impl Compose for ComputeNodeConfig {
     fn compose(&self) -> Result<ComposeService> {
         let mut command = Command::new("compute-node");
         ComputeNodeService::apply_command_args(&mut command, self)?;
-        let command = get_cmd_args(&command, false)?;
+        let command = get_cmd_args(&command, true)?;
 
         let provide_meta_node = self.provide_meta_node.as_ref().unwrap();
         let provide_minio = self.provide_minio.as_ref().unwrap();
 
         Ok(ComposeService {
-            image: DOCKER_COMPUTE_NODE_IMAGE.into(),
+            image: DOCKER_ALL_NODE_IMAGE.into(),
             command,
             expose: vec![self.port.to_string(), self.exporter_port.to_string()],
             depends_on: provide_meta_node
@@ -130,10 +131,10 @@ impl Compose for MetaNodeConfig {
     fn compose(&self) -> Result<ComposeService> {
         let mut command = Command::new("meta-node");
         MetaNodeService::apply_command_args(&mut command, self)?;
-        let command = get_cmd_args(&command, false)?;
+        let command = get_cmd_args(&command, true)?;
 
         Ok(ComposeService {
-            image: DOCKER_META_NODE_IMAGE.into(),
+            image: DOCKER_ALL_NODE_IMAGE.into(),
             command,
             expose: vec![
                 self.port.to_string(),
@@ -149,12 +150,12 @@ impl Compose for FrontendConfig {
     fn compose(&self) -> Result<ComposeService> {
         let mut command = Command::new("frontend-node");
         FrontendServiceV2::apply_command_args(&mut command, self)?;
-        let command = get_cmd_args(&command, false)?;
+        let command = get_cmd_args(&command, true)?;
 
         let provide_meta_node = self.provide_meta_node.as_ref().unwrap();
 
         Ok(ComposeService {
-            image: DOCKER_FRONTEND_NODE_IMAGE.into(),
+            image: DOCKER_ALL_NODE_IMAGE.into(),
             command,
             ports: vec![format!("{}:{}", self.port, self.port)],
             expose: vec![self.port.to_string()],
@@ -168,13 +169,13 @@ impl Compose for CompactorConfig {
     fn compose(&self) -> Result<ComposeService> {
         let mut command = Command::new("compactor-node");
         CompactorService::apply_command_args(&mut command, self)?;
-        let command = get_cmd_args(&command, false)?;
+        let command = get_cmd_args(&command, true)?;
 
         let provide_meta_node = self.provide_meta_node.as_ref().unwrap();
         let provide_minio = self.provide_minio.as_ref().unwrap();
 
         Ok(ComposeService {
-            image: DOCKER_COMPACTOR_NODE_IMAGE.into(),
+            image: DOCKER_ALL_NODE_IMAGE.into(),
             command,
             expose: vec![self.port.to_string()],
             depends_on: provide_meta_node


### PR DESCRIPTION
Signed-off-by: Alex Chi <iskyzh@gmail.com>

## What's changed and what's your intention?

Due to image build issue, compactor is not added in prior PRs. This PR adds compactor in docker-compose. Need test before merging.

To avoid users are using different version of the images, we now use `risingwave` single binary image to start all components. When https://github.com/singularity-data/risingwave/issues/2300 has been done, we can change back to use separate images.

## Checklist

- [x] I have written necessary docs and comments
- [x] I have added necessary unit tests and integration tests

## Refer to a related PR or issue link (optional)
