### PR TITLE
chore: increase e2e timeout before fine tune hummock compaction

### DIFF
--- a/.github/workflow-template/jobs/e2e-risedev.yml
+++ b/.github/workflow-template/jobs/e2e-risedev.yml
@@ -107,7 +107,7 @@ jobs:
         run: ~/cargo-make/makers ci-kill
 
       - name: e2e, ci-3cn-1fe, delta join
-        timeout-minutes: 2
+        timeout-minutes: 3
         run: |
           ~/cargo-make/makers ci-start ci-3cn-1fe
           sqllogictest -p 4566 './e2e_test/v2/streaming_delta_join/**/*.slt'
@@ -116,7 +116,7 @@ jobs:
         run: ~/cargo-make/makers ci-kill
 
       - name: e2e, ci-3cn-1fe, batch distributed
-        timeout-minutes: 2
+        timeout-minutes: 3
         run: |
           ~/cargo-make/makers ci-start ci-3cn-1fe
           sqllogictest -p 4566 './e2e_test/v2/ddl/**/*.slt'
@@ -126,7 +126,7 @@ jobs:
         run: ~/cargo-make/makers ci-kill
 
       - name: e2e test streaming 3-node (legacy frontend)
-        timeout-minutes: 4
+        timeout-minutes: 5
         run: |
           ~/cargo-make/makers ci-start ci-3node
           sqllogictest -p 4567 -d dev './e2e_test/streaming/**/*.slt'
@@ -135,7 +135,7 @@ jobs:
         run: ~/cargo-make/makers ci-kill
 
       - name: e2e test batch 3-node (legacy frontend)
-        timeout-minutes: 2
+        timeout-minutes: 3
         run: |
           RW_IMPLICIT_FLUSH=1 ~/cargo-make/makers ci-start ci-3node
           sqllogictest -p 4567 -d dev --engine risingwave './e2e_test/batch/**/*.slt'

--- a/.github/workflow-template/jobs/e2e-risedev.yml
+++ b/.github/workflow-template/jobs/e2e-risedev.yml
@@ -98,7 +98,7 @@ jobs:
       # if the degradation is reasonable or to be fixed soon.
 
       - name: e2e, ci-3cn-1fe, streaming
-        timeout-minutes: 3
+        timeout-minutes: 4
         run: |
           ~/cargo-make/makers ci-start ci-3cn-1fe
           sqllogictest -p 4566 './e2e_test/v2/streaming/**/*.slt'

--- a/.github/workflows/main-cron.yml
+++ b/.github/workflows/main-cron.yml
@@ -231,14 +231,14 @@ jobs:
       - name: Kill cluster
         run: ~/cargo-make/makers ci-kill
       - name: e2e, ci-3cn-1fe, delta join
-        timeout-minutes: 2
+        timeout-minutes: 3
         run: |
           ~/cargo-make/makers ci-start ci-3cn-1fe
           sqllogictest -p 4566 './e2e_test/v2/streaming_delta_join/**/*.slt'
       - name: Kill cluster
         run: ~/cargo-make/makers ci-kill
       - name: e2e, ci-3cn-1fe, batch distributed
-        timeout-minutes: 2
+        timeout-minutes: 3
         run: |
           ~/cargo-make/makers ci-start ci-3cn-1fe
           sqllogictest -p 4566 './e2e_test/v2/ddl/**/*.slt'
@@ -246,14 +246,14 @@ jobs:
       - name: Kill cluster
         run: ~/cargo-make/makers ci-kill
       - name: e2e test streaming 3-node (legacy frontend)
-        timeout-minutes: 4
+        timeout-minutes: 5
         run: |
           ~/cargo-make/makers ci-start ci-3node
           sqllogictest -p 4567 -d dev './e2e_test/streaming/**/*.slt'
       - name: Kill cluster
         run: ~/cargo-make/makers ci-kill
       - name: e2e test batch 3-node (legacy frontend)
-        timeout-minutes: 2
+        timeout-minutes: 3
         run: |
           RW_IMPLICIT_FLUSH=1 ~/cargo-make/makers ci-start ci-3node
           sqllogictest -p 4567 -d dev --engine risingwave './e2e_test/batch/**/*.slt'

--- a/.github/workflows/main-cron.yml
+++ b/.github/workflows/main-cron.yml
@@ -224,7 +224,7 @@ jobs:
           ~/cargo-make/makers pre-start-playground
           ~/cargo-make/makers link-all-in-one-binaries
       - name: e2e, ci-3cn-1fe, streaming
-        timeout-minutes: 3
+        timeout-minutes: 4
         run: |
           ~/cargo-make/makers ci-start ci-3cn-1fe
           sqllogictest -p 4566 './e2e_test/v2/streaming/**/*.slt'

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -279,14 +279,14 @@ jobs:
       - name: Kill cluster
         run: ~/cargo-make/makers ci-kill
       - name: e2e, ci-3cn-1fe, delta join
-        timeout-minutes: 2
+        timeout-minutes: 3
         run: |
           ~/cargo-make/makers ci-start ci-3cn-1fe
           sqllogictest -p 4566 './e2e_test/v2/streaming_delta_join/**/*.slt'
       - name: Kill cluster
         run: ~/cargo-make/makers ci-kill
       - name: e2e, ci-3cn-1fe, batch distributed
-        timeout-minutes: 2
+        timeout-minutes: 3
         run: |
           ~/cargo-make/makers ci-start ci-3cn-1fe
           sqllogictest -p 4566 './e2e_test/v2/ddl/**/*.slt'
@@ -294,14 +294,14 @@ jobs:
       - name: Kill cluster
         run: ~/cargo-make/makers ci-kill
       - name: e2e test streaming 3-node (legacy frontend)
