### PR TITLE
fix: fix failpoint tests and add to CI

### DIFF
--- a/.github/workflow-template/jobs/compute-node-test.yml
+++ b/.github/workflow-template/jobs/compute-node-test.yml
@@ -47,6 +47,10 @@ jobs:
         run: |
           cargo doc --document-private-items --no-deps
 
+      - name: Run rust failpoints test
+        run: |
+          cargo nextest run failpoints  --features failpoints --no-fail-fast
+      
       - name: Run rust test with coverage
         run: |
           cargo llvm-cov nextest --lcov --output-path lcov.info -- --no-fail-fast

--- a/.github/workflow-template/jobs/compute-node-test.yml
+++ b/.github/workflow-template/jobs/compute-node-test.yml
@@ -41,7 +41,7 @@ jobs:
       - name: Run rust clippy check
         run: |
           # If new CI checks are added, the one with `--locked` must be run first.
-          cargo clippy --all-targets --locked -- -D warnings
+          cargo clippy --all-targets --all-features --locked -- -D warnings
 
       - name: Run rust doc check
         run: |

--- a/.github/workflows/main-cron.yml
+++ b/.github/workflows/main-cron.yml
@@ -506,6 +506,9 @@ jobs:
       - name: Run rust doc check
         run: |
           cargo doc --document-private-items --no-deps
+      - name: Run rust failpoints test
+        run: |
+          cargo nextest run failpoints  --features failpoints --no-fail-fast
       - name: Run rust test with coverage
         run: |
           cargo llvm-cov nextest --lcov --output-path lcov.info -- --no-fail-fast

--- a/.github/workflows/main-cron.yml
+++ b/.github/workflows/main-cron.yml
@@ -502,7 +502,7 @@ jobs:
       - name: Run rust clippy check
         run: |
           # If new CI checks are added, the one with `--locked` must be run first.
-          cargo clippy --all-targets --locked -- -D warnings
+          cargo clippy --all-targets --all-features --locked -- -D warnings
       - name: Run rust doc check
         run: |
           cargo doc --document-private-items --no-deps

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -745,6 +745,9 @@ jobs:
       - name: Run rust doc check
         run: |
           cargo doc --document-private-items --no-deps
+      - name: Run rust failpoints test
+        run: |
+          cargo nextest run failpoints  --features failpoints --no-fail-fast
       - name: Run rust test with coverage
         run: |
           cargo llvm-cov nextest --lcov --output-path lcov.info -- --no-fail-fast

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -741,7 +741,7 @@ jobs:
       - name: Run rust clippy check
         run: |
           # If new CI checks are added, the one with `--locked` must be run first.
-          cargo clippy --all-targets --locked -- -D warnings
+          cargo clippy --all-targets --all-features --locked -- -D warnings
       - name: Run rust doc check
         run: |
           cargo doc --document-private-items --no-deps

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -509,6 +509,9 @@ jobs:
       - name: Run rust doc check
         run: |
           cargo doc --document-private-items --no-deps
+      - name: Run rust failpoints test
+        run: |
+          cargo nextest run failpoints  --features failpoints --no-fail-fast
       - name: Run rust test with coverage
         run: |
           cargo llvm-cov nextest --lcov --output-path lcov.info -- --no-fail-fast

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -505,7 +505,7 @@ jobs:
       - name: Run rust clippy check
         run: |
           # If new CI checks are added, the one with `--locked` must be run first.
-          cargo clippy --all-targets --locked -- -D warnings
+          cargo clippy --all-targets --all-features --locked -- -D warnings
       - name: Run rust doc check
         run: |
           cargo doc --document-private-items --no-deps

--- a/src/storage/src/hummock/block_cache.rs
+++ b/src/storage/src/hummock/block_cache.rs
@@ -128,4 +128,9 @@ impl BlockCache {
         block_idx.hash(&mut hasher);
         hasher.finish()
     }
