### PR TITLE
fix(storage): revert periodic compaction trigger frequency

### DIFF
--- a/src/meta/src/hummock/mod.rs
+++ b/src/meta/src/hummock/mod.rs
@@ -131,7 +131,7 @@ where
     // TODO: remove this periodic trigger after #2121
     let request_sender = compaction_scheduler.request_sender();
     tokio::spawn(async move {
-        let mut min_interval = tokio::time::interval(Duration::from_secs(5));
+        let mut min_interval = tokio::time::interval(Duration::from_secs(10));
         loop {
             min_interval.tick().await;
             if request_sender.send(0.into()).is_err() {


### PR DESCRIPTION
## What's changed and what's your intention?

Compaction trigger frequency was changed from 10s to 5s by previous PR, which results legacy e2e latency increasing.

This PR reverts it. We will investigate and fine tune compaction parameters including this one.

## Checklist

## Refer to a related PR or issue link (optional)