-        timeout-minutes: 4
+        timeout-minutes: 5
         run: |
           ~/cargo-make/makers ci-start ci-3node
           sqllogictest -p 4567 -d dev './e2e_test/streaming/**/*.slt'
       - name: Kill cluster
         run: ~/cargo-make/makers ci-kill
       - name: e2e test batch 3-node (legacy frontend)
-        timeout-minutes: 2
+        timeout-minutes: 3
         run: |
           RW_IMPLICIT_FLUSH=1 ~/cargo-make/makers ci-start ci-3node
           sqllogictest -p 4567 -d dev --engine risingwave './e2e_test/batch/**/*.slt'
@@ -402,14 +402,14 @@ jobs:
       - name: Kill cluster
         run: ~/cargo-make/makers ci-kill
       - name: e2e, ci-3cn-1fe, delta join
-        timeout-minutes: 2
+        timeout-minutes: 3
         run: |
           ~/cargo-make/makers ci-start ci-3cn-1fe
           sqllogictest -p 4566 './e2e_test/v2/streaming_delta_join/**/*.slt'
       - name: Kill cluster
         run: ~/cargo-make/makers ci-kill
       - name: e2e, ci-3cn-1fe, batch distributed
-        timeout-minutes: 2
+        timeout-minutes: 3
         run: |
           ~/cargo-make/makers ci-start ci-3cn-1fe
           sqllogictest -p 4566 './e2e_test/v2/ddl/**/*.slt'
@@ -417,14 +417,14 @@ jobs:
       - name: Kill cluster
         run: ~/cargo-make/makers ci-kill
       - name: e2e test streaming 3-node (legacy frontend)
-        timeout-minutes: 4
+        timeout-minutes: 5
         run: |
           ~/cargo-make/makers ci-start ci-3node
           sqllogictest -p 4567 -d dev './e2e_test/streaming/**/*.slt'
       - name: Kill cluster
         run: ~/cargo-make/makers ci-kill
       - name: e2e test batch 3-node (legacy frontend)
-        timeout-minutes: 2
+        timeout-minutes: 3
         run: |
           RW_IMPLICIT_FLUSH=1 ~/cargo-make/makers ci-start ci-3node
           sqllogictest -p 4567 -d dev --engine risingwave './e2e_test/batch/**/*.slt'

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -272,7 +272,7 @@ jobs:
           ~/cargo-make/makers pre-start-playground
           ~/cargo-make/makers link-all-in-one-binaries
       - name: e2e, ci-3cn-1fe, streaming
-        timeout-minutes: 3
+        timeout-minutes: 4
         run: |
           ~/cargo-make/makers ci-start ci-3cn-1fe
           sqllogictest -p 4566 './e2e_test/v2/streaming/**/*.slt'
@@ -395,7 +395,7 @@ jobs:
           ~/cargo-make/makers pre-start-playground
           ~/cargo-make/makers link-all-in-one-binaries
       - name: e2e, ci-3cn-1fe, streaming
-        timeout-minutes: 3
+        timeout-minutes: 4
         run: |
           ~/cargo-make/makers ci-start ci-3cn-1fe
           sqllogictest -p 4566 './e2e_test/v2/streaming/**/*.slt'

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -227,7 +227,7 @@ jobs:
           ~/cargo-make/makers pre-start-playground
           ~/cargo-make/makers link-all-in-one-binaries
       - name: e2e, ci-3cn-1fe, streaming
-        timeout-minutes: 3
+        timeout-minutes: 4
         run: |
           ~/cargo-make/makers ci-start ci-3cn-1fe
           sqllogictest -p 4566 './e2e_test/v2/streaming/**/*.slt'

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -234,14 +234,14 @@ jobs:
       - name: Kill cluster
         run: ~/cargo-make/makers ci-kill
       - name: e2e, ci-3cn-1fe, delta join
-        timeout-minutes: 2
+        timeout-minutes: 3
         run: |
           ~/cargo-make/makers ci-start ci-3cn-1fe
           sqllogictest -p 4566 './e2e_test/v2/streaming_delta_join/**/*.slt'
       - name: Kill cluster
         run: ~/cargo-make/makers ci-kill
       - name: e2e, ci-3cn-1fe, batch distributed
-        timeout-minutes: 2
+        timeout-minutes: 3
         run: |
           ~/cargo-make/makers ci-start ci-3cn-1fe
           sqllogictest -p 4566 './e2e_test/v2/ddl/**/*.slt'
@@ -249,14 +249,14 @@ jobs:
       - name: Kill cluster
         run: ~/cargo-make/makers ci-kill
       - name: e2e test streaming 3-node (legacy frontend)
-        timeout-minutes: 4
+        timeout-minutes: 5
         run: |
           ~/cargo-make/makers ci-start ci-3node
           sqllogictest -p 4567 -d dev './e2e_test/streaming/**/*.slt'
       - name: Kill cluster
         run: ~/cargo-make/makers ci-kill
       - name: e2e test batch 3-node (legacy frontend)
-        timeout-minutes: 2
+        timeout-minutes: 3
         run: |
           RW_IMPLICIT_FLUSH=1 ~/cargo-make/makers ci-start ci-3node
           sqllogictest -p 4567 -d dev --engine risingwave './e2e_test/batch/**/*.slt'


### PR DESCRIPTION
## What's changed and what's your intention?

As we've refactored hummock compaction in https://github.com/singularity-data/risingwave/pull/2242, we observed `ci-3cn-1fe, streaming` is slower up to ~20 seconds. **We will fine tune the compaction picker**. Before that, this PR temporarily increases e2e timeout by 1 minute.

## Checklist

## Refer to a related PR or issue link (optional)