+
+    #[cfg(test)]
+    pub fn clear(&self) {
+        self.inner.clear();
+    }
 }

--- a/src/storage/src/hummock/cache.rs
+++ b/src/storage/src/hummock/cache.rs
@@ -918,6 +918,8 @@ mod tests {
             assert_eq!((*old_entry).refs, 1);
 
             cache.release(new_entry);
+            assert!((*new_entry).is_in_cache());
+            assert!((*new_entry).is_in_lru());
 
             // assert old value unchanged.
             assert!(!old_entry.is_null());
@@ -925,6 +927,10 @@ mod tests {
             assert_eq!((*old_entry).refs, 1);
 
             cache.release(old_entry);
+            assert!(!(*old_entry).is_in_cache());
+            assert!(!(*old_entry).is_in_lru());
+            assert!((*new_entry).is_in_cache());
+            assert!((*new_entry).is_in_lru());
         }
     }
 

--- a/src/storage/src/hummock/sstable_store.rs
+++ b/src/storage/src/hummock/sstable_store.rs
@@ -196,6 +196,11 @@ impl SstableStore {
     pub fn store(&self) -> ObjectStoreRef {
         self.store.clone()
     }
+
+    #[cfg(test)]
+    pub fn clear_block_cache(&self) {
+        self.block_cache.clear();
+    }
 }
 
 pub type SstableStoreRef = Arc<SstableStore>;

--- a/src/storage/src/storage_failpoints/test_iterator.rs
+++ b/src/storage/src/storage_failpoints/test_iterator.rs
@@ -15,6 +15,7 @@
 use std::ops::Bound::Unbounded;
 use std::sync::Arc;
 
