### PR TITLE
feat(risedev): support host network mode

### DIFF
--- a/docker/README.md
+++ b/docker/README.md
@@ -41,3 +41,15 @@ docker-compose down -v
 
 For RisingWave kernel hackers, we always recommend using [risedev](../src/risedevtool/README.md) to start the full cluster, instead of using docker images.
 See [CONTRIBUTING](../CONTRIBUTING.md) for more information.
+
+# Deploy with RiseDev Compose
+
+If you want to deploy with docker-compose without using something like docker swarm, we can use host network mode and separately start components on different servers.
+
+Firstly, you'll need 5 servers with 5 host names: `rw-source`, `rw-meta`, `rw-compute-1`, `rw-compute-2` and `rw-compute-3`. The hostnames will need to be resolved into IP by DNS or `/etc/hosts`. After that, run the compose command:
+
+```bash
+./risedev compose compose-3node-host-deploy --host-mode
+```
+
+In the docker directory you'll find 5 docker-compose files, to be deployed at 5 servers separately.

--- a/risedev.yml
+++ b/risedev.yml
@@ -151,6 +151,58 @@ risedev:
       listen-address: "0.0.0.0"
       address: ${id}
 
+  # special config for deployment, see related PR for more information
+  compose-3node-host-deploy:
+    - use: minio
+      id: minio-0
+      address: rw-source
+      listen-address: "0.0.0.0"
+      console-address: "0.0.0.0"
+
+    - use: meta-node
+      # Id must starts with `meta-node`, therefore to be picked up by other
+      # components.
+      id: meta-node-0
+
+      # Advertise address can be `id`, so as to use docker's DNS. If running
+      # in host network mode, we should use IP directly in this field.
+      address: rw-meta
+
+      listen-address: "0.0.0.0"
+
+    - use: compute-node
+      id: compute-node-0
+      listen-address: "0.0.0.0"
+      address: rw-compute-1
+
+    - use: compute-node
+      id: compute-node-1
+      listen-address: "0.0.0.0"
+      address: rw-compute-2
+
+    - use: compute-node
+      id: compute-node-2
+      listen-address: "0.0.0.0"
+      address: rw-compute-3
+
+    - use: frontend
+      id: frontend-node-0
+      listen-address: "0.0.0.0"
+      address: rw-meta
+
+    - use: compactor
+      id: compactor-0
+      listen-address: "0.0.0.0"
+      address: rw-source
+
+    - use: redpanda
+      address: rw-source
+
+    - use: prometheus
+      id: prometheus-0
+      listen-address: "0.0.0.0"
+      address: rw-meta
+
   #################################
   ### Configurations used on CI ###
   #################################
@@ -536,3 +588,6 @@ template:
 
     # Port used on host (e.g. import data, connecting using kafkacat)
     outside-port: 9092
+
+    # Connect address
+    address: ${id}

--- a/src/risedevtool/src/bin/risedev-compose.rs
+++ b/src/risedevtool/src/bin/risedev-compose.rs
@@ -20,7 +20,8 @@ use std::path::Path;
 use anyhow::{anyhow, Result};
 use clap::Parser;
 use risedev::{
-    Compose, ComposeFile, ComposeVolume, ConfigExpander, DockerImageConfig, ServiceConfig,
+    Compose, ComposeFile, ComposeService, ComposeVolume, ConfigExpander, DockerImageConfig,
+    ServiceConfig,
 };
 use serde::Deserialize;
 
