### PR TITLE
fix(cell_based_table): forbid unsorted column id

### DIFF
--- a/src/storage/src/lib.rs
+++ b/src/storage/src/lib.rs
@@ -34,6 +34,7 @@
 #![feature(let_chains)]
 #![feature(test)]
 #![feature(custom_test_frameworks)]
+#![feature(is_sorted)]
 #![test_runner(hummock::test_runner::run_failpont_tests)]
 
 pub mod cell_based_row_deserializer;

--- a/src/storage/src/table/cell_based_table.rs
+++ b/src/storage/src/table/cell_based_table.rs
@@ -87,13 +87,6 @@ impl<S: StateStore> CellBasedTable<S> {
         );
         let column_ids = generate_column_id(&column_descs);
 
-        assert!(
-            column_ids
-                .iter()
-                .is_sorted_by(|x, y| x.get_id().partial_cmp(&y.get_id())),
-            "cell based table currently only support sorted column id"
-        );
-
         Self {
             keyspace,
             schema,
@@ -240,6 +233,14 @@ impl<S: StateStore> CellBasedTable<S> {
                         .into_iter()
                         .map(|(k, v)| Ok::<_, StorageError>((generate_cell_id_from_pk(&k)?, k, v)))
                         .try_collect()?;
+
+                    debug_assert!(
+                        self.column_ids
+                            .iter()
+                            .is_sorted_by(|x, y| x.get_id().partial_cmp(&y.get_id())),
+                        "cell based table currently only support sorted column id"
+                    );
+
                     // TODO: support un-sorted cell id
                     let merged_iter = insert_bytes_iter
                         .into_iter()
@@ -322,6 +323,14 @@ impl<S: StateStore> CellBasedTable<S> {
                         .into_iter()
                         .map(|(k, v)| Ok::<_, StorageError>((generate_cell_id_from_pk(&k)?, k, v)))
                         .try_collect()?;
+
+                    debug_assert!(
+                        self.column_ids
+                            .iter()
+                            .is_sorted_by(|x, y| x.get_id().partial_cmp(&y.get_id())),
+                        "cell based table currently only support sorted column id"
+                    );
+
                     // TODO: support un-sorted cell id
                     let merged_iter = insert_bytes_iter
                         .into_iter()

--- a/src/stream/src/executor/mview/table_state_tests.rs
+++ b/src/stream/src/executor/mview/table_state_tests.rs
@@ -535,6 +535,7 @@ async fn test_get_row_for_string() {
 }
 
 #[tokio::test]
+#[ignore]
 async fn test_shuffled_column_id_for_get_row() {
     let state_store = MemoryStateStore::new();
     let column_ids = vec![ColumnId::from(3), ColumnId::from(2), ColumnId::from(1)];


### PR DESCRIPTION
Signed-off-by: Alex Chi <iskyzh@gmail.com>

## What's changed and what's your intention?

The current delete-insert logic only applies to sorted column ids. So we disabled one test case and forbidden this. cc @wcy-fdu may enable the shuffled column test case in the future. Also I found that shuffled column test case didn't cover the code path of first delete then insert (producing RowOp::Update). May test this in the future.

## Checklist

- [x] I have written necessary docs and comments
- [x] I have added necessary unit tests and integration tests

## Refer to a related PR or issue link (optional)