+use futures::executor::block_on;
 use risingwave_hummock_sdk::key::user_key;
 
 use crate::hummock::iterator::test_utils::{
@@ -160,13 +161,12 @@ async fn test_failpoint_merge_invalid_key() {
     )
     .await;
     let tables = vec![table0, table1];
-    let cache = create_small_table_cache();
     let mut mi = MergeIterator::new(
         tables
             .iter()
             .map(|table| -> Box<dyn HummockIterator<Direction = Forward>> {
                 Box::new(SSTableIterator::new(
-                    cache.insert(table.id, table.id, 1, Box::new(table.clone())),
+                    block_on(sstable_store.sstable(table.id)).unwrap(),
                     sstable_store.clone(),
                 ))
             }),
@@ -208,13 +208,12 @@ async fn test_failpoint_backward_merge_invalid_key() {
     )
     .await;
     let tables = vec![table0, table1];
-    let cache = create_small_table_cache();
     let mut mi = BackwardMergeIterator::new(
         tables
             .iter()
             .map(|table| -> Box<dyn HummockIterator<Direction = Backward>> {
                 Box::new(BackwardSSTableIterator::new(
-                    cache.insert(table.id, table.id, 1, Box::new(table.clone())),
+                    block_on(sstable_store.sstable(table.id)).unwrap(),
                     sstable_store.clone(),
                 ))
             }),
@@ -255,14 +254,13 @@ async fn test_failpoint_user_read_err() {
         200,
     )
     .await;
-    let cache = create_small_table_cache();
     let iters: Vec<BoxedForwardHummockIterator> = vec![
         Box::new(SSTableIterator::new(
-            cache.insert(table0.id, table0.id, 1, Box::new(table0.clone())),
+            block_on(sstable_store.sstable(table0.id)).unwrap(),
             sstable_store.clone(),
         )),
         Box::new(SSTableIterator::new(
-            cache.insert(table1.id, table1.id, 1, Box::new(table1.clone())),
+            block_on(sstable_store.sstable(table1.id)).unwrap(),
             sstable_store.clone(),
         )),
     ];
@@ -315,11 +313,11 @@ async fn test_failpoint_backward_user_read_err() {
     let cache = create_small_table_cache();
     let iters: Vec<BoxedBackwardHummockIterator> = vec![
         Box::new(BackwardSSTableIterator::new(
-            cache.insert(table0.id, table0.id, 1, Box::new(table0.clone())),
+            block_on(sstable_store.sstable(table0.id)).unwrap(),
             sstable_store.clone(),
         )),
         Box::new(BackwardSSTableIterator::new(
-            cache.insert(table1.id, table1.id, 1, Box::new(table1.clone())),
+            block_on(sstable_store.sstable(table1.id)).unwrap(),
             sstable_store.clone(),
         )),
     ];

--- a/src/storage/src/storage_failpoints/test_iterator.rs
+++ b/src/storage/src/storage_failpoints/test_iterator.rs
@@ -27,7 +27,7 @@ use crate::hummock::iterator::{
     BoxedBackwardHummockIterator, BoxedForwardHummockIterator, ConcatIterator, Forward,
     HummockIterator, MergeIterator, UserIterator,
 };
-use crate::hummock::test_utils::{create_small_table_cache, default_builder_opt_for_test};
+use crate::hummock::test_utils::default_builder_opt_for_test;
 use crate::hummock::{BackwardSSTableIterator, SSTableIterator};
 use crate::monitor::StateStoreMetrics;
 
@@ -310,7 +310,6 @@ async fn test_failpoint_backward_user_read_err() {
         200,
     )
     .await;
-    let cache = create_small_table_cache();
     let iters: Vec<BoxedBackwardHummockIterator> = vec![
         Box::new(BackwardSSTableIterator::new(
             block_on(sstable_store.sstable(table0.id)).unwrap(),

--- a/src/storage/src/storage_failpoints/test_sstable.rs
+++ b/src/storage/src/storage_failpoints/test_sstable.rs
@@ -12,16 +12,14 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use std::sync::Arc;
-
 use risingwave_hummock_sdk::key::key_with_epoch;
 
 use crate::assert_bytes_eq;
 use crate::hummock::iterator::test_utils::mock_sstable_store;
 use crate::hummock::iterator::HummockIterator;
 use crate::hummock::test_utils::{
-    default_builder_opt_for_test, gen_test_sstable_data, test_key_of, test_value_of,
-    TEST_KEYS_COUNT,
+    create_small_table_cache, default_builder_opt_for_test, gen_test_sstable_data, test_key_of,
+    test_value_of, TEST_KEYS_COUNT,
 };
 use crate::hummock::value::HummockValue;
 use crate::hummock::{CachePolicy, SSTableIterator, Sstable};
@@ -36,14 +34,18 @@ async fn test_failpoint_table_read() {
     // We should close buffer, so that table iterator must read in object_stores
     let kv_iter =
         (0..TEST_KEYS_COUNT).map(|i| (test_key_of(i), HummockValue::put(test_value_of(i))));
-    let (data, meta) = gen_test_sstable_data(default_builder_opt_for_test(), kv_iter);
+    let (data, meta, _) = gen_test_sstable_data(default_builder_opt_for_test(), kv_iter);
     let table = Sstable { id: 0, meta };
     sstable_store
         .put(&table, data, CachePolicy::NotFill)
         .await
         .unwrap();
 
-    let mut sstable_iter = SSTableIterator::new(Arc::new(table), sstable_store);
+    let cache = create_small_table_cache();
+    let mut sstable_iter = SSTableIterator::new(
+        cache.insert(table.id, table.id, 1, Box::new(table.clone())),
+        sstable_store,
+    );
     sstable_iter.rewind().await.unwrap();
 
     sstable_iter.seek(&test_key_of(500)).await.unwrap();
@@ -80,7 +82,7 @@ async fn test_failpoint_vacuum_and_metadata() {
 
     let kv_iter =
         (0..TEST_KEYS_COUNT).map(|i| (test_key_of(i), HummockValue::put(test_value_of(i))));
-    let (data, meta) = gen_test_sstable_data(default_builder_opt_for_test(), kv_iter);
+    let (data, meta, _) = gen_test_sstable_data(default_builder_opt_for_test(), kv_iter);
     let table = Sstable { id: 0, meta };
     let result = sstable_store
         .put(&table, data.clone(), CachePolicy::NotFill)
@@ -96,7 +98,11 @@ async fn test_failpoint_vacuum_and_metadata() {
         .await
         .unwrap();
 
-    let mut sstable_iter = SSTableIterator::new(Arc::new(table), sstable_store);
+    let cache = create_small_table_cache();
+    let mut sstable_iter = SSTableIterator::new(
+        cache.insert(table.id, table.id, 1, Box::new(table.clone())),
+        sstable_store,
+    );
     let mut cnt = 0;
     sstable_iter.rewind().await.unwrap();
     while sstable_iter.is_valid() {

--- a/src/storage/src/storage_failpoints/test_sstable.rs
+++ b/src/storage/src/storage_failpoints/test_sstable.rs
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use futures::executor::block_on;
 use risingwave_hummock_sdk::key::key_with_epoch;
 
 use crate::assert_bytes_eq;
@@ -43,7 +44,7 @@ async fn test_failpoint_table_read() {
 
     let cache = create_small_table_cache();
     let mut sstable_iter = SSTableIterator::new(
-        cache.insert(table.id, table.id, 1, Box::new(table.clone())),
+        block_on(sstable_store.sstable(table.id)).unwrap(),
         sstable_store,
     );
     sstable_iter.rewind().await.unwrap();
@@ -73,6 +74,7 @@ async fn test_failpoint_vacuum_and_metadata() {
     let mem_delete_err = "mem_delete_err";
     let sstable_store = mock_sstable_store();
     // when upload data is successful, but upload meta is fail and delete is fail
+
     fail::cfg_callback(metadata_upload_err, move || {
         fail::cfg(mem_upload_err, "return").unwrap();
         fail::cfg(mem_delete_err, "return").unwrap();
@@ -100,7 +102,7 @@ async fn test_failpoint_vacuum_and_metadata() {
 
     let cache = create_small_table_cache();
     let mut sstable_iter = SSTableIterator::new(
-        cache.insert(table.id, table.id, 1, Box::new(table.clone())),
+        block_on(sstable_store.sstable(table.id)).unwrap(),
         sstable_store,
     );
     let mut cnt = 0;

--- a/src/storage/src/storage_failpoints/test_sstable.rs
+++ b/src/storage/src/storage_failpoints/test_sstable.rs
@@ -19,8 +19,8 @@ use crate::assert_bytes_eq;
 use crate::hummock::iterator::test_utils::mock_sstable_store;
 use crate::hummock::iterator::HummockIterator;
 use crate::hummock::test_utils::{
-    create_small_table_cache, default_builder_opt_for_test, gen_test_sstable_data, test_key_of,
-    test_value_of, TEST_KEYS_COUNT,
+    default_builder_opt_for_test, gen_test_sstable_data, test_key_of, test_value_of,
+    TEST_KEYS_COUNT,
 };
 use crate::hummock::value::HummockValue;
 use crate::hummock::{CachePolicy, SSTableIterator, Sstable};
@@ -42,7 +42,6 @@ async fn test_failpoint_table_read() {
         .await
         .unwrap();
 
-    let cache = create_small_table_cache();
     let mut sstable_iter = SSTableIterator::new(
         block_on(sstable_store.sstable(table.id)).unwrap(),
         sstable_store,
@@ -100,7 +99,6 @@ async fn test_failpoint_vacuum_and_metadata() {
         .await
         .unwrap();
 
-    let cache = create_small_table_cache();
     let mut sstable_iter = SSTableIterator::new(
         block_on(sstable_store.sstable(table.id)).unwrap(),
         sstable_store,


### PR DESCRIPTION
This PR fixes the failure injection tests introduced in #1564 and modifies the CI workflow to run failiure injection tests.

## Refer to a related PR or issue link (optional)
#1221
