### PR TITLE
fix(frontend): fix panic on `LogicalHopWindow::prune_col`

### DIFF
--- a/src/frontend/src/optimizer/plan_node/logical_hop_window.rs
+++ b/src/frontend/src/optimizer/plan_node/logical_hop_window.rs
@@ -150,9 +150,12 @@ impl ColPrunable for LogicalHopWindow {
         self.must_contain_columns(required_cols);
         let require_win_start = required_cols.contains(self.window_start_col_idx());
         let require_win_end = required_cols.contains(self.window_end_col_idx());
-
         let o2i = self.o2i_col_mapping();
-        let input_required_cols = o2i.rewrite_bitset(required_cols);
+        let input_required_cols = {
+            let mut tmp = o2i.rewrite_bitset(required_cols);
+            tmp.put(self.time_col.index());
+            tmp
+        };
         let input = self.input.prune_col(&input_required_cols);
         let input_change = ColIndexMapping::with_remaining_columns(&input_required_cols);
         let (new_hop, _) = self.rewrite_with_input(input, input_change);


### PR DESCRIPTION
## What's changed and what's your intention?

When performing column pruning for `LogicalHopWindow`, `time_col` should be kept.

## Checklist

- [x] I have written the necessary docs and comments
- [x] I have added necessary unit tests and integration tests

## Refer to a related PR or issue link (optional)
fix #2320
