### PR TITLE
feat(bitmap): remove old bitmap in sstablemeta

### DIFF
--- a/src/storage/src/hummock/sstable/mod.rs
+++ b/src/storage/src/hummock/sstable/mod.rs
@@ -133,7 +133,6 @@ impl BlockMeta {
 pub struct SstableMeta {
     pub block_metas: Vec<BlockMeta>,
     pub bloom_filter: Vec<u8>,
-    pub bitmap: Vec<u8>,
     pub estimated_size: u32,
     pub key_count: u32,
     pub smallest_key: Vec<u8>,
@@ -149,7 +148,6 @@ impl SstableMeta {
     /// | N (4B) |
     /// | block meta 0 | ... | block meta N-1 |
     /// | bloom filter len (4B) | bloom filter |
-    /// | bitmap len (4B) | bitmap |
     /// | estimated size (4B) | key count (4B) |
     /// | smallest key len (4B) | smallest key |
     /// | largest key len (4B) | largest key |
@@ -162,7 +160,6 @@ impl SstableMeta {
             block_meta.encode(&mut buf);
         }
         put_length_prefixed_slice(&mut buf, &self.bloom_filter);
-        put_length_prefixed_slice(&mut buf, &self.bitmap);
         buf.put_u32_le(self.estimated_size as u32);
         buf.put_u32_le(self.key_count as u32);
         put_length_prefixed_slice(&mut buf, &self.smallest_key);
@@ -200,7 +197,6 @@ impl SstableMeta {
             block_metas.push(BlockMeta::decode(buf));
         }
         let bloom_filter = get_length_prefixed_slice(buf);
-        let bitmap = get_length_prefixed_slice(buf);
         let estimated_size = buf.get_u32_le();
         let key_count = buf.get_u32_le();
         let smallest_key = get_length_prefixed_slice(buf);
@@ -209,7 +205,6 @@ impl SstableMeta {
         Ok(Self {
             block_metas,
             bloom_filter,
-            bitmap,
             estimated_size,
             key_count,
             smallest_key,
@@ -228,8 +223,6 @@ impl SstableMeta {
             .sum::<usize>()
             + 4 // bloom filter len
             + self.bloom_filter.len()
-            + 4 // bitmap len
-            + self.bitmap.len()
             + 4 // estimated size
             + 4 // key count
             + 4 // key len
@@ -262,7 +255,6 @@ mod tests {
                 },
             ],
             bloom_filter: b"0123456789".to_vec(),
-            bitmap: b"".to_vec(),
             estimated_size: 123,
             key_count: 123,
             smallest_key: b"0-smallest-key".to_vec(),


### PR DESCRIPTION
## What's changed and what's your intention?

since we have bitmap in object store now, we need to remove old bitmap in sstablemeta

## Checklist

## Refer to a related PR or issue link (optional)
