### PR TITLE
chore(batch): remove outdated TODO in MergeSortExchangeExecutor

### DIFF
--- a/src/batch/src/executor2/merge_sort_exchange.rs
+++ b/src/batch/src/executor2/merge_sort_exchange.rs
@@ -40,7 +40,6 @@ pub type MergeSortExchangeExecutor2 = MergeSortExchangeExecutor2Impl<DefaultCrea
 /// The outputs of all the sources have been sorted in the same way.
 ///
 /// The size of the output is determined both by `K_PROCESSING_WINDOW_SIZE`.
-/// TODO: Does not handle `visibility` for now.
 pub struct MergeSortExchangeExecutor2Impl<C> {
     server_addr: HostAddr,
     env: BatchEnvironment,


### PR DESCRIPTION
## What's changed and what's your intention?
visibility has been handled at https://github.com/singularity-data/risingwave/blob/lz/todo/src/batch/src/executor2/merge_sort_exchange.rs#L128.

Remove outdated TODO comments.