### PR TITLE
feat(source): support recover state from SourceStateHandler

### DIFF
--- a/src/batch/src/executor2/delete.rs
+++ b/src/batch/src/executor2/delete.rs
@@ -217,10 +217,10 @@ mod tests {
         // Read
         let chunk = reader.next().await?;
 
-        assert_eq!(chunk.ops().to_vec(), vec![Op::Delete; 5]);
+        assert_eq!(chunk.chunk.ops().to_vec(), vec![Op::Delete; 5]);
 
         assert_eq!(
-            chunk.columns()[0]
+            chunk.chunk.columns()[0]
                 .array()
                 .as_int64()
                 .iter()
@@ -229,7 +229,7 @@ mod tests {
         );
 
         assert_eq!(
-            chunk.columns()[1]
+            chunk.chunk.columns()[1]
                 .array()
                 .as_int64()
                 .iter()

--- a/src/batch/src/executor2/insert.rs
+++ b/src/batch/src/executor2/insert.rs
@@ -259,7 +259,7 @@ mod tests {
         let chunk = reader.next().await?;
 
         assert_eq!(
-            chunk.columns()[0]
+            chunk.chunk.columns()[0]
                 .array()
                 .as_int64()
                 .iter()
@@ -268,7 +268,7 @@ mod tests {
         );
 
         assert_eq!(
-            chunk.columns()[1]
+            chunk.chunk.columns()[1]
                 .array()
                 .as_int64()
                 .iter()

--- a/src/connector/src/base.rs
+++ b/src/connector/src/base.rs
@@ -68,6 +68,9 @@ pub struct ConnectorState {
 
 impl ConnectorState {
     pub fn from_hashmap(state: HashMap<String, String>) -> Vec<Self> {
+        if state.is_empty() {
+            return vec![];
+        }
         let mut connector_states: Vec<Self> = Vec::with_capacity(state.len());
         for (split, offset) in state {
             connector_states.push(Self {

--- a/src/connector/src/base.rs
+++ b/src/connector/src/base.rs
@@ -12,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use std::collections::HashMap;
+
 use anyhow::{anyhow, Result};
 use async_trait::async_trait;
 use bytes::Bytes;
@@ -62,6 +64,20 @@ pub struct ConnectorState {
     pub identifier: Bytes,
     pub start_offset: String,
     pub end_offset: String,
+}
+
+impl ConnectorState {
+    pub fn from_hashmap(state: HashMap<String, String>) -> Vec<Self> {
+        let mut connector_states: Vec<Self> = Vec::with_capacity(state.len());
+        for (split, offset) in state {
+            connector_states.push(Self {
+                identifier: Bytes::from(split),
+                start_offset: offset.clone(),
+                end_offset: "".to_string(),
+            })
+        }
+        connector_states
+    }
 }
 
 impl From<SplitImpl> for ConnectorState {

--- a/src/connector/src/dummy_connector.rs
+++ b/src/connector/src/dummy_connector.rs
@@ -1,0 +1,25 @@
+use anyhow::Result;
+use async_trait::async_trait;
+
+use crate::{ConnectorStateV2, Properties, SourceMessage, SplitReader};
+
+/// [`DummySplitReader`] is a placeholder for source executor that is assigned no split. It will
+/// wait forever when calling `next`.
+#[derive(Clone, Debug)]
+pub struct DummySplitReader;
+
+#[async_trait]
+impl SplitReader for DummySplitReader {
+    async fn next(&mut self) -> Result<Option<Vec<SourceMessage>>> {
+        // the dead loop is intentional
+        #[allow(clippy::empty_loop)]
+        loop {}
+    }
+
+    async fn new(_properties: Properties, _state: ConnectorStateV2) -> Result<Self>
+    where
+        Self: Sized,
+    {
+        Ok(Self {})
+    }
+}

--- a/src/connector/src/dummy_connector.rs
+++ b/src/connector/src/dummy_connector.rs
@@ -1,4 +1,5 @@
 use anyhow::Result;
+use futures::future;
 use async_trait::async_trait;
 
 use crate::{ConnectorStateV2, Properties, SourceMessage, SplitReader};
@@ -11,9 +12,10 @@ pub struct DummySplitReader;
 #[async_trait]
 impl SplitReader for DummySplitReader {
     async fn next(&mut self) -> Result<Option<Vec<SourceMessage>>> {
-        // the dead loop is intentional
-        #[allow(clippy::empty_loop)]
-        loop {}
+        let pending = future::pending();
+        let () = pending.await;
+
+        unreachable!()
     }
 
     async fn new(_properties: Properties, _state: ConnectorStateV2) -> Result<Self>

--- a/src/connector/src/dummy_connector.rs
+++ b/src/connector/src/dummy_connector.rs
@@ -1,6 +1,6 @@
 use anyhow::Result;
-use futures::future;
 use async_trait::async_trait;
+use futures::future;
 
 use crate::{ConnectorStateV2, Properties, SourceMessage, SplitReader};
 

--- a/src/connector/src/lib.rs
+++ b/src/connector/src/lib.rs
@@ -36,4 +36,5 @@ mod pulsar;
 mod utils;
 pub use base::*;
 pub use utils::{AnyhowProperties, Properties};
+pub mod dummy_connector;
 pub mod state;

--- a/src/connector/src/state.rs
+++ b/src/connector/src/state.rs
@@ -24,7 +24,7 @@ use risingwave_storage::{Keyspace, StateStore};
 #[allow(unused_imports)]
 use serde::{Deserialize, Serialize};
 
-use crate::{ConnectorState, ConnectorStateV2, SplitImpl, SplitMetaData};
+use crate::{ConnectorState, SplitImpl, SplitMetaData};
 
 /// `SourceState` Represents an abstraction of state,
 /// e.g. if the Kafka Source state consists of `topic` `partition_id` and `offset`.

--- a/src/connector/src/state.rs
+++ b/src/connector/src/state.rs
@@ -17,17 +17,14 @@ use std::fmt::Debug;
 use anyhow::{anyhow, Result};
 use bytes::Bytes;
 use log::error;
+use risingwave_common::error::ErrorCode::InternalError;
+use risingwave_common::error::{Result as RwResult, RwError};
 use risingwave_storage::storage_value::StorageValue;
 use risingwave_storage::{Keyspace, StateStore};
 #[allow(unused_imports)]
 use serde::{Deserialize, Serialize};
 
-use crate::SplitMetaData;
-
-use risingwave_common::error::RwError;
-use risingwave_common::error::ErrorCode::InternalError;
-
-use crate::{ConnectorStateV2, SplitImpl, ConnectorState};
+use crate::{ConnectorState, ConnectorStateV2, SplitImpl, SplitMetaData};
 
 /// `SourceState` Represents an abstraction of state,
 /// e.g. if the Kafka Source state consists of `topic` `partition_id` and `offset`.
@@ -168,16 +165,40 @@ impl<S: StateStore> SourceStateHandler<S> {
         }
     }
 
-    pub async fn try_recover_from_state_store(&self, stream_source_splits: &[SplitImpl], epoch: u64) -> Result<ConnectorStateV2> {
-        if stream_source_splits.len() == 0 {
-            return Ok(ConnectorStateV2::None);
+    pub async fn try_recover_from_state_store(
+        &self,
+        stream_source_splits: &SplitImpl,
+        epoch: u64,
+    ) -> RwResult<ConnectorState> {
+        let mut state = self
+            .restore_states(stream_source_splits.id())
+            .await
+            .map_err(|e| RwError::from(InternalError(e.to_string())))?
+            .iter()
+            .filter(|(e, _)| e == &epoch)
+            .map(|(_, s)| {
+                ConnectorState::restore_from_bytes(s)
+                    .map_err(|e| RwError::from(InternalError(e.to_string())))
+            })
+            .collect::<RwResult<Vec<ConnectorState>>>()?;
+
+        assert!(state.len() <= 1);
+
+        if state.len() == 1 {
+            Ok(state.pop().unwrap())
+        } else if state.is_empty() {
+            Err(RwError::from(InternalError(format!(
+                "cannot found state for {:?}, epoch: {:?}",
+                stream_source_splits, epoch
+            ))))
+        } else {
+            Err(RwError::from(InternalError(format!(
+                "expected load one state from epoch {:?}, got {:?}: {:?}",
+                epoch,
+                state.len(),
+                state
+            ))))
         }
-        let state = self.restore_states(stream_source_splits[0].id()).await..map_err(|e| RwError::from(InternalError(e.to_string())))?
-        .iter().filter(|(e, _)| e == &epoch).map(|(_, s)| {
-            ConnectorState::restore_from_bytes(s)
-                .map_err(|e| RwError::from(InternalError(e.to_string())))
-        }).collect::<Result<Vec<ConnectorState>>>()?;
-        Ok()
     }
 }
 

--- a/src/source/src/connector_source.rs
+++ b/src/source/src/connector_source.rs
@@ -63,7 +63,7 @@ impl ConnectorSource {
     /// Create a new stream reader.
     pub async fn stream_reader(
         &self,
-        splits: Vec<SplitImpl>,
+        splits: ConnectorStateV2,
         column_ids: Vec<ColumnId>,
     ) -> Result<ConnectorStreamReader> {
         log::debug!(
@@ -72,12 +72,9 @@ impl ConnectorSource {
             splits
         );
 
-        let reader = SplitReaderImpl::create(
-            Properties::new(self.config.0.clone()),
-            ConnectorStateV2::Splits(splits),
-        )
-        .await
-        .to_rw_result()?;
+        let reader = SplitReaderImpl::create(Properties::new(self.config.0.clone()), splits)
+            .await
+            .to_rw_result()?;
 
         let columns = self.get_target_columns(column_ids)?;
 

--- a/src/source/src/connector_source.rs
+++ b/src/source/src/connector_source.rs
@@ -21,7 +21,7 @@ use risingwave_common::array::StreamChunk;
 use risingwave_common::catalog::ColumnId;
 use risingwave_common::error::ErrorCode::InternalError;
 use risingwave_common::error::{Result, RwError, ToRwResult};
-use risingwave_connector::{ConnectorStateV2, Properties, SplitImpl, SplitReaderImpl};
+use risingwave_connector::{ConnectorStateV2, Properties, SplitReaderImpl};
 
 use crate::common::SourceChunkBuilder;
 use crate::{SourceColumnDesc, SourceParserImpl, StreamChunkWithState, StreamSourceReader};
@@ -111,7 +111,7 @@ impl StreamSourceReader for ConnectorStreamReader {
                     if let Some(content) = msg.payload {
                         *split_offset_mapping
                             .entry(msg.split_id.clone())
-                            .or_insert("".to_string()) = msg.offset.to_string();
+                            .or_insert_with(|| "".to_string()) = msg.offset.to_string();
                         events.push(self.parser.parse(content.as_ref(), &self.columns)?);
                     }
                 }

--- a/src/source/src/connector_source.rs
+++ b/src/source/src/connector_source.rs
@@ -101,7 +101,7 @@ impl StreamSourceReader for ConnectorStreamReader {
         match self.reader.next().await.to_rw_result()? {
             None => Ok(StreamChunkWithState {
                 chunk: StreamChunk::default(),
-                split_offset_mapping: HashMap::new(),
+                split_offset_mapping: None,
             }),
             Some(batch) => {
                 let mut events = Vec::with_capacity(batch.len());
@@ -128,7 +128,7 @@ impl StreamSourceReader for ConnectorStreamReader {
                         Self::build_columns(&self.columns, rows.as_ref())?,
                         None,
                     ),
-                    split_offset_mapping,
+                    split_offset_mapping: Some(split_offset_mapping),
                 })
             }
         }

--- a/src/source/src/lib.rs
+++ b/src/source/src/lib.rs
@@ -85,7 +85,7 @@ impl StreamSourceReader for SourceStreamReaderImpl {
 
 /// [`StreamChunkWithState`] returns stream chunk together with offset for each split. In the
 /// current design, one connector source can have multiple split reader. The keys are unique
-/// split_ids and values are the latest offset for each split.
+/// `split_id` and values are the latest offset for each split.
 #[derive(Clone, Debug)]
 pub struct StreamChunkWithState {
     pub chunk: StreamChunk,

--- a/src/source/src/lib.rs
+++ b/src/source/src/lib.rs
@@ -89,7 +89,7 @@ impl StreamSourceReader for SourceStreamReaderImpl {
 #[derive(Clone, Debug)]
 pub struct StreamChunkWithState {
     pub chunk: StreamChunk,
-    pub split_offset_mapping: HashMap<String, String>,
+    pub split_offset_mapping: Option<HashMap<String, String>>,
 }
 
 #[async_trait]

--- a/src/source/src/table_v2.rs
+++ b/src/source/src/table_v2.rs
@@ -12,7 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use std::collections::HashMap;
 use std::sync::atomic::{AtomicUsize, Ordering};
 use std::sync::RwLock;
 
@@ -148,7 +147,7 @@ impl StreamSourceReader for TableV2StreamReader {
 
         Ok(StreamChunkWithState {
             chunk,
-            split_offset_mapping: HashMap::new(),
+            split_offset_mapping: None,
         })
     }
 }

--- a/src/stream/src/executor_v2/source.rs
+++ b/src/stream/src/executor_v2/source.rs
@@ -313,7 +313,7 @@ impl<S: StateStore> SourceExecutor<S> {
                     let chunk_with_state =
                         chunk_with_state.map_err(StreamExecutorError::source_error)?;
                     self.state_cache = Some(ConnectorState::from_hashmap(
-                        chunk_with_state.split_offset_mapping,
+                        chunk_with_state.split_offset_mapping.unwrap(),
                     ));
                     let mut chunk = chunk_with_state.chunk;
 


### PR DESCRIPTION
## What's changed and what's your intention?

***PLEASE DO NOT LEAVE THIS EMPTY !!!***

Please explain **IN DETAIL** what the changes are in this PR and why they are needed:

introduce SourceStateHandler for source executor. 

* introduce `DummyConnector`, it will serve as an idle connector for the executor which is assigned no split.  
* in the current design, one connector source should handle multiple splits but it is not implemented yet. It will check `SourceExecutor.stream_source_splits` can have at most 1 element. 

---

- Summarize your change (**mandatory**)
- How does this PR work? Need a brief introduction for the changed logic (optional)
- Describe clearly one logical change and avoid lazy messages (optional)
- Describe any limitations of the current code (optional)

## Checklist

- [x] I have written necessary docs and comments
- [x] I have added necessary unit tests and integration tests

## Refer to a related PR or issue link (optional)

this pr is based on #2257  so merge this before that. 
