### PR TITLE
fix(dashboard-v2): failed to render because API is changed

### DIFF
--- a/dashboard/components/StreamingView.js
+++ b/dashboard/components/StreamingView.js
@@ -57,7 +57,6 @@ const PopupBox = styled("div")({
   alignItems: "center",
   backgroundColor: "white",
   borderRadius: "20px",
-  boxShadow: "14px 14px 28px #e6e6e6, -14px -14px 28px #ffffff"
 });
 
 const PopupBoxHeader = styled("div")({

--- a/dashboard/lib/graaphEngine/canvasEngine.js
+++ b/dashboard/lib/graaphEngine/canvasEngine.js
@@ -136,7 +136,7 @@ export class Group extends DrawElement {
   _appendText = () => {
     return (content) => new Text({
       ...this.basicSetting, ...{
-        canvasElement: new fabric.Text(content, { selectable: false, textAlign: "justify-center" })
+        canvasElement: new fabric.Text(content || "undefined", { selectable: false, textAlign: "justify-center" })
       }
     });
   }

--- a/dashboard/lib/streamPlan/parser.js
+++ b/dashboard/lib/streamPlan/parser.js
@@ -227,7 +227,7 @@ export default class StreamPlanParser {
       }
       mvTableIdToChainViewActorList.set(mviewNode.typeInfo.tableRefId.tableId, [...list.values()]);
     }
-    
+
     return mvTableIdToChainViewActorList;
   }
 
@@ -302,18 +302,18 @@ export default class StreamPlanParser {
     let rootNode;
     this.parsedActorMap.set(actorId, actor);
     if (actorProto.dispatcher && actorProto.dispatcher[0].type) {
-      let nodeBeforeDispatcher = this.parseNode(actor.actorId, actorProto.nodes, "2");
+      let nodeBeforeDispatcher = this.parseNode(actor.actorId, actorProto.nodes);
       rootNode = this.newDispatcher(actor.actorId, actorProto.dispatcher[0].type, actorProto.downstreamActorId);
       rootNode.nextNodes = [nodeBeforeDispatcher];
     } else {
-      rootNode = this.parseNode(actorId, actorProto.nodes, "1");
+      rootNode = this.parseNode(actorId, actorProto.nodes);
     }
     actor.rootNode = rootNode;
 
     return actor;
   }
 
-  parseNode(actorId, nodeProto, n) {
+  parseNode(actorId, nodeProto) {
     let id = getNodeId(nodeProto, actorId);
     if (this.parsedNodeMap.has(id)) {
       return this.parsedNodeMap.get(id);
@@ -323,7 +323,7 @@ export default class StreamPlanParser {
 
     if (nodeProto.input !== undefined) {
       for (let nextNodeProto of nodeProto.input) {
-        newNode.nextNodes.push(this.parseNode(actorId, nextNodeProto, "3"));
+        newNode.nextNodes.push(this.parseNode(actorId, nextNodeProto));
       }
     }
 

--- a/dashboard/lib/streamPlan/parser.js
+++ b/dashboard/lib/streamPlan/parser.js
@@ -22,8 +22,8 @@ function generateNewNodeId() {
   return "g" + (++cnt);
 }
 
-function getNodeId(nodeProto) {
-  return nodeProto.operatorId === undefined ? generateNewNodeId() : "o" + nodeProto.operatorId;
+function getNodeId(nodeProto, actorId) {
+  return actorId + ":" + (nodeProto.operatorId === undefined ? generateNewNodeId() : "o" + nodeProto.operatorId);
 }
 
 class Node {
@@ -55,9 +55,9 @@ class StreamNode extends Node {
   }
 
   parseType(nodeProto) {
-    let typeReg = new RegExp('.+Node');
+    let types = new Set(["source", "project", "filter", "materialize", "localSimpleAgg", "globalSimpleAgg", "hashAgg", "appendOnlyTopN", "hashJoin", "topN", "hopWindow", "merge", "exchange", "chain", "batchPlan", "lookup", "arrange", "lookupUnion", "union", "deltaIndexJoin"]);
     for (let [type, _] of Object.entries(nodeProto)) {
-      if (typeReg.test(type)) {
+      if (types.has(type)) {
         return type;
       }
     }
@@ -144,15 +144,27 @@ export default class StreamPlanParser {
       this.parsedActorList.push(actor);
     }
 
+    /** @type {Set<Actor>} */
     this.fragmentRepresentedActors = this._constructRepresentedActorList();
 
-    /**
-     * @type {Map<number, Array<number>}
-     */
+    /** @type {Map<number, Array<number>} */
     this.mvTableIdToSingleViewActorList = this._constructSingleViewMvList();
+    
+     /** @type {Map<number, Array<number>} */
     this.mvTableIdToChainViewActorList = this._constructChainViewMvList()
   }
-
+  
+  /**
+   * Randomly select a actor to represent its
+   * fragment, and append a property named `representedActorList`
+   * to store all the other actors in the same fragement.
+   * 
+   * Actors are degree of parallelism of a fragment, such that one of 
+   * the actor in a fragement can represent all the other actor in
+   * the same fragment. 
+   * 
+   * @returns A Set containing actors representing its fragment.
+   */
   _constructRepresentedActorList() {
     const fragmentId2actorList = new Map();
     let fragmentRepresentedActors = new Set();
@@ -164,10 +176,12 @@ export default class StreamPlanParser {
         fragmentId2actorList.get(actor.fragmentId).push(actor);
       }
     }
+
     for (let actor of fragmentRepresentedActors) {
-      actor.representedActorList = cloneDeep(fragmentId2actorList.get(actor.fragmentId)).sort(x => x.actorId);
+      actor.representedActorList = fragmentId2actorList.get(actor.fragmentId).sort(x => x.actorId);
       actor.representedWorkNodes = new Set();
       for (let representedActor of actor.representedActorList) {
+        representedActor.representedActorList = actor.representedActorList;
         actor.representedWorkNodes.add(representedActor.computeNodeAddress);
       }
     }
@@ -213,7 +227,7 @@ export default class StreamPlanParser {
       }
       mvTableIdToChainViewActorList.set(mviewNode.typeInfo.tableRefId.tableId, [...list.values()]);
     }
-
+    
     return mvTableIdToChainViewActorList;
   }
 
@@ -288,19 +302,19 @@ export default class StreamPlanParser {
     let rootNode;
     this.parsedActorMap.set(actorId, actor);
     if (actorProto.dispatcher && actorProto.dispatcher[0].type) {
-      let nodeBeforeDispatcher = this.parseNode(actor.actorId, actorProto.nodes);
+      let nodeBeforeDispatcher = this.parseNode(actor.actorId, actorProto.nodes, "2");
       rootNode = this.newDispatcher(actor.actorId, actorProto.dispatcher[0].type, actorProto.downstreamActorId);
       rootNode.nextNodes = [nodeBeforeDispatcher];
     } else {
-      rootNode = this.parseNode(actorId, actorProto.nodes);
+      rootNode = this.parseNode(actorId, actorProto.nodes, "1");
     }
     actor.rootNode = rootNode;
 
     return actor;
   }
 
-  parseNode(actorId, nodeProto) {
-    let id = getNodeId(nodeProto);
+  parseNode(actorId, nodeProto, n) {
+    let id = getNodeId(nodeProto, actorId);
     if (this.parsedNodeMap.has(id)) {
       return this.parsedNodeMap.get(id);
     }
@@ -309,11 +323,11 @@ export default class StreamPlanParser {
 
     if (nodeProto.input !== undefined) {
       for (let nextNodeProto of nodeProto.input) {
-        newNode.nextNodes.push(this.parseNode(actorId, nextNodeProto));
+        newNode.nextNodes.push(this.parseNode(actorId, nextNodeProto, "3"));
       }
     }
 
-    if (newNode.type === "mergeNode" && newNode.typeInfo.upstreamActorId) {
+    if (newNode.type === "merge" && newNode.typeInfo.upstreamActorId) {
       for (let upStreamActorId of newNode.typeInfo.upstreamActorId) {
         if (!this.actorId2Proto.has(upStreamActorId)) {
           continue;
@@ -322,7 +336,7 @@ export default class StreamPlanParser {
       }
     }
 
-    if (newNode.type === "chainNode" && newNode.typeInfo.upstreamActorIds) {
+    if (newNode.type === "chain" && newNode.typeInfo.upstreamActorIds) {
       for (let upStreamActorId of newNode.typeInfo.upstreamActorIds) {
         if (!this.actorId2Proto.has(upStreamActorId)) {
           continue;
@@ -331,7 +345,7 @@ export default class StreamPlanParser {
       }
     }
     
-    if (newNode.type === "materializeNode") {
+    if (newNode.type === "materialize") {
       this.actorIdTomviewNodes.set(actorId, newNode);
     }
 

--- a/dashboard/lib/streamPlan/streamChartHelper.js
+++ b/dashboard/lib/streamPlan/streamChartHelper.js
@@ -802,9 +802,10 @@ export class StreamChartHelper {
     }
     for (let actor of fragmentRepresentedActors) {
       for (let outputActorNode of actor.output) {
-        dagNodeMap.get(actor.actorId).nextNodes.push(
-          dagNodeMap.get(outputActorNode.actorId)
-        )
+        let outputDagNode = dagNodeMap.get(outputActorNode.actorId);
+        if(outputDagNode){ // the output actor node is in a represented actor
+          dagNodeMap.get(actor.actorId).nextNodes.push(outputDagNode)
+        }
       }
     }
     let actorDagNodes = [];


### PR DESCRIPTION
## What's changed and what's your intention?

Fixed parser for two changes in the meta-node API: 1) operatorId is not unique now 2) some properties in operators are renamed (#2255)

This PR just roughly fixed #2359. I will figure out a better solution. (For example, use data definitions in `proto`)

## Checklist

- [x] I have written necessary docs and comments
- [x] I have added necessary unit tests and integration tests

