### PR TITLE
chore(frontend): add test for delta join with projection

### DIFF
--- a/e2e_test/v2/streaming/index.slt
+++ b/e2e_test/v2/streaming/index.slt
@@ -91,15 +91,28 @@ statement ok
 drop materialized view iii_mv2
 
 statement ok
-create materialized view iii_mv3 as select v2 from iii_t1, iii_t2 where iii_t1.v1 = iii_t2.v3;
+create materialized view iii_mv3 as select v4 from iii_t1, iii_t2 where iii_t1.v1 = iii_t2.v3;
 
 query IIII rowsort
-select v2 from iii_mv3;
+select v4 from iii_mv3;
 ----
-0
-0
-0
-0
+5
+5
+5
+5
+4
+4
+4
+4
+3
+3
+3
+3
+2
+2
+2
+2
+5
 
 statement ok
 drop materialized view iii_mv3

--- a/e2e_test/v2/streaming/index.slt
+++ b/e2e_test/v2/streaming/index.slt
@@ -1,3 +1,6 @@
+# NOTE: if this file is changed, also change `index.yaml` in planner test to ensure
+# create mv is using index.
+
 statement ok
 create table iii_t1 (v1 int, v2 int);
 
@@ -86,6 +89,20 @@ select v1, v2, v3, v4 from iii_mv2;
 
 statement ok
 drop materialized view iii_mv2
+
+statement ok
+create materialized view iii_mv3 as select v2 from iii_t1, iii_t2 where iii_t1.v1 = iii_t2.v3;
+
+query IIII rowsort
+select v2 from iii_mv3;
+----
+0
+0
+0
+0
+
+statement ok
+drop materialized view iii_mv3
 
 statement ok
 drop materialized view iii_index_2

--- a/src/frontend/test_runner/tests/testdata/index.yaml
+++ b/src/frontend/test_runner/tests/testdata/index.yaml
@@ -3,7 +3,7 @@
     create table t2 (v3 int, v4 numeric, v5 bigint);
     create index t1_v1 on t1(v1);
     create index t2_v3 on t2(v3);
-    /* should generate delta join plan, and stream index scan (pk not correct for now) */
+    /* should generate delta join plan, and stream index scan */
     select * from t1, t2 where t1.v1 = t2.v3;
   stream_plan: |
     StreamMaterialize { columns: [v1, v2, _row_id#0(hidden), v3, v4, v5, _row_id#1(hidden)], pk_columns: [_row_id#0, _row_id#1] }
@@ -11,3 +11,32 @@
         StreamDeltaJoin { type: Inner, predicate: $0 = $3 }
           StreamIndexScan { index: t1_v1, columns: [v1, v2, _row_id#0], pk_indices: [2] }
           StreamIndexScan { index: t2_v3, columns: [v3, v4, v5, _row_id#0], pk_indices: [3] }
+- id: index_slt
+  sql: |
+    create table iii_t1 (v1 int, v2 int);
+    create table iii_t2 (v3 int, v4 int);
+    create table iii_t3 (v5 int, v6 int);
+    create materialized view iii_mv1 as select * from iii_t1, iii_t2, iii_t3 where iii_t1.v1 = iii_t2.v3 and iii_t1.v1 = iii_t3.v5;
+    create index iii_index_1 on iii_t1(v1);
+    create index iii_index_2 on iii_t2(v3);
+- before:
+    - index_slt
+  sql: |
+    select * from iii_t1, iii_t2 where iii_t1.v1 = iii_t2.v3;
+  stream_plan: |
+    StreamMaterialize { columns: [v1, v2, _row_id#0(hidden), v3, v4, _row_id#1(hidden)], pk_columns: [_row_id#0, _row_id#1] }
+      StreamExchange { dist: HashShard([2, 5]) }
+        StreamDeltaJoin { type: Inner, predicate: $0 = $3 }
+          StreamIndexScan { index: iii_index_1, columns: [v1, v2, _row_id#0], pk_indices: [2] }
+          StreamIndexScan { index: iii_index_2, columns: [v3, v4, _row_id#0], pk_indices: [2] }
+- before:
+    - index_slt
+  sql: |
+    select v2 from iii_t1, iii_t2 where iii_t1.v1 = iii_t2.v3;
+  stream_plan: |
+    StreamMaterialize { columns: [v2, _row_id#0(hidden), _row_id#1(hidden)], pk_columns: [_row_id#0, _row_id#1] }
+      StreamExchange { dist: HashShard([1, 2]) }
+        StreamProject { exprs: [$1, $2, $4], expr_alias: [v2,  ,  ] }
+          StreamDeltaJoin { type: Inner, predicate: $0 = $3 }
+            StreamIndexScan { index: iii_index_1, columns: [v1, v2, _row_id#0], pk_indices: [2] }
+            StreamIndexScan { index: iii_index_2, columns: [v3, _row_id#0], pk_indices: [1] }

--- a/src/frontend/test_runner/tests/testdata/index.yaml
+++ b/src/frontend/test_runner/tests/testdata/index.yaml
@@ -32,11 +32,11 @@
 - before:
     - index_slt
   sql: |
-    select v2 from iii_t1, iii_t2 where iii_t1.v1 = iii_t2.v3;
+    select v4 from iii_t1, iii_t2 where iii_t1.v1 = iii_t2.v3;
   stream_plan: |
-    StreamMaterialize { columns: [v2, _row_id#0(hidden), _row_id#1(hidden)], pk_columns: [_row_id#0, _row_id#1] }
+    StreamMaterialize { columns: [v4, _row_id#0(hidden), _row_id#1(hidden)], pk_columns: [_row_id#0, _row_id#1] }
       StreamExchange { dist: HashShard([1, 2]) }
-        StreamProject { exprs: [$1, $2, $4], expr_alias: [v2,  ,  ] }
-          StreamDeltaJoin { type: Inner, predicate: $0 = $3 }
-            StreamIndexScan { index: iii_index_1, columns: [v1, v2, _row_id#0], pk_indices: [2] }
-            StreamIndexScan { index: iii_index_2, columns: [v3, _row_id#0], pk_indices: [1] }
+        StreamProject { exprs: [$3, $1, $4], expr_alias: [v4,  ,  ] }
+          StreamDeltaJoin { type: Inner, predicate: $0 = $2 }
+            StreamIndexScan { index: iii_index_1, columns: [v1, _row_id#0], pk_indices: [1] }
+            StreamIndexScan { index: iii_index_2, columns: [v3, v4, _row_id#0], pk_indices: [2] }


### PR DESCRIPTION
Signed-off-by: Alex Chi <iskyzh@gmail.com>

## What's changed and what's your intention?

As title. Anyway, if there's projection between HashJoin and IndexScan, then the plan cannot be converted to delta join (for now). This PR adds test for projection outside join.

## Checklist

- [x] I have written necessary docs and comments
- [x] I have added necessary unit tests and integration tests

## Refer to a related PR or issue link (optional)
