### PR TITLE
chore: temporarily increase legacy e2e timeout before fine tune compaction

### DIFF
--- a/.github/workflow-template/jobs/e2e-risedev.yml
+++ b/.github/workflow-template/jobs/e2e-risedev.yml
@@ -126,7 +126,7 @@ jobs:
         run: ~/cargo-make/makers ci-kill
 
       - name: e2e test streaming 3-node (legacy frontend)
-        timeout-minutes: 5
+        timeout-minutes: 10
         run: |
           ~/cargo-make/makers ci-start ci-3node
           sqllogictest -p 4567 -d dev './e2e_test/streaming/**/*.slt'
@@ -135,7 +135,7 @@ jobs:
         run: ~/cargo-make/makers ci-kill
 
       - name: e2e test batch 3-node (legacy frontend)
-        timeout-minutes: 3
+        timeout-minutes: 6
         run: |
           RW_IMPLICIT_FLUSH=1 ~/cargo-make/makers ci-start ci-3node
           sqllogictest -p 4567 -d dev --engine risingwave './e2e_test/batch/**/*.slt'

--- a/.github/workflows/main-cron.yml
+++ b/.github/workflows/main-cron.yml
@@ -246,14 +246,14 @@ jobs:
       - name: Kill cluster
         run: ~/cargo-make/makers ci-kill
       - name: e2e test streaming 3-node (legacy frontend)
-        timeout-minutes: 5
+        timeout-minutes: 10
         run: |
           ~/cargo-make/makers ci-start ci-3node
           sqllogictest -p 4567 -d dev './e2e_test/streaming/**/*.slt'
       - name: Kill cluster
         run: ~/cargo-make/makers ci-kill
       - name: e2e test batch 3-node (legacy frontend)
-        timeout-minutes: 3
+        timeout-minutes: 6
         run: |
           RW_IMPLICIT_FLUSH=1 ~/cargo-make/makers ci-start ci-3node
           sqllogictest -p 4567 -d dev --engine risingwave './e2e_test/batch/**/*.slt'

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -294,14 +294,14 @@ jobs:
       - name: Kill cluster
         run: ~/cargo-make/makers ci-kill
       - name: e2e test streaming 3-node (legacy frontend)
-        timeout-minutes: 5
+        timeout-minutes: 10
         run: |
           ~/cargo-make/makers ci-start ci-3node
           sqllogictest -p 4567 -d dev './e2e_test/streaming/**/*.slt'
       - name: Kill cluster
         run: ~/cargo-make/makers ci-kill
       - name: e2e test batch 3-node (legacy frontend)
-        timeout-minutes: 3
+        timeout-minutes: 6
         run: |
           RW_IMPLICIT_FLUSH=1 ~/cargo-make/makers ci-start ci-3node
           sqllogictest -p 4567 -d dev --engine risingwave './e2e_test/batch/**/*.slt'
@@ -417,14 +417,14 @@ jobs:
       - name: Kill cluster
         run: ~/cargo-make/makers ci-kill
       - name: e2e test streaming 3-node (legacy frontend)
-        timeout-minutes: 5
+        timeout-minutes: 10
         run: |
           ~/cargo-make/makers ci-start ci-3node
           sqllogictest -p 4567 -d dev './e2e_test/streaming/**/*.slt'
       - name: Kill cluster
         run: ~/cargo-make/makers ci-kill
       - name: e2e test batch 3-node (legacy frontend)
-        timeout-minutes: 3
+        timeout-minutes: 6
         run: |
           RW_IMPLICIT_FLUSH=1 ~/cargo-make/makers ci-start ci-3node
           sqllogictest -p 4567 -d dev --engine risingwave './e2e_test/batch/**/*.slt'

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -249,14 +249,14 @@ jobs:
       - name: Kill cluster
         run: ~/cargo-make/makers ci-kill
       - name: e2e test streaming 3-node (legacy frontend)
-        timeout-minutes: 5
+        timeout-minutes: 10
         run: |
           ~/cargo-make/makers ci-start ci-3node
           sqllogictest -p 4567 -d dev './e2e_test/streaming/**/*.slt'
       - name: Kill cluster
         run: ~/cargo-make/makers ci-kill
       - name: e2e test batch 3-node (legacy frontend)
-        timeout-minutes: 3
+        timeout-minutes: 6
         run: |
           RW_IMPLICIT_FLUSH=1 ~/cargo-make/makers ci-start ci-3node
           sqllogictest -p 4567 -d dev --engine risingwave './e2e_test/batch/**/*.slt'


### PR DESCRIPTION
Legacy e2e is slower than expected after https://github.com/singularity-data/risingwave/pull/2242. This PR temporarily sets e2e timeout large enough and will revert soon.

## Checklist
## Refer to a related PR or issue link (optional)
