### PR TITLE
refactor(storage): batch version deletion in vacuum

### DIFF
--- a/src/meta/src/hummock/compactor_manager.rs
+++ b/src/meta/src/hummock/compactor_manager.rs
@@ -34,6 +34,7 @@ impl Compactor {
         compact_task: Option<CompactTask>,
         vacuum_task: Option<VacuumTask>,
     ) -> Result<()> {
+        // TODO: compactor node backpressure
         self.sender
             .send(Ok(SubscribeCompactTasksResponse {
                 compact_task,

--- a/src/meta/src/hummock/hummock_manager.rs
+++ b/src/meta/src/hummock/hummock_manager.rs
@@ -977,15 +977,11 @@ where
     }
 
     /// List version ids in ascending order.
-    pub async fn list_version_ids_asc(
-        &self,
-        limit: Option<usize>,
-    ) -> Result<Vec<HummockVersionId>> {
+    pub async fn list_version_ids_asc(&self) -> Result<Vec<HummockVersionId>> {
         let versioning_guard = self.versioning.read().await;
         let version_ids = versioning_guard
             .hummock_versions
             .keys()
-            .take(limit.unwrap_or(usize::MAX))
             .cloned()
             .collect_vec();
         Ok(version_ids)

--- a/src/meta/src/hummock/hummock_manager.rs
+++ b/src/meta/src/hummock/hummock_manager.rs
@@ -798,7 +798,6 @@ where
             new_hummock_version.uncommitted_epochs.swap_remove(idx);
         }
         // Create a new_version, possibly merely to bump up the version id and max_committed_epoch.
-        // TODO: avoid this.
         new_hummock_version.max_committed_epoch = epoch;
         commit_multi_var!(self, None, new_hummock_version, current_version_id)?;
 

--- a/src/meta/src/hummock/hummock_manager.rs
+++ b/src/meta/src/hummock/hummock_manager.rs
@@ -976,11 +976,15 @@ where
     }
 
     /// List version ids in ascending order. TODO: support limit parameter
-    pub async fn list_version_ids_asc(&self) -> Result<Vec<HummockVersionId>> {
+    pub async fn list_version_ids_asc(
+        &self,
+        limit: Option<usize>,
+    ) -> Result<Vec<HummockVersionId>> {
         let versioning_guard = self.versioning.read().await;
         let version_ids = versioning_guard
             .hummock_versions
             .keys()
+            .take(limit.unwrap_or(usize::MAX))
             .cloned()
             .collect_vec();
         Ok(version_ids)
@@ -1048,36 +1052,34 @@ where
         Ok(())
     }
 
-    /// Delete metadata of the given `version_id`
-    pub async fn delete_version(&self, version_id: HummockVersionId) -> Result<()> {
+    /// Delete metadata of the given `version_ids`
+    pub async fn delete_versions(&self, version_ids: &[HummockVersionId]) -> Result<()> {
         let mut versioning_guard = self.versioning.write().await;
-        // Delete record in HummockVersion if any.
-        if versioning_guard.hummock_versions.get(&version_id).is_none() {
-            return Ok(());
-        }
         let versioning = versioning_guard.deref_mut();
         let pinned_versions_ref = &versioning.pinned_versions;
         let mut hummock_versions = VarTransaction::new(&mut versioning.hummock_versions);
         let mut stale_sstables = VarTransaction::new(&mut versioning.stale_sstables);
-        hummock_versions.remove(&version_id);
-        // Delete record in HummockTablesToDelete if any.
-        if let Some(ssts_to_delete) = stale_sstables.get_mut(&version_id) {
-            if !ssts_to_delete.id.is_empty() {
-                return Err(Error::InternalError(format!(
-                    "Version {} still has stale ssts undeleted:{:?}",
-                    version_id, ssts_to_delete.id
-                )));
+        for version_id in version_ids {
+            if hummock_versions.remove(version_id).is_none() {
+                continue;
+            }
+            if let Some(ssts_to_delete) = stale_sstables.get_mut(version_id) {
+                if !ssts_to_delete.id.is_empty() {
+                    return Err(Error::InternalError(format!(
+                        "Version {} still has stale ssts undeleted:{:?}",
+                        version_id, ssts_to_delete.id
+                    )));
+                }
+            }
+            stale_sstables.remove(version_id);
+
+            for version_pin in pinned_versions_ref.values() {
+                assert!(
+                    !version_pin.version_id.contains(version_id),
+                    "version still referenced shouldn't be deleted."
+                );
             }
         }
-        stale_sstables.remove(&version_id);
-
-        for version_pin in pinned_versions_ref.values() {
-            assert!(
-                !version_pin.version_id.contains(&version_id),
-                "version still referenced shouldn't be deleted."
-            );
-        }
-
         commit_multi_var!(self, None, hummock_versions, stale_sstables)?;
 
         #[cfg(test)]

--- a/src/meta/src/hummock/hummock_manager.rs
+++ b/src/meta/src/hummock/hummock_manager.rs
@@ -798,6 +798,7 @@ where
             new_hummock_version.uncommitted_epochs.swap_remove(idx);
         }
         // Create a new_version, possibly merely to bump up the version id and max_committed_epoch.
+        // TODO: avoid this.
         new_hummock_version.max_committed_epoch = epoch;
         commit_multi_var!(self, None, new_hummock_version, current_version_id)?;
 
@@ -975,7 +976,7 @@ where
         Ok(())
     }
 
-    /// List version ids in ascending order. TODO: support limit parameter
+    /// List version ids in ascending order.
     pub async fn list_version_ids_asc(
         &self,
         limit: Option<usize>,

--- a/src/meta/src/hummock/hummock_manager_tests.rs
+++ b/src/meta/src/hummock/hummock_manager_tests.rs
@@ -641,7 +641,11 @@ async fn test_hummock_manager_basic() {
 
     // test list_version_ids_asc
     assert_eq!(
-        hummock_manager.list_version_ids_asc().await.unwrap().len(),
+        hummock_manager
+            .list_version_ids_asc(None)
+            .await
+            .unwrap()
+            .len(),
         1
     );
 
@@ -655,7 +659,7 @@ async fn test_hummock_manager_basic() {
 
     // test list_version_ids_asc
     assert_eq!(
-        hummock_manager.list_version_ids_asc().await.unwrap(),
+        hummock_manager.list_version_ids_asc(None).await.unwrap(),
         vec![FIRST_VERSION_ID, FIRST_VERSION_ID + 1]
     );
 
@@ -717,11 +721,11 @@ async fn test_hummock_manager_basic() {
 
     // test delete_version
     hummock_manager
-        .delete_version(FIRST_VERSION_ID)
+        .delete_versions(&[FIRST_VERSION_ID])
         .await
         .unwrap();
     assert_eq!(
-        hummock_manager.list_version_ids_asc().await.unwrap(),
+        hummock_manager.list_version_ids_asc(None).await.unwrap(),
         vec![FIRST_VERSION_ID + 1]
     );
 }

--- a/src/meta/src/hummock/hummock_manager_tests.rs
+++ b/src/meta/src/hummock/hummock_manager_tests.rs
@@ -641,11 +641,7 @@ async fn test_hummock_manager_basic() {
 
     // test list_version_ids_asc
     assert_eq!(
-        hummock_manager
-            .list_version_ids_asc(None)
-            .await
-            .unwrap()
-            .len(),
+        hummock_manager.list_version_ids_asc().await.unwrap().len(),
         1
     );
 
@@ -659,7 +655,7 @@ async fn test_hummock_manager_basic() {
 
     // test list_version_ids_asc
     assert_eq!(
-        hummock_manager.list_version_ids_asc(None).await.unwrap(),
+        hummock_manager.list_version_ids_asc().await.unwrap(),
         vec![FIRST_VERSION_ID, FIRST_VERSION_ID + 1]
     );
 
@@ -725,7 +721,7 @@ async fn test_hummock_manager_basic() {
         .await
         .unwrap();
     assert_eq!(
-        hummock_manager.list_version_ids_asc(None).await.unwrap(),
+        hummock_manager.list_version_ids_asc().await.unwrap(),
         vec![FIRST_VERSION_ID + 1]
     );
 }

--- a/src/meta/src/hummock/vacuum.rs
+++ b/src/meta/src/hummock/vacuum.rs
@@ -170,7 +170,7 @@ where
             let compactor = match self.compactor_manager.next_compactor() {
                 None => {
                     tracing::warn!("No vacuum worker is available.");
-                    return Ok(vec![]);
+                    break;
                 }
                 Some(compactor) => compactor,
             };

--- a/src/meta/src/hummock/vacuum.rs
+++ b/src/meta/src/hummock/vacuum.rs
@@ -99,13 +99,19 @@ where
                 }
                 if versions_to_delete.len() >= batch_size {
                     vacuum_count += versions_to_delete.len();
-                    // Delete version metadata
                     self.hummock_manager
                         .delete_versions(&versions_to_delete)
                         .await?;
                     versions_to_delete.clear();
                 }
             }
+        }
+        if !versions_to_delete.is_empty() {
+            vacuum_count += versions_to_delete.len();
+            self.hummock_manager
+                .delete_versions(&versions_to_delete)
+                .await?;
+            versions_to_delete.clear();
         }
         Ok(vacuum_count as u64)
     }

--- a/src/meta/src/hummock/vacuum.rs
+++ b/src/meta/src/hummock/vacuum.rs
@@ -163,7 +163,7 @@ where
         };
 
         let mut batch_idx = 0;
-        let batch_size = 64usize;
+        let batch_size = 32usize;
         let mut sent_batch = Vec::with_capacity(ssts_to_delete.len());
         while batch_idx < ssts_to_delete.len() {
             let delete_batch = ssts_to_delete


### PR DESCRIPTION
## What's changed and what's your intention?

Handle multiple version metadata deletions in one go, to reduce meta store transactions.

## Checklist


## Refer to a related PR or issue link (optional)
