### PR TITLE
fix: panic worker node when it's removed by meta node

### DIFF
--- a/src/common/src/error.rs
+++ b/src/common/src/error.rs
@@ -123,6 +123,11 @@ pub enum ErrorCode {
     #[error("Error while interact with meta service: {0}")]
     MetaError(String),
 
+    /// This error occurs when the meta node receives heartbeat from a previous removed worker
+    /// node. Currently we don't support re-register, and the worker node need a full restart.
+    #[error("Unknown worker")]
+    UnknownWorker,
+
     /// `Eof` represents an upstream node will not generate new data. This error is rare in our
     /// system, currently only used in the `BatchQueryExecutor` as an ephemeral solution.
     #[error("End of the stream")]
@@ -289,6 +294,7 @@ impl ErrorCode {
             ErrorCode::CatalogError(..) => 21,
             ErrorCode::Eof => 22,
             ErrorCode::BindError(_) => 23,
+            ErrorCode::UnknownWorker => 24,
             ErrorCode::UnknownError(_) => 101,
         }
     }

--- a/src/meta/src/cluster/mod.rs
+++ b/src/meta/src/cluster/mod.rs
@@ -21,7 +21,7 @@ use std::sync::Arc;
 use std::time::{Duration, SystemTime};
 
 use itertools::Itertools;
-use risingwave_common::error::{internal_error, Result};
+use risingwave_common::error::{internal_error, ErrorCode, Result};
 use risingwave_common::try_match_expand;
 use risingwave_pb::common::worker_node::State;
 use risingwave_pb::common::{HostAddress, ParallelUnit, ParallelUnitType, WorkerNode, WorkerType};
@@ -217,10 +217,11 @@ where
         let mut core = self.core.write().await;
 
         if let Some(worker) = core.get_worker_by_id(worker_id) {
-            core.update_worker_ttl(worker.key().unwrap(), self.max_heartbeat_interval)
+            core.update_worker_ttl(worker.key().unwrap(), self.max_heartbeat_interval);
+            Ok(())
+        } else {
+            Err(ErrorCode::UnknownWorker.into())
         }
-
-        Ok(())
     }
 
     pub async fn start_heartbeat_checker(

--- a/src/rpc_client/src/meta_client.rs
+++ b/src/rpc_client/src/meta_client.rs
@@ -17,7 +17,7 @@ use std::time::Duration;
 use async_trait::async_trait;
 use paste::paste;
 use risingwave_common::catalog::{CatalogVersion, TableId};
-use risingwave_common::error::ErrorCode::InternalError;
+use risingwave_common::error::ErrorCode::{self, InternalError};
 use risingwave_common::error::{Result, ToRwResult};
 use risingwave_common::try_match_expand;
 use risingwave_common::util::addr::HostAddr;
@@ -286,6 +286,12 @@ impl MetaClient {
                     Ok(Ok(_)) => {}
                     Ok(Err(err)) => {
                         tracing::warn!("Failed to send_heartbeat: error {}", err);
+                        if err
+                            .to_string()
+                            .contains(&ErrorCode::UnknownWorker.to_string())
+                        {
+                            panic!("Already removed by the meta node. Need to restart the worker");
+                        }
                     }
                     Err(err) => {
                         tracing::warn!("Failed to send_heartbeat: timeout {}", err);


### PR DESCRIPTION
## What's changed and what's your intention?

A temporary fix to reduce confusion like https://github.com/singularity-data/risingwave/issues/2367

Not done: set a larger heartbeat interval for `dev-compute-node`, so that users can be happier debugging.

## Checklist

- [x] I have written necessary docs and comments
- [x] I have added necessary unit tests and integration tests