@@ -33,6 +34,11 @@ pub struct RiseDevComposeOpts {
 
     #[clap(default_value = "compose")]
     profile: String,
+
+    /// Whether to use `network_mode: host` for compose. If enabled, will generate multiple compose
+    /// files based on listen address.
+    #[clap(long)]
+    host_mode: bool,
 }
 
 fn load_docker_image_config(risedev_config: &str) -> Result<DockerImageConfig> {
@@ -57,26 +63,26 @@ fn main() -> Result<()> {
     let risedev_config = ConfigExpander::expand(&risedev_config)?;
     let (steps, services) = ConfigExpander::select(&risedev_config, &opts.profile)?;
 
-    let mut compose_services = BTreeMap::new();
+    let mut compose_services: BTreeMap<String, BTreeMap<String, ComposeService>> = BTreeMap::new();
     let mut volumes = BTreeMap::new();
 
     for step in steps.iter() {
         let service = services.get(step).unwrap();
-        let mut compose = match service {
+        let (address, mut compose) = match service {
             ServiceConfig::Minio(c) => {
                 volumes.insert(c.id.clone(), ComposeVolume::default());
-                c.compose(&docker_image_config)?
+                (c.address.clone(), c.compose(&docker_image_config)?)
             }
             ServiceConfig::Etcd(_) => return Err(anyhow!("not supported")),
             ServiceConfig::Prometheus(c) => {
                 volumes.insert(c.id.clone(), ComposeVolume::default());
-                c.compose(&docker_image_config)?
+                (c.address.clone(), c.compose(&docker_image_config)?)
             }
-            ServiceConfig::ComputeNode(c) => c.compose(&docker_image_config)?,
-            ServiceConfig::MetaNode(c) => c.compose(&docker_image_config)?,
+            ServiceConfig::ComputeNode(c) => (c.address.clone(), c.compose(&docker_image_config)?),
+            ServiceConfig::MetaNode(c) => (c.address.clone(), c.compose(&docker_image_config)?),
             ServiceConfig::Frontend(_) => return Err(anyhow!("not supported")),
-            ServiceConfig::FrontendV2(c) => c.compose(&docker_image_config)?,
-            ServiceConfig::Compactor(c) => c.compose(&docker_image_config)?,
+            ServiceConfig::FrontendV2(c) => (c.address.clone(), c.compose(&docker_image_config)?),
+            ServiceConfig::Compactor(c) => (c.address.clone(), c.compose(&docker_image_config)?),
             ServiceConfig::Grafana(_) => {
                 return Err(anyhow!("not supported, please run Grafana outside cluster"))
             }
@@ -88,25 +94,64 @@ fn main() -> Result<()> {
                 return Err(anyhow!("not supported, please use redpanda instead"))
             }
             ServiceConfig::AwsS3(_) => continue,
-            ServiceConfig::RedPanda(c) => c.compose(&docker_image_config)?,
+            ServiceConfig::RedPanda(c) => (c.address.clone(), c.compose(&docker_image_config)?),
         };
         compose.container_name = service.id().to_string();
-        compose_services.insert(step.to_string(), compose);
+        if opts.host_mode {
+            compose.network_mode = Some("host".into());
+            compose.volumes.push("/etc/hosts:/etc/hosts".into());
+            compose.depends_on = vec![];
+        }
+        compose_services
+            .entry(address)
+            .or_default()
+            .insert(step.to_string(), compose);
     }
 
-    let compose_file = ComposeFile {
-        version: "3".into(),
-        services: compose_services,
-        volumes,
-        name: format!("risingwave-{}", opts.profile),
-    };
+    if opts.host_mode {
+        for (node, services) in compose_services {
+            let mut node_volumes = BTreeMap::new();
+            services.keys().for_each(|k| {
+                if let Some(v) = volumes.get(k) {
+                    node_volumes.insert(k.clone(), v.clone());
+                }
+            });
+            let compose_file = ComposeFile {
+                version: "3".into(),
+                services,
+                volumes: node_volumes,
+                name: format!("risingwave-{}", opts.profile),
+            };
 
-    let yaml = serde_yaml::to_string(&compose_file)?;
+            let yaml = serde_yaml::to_string(&compose_file)?;
 
-    if let Some(directory) = opts.directory {
-        fs::write(Path::new(&directory).join("docker-compose.yml"), yaml)?;
+            if let Some(ref directory) = opts.directory {
+                fs::write(Path::new(directory).join(format!("{}.yml", node)), yaml)?;
+            } else {
+                return Err(anyhow!("need to specify a directory"));
+            }
+        }
     } else {
-        println!("{}", yaml);
+        let mut services = BTreeMap::new();
+        for (_, s) in compose_services {
+            for (k, v) in s {
+                services.insert(k, v);
+            }
+        }
+        let compose_file = ComposeFile {
+            version: "3".into(),
+            services,
+            volumes,
+            name: format!("risingwave-{}", opts.profile),
+        };
+
+        let yaml = serde_yaml::to_string(&compose_file)?;
+
+        if let Some(directory) = opts.directory {
+            fs::write(Path::new(&directory).join("docker-compose.yml"), yaml)?;
+        } else {
+            println!("{}", yaml);
+        }
     }
 
     Ok(())

--- a/src/risedevtool/src/compose.rs
+++ b/src/risedevtool/src/compose.rs
@@ -39,6 +39,7 @@ pub struct ComposeService {
     pub environment: HashMap<String, String>,
     pub user: Option<String>,
     pub container_name: String,
+    pub network_mode: Option<String>,
 }
 
 #[derive(Debug, Clone, Serialize)]
@@ -255,8 +256,8 @@ impl Compose for RedPandaConfig {
         ));
 
         command.arg("--advertise-kafka-addr").arg(format!(
-            "PLAINTEXT://redpanda:{},OUTSIDE://localhost:{}",
-            self.internal_port, self.outside_port
+            "PLAINTEXT://{}:{},OUTSIDE://localhost:{}",
+            self.address, self.internal_port, self.outside_port
         ));
 
         let command = get_cmd_args(&command, true)?;
@@ -264,7 +265,10 @@ impl Compose for RedPandaConfig {
         Ok(ComposeService {
             image: image.redpanda.clone(),
             command,
-            expose: vec![self.internal_port.to_string()],
+            expose: vec![
+                self.internal_port.to_string(),
+                self.outside_port.to_string(),
+            ],
             ports: vec![format!("{}:{}", self.outside_port, self.outside_port)],
             ..Default::default()
         })

--- a/src/risedevtool/src/service_config.rs
+++ b/src/risedevtool/src/service_config.rs
@@ -236,6 +236,7 @@ pub struct RedPandaConfig {
     pub id: String,
     pub internal_port: u16,
     pub outside_port: u16,
+    pub address: String,
 }
 
 /// All service configuration


### PR DESCRIPTION
Signed-off-by: Alex Chi <iskyzh@gmail.com>

## What's changed and what's your intention?

I tried a little bit to deploy services across 5 EC2, and succeeded. Basically, I'm using Terraform to start all servers, install docker, and then start components with docker-compose generated by risedev. This PR enables risedev to generate docker-compose files with host network mode, and those files can be deployed to different servers.

<img width="279" alt="image" src="https://user-images.githubusercontent.com/4198311/167583066-e861433d-dce0-431b-aba5-e4dfe49e8065.png">

For the Terraform config and other deploy scripts, maybe I'll have another repo to store it.

## Checklist

- [x] I have written necessary docs and comments
- [x] I have added necessary unit tests and integration tests

## Refer to a related PR or issue link (optional)
