### PR TITLE
fix(meta): clean up all aborted creating mv when recovery

### DIFF
--- a/src/meta/src/barrier/mod.rs
+++ b/src/meta/src/barrier/mod.rs
@@ -218,7 +218,7 @@ where
             state.prev_epoch = new_epoch;
 
             let (new_epoch, actors_to_finish, finished_create_mviews) =
-                self.recovery(state.prev_epoch, None).await;
+                self.recovery(state.prev_epoch).await;
             unfinished.add(new_epoch.0, actors_to_finish, vec![]);
             for finished in finished_create_mviews {
                 unfinished.finish_actors(finished.epoch, once(finished.actor_id));
@@ -262,7 +262,7 @@ where
                 &info,
                 &state.prev_epoch,
                 &new_epoch,
-                command.clone(),
+                command,
             );
 
             let mut notifiers = notifiers;
@@ -288,7 +288,7 @@ where
                     if self.enable_recovery {
                         // If failed, enter recovery mode.
                         let (new_epoch, actors_to_finish, finished_create_mviews) =
-                            self.recovery(state.prev_epoch, Some(command)).await;
+                            self.recovery(state.prev_epoch).await;
                         unfinished = UnfinishedNotifiers::default();
                         unfinished.add(new_epoch.0, actors_to_finish, vec![]);
                         for finished in finished_create_mviews {

--- a/src/meta/src/stream/meta.rs
+++ b/src/meta/src/stream/meta.rs
@@ -120,17 +120,20 @@ where
     }
 
     /// Cancel creation of a new `TableFragments` and delete it from meta store.
-    pub async fn cancel_create_table_fragments(&self, table_id: TableId) -> Result<()> {
+    pub async fn cancel_create_table_fragments(&self, table_id: &TableId) -> Result<()> {
         let map = &mut self.core.write().await.table_fragments;
 
-        map.remove(&table_id).ok_or_else(|| {
-            RwError::from(InternalError(format!(
+        match map.entry(*table_id) {
+            Entry::Occupied(o) => {
+                TableFragments::delete(&*self.meta_store, &table_id.table_id).await?;
+                o.remove();
+                Ok(())
+            }
+            Entry::Vacant(_) => Err(RwError::from(InternalError(format!(
                 "table_fragment not exist: id={}",
                 table_id
-            )))
-        })?;
-
-        Ok(())
+            )))),
+        }
     }
 
     /// Finish create a new `TableFragments` and update the actors' state to `ActorState::Running`,

--- a/src/meta/src/stream/meta.rs
+++ b/src/meta/src/stream/meta.rs
@@ -119,6 +119,20 @@ where
         }
     }
 
+    /// Cancel creation of a new `TableFragments` and delete it from meta store.
+    pub async fn cancel_create_table_fragments(&self, table_id: TableId) -> Result<()> {
+        let map = &mut self.core.write().await.table_fragments;
+
+        map.remove(&table_id).ok_or_else(|| {
+            RwError::from(InternalError(format!(
+                "table_fragment not exist: id={}",
+                table_id
+            )))
+        })?;
+
+        Ok(())
+    }
+
     /// Finish create a new `TableFragments` and update the actors' state to `ActorState::Running`,
     /// besides also update all dependent tables' downstream actors info.
     pub async fn finish_create_table_fragments(

--- a/src/meta/src/stream/stream_manager.rs
+++ b/src/meta/src/stream/stream_manager.rs
@@ -603,13 +603,21 @@ where
         self.fragment_manager
             .start_create_table_fragments(table_fragments.clone())
             .await?;
-        self.barrier_manager
+        let table_id = table_fragments.table_id();
+        if let Err(err) = self
+            .barrier_manager
             .run_command(Command::CreateMaterializedView {
                 table_fragments,
                 table_sink_map,
                 dispatches,
             })
-            .await?;
+            .await
+        {
+            self.fragment_manager
+                .cancel_create_table_fragments(table_id)
+                .await?;
+            return Err(err);
+        }
 
         Ok(())
     }

--- a/src/meta/src/stream/stream_manager.rs
+++ b/src/meta/src/stream/stream_manager.rs
@@ -614,7 +614,7 @@ where
             .await
         {
             self.fragment_manager
-                .cancel_create_table_fragments(table_id)
+                .cancel_create_table_fragments(&table_id)
                 .await?;
             return Err(err);
         }


### PR DESCRIPTION
## What's changed and what's your intention?

As title, all aborted creating mv should be cleaned, not only the mv in prev command.

Please explain **IN DETAIL** what the changes are in this PR and why they are needed:

- Summarize your change (**mandatory**)
- How does this PR work? Need a brief introduction for the changed logic (optional)
- Describe clearly one logical change and avoid lazy messages (optional)
- Describe any limitations of the current code (optional)

## Checklist

- [x] I have written necessary docs and comments
- [x] I have added necessary unit tests and integration tests

## Refer to a related PR or issue link (optional)
