### PR TITLE
refactor(failpoints): enable disabling bloom filter and block cache in failpoints test

### DIFF
--- a/src/storage/src/hummock/iterator/test_utils.rs
+++ b/src/storage/src/hummock/iterator/test_utils.rs
@@ -24,12 +24,9 @@ use risingwave_hummock_sdk::HummockSSTableId;
 
 use crate::hummock::iterator::BoxedForwardHummockIterator;
 pub use crate::hummock::test_utils::default_builder_opt_for_test;
-use crate::hummock::test_utils::{
-    create_small_table_cache, gen_test_sstable, gen_test_sstable_inner,
-};
+use crate::hummock::test_utils::{create_small_table_cache, gen_test_sstable};
 use crate::hummock::{
-    CachePolicy, HummockValue, SSTableBuilderOptions, SSTableIterator, Sstable, SstableStore,
-    SstableStoreRef,
+    HummockValue, SSTableBuilderOptions, SSTableIterator, Sstable, SstableStore, SstableStoreRef,
 };
 use crate::monitor::StateStoreMetrics;
 use crate::object::{InMemObjectStore, ObjectStoreImpl, ObjectStoreRef};
@@ -99,28 +96,6 @@ pub async fn gen_iterator_test_sstable_base(
             )
         }),
         sstable_store,
-    )
-    .await
-}
-
-pub async fn gen_iterator_test_sstable_base_without_buf(
-    sst_id: HummockSSTableId,
-    opts: SSTableBuilderOptions,
-    idx_mapping: impl Fn(usize) -> usize,
-    sstable_store: SstableStoreRef,
-    total: usize,
-) -> Sstable {
-    gen_test_sstable_inner(
-        opts,
-        sst_id,
-        (0..total).map(|i| {
-            (
-                iterator_test_key_of(idx_mapping(i)),
-                HummockValue::put(iterator_test_value_of(idx_mapping(i))),
-            )
-        }),
-        sstable_store,
-        CachePolicy::NotFill,
     )
     .await
 }

--- a/src/storage/src/hummock/sstable_store.rs
+++ b/src/storage/src/hummock/sstable_store.rs
@@ -142,6 +142,17 @@ impl SstableStore {
             Ok(Box::new(block))
         };
 
+        let disable_cache: fn() -> bool = || {
+            fail_point!("disable_block_cache", |_| true);
+            false
+        };
+
+        let policy = if disable_cache() {
+            CachePolicy::Disable
+        } else {
+            policy
+        };
+
         match policy {
             CachePolicy::Fill => {
                 self.block_cache


### PR DESCRIPTION
## What's changed and what's your intention?

In this PR, we enable disabling bloom filter and block cache in failpoints test, so that we can have finer grained control over the read path when we explicitly want to read from object store directly.

## Checklist

- [x] I have written necessary docs and comments
- [x] I have added necessary unit tests and integration tests

## Refer to a related PR or issue link (optional)
