### PR TITLE
refactor(frontend): (WIP) decouple output column alias from plan schema field name

### DIFF
--- a/src/frontend/src/binder/mod.rs
+++ b/src/frontend/src/binder/mod.rs
@@ -112,6 +112,6 @@ pub mod test_utils {
 }
 
 /// The column name stored in [`BindContext`] for a column without an alias.
-const UNNAMED_COLUMN: &str = "?column?";
+pub const UNNAMED_COLUMN: &str = "?column?";
 /// The table name stored in [`BindContext`] for a subquery without an alias.
 const UNNAMED_SUBQUERY: &str = "?subquery?";

--- a/src/frontend/src/handler/create_index.rs
+++ b/src/frontend/src/handler/create_index.rs
@@ -104,6 +104,8 @@ pub(crate) fn gen_create_index_plan(
         let mut required_cols = FixedBitSet::with_capacity(scan_node.schema().len());
         required_cols.toggle_range(..);
         required_cols.toggle(0);
+        let mut out_names = scan_node.schema().names();
+        out_names.remove(0);
 
         PlanRoot::new(
             scan_node.into(),
@@ -115,6 +117,7 @@ pub(crate) fn gen_create_index_plan(
                     .collect(),
             ),
             required_cols,
+            out_names,
         )
         .gen_create_index_plan(index_name.to_string(), table.id())?
     };

--- a/src/frontend/src/handler/create_table.rs
+++ b/src/frontend/src/handler/create_table.rs
@@ -95,12 +95,15 @@ pub(crate) fn gen_materialized_source_plan(
         let mut required_cols = FixedBitSet::with_capacity(source_node.schema().len());
         required_cols.toggle_range(..);
         required_cols.toggle(0);
+        let mut out_names = source_node.schema().names();
+        out_names.remove(0);
 
         PlanRoot::new(
             source_node,
             Distribution::HashShard(vec![0]),
             Order::any().clone(),
             required_cols,
+            out_names,
         )
         .gen_create_mv_plan(source.name.clone())?
     };

--- a/src/frontend/src/handler/dml.rs
+++ b/src/frontend/src/handler/dml.rs
@@ -38,11 +38,9 @@ pub async fn handle_dml(context: OptimizerContext, stmt: Statement) -> Result<Pg
 
     let (plan, pg_descs) = {
         // Subblock to make sure PlanRef (an Rc) is dropped before `await` below.
-        let plan = Planner::new(context.into())
-            .plan(bound)?
-            .gen_batch_query_plan()?;
-
-        let pg_descs = plan.schema().fields().iter().map(to_pg_field).collect();
+        let root = Planner::new(context.into()).plan(bound)?;
+        let pg_descs = root.schema().fields().iter().map(to_pg_field).collect();
+        let plan = root.gen_batch_query_plan()?;
 
         (plan.to_batch_prost(), pg_descs)
     };

--- a/src/frontend/src/handler/query.rs
+++ b/src/frontend/src/handler/query.rs
@@ -105,21 +105,21 @@ async fn distribute_execute(
     let session = context.session_ctx.clone();
     // Subblock to make sure PlanRef (an Rc) is dropped before `await` below.
     let (query, pg_descs) = {
-        let plan = Planner::new(context.into())
-            .plan(stmt)?
-            .gen_batch_query_plan()?;
+        let root = Planner::new(context.into()).plan(stmt)?;
 
-        info!(
-            "Generated distributed plan: {:?}",
-            plan.explain_to_string()?
-        );
-
-        let pg_descs = plan
+        let pg_descs = root
             .schema()
             .fields()
             .iter()
             .map(to_pg_field)
             .collect::<Vec<PgFieldDescriptor>>();
+
+        let plan = root.gen_batch_query_plan()?;
+
+        info!(
+            "Generated distributed plan: {:?}",
+            plan.explain_to_string()?
+        );
 
         let plan_fragmenter = BatchPlanFragmenter::new(session.env().worker_node_manager_ref());
         let query = plan_fragmenter.split(plan)?;

--- a/src/frontend/src/optimizer/mod.rs
+++ b/src/frontend/src/optimizer/mod.rs
@@ -50,6 +50,7 @@ pub struct PlanRoot {
     required_dist: Distribution,
     required_order: Order,
     out_fields: FixedBitSet,
+    out_names: Vec<String>,
     schema: Schema,
 }
 
@@ -59,6 +60,7 @@ impl PlanRoot {
         required_dist: Distribution,
         required_order: Order,
         out_fields: FixedBitSet,
+        out_names: Vec<String>,
     ) -> Self {
         let input_schema = plan.schema();
         assert_eq!(input_schema.fields().len(), out_fields.len());
@@ -74,6 +76,7 @@ impl PlanRoot {
             required_dist,
             required_order,
             out_fields,
+            out_names,
             schema,
         }
     }
@@ -235,6 +238,7 @@ impl PlanRoot {
             mv_name,
             self.required_order.clone(),
             self.out_fields.clone(),
+            self.out_names.clone(),
             None,
         )
     }
@@ -251,6 +255,7 @@ impl PlanRoot {
             mv_name,
             self.required_order.clone(),
             self.out_fields.clone(),
+            self.out_names.clone(),
             Some(index_on),
         )
     }
@@ -284,11 +289,13 @@ mod tests {
         )
         .into();
         let out_fields = FixedBitSet::with_capacity_and_blocks(2, [1]);
+        let out_names = vec!["v1".into()];
         let root = PlanRoot::new(
             values,
             Distribution::any().clone(),
             Order::any().clone(),
             out_fields,
+            out_names,
         );
         let subplan = root.as_subplan();
         assert_eq!(

--- a/src/frontend/src/optimizer/mod.rs
+++ b/src/frontend/src/optimizer/mod.rs
@@ -64,6 +64,7 @@ impl PlanRoot {
     ) -> Self {
         let input_schema = plan.schema();
         assert_eq!(input_schema.fields().len(), out_fields.len());
+        assert_eq!(out_fields.count_ones(..), out_names.len());
 
         let schema = Schema {
             fields: out_fields

--- a/src/frontend/src/optimizer/mod.rs
+++ b/src/frontend/src/optimizer/mod.rs
@@ -215,7 +215,7 @@ impl PlanRoot {
                 self.required_order = out_col_change
                     .rewrite_required_order(&self.required_order)
                     .unwrap();
-                self.out_fields = out_col_change.rewrite_bitset(&self.out_fields);
+                self.out_fields = out_col_change.rewrite_bitset2(&self.out_fields);
                 self.schema = plan.schema().clone();
                 plan.to_stream_with_dist_required(&self.required_dist)
             }

--- a/src/frontend/src/optimizer/mod.rs
+++ b/src/frontend/src/optimizer/mod.rs
@@ -69,7 +69,12 @@ impl PlanRoot {
         let schema = Schema {
             fields: out_fields
                 .ones()
-                .map(|i| input_schema.fields()[i].clone())
+                .zip_eq(&out_names)
+                .map(|(i, name)| {
+                    let mut f = input_schema.fields()[i].clone();
+                    f.name = name.clone();
+                    f
+                })
                 .collect(),
         };
         Self {
@@ -91,8 +96,7 @@ impl PlanRoot {
     }
 
     /// Get a reference to the plan root's schema.
-    #[allow(dead_code)]
-    fn schema(&self) -> &Schema {
+    pub fn schema(&self) -> &Schema {
         &self.schema
     }
 

--- a/src/frontend/src/optimizer/plan_node/logical_project.rs
+++ b/src/frontend/src/optimizer/plan_node/logical_project.rs
@@ -147,6 +147,7 @@ impl LogicalProject {
                     }
                     None => (format!("expr#{}", id), vec![], String::new()),
                 };
+                // let name = default_name;  // Even this cleanup is unnecessary.
                 let name = alias.clone().unwrap_or(default_name);
                 Field::with_struct(expr.return_type(), name, sub_fields, type_name)
             })

--- a/src/frontend/src/optimizer/plan_node/logical_project.rs
+++ b/src/frontend/src/optimizer/plan_node/logical_project.rs
@@ -259,12 +259,7 @@ impl ColPrunable for LogicalProject {
         // Rewrite each InputRef with new index.
         let (exprs, expr_alias) = required_cols
             .ones()
-            .map(|id| {
-                (
-                    mapping.rewrite_expr(self.exprs[id].clone()),
-                    None,
-                )
-            })
+            .map(|id| (mapping.rewrite_expr(self.exprs[id].clone()), None))
             .unzip();
 
         // Reconstruct the LogicalProject.

--- a/src/frontend/src/optimizer/rule/project_merge.rs
+++ b/src/frontend/src/optimizer/rule/project_merge.rs
@@ -34,14 +34,7 @@ impl Rule for ProjectMergeRule {
             .cloned()
             .map(|expr| subst.rewrite_expr(expr))
             .collect();
-        Some(
-            LogicalProject::new(
-                inner_project.input(),
-                exprs,
-                outer_project.expr_alias().to_owned(),
-            )
-            .into(),
-        )
+        Some(LogicalProject::new(inner_project.input(), exprs, outer_project.expr_alias()).into())
     }
 }
 

--- a/src/frontend/src/planner/delete.rs
+++ b/src/frontend/src/planner/delete.rs
@@ -38,8 +38,9 @@ impl Planner {
         let dist = Distribution::Any;
         let mut out_fields = FixedBitSet::with_capacity(plan.schema().len());
         out_fields.insert_range(..);
+        let out_names = plan.schema().names();
 
-        let root = PlanRoot::new(plan, dist, order, out_fields);
+        let root = PlanRoot::new(plan, dist, order, out_fields, out_names);
         Ok(root)
     }
 }

--- a/src/frontend/src/planner/insert.rs
+++ b/src/frontend/src/planner/insert.rs
@@ -40,7 +40,8 @@ impl Planner {
         let dist = Distribution::Any;
         let mut out_fields = FixedBitSet::with_capacity(plan.schema().len());
         out_fields.insert_range(..);
-        let root = PlanRoot::new(plan, dist, order, out_fields);
+        let out_names = plan.schema().names();
+        let root = PlanRoot::new(plan, dist, order, out_fields, out_names);
         Ok(root)
     }
 }

--- a/src/frontend/src/planner/query.rs
+++ b/src/frontend/src/planner/query.rs
@@ -27,6 +27,7 @@ impl Planner {
     /// Plan a [`BoundQuery`]. Need to bind before planning.
     pub fn plan_query(&mut self, query: BoundQuery) -> Result<PlanRoot> {
         let extra_order_exprs_len = query.extra_order_exprs.len();
+        let out_names = query.schema().names();
         let mut plan = self.plan_set_expr(query.body, query.extra_order_exprs)?;
         let order = Order {
             field_order: query.order,
@@ -45,7 +46,7 @@ impl Planner {
         let dist = Distribution::Single;
         let mut out_fields = FixedBitSet::with_capacity(plan.schema().len());
         out_fields.insert_range(..plan.schema().len() - extra_order_exprs_len);
-        let root = PlanRoot::new(plan, dist, order, out_fields);
+        let root = PlanRoot::new(plan, dist, order, out_fields, out_names);
         Ok(root)
     }
 }

--- a/src/frontend/src/utils/column_index_mapping.rs
+++ b/src/frontend/src/utils/column_index_mapping.rs
@@ -336,6 +336,21 @@ impl ColIndexMapping {
         }
         ret
     }
+
+    pub fn rewrite_bitset2(&self, bitset: &FixedBitSet) -> FixedBitSet {
+        assert_eq!(bitset.len(), self.source_size());
+        let mut ret = FixedBitSet::with_capacity(self.target_size());
+        let mut z = vec![];
+        for i in bitset.ones() {
+            let ni = self.map(i);
+            ret.insert(ni);
+            z.push(ni);
+        }
+        for i in 1..z.len() {
+            assert!(z[i - 1] < z[i]);
+        }
+        ret
+    }
 }
 
 impl ExprRewriter for ColIndexMapping {

--- a/src/frontend/test_runner/tests/testdata/agg.yaml
+++ b/src/frontend/test_runner/tests/testdata/agg.yaml
@@ -19,13 +19,13 @@
     select v1, min(v2) + max(v3) * count(v1) from t group by v1;
   batch_plan: |
     BatchExchange { order: [], dist: Single }
-      BatchProject { exprs: [$0, ($1 + ($2 * $3))], expr_alias: [v1,  ] }
+      BatchProject { exprs: [$0, ($1 + ($2 * $3))], expr_alias: [ ,  ] }
         BatchHashAgg { group_keys: [$0], aggs: [min($1), max($2), count($0)] }
           BatchExchange { order: [], dist: HashShard([0]) }
             BatchScan { table: t, columns: [v1, v2, v3] }
   stream_plan: |
     StreamMaterialize { columns: [v1, expr#1], pk_columns: [v1] }
-      StreamProject { exprs: [$0, ($2 + ($3 * $4))], expr_alias: [v1,  ] }
+      StreamProject { exprs: [$0, ($2 + ($3 * $4))], expr_alias: [ ,  ] }
         StreamHashAgg { group_keys: [$0], aggs: [count, min($1), max($2), count($0)] }
           StreamExchange { dist: HashShard([0]) }
             StreamTableScan { table: t, columns: [v1, v2, v3, _row_id#0], pk_indices: [3] }
@@ -56,14 +56,14 @@
     select v3, min(v1) * avg(v1+v2) from t group by v3;
   batch_plan: |
     BatchExchange { order: [], dist: Single }
-      BatchProject { exprs: [$0, ($1 * ($2::Decimal / $3))], expr_alias: [v3,  ] }
+      BatchProject { exprs: [$0, ($1 * ($2::Decimal / $3))], expr_alias: [ ,  ] }
         BatchHashAgg { group_keys: [$0], aggs: [min($1), sum($2), count($2)] }
           BatchProject { exprs: [$2, $0, ($0 + $1)], expr_alias: [ ,  ,  ] }
             BatchExchange { order: [], dist: HashShard([2]) }
               BatchScan { table: t, columns: [v1, v2, v3] }
   stream_plan: |
     StreamMaterialize { columns: [v3, expr#1], pk_columns: [v3] }
-      StreamProject { exprs: [$0, ($2 * ($3::Decimal / $4))], expr_alias: [v3,  ] }
+      StreamProject { exprs: [$0, ($2 * ($3::Decimal / $4))], expr_alias: [ ,  ] }
         StreamHashAgg { group_keys: [$0], aggs: [count, min($1), sum($2), count($2)] }
           StreamProject { exprs: [$2, $0, ($0 + $1), $3], expr_alias: [ ,  ,  ,  ] }
             StreamExchange { dist: HashShard([2]) }
@@ -82,7 +82,7 @@
     create table t(v1 int, v2 int, v3 int);
     select v1, sum(v1 * v2) as sum from t group by (v1 + v2) / v3, v1;
   logical_plan: |
-    LogicalProject { exprs: [$1, $2], expr_alias: [v1, sum] }
+    LogicalProject { exprs: [$1, $2], expr_alias: [ ,  ] }
       LogicalAgg { group_keys: [0, 1], agg_calls: [sum($2)] }
         LogicalProject { exprs: [(($1 + $2) / $3), $1, ($1 * $2)], expr_alias: [ ,  ,  ] }
           LogicalScan { table: t, columns: [_row_id#0, v1, v2, v3] }
@@ -133,14 +133,14 @@
     select v1, sum(v2 + v3) / count(v2 + v3) + max(v1) from t group by v1;
   batch_plan: |
     BatchExchange { order: [], dist: Single }
-      BatchProject { exprs: [$0, (($1 / $2) + $3)], expr_alias: [v1,  ] }
+      BatchProject { exprs: [$0, (($1 / $2) + $3)], expr_alias: [ ,  ] }
         BatchHashAgg { group_keys: [$0], aggs: [sum($1), count($1), max($0)] }
           BatchProject { exprs: [$0, ($1 + $2)], expr_alias: [ ,  ] }
             BatchExchange { order: [], dist: HashShard([0]) }
               BatchScan { table: t, columns: [v1, v2, v3] }
   stream_plan: |
     StreamMaterialize { columns: [v1, expr#1], pk_columns: [v1] }
-      StreamProject { exprs: [$0, (($2 / $3) + $4)], expr_alias: [v1,  ] }
+      StreamProject { exprs: [$0, (($2 / $3) + $4)], expr_alias: [ ,  ] }
         StreamHashAgg { group_keys: [$0], aggs: [count, sum($1), count($1), max($0)] }
           StreamProject { exprs: [$0, ($1 + $2), $3], expr_alias: [ ,  ,  ] }
             StreamExchange { dist: HashShard([0]) }
@@ -191,7 +191,7 @@
     select distinct v1 from t;
   logical_plan: |
     LogicalAgg { group_keys: [0], agg_calls: [] }
-      LogicalProject { exprs: [$1], expr_alias: [v1] }
+      LogicalProject { exprs: [$1], expr_alias: [ ] }
         LogicalScan { table: t, columns: [_row_id#0, v1, v2] }
 - sql: |
     /* distinct with agg */

--- a/src/frontend/test_runner/tests/testdata/basic_query.yaml
+++ b/src/frontend/test_runner/tests/testdata/basic_query.yaml
@@ -67,7 +67,7 @@
     create table t(a Boolean);
     select * from t where (NULL IS NULL) IS TRUE AND FALSE IS FALSE AND a;
   logical_plan: |
-    LogicalProject { exprs: [$1], expr_alias: [a] }
+    LogicalProject { exprs: [$1], expr_alias: [ ] }
       LogicalFilter { predicate: $1 }
         LogicalScan { table: t, columns: [_row_id#0, a] }
 - sql: |
@@ -75,7 +75,7 @@
     create table t(a Boolean);
     select * from t where (NULL IS NOT TRUE) IS NOT FALSE AND a IS NOT TRUE;
   logical_plan: |
-    LogicalProject { exprs: [$1], expr_alias: [a] }
+    LogicalProject { exprs: [$1], expr_alias: [ ] }
       LogicalFilter { predicate: IsNotTrue($1) }
         LogicalScan { table: t, columns: [_row_id#0, a] }
 - sql: |
@@ -83,7 +83,7 @@
     create table t(a double precision);
     select * from t where (a IS NOT NULL AND 3.14 IS NOT NULL) OR (NULL IS NOT NULL);
   logical_plan: |
-    LogicalProject { exprs: [$1], expr_alias: [a] }
+    LogicalProject { exprs: [$1], expr_alias: [ ] }
       LogicalFilter { predicate: IsNotNull($1) }
         LogicalScan { table: t, columns: [_row_id#0, a] }
 - sql: |
@@ -104,8 +104,7 @@
     select a from t as t2(a);
   batch_plan: |
     BatchExchange { order: [], dist: Single }
-      BatchProject { exprs: [$0], expr_alias: [a] }
-        BatchScan { table: t, columns: [v1] }
+      BatchScan { table: t, columns: [v1] }
 - sql: |
     create table t (v1 int, v2 int);
     delete from t;

--- a/src/frontend/test_runner/tests/testdata/column_pruning.yaml
+++ b/src/frontend/test_runner/tests/testdata/column_pruning.yaml
@@ -2,7 +2,7 @@
     create table t (v1 bigint, v2 double precision);
     select v1 from t
   logical_plan: |
-    LogicalProject { exprs: [$1], expr_alias: [v1] }
+    LogicalProject { exprs: [$1], expr_alias: [ ] }
       LogicalScan { table: t, columns: [_row_id#0, v1, v2] }
   optimized_logical_plan: |
     LogicalScan { table: t, columns: [v1] }
@@ -11,11 +11,11 @@
     create table t (v1 bigint, v2 double precision, v3 int);
     select v1 from t where v2 > 2
   logical_plan: |
-    LogicalProject { exprs: [$1], expr_alias: [v1] }
+    LogicalProject { exprs: [$1], expr_alias: [ ] }
       LogicalFilter { predicate: ($2 > 2:Int32) }
         LogicalScan { table: t, columns: [_row_id#0, v1, v2, v3] }
   optimized_logical_plan: |
-    LogicalProject { exprs: [$0], expr_alias: [v1] }
+    LogicalProject { exprs: [$0], expr_alias: [ ] }
       LogicalFilter { predicate: ($1 > 2:Int32) }
         LogicalScan { table: t, columns: [v1, v2] }
 - sql: |
@@ -24,12 +24,12 @@
     create table t2 (v1 int not null, v2 int not null, v3 int);
     select t1.v1, t2.v1 from t1 join t2 on t1.v2 = t2.v2;
   logical_plan: |
-    LogicalProject { exprs: [$1, $5], expr_alias: [v1, v1] }
+    LogicalProject { exprs: [$1, $5], expr_alias: [ ,  ] }
       LogicalJoin { type: Inner, on: ($2 = $6) }
         LogicalScan { table: t1, columns: [_row_id#0, v1, v2, v3] }
         LogicalScan { table: t2, columns: [_row_id#0, v1, v2, v3] }
   optimized_logical_plan: |
-    LogicalProject { exprs: [$0, $2], expr_alias: [v1, v1] }
+    LogicalProject { exprs: [$0, $2], expr_alias: [ ,  ] }
       LogicalJoin { type: Inner, on: ($1 = $3) }
         LogicalScan { table: t1, columns: [v1, v2] }
         LogicalScan { table: t2, columns: [v1, v2] }
@@ -104,13 +104,13 @@
     create table t2 (v1 int not null, v2 int not null, v3 int);
     select t1.v1, t2.v1 from t1 join t2 on t1.v2 = t2.v2 where t1.v3 < 1;
   logical_plan: |
-    LogicalProject { exprs: [$1, $5], expr_alias: [v1, v1] }
+    LogicalProject { exprs: [$1, $5], expr_alias: [ ,  ] }
       LogicalFilter { predicate: ($3 < 1:Int32) }
         LogicalJoin { type: Inner, on: ($2 = $6) }
           LogicalScan { table: t1, columns: [_row_id#0, v1, v2, v3] }
           LogicalScan { table: t2, columns: [_row_id#0, v1, v2, v3] }
   optimized_logical_plan: |
-    LogicalProject { exprs: [$0, $2], expr_alias: [v1, v1] }
+    LogicalProject { exprs: [$0, $2], expr_alias: [ ,  ] }
       LogicalJoin { type: Inner, on: ($1 = $3) }
         LogicalProject { exprs: [$0, $1], expr_alias: [ ,  ] }
           LogicalFilter { predicate: ($2 < 1:Int32) }
@@ -136,10 +136,10 @@
     create table t1 (a int, b int, created_at timestamp);
     select a, window_end from hop(t1, created_at, interval '15' minute, interval '30' minute)
   logical_plan: |
-    LogicalProject { exprs: [$1, $5], expr_alias: [a, window_end] }
+    LogicalProject { exprs: [$1, $5], expr_alias: [ ,  ] }
       LogicalHopWindow { time_col: $3 slide: 00:15:00 size: 00:30:00 }
         LogicalScan { table: t1, columns: [_row_id#0, a, b, created_at] }
   optimized_logical_plan: |
-    LogicalProject { exprs: [$0, $3], expr_alias: [a, window_end] }
+    LogicalProject { exprs: [$0, $3], expr_alias: [ ,  ] }
       LogicalHopWindow { time_col: $1 slide: 00:15:00 size: 00:30:00 }
         LogicalScan { table: t1, columns: [a, created_at] }

--- a/src/frontend/test_runner/tests/testdata/index.yaml
+++ b/src/frontend/test_runner/tests/testdata/index.yaml
@@ -36,7 +36,7 @@
   stream_plan: |
     StreamMaterialize { columns: [v4, _row_id#0(hidden), _row_id#1(hidden)], pk_columns: [_row_id#0, _row_id#1] }
       StreamExchange { dist: HashShard([1, 2]) }
-        StreamProject { exprs: [$3, $1, $4], expr_alias: [v4,  ,  ] }
+        StreamProject { exprs: [$3, $1, $4], expr_alias: [ ,  ,  ] }
           StreamDeltaJoin { type: Inner, predicate: $0 = $2 }
             StreamIndexScan { index: iii_index_1, columns: [v1, _row_id#0], pk_indices: [1] }
             StreamIndexScan { index: iii_index_2, columns: [v3, v4, _row_id#0], pk_indices: [2] }

--- a/src/frontend/test_runner/tests/testdata/join.yaml
+++ b/src/frontend/test_runner/tests/testdata/join.yaml
@@ -4,7 +4,7 @@
     create table t3 (v5 int, v6 int);
     select * from t1, t2, t3 where t1.v1 = t2.v3 and t1.v1 = t3.v5;
   logical_plan: |
-    LogicalProject { exprs: [$1, $2, $4, $5, $7, $8], expr_alias: [v1, v2, v3, v4, v5, v6] }
+    LogicalProject { exprs: [$1, $2, $4, $5, $7, $8], expr_alias: [ ,  ,  ,  ,  ,  ] }
       LogicalFilter { predicate: ($1 = $4) AND ($1 = $7) }
         LogicalJoin { type: Inner, on: true }
           LogicalJoin { type: Inner, on: true }
@@ -27,19 +27,18 @@
     create table t (v1 int, v2 int);
     select t1.v1 as t1v1, t2.v1 as t2v1 from t t1 join t t2 on t1.v1 = t2.v1;
   logical_plan: |
-    LogicalProject { exprs: [$1, $4], expr_alias: [t1v1, t2v1] }
+    LogicalProject { exprs: [$1, $4], expr_alias: [ ,  ] }
       LogicalJoin { type: Inner, on: ($1 = $4) }
         LogicalScan { table: t, columns: [_row_id#0, v1, v2] }
         LogicalScan { table: t, columns: [_row_id#0, v1, v2] }
   stream_plan: |
-    StreamMaterialize { columns: [t1v1, t2v1, _row_id#0(hidden), _row_id#1(hidden)], pk_columns: [_row_id#0, _row_id#1] }
-      StreamExchange { dist: HashShard([2, 3]) }
-        StreamProject { exprs: [$0, $2, $1, $3], expr_alias: [t1v1, t2v1,  ,  ] }
-          StreamHashJoin { type: Inner, predicate: $0 = $2 }
-            StreamExchange { dist: HashShard([0]) }
-              StreamTableScan { table: t, columns: [v1, _row_id#0], pk_indices: [1] }
-            StreamExchange { dist: HashShard([0]) }
-              StreamTableScan { table: t, columns: [v1, _row_id#0], pk_indices: [1] }
+    StreamMaterialize { columns: [t1v1, _row_id#0(hidden), t2v1, _row_id#1(hidden)], pk_columns: [_row_id#0, _row_id#1] }
+      StreamExchange { dist: HashShard([1, 3]) }
+        StreamHashJoin { type: Inner, predicate: $0 = $2 }
+          StreamExchange { dist: HashShard([0]) }
+            StreamTableScan { table: t, columns: [v1, _row_id#0], pk_indices: [1] }
+          StreamExchange { dist: HashShard([0]) }
+            StreamTableScan { table: t, columns: [v1, _row_id#0], pk_indices: [1] }
 - sql: |
     create table t1 (v1 int, v2 int);
     create table t2 (v1 int, v2 int);
@@ -47,36 +46,34 @@
     select t1.v1 as t1_v1, t1.v2 as t1_v2, t2.v1 as t2_v1, t2.v2 as t2_v2, t3.v1 as t3_v1, t3.v2 as t3_v2 from t1 join t2 on (t1.v1 = t2.v1) join t3 on (t2.v2 = t3.v2);
   batch_plan: |
     BatchExchange { order: [], dist: Single }
-      BatchProject { exprs: [$0, $1, $2, $3, $4, $5], expr_alias: [t1_v1, t1_v2, t2_v1, t2_v2, t3_v1, t3_v2] }
-        BatchHashJoin { type: Inner, predicate: $3 = $5 }
-          BatchExchange { order: [], dist: HashShard([3]) }
-            BatchHashJoin { type: Inner, predicate: $0 = $2 }
-              BatchExchange { order: [], dist: HashShard([0]) }
-                BatchScan { table: t1, columns: [v1, v2] }
-              BatchExchange { order: [], dist: HashShard([0]) }
-                BatchScan { table: t2, columns: [v1, v2] }
-          BatchExchange { order: [], dist: HashShard([1]) }
-            BatchScan { table: t3, columns: [v1, v2] }
+      BatchHashJoin { type: Inner, predicate: $3 = $5 }
+        BatchExchange { order: [], dist: HashShard([3]) }
+          BatchHashJoin { type: Inner, predicate: $0 = $2 }
+            BatchExchange { order: [], dist: HashShard([0]) }
+              BatchScan { table: t1, columns: [v1, v2] }
+            BatchExchange { order: [], dist: HashShard([0]) }
+              BatchScan { table: t2, columns: [v1, v2] }
+        BatchExchange { order: [], dist: HashShard([1]) }
+          BatchScan { table: t3, columns: [v1, v2] }
   stream_plan: |
-    StreamMaterialize { columns: [t1_v1, t1_v2, t2_v1, t2_v2, t3_v1, t3_v2, _row_id#0(hidden), _row_id#1(hidden), _row_id#2(hidden)], pk_columns: [_row_id#0, _row_id#1, _row_id#2] }
-      StreamExchange { dist: HashShard([6, 7, 8]) }
-        StreamProject { exprs: [$0, $1, $3, $4, $6, $7, $2, $5, $8], expr_alias: [t1_v1, t1_v2, t2_v1, t2_v2, t3_v1, t3_v2,  ,  ,  ] }
-          StreamHashJoin { type: Inner, predicate: $4 = $7 }
-            StreamExchange { dist: HashShard([4]) }
-              StreamHashJoin { type: Inner, predicate: $0 = $3 }
-                StreamExchange { dist: HashShard([0]) }
-                  StreamTableScan { table: t1, columns: [v1, v2, _row_id#0], pk_indices: [2] }
-                StreamExchange { dist: HashShard([0]) }
-                  StreamTableScan { table: t2, columns: [v1, v2, _row_id#0], pk_indices: [2] }
-            StreamExchange { dist: HashShard([1]) }
-              StreamTableScan { table: t3, columns: [v1, v2, _row_id#0], pk_indices: [2] }
+    StreamMaterialize { columns: [t1_v1, t1_v2, _row_id#0(hidden), t2_v1, t2_v2, _row_id#1(hidden), t3_v1, t3_v2, _row_id#2(hidden)], pk_columns: [_row_id#0, _row_id#1, _row_id#2] }
+      StreamExchange { dist: HashShard([2, 5, 8]) }
+        StreamHashJoin { type: Inner, predicate: $4 = $7 }
+          StreamExchange { dist: HashShard([4]) }
+            StreamHashJoin { type: Inner, predicate: $0 = $3 }
+              StreamExchange { dist: HashShard([0]) }
+                StreamTableScan { table: t1, columns: [v1, v2, _row_id#0], pk_indices: [2] }
+              StreamExchange { dist: HashShard([0]) }
+                StreamTableScan { table: t2, columns: [v1, v2, _row_id#0], pk_indices: [2] }
+          StreamExchange { dist: HashShard([1]) }
+            StreamTableScan { table: t3, columns: [v1, v2, _row_id#0], pk_indices: [2] }
 - sql: |
     create table t1 (v1 int not null, v2 int not null);
     create table t2 (v1 int not null, v2 int not null);
     select t1.v2 as t1_v2, t2.v2 as t2_v2 from t1 join t2 on t1.v1 = t2.v1;
   batch_plan: |
     BatchExchange { order: [], dist: Single }
-      BatchProject { exprs: [$1, $3], expr_alias: [t1_v2, t2_v2] }
+      BatchProject { exprs: [$1, $3], expr_alias: [ ,  ] }
         BatchHashJoin { type: Inner, predicate: $0 = $2 }
           BatchExchange { order: [], dist: HashShard([0]) }
             BatchScan { table: t1, columns: [v1, v2] }
@@ -85,7 +82,7 @@
   stream_plan: |
     StreamMaterialize { columns: [t1_v2, t2_v2, _row_id#0(hidden), _row_id#1(hidden)], pk_columns: [_row_id#0, _row_id#1] }
       StreamExchange { dist: HashShard([2, 3]) }
-        StreamProject { exprs: [$1, $4, $2, $5], expr_alias: [t1_v2, t2_v2,  ,  ] }
+        StreamProject { exprs: [$1, $4, $2, $5], expr_alias: [ ,  ,  ,  ] }
           StreamHashJoin { type: Inner, predicate: $0 = $3 }
             StreamExchange { dist: HashShard([0]) }
               StreamTableScan { table: t1, columns: [v1, v2, _row_id#0], pk_indices: [2] }
@@ -96,7 +93,7 @@
     create table t2 (v1 int not null, v2 int not null);
     select t1.v2 as t1_v2, t2.v2 as t2_v2 from t1 join t2 on t1.v1 > t2.v1 and t1.v2 < 10;
   batch_plan: |
-    BatchProject { exprs: [$1, $3], expr_alias: [t1_v2, t2_v2] }
+    BatchProject { exprs: [$1, $3], expr_alias: [ ,  ] }
       BatchNestedLoopJoin { type: Inner, predicate: ($0 > $2) AND ($1 < 10:Int32) }
         BatchExchange { order: [], dist: Single }
           BatchScan { table: t1, columns: [v1, v2] }

--- a/src/frontend/test_runner/tests/testdata/limit.yaml
+++ b/src/frontend/test_runner/tests/testdata/limit.yaml
@@ -3,21 +3,21 @@
     select * from t limit 4;
   logical_plan: |
     LogicalLimit { limit: 4, offset: 0 }
-      LogicalProject { exprs: [$1], expr_alias: [v] }
+      LogicalProject { exprs: [$1], expr_alias: [ ] }
         LogicalScan { table: t, columns: [_row_id#0, v] }
 - sql: |
     create table t (v int not null);
     select * from t offset 4;
   logical_plan: |
     LogicalLimit { limit: 9223372036854775807, offset: 4 }
-      LogicalProject { exprs: [$1], expr_alias: [v] }
+      LogicalProject { exprs: [$1], expr_alias: [ ] }
         LogicalScan { table: t, columns: [_row_id#0, v] }
 - sql: |
     create table t (v int not null);
     select * from ( select * from t limit 5 ) limit 4;
   logical_plan: |
     LogicalLimit { limit: 4, offset: 0 }
-      LogicalProject { exprs: [$0], expr_alias: [v] }
+      LogicalProject { exprs: [$0], expr_alias: [ ] }
         LogicalLimit { limit: 5, offset: 0 }
-          LogicalProject { exprs: [$1], expr_alias: [v] }
+          LogicalProject { exprs: [$1], expr_alias: [ ] }
             LogicalScan { table: t, columns: [_row_id#0, v] }

--- a/src/frontend/test_runner/tests/testdata/mv_on_mv.yaml
+++ b/src/frontend/test_runner/tests/testdata/mv_on_mv.yaml
@@ -10,11 +10,10 @@
   sql: |
     select m1.v1 as m1v1, m1.v2 as m1v2, m2.v1 as m2v1, m2.v2 as m2v2 from m1 join m2 on m1.v1 = m2.v1;
   stream_plan: |
-    StreamMaterialize { columns: [m1v1, m1v2, m2v1, m2v2, _row_id#0(hidden), _row_id#1(hidden)], pk_columns: [_row_id#0, _row_id#1] }
-      StreamExchange { dist: HashShard([4, 5]) }
-        StreamProject { exprs: [$0, $1, $3, $4, $2, $5], expr_alias: [m1v1, m1v2, m2v1, m2v2,  ,  ] }
-          StreamHashJoin { type: Inner, predicate: $0 = $3 }
-            StreamExchange { dist: HashShard([0]) }
-              StreamTableScan { table: m1, columns: [v1, v2, _row_id#0], pk_indices: [2] }
-            StreamExchange { dist: HashShard([0]) }
-              StreamTableScan { table: m2, columns: [v1, v2, _row_id#0], pk_indices: [2] }
+    StreamMaterialize { columns: [m1v1, m1v2, _row_id#0(hidden), m2v1, m2v2, _row_id#1(hidden)], pk_columns: [_row_id#0, _row_id#1] }
+      StreamExchange { dist: HashShard([2, 5]) }
+        StreamHashJoin { type: Inner, predicate: $0 = $3 }
+          StreamExchange { dist: HashShard([0]) }
+            StreamTableScan { table: m1, columns: [v1, v2, _row_id#0], pk_indices: [2] }
+          StreamExchange { dist: HashShard([0]) }
+            StreamTableScan { table: m2, columns: [v1, v2, _row_id#0], pk_indices: [2] }

--- a/src/frontend/test_runner/tests/testdata/nexmark.yaml
+++ b/src/frontend/test_runner/tests/testdata/nexmark.yaml
@@ -60,11 +60,11 @@
     FROM bid;
   batch_plan: |
     BatchExchange { order: [], dist: Single }
-      BatchProject { exprs: [$0, $1, (0.908:Decimal * $2), $3], expr_alias: [auction, bidder, price, dateTime] }
+      BatchProject { exprs: [$0, $1, (0.908:Decimal * $2), $3], expr_alias: [ ,  ,  ,  ] }
         BatchScan { table: bid, columns: [auction, bidder, price, dateTime] }
   stream_plan: |
     StreamMaterialize { columns: [auction, bidder, price, dateTime, _row_id#0(hidden)], pk_columns: [_row_id#0] }
-      StreamProject { exprs: [$0, $1, (0.908:Decimal * $2), $3, $4], expr_alias: [auction, bidder, price, dateTime,  ] }
+      StreamProject { exprs: [$0, $1, (0.908:Decimal * $2), $3, $4], expr_alias: [ ,  ,  ,  ,  ] }
         StreamTableScan { table: bid, columns: [auction, bidder, price, dateTime, _row_id#0], pk_indices: [4] }
 - id: nexmark_q2
   before:
@@ -90,7 +90,7 @@
         A.category = 10 and (P.state = 'or' OR P.state = 'id' OR P.state = 'ca');
   batch_plan: |
     BatchExchange { order: [], dist: Single }
-      BatchProject { exprs: [$3, $4, $5, $0], expr_alias: [name, city, state, id] }
+      BatchProject { exprs: [$3, $4, $5, $0], expr_alias: [ ,  ,  ,  ] }
         BatchHashJoin { type: Inner, predicate: $1 = $2 }
           BatchProject { exprs: [$0, $1], expr_alias: [ ,  ] }
             BatchExchange { order: [], dist: HashShard([1]) }
@@ -102,7 +102,7 @@
   stream_plan: |
     StreamMaterialize { columns: [name, city, state, id, _row_id#0(hidden), _row_id#1(hidden)], pk_columns: [_row_id#0, _row_id#1] }
       StreamExchange { dist: HashShard([4, 5]) }
-        StreamProject { exprs: [$4, $5, $6, $0, $2, $7], expr_alias: [name, city, state, id,  ,  ] }
+        StreamProject { exprs: [$4, $5, $6, $0, $2, $7], expr_alias: [ ,  ,  ,  ,  ,  ] }
           StreamHashJoin { type: Inner, predicate: $1 = $3 }
             StreamProject { exprs: [$0, $1, $3], expr_alias: [ ,  ,  ] }
               StreamExchange { dist: HashShard([1]) }
@@ -127,7 +127,7 @@
     GROUP BY Q.category;
   batch_plan: |
     BatchExchange { order: [], dist: Single }
-      BatchProject { exprs: [$0, ($1 / $2)], expr_alias: [category,  ] }
+      BatchProject { exprs: [$0, ($1 / $2)], expr_alias: [ ,  ] }
         BatchHashAgg { group_keys: [$0], aggs: [sum($1), count($1)] }
           BatchExchange { order: [], dist: HashShard([0]) }
             BatchProject { exprs: [$1, $2], expr_alias: [ ,  ] }
@@ -143,7 +143,7 @@
   stream_plan: |
     StreamMaterialize { columns: [category, expr#1], pk_columns: [category] }
       StreamExchange { dist: HashShard([0]) }
-        StreamProject { exprs: [$0, ($2 / $3)], expr_alias: [category,  ] }
+        StreamProject { exprs: [$0, ($2 / $3)], expr_alias: [ ,  ] }
           StreamHashAgg { group_keys: [$0], aggs: [count, sum($1), count($1)] }
             StreamProject { exprs: [$1, $3, $0], expr_alias: [ ,  ,  ] }
               StreamHashAgg { group_keys: [$0, $1], aggs: [count, max($2)] }

--- a/src/frontend/test_runner/tests/testdata/order_by.yaml
+++ b/src/frontend/test_runner/tests/testdata/order_by.yaml
@@ -21,7 +21,7 @@
   batch_plan: |
     BatchExchange { order: [$0 ASC], dist: Single }
       BatchSort { order: [$0 ASC] }
-        BatchProject { exprs: [$0, ($0 + 1:Int32)], expr_alias: [v1,  ] }
+        BatchProject { exprs: [$0, ($0 + 1:Int32)], expr_alias: [ ,  ] }
           BatchScan { table: t, columns: [v1] }
 - sql: |
     create table t (v1 bigint, v2 double precision);
@@ -36,20 +36,19 @@
   batch_plan: |
     BatchExchange { order: [$0 ASC], dist: Single }
       BatchSort { order: [$0 ASC] }
-        BatchProject { exprs: [$0], expr_alias: [a1] }
-          BatchScan { table: t, columns: [v1] }
+        BatchScan { table: t, columns: [v1] }
 - sql: |
     create table t (v1 bigint, v2 double precision);
     select * from t order by 1+1;
   batch_plan: |
-    BatchProject { exprs: [$0, $1], expr_alias: [v1, v2] }
+    BatchProject { exprs: [$0, $1], expr_alias: [ ,  ] }
       BatchExchange { order: [$2 ASC], dist: Single }
         BatchSort { order: [$2 ASC] }
-          BatchProject { exprs: [$0, $1, (1:Int32 + 1:Int32)], expr_alias: [v1, v2,  ] }
+          BatchProject { exprs: [$0, $1, (1:Int32 + 1:Int32)], expr_alias: [ ,  ,  ] }
             BatchScan { table: t, columns: [v1, v2] }
   stream_plan: |
     StreamMaterialize { columns: [v1, v2, expr#2(hidden), _row_id#0(hidden)], pk_columns: [_row_id#0], order_descs: [expr#2, _row_id#0] }
-      StreamProject { exprs: [$0, $1, (1:Int32 + 1:Int32), $2], expr_alias: [v1, v2,  ,  ] }
+      StreamProject { exprs: [$0, $1, (1:Int32 + 1:Int32), $2], expr_alias: [ ,  ,  ,  ] }
         StreamTableScan { table: t, columns: [v1, v2, _row_id#0], pk_indices: [2] }
 - sql: |
     create table t (v1 bigint, v2 double precision);
@@ -84,17 +83,17 @@
     create table t (x int, y int, z int);
     select x, y from t order by x + y, z;
   optimized_logical_plan: |
-    LogicalProject { exprs: [$0, $1, ($0 + $1), $2], expr_alias: [x, y,  ,  ] }
+    LogicalProject { exprs: [$0, $1, ($0 + $1), $2], expr_alias: [ ,  ,  ,  ] }
       LogicalScan { table: t, columns: [x, y, z] }
   batch_plan: |
-    BatchProject { exprs: [$0, $1], expr_alias: [x, y] }
+    BatchProject { exprs: [$0, $1], expr_alias: [ ,  ] }
       BatchExchange { order: [$2 ASC, $3 ASC], dist: Single }
         BatchSort { order: [$2 ASC, $3 ASC] }
-          BatchProject { exprs: [$0, $1, ($0 + $1), $2], expr_alias: [x, y,  ,  ] }
+          BatchProject { exprs: [$0, $1, ($0 + $1), $2], expr_alias: [ ,  ,  ,  ] }
             BatchScan { table: t, columns: [x, y, z] }
   stream_plan: |
     StreamMaterialize { columns: [x, y, expr#2(hidden), z(hidden), _row_id#0(hidden)], pk_columns: [_row_id#0], order_descs: [expr#2, z, _row_id#0] }
-      StreamProject { exprs: [$0, $1, ($0 + $1), $2, $3], expr_alias: [x, y,  ,  ,  ] }
+      StreamProject { exprs: [$0, $1, ($0 + $1), $2, $3], expr_alias: [ ,  ,  ,  ,  ] }
         StreamTableScan { table: t, columns: [x, y, z, _row_id#0], pk_indices: [3] }
 - sql: |
     /* order by the number of an output column */

--- a/src/frontend/test_runner/tests/testdata/predicate_pushdown.yaml
+++ b/src/frontend/test_runner/tests/testdata/predicate_pushdown.yaml
@@ -3,7 +3,7 @@
     create table t2 (v1 int, v2 int, v3 int);
     select * from t1 join t2 on t1.v1=t2.v2 and t1.v1>1 where t2.v2>2;
   logical_plan: |
-    LogicalProject { exprs: [$1, $2, $3, $5, $6, $7], expr_alias: [v1, v2, v3, v1, v2, v3] }
+    LogicalProject { exprs: [$1, $2, $3, $5, $6, $7], expr_alias: [ ,  ,  ,  ,  ,  ] }
       LogicalFilter { predicate: ($6 > 2:Int32) }
         LogicalJoin { type: Inner, on: ($1 = $6) AND ($1 > 1:Int32) }
           LogicalScan { table: t1, columns: [_row_id#0, v1, v2, v3] }
@@ -18,9 +18,9 @@
     create table t (v1 bigint, v2 double precision);
     select * from (select * from t) where v2 > 1;
   logical_plan: |
-    LogicalProject { exprs: [$0, $1], expr_alias: [v1, v2] }
+    LogicalProject { exprs: [$0, $1], expr_alias: [ ,  ] }
       LogicalFilter { predicate: ($1 > 1:Int32) }
-        LogicalProject { exprs: [$1, $2], expr_alias: [v1, v2] }
+        LogicalProject { exprs: [$1, $2], expr_alias: [ ,  ] }
           LogicalScan { table: t, columns: [_row_id#0, v1, v2] }
   optimized_logical_plan: |
     LogicalFilter { predicate: ($1 > 1:Int32) }
@@ -29,40 +29,39 @@
     create table t (v1 bigint, v2 double precision);
     select v1 from (select v2, v1 from t) where v2 > 1;
   logical_plan: |
-    LogicalProject { exprs: [$1], expr_alias: [v1] }
+    LogicalProject { exprs: [$1], expr_alias: [ ] }
       LogicalFilter { predicate: ($0 > 1:Int32) }
-        LogicalProject { exprs: [$2, $1], expr_alias: [v2, v1] }
+        LogicalProject { exprs: [$2, $1], expr_alias: [ ,  ] }
           LogicalScan { table: t, columns: [_row_id#0, v1, v2] }
   optimized_logical_plan: |
-    LogicalProject { exprs: [$0], expr_alias: [v1] }
+    LogicalProject { exprs: [$0], expr_alias: [ ] }
       LogicalFilter { predicate: ($1 > 1:Int32) }
         LogicalScan { table: t, columns: [v1, v2] }
 - sql: |
     create table t (v1 bigint, v2 double precision);
     select v1 from (select v2 as a2, v1 from t where v1 > 2) where a2 > 1;
   logical_plan: |
-    LogicalProject { exprs: [$1], expr_alias: [v1] }
+    LogicalProject { exprs: [$1], expr_alias: [ ] }
       LogicalFilter { predicate: ($0 > 1:Int32) }
-        LogicalProject { exprs: [$2, $1], expr_alias: [a2, v1] }
+        LogicalProject { exprs: [$2, $1], expr_alias: [ ,  ] }
           LogicalFilter { predicate: ($1 > 2:Int32) }
             LogicalScan { table: t, columns: [_row_id#0, v1, v2] }
   optimized_logical_plan: |
-    LogicalProject { exprs: [$0], expr_alias: [v1] }
+    LogicalProject { exprs: [$0], expr_alias: [ ] }
       LogicalFilter { predicate: ($1 > 1:Int32) AND ($0 > 2:Int32) }
         LogicalScan { table: t, columns: [v1, v2] }
 - sql: |
     create table t(v1 int, v2 int, v3 int, v4 int);
     select * from (select v1, min(v2) as min from t group by v1) where v1 > 1 and min > 1 and 1 > 0 and v1 > min;
   logical_plan: |
-    LogicalProject { exprs: [$0, $1], expr_alias: [v1, min] }
+    LogicalProject { exprs: [$0, $1], expr_alias: [ ,  ] }
       LogicalFilter { predicate: ($0 > 1:Int32) AND ($1 > 1:Int32) AND (1:Int32 > 0:Int32) AND ($0 > $1) }
-        LogicalProject { exprs: [$0, $1], expr_alias: [v1, min] }
+        LogicalProject { exprs: [$0, $1], expr_alias: [ ,  ] }
           LogicalAgg { group_keys: [0], agg_calls: [min($1)] }
             LogicalProject { exprs: [$1, $2], expr_alias: [ ,  ] }
               LogicalScan { table: t, columns: [_row_id#0, v1, v2, v3, v4] }
   optimized_logical_plan: |
-    LogicalProject { exprs: [$0, $1], expr_alias: [v1, min] }
-      LogicalFilter { predicate: ($1 > 1:Int32) AND ($0 > $1) }
-        LogicalAgg { group_keys: [0], agg_calls: [min($1)] }
-          LogicalFilter { predicate: ($0 > 1:Int32) AND (1:Int32 > 0:Int32) }
-            LogicalScan { table: t, columns: [v1, v2] }
+    LogicalFilter { predicate: ($1 > 1:Int32) AND ($0 > $1) }
+      LogicalAgg { group_keys: [0], agg_calls: [min($1)] }
+        LogicalFilter { predicate: ($0 > 1:Int32) AND (1:Int32 > 0:Int32) }
+          LogicalScan { table: t, columns: [v1, v2] }

--- a/src/frontend/test_runner/tests/testdata/stream_proto.yaml
+++ b/src/frontend/test_runner/tests/testdata/stream_proto.yaml
@@ -649,7 +649,7 @@
           - dataType:
               typeName: INT64
               isNullable: true
-            name: sum_v1
+            name: "agg#1"
           - dataType:
               typeName: INT32
               isNullable: true
@@ -673,7 +673,7 @@
       - dataType:
           typeName: INT64
           isNullable: true
-        name: sum_v1
+        name: "agg#1"
       - dataType:
           typeName: INT32
           isNullable: true

--- a/src/frontend/test_runner/tests/testdata/struct_query.yaml
+++ b/src/frontend/test_runner/tests/testdata/struct_query.yaml
@@ -32,7 +32,7 @@
     create materialized view t as select * from s;
     select (t).country.city,(t).country,(country).city.address from t;
   logical_plan: |
-    LogicalProject { exprs: [Field($1, 1:Int32), $1, Field(Field($1, 1:Int32), 0:Int32)], expr_alias: [city, country, address] }
+    LogicalProject { exprs: [Field($1, 1:Int32), $1, Field(Field($1, 1:Int32), 0:Int32)], expr_alias: [ ,  ,  ] }
       LogicalScan { table: t, columns: [id, country, zipcode, rate, _row_id#0] }
   create_source:
     row_format: protobuf
@@ -59,7 +59,7 @@
     create materialized view t as select * from s;
     select (t).country1.city.*,(t.country2).*,(country3).city.* from t;
   logical_plan: |
-    LogicalProject { exprs: [Field(Field($1, 1:Int32), 0:Int32), Field(Field($1, 1:Int32), 1:Int32), Field($2, 0:Int32), Field($2, 1:Int32), Field($2, 2:Int32), Field(Field($3, 1:Int32), 0:Int32), Field(Field($3, 1:Int32), 1:Int32)], expr_alias: [address, zipcode, address, city, zipcode, address, zipcode] }
+    LogicalProject { exprs: [Field(Field($1, 1:Int32), 0:Int32), Field(Field($1, 1:Int32), 1:Int32), Field($2, 0:Int32), Field($2, 1:Int32), Field($2, 2:Int32), Field(Field($3, 1:Int32), 0:Int32), Field(Field($3, 1:Int32), 1:Int32)], expr_alias: [ ,  ,  ,  ,  ,  ,  ] }
       LogicalScan { table: t, columns: [id, country1, country2, country3, zipcode, rate, _row_id#0] }
   create_source:
     row_format: protobuf
@@ -88,8 +88,8 @@
     create materialized view t as select * from s;
     select (c).zipcode from (select (t).country.city as c from t);
   logical_plan: |
-    LogicalProject { exprs: [Field($0, 1:Int32)], expr_alias: [zipcode] }
-      LogicalProject { exprs: [Field($1, 1:Int32)], expr_alias: [c] }
+    LogicalProject { exprs: [Field($0, 1:Int32)], expr_alias: [ ] }
+      LogicalProject { exprs: [Field($1, 1:Int32)], expr_alias: [ ] }
         LogicalScan { table: t, columns: [id, country, zipcode, rate, _row_id#0] }
   create_source:
     row_format: protobuf
@@ -116,8 +116,8 @@
     create materialized view t as select * from s;
     select (c).zipcode from (select min((t).country.city) as c from t);
   logical_plan: |
-    LogicalProject { exprs: [Field($0, 1:Int32)], expr_alias: [zipcode] }
-      LogicalProject { exprs: [$0], expr_alias: [c] }
+    LogicalProject { exprs: [Field($0, 1:Int32)], expr_alias: [ ] }
+      LogicalProject { exprs: [$0], expr_alias: [ ] }
         LogicalAgg { group_keys: [], agg_calls: [min($0)] }
           LogicalProject { exprs: [Field($1, 1:Int32)], expr_alias: [ ] }
             LogicalScan { table: t, columns: [id, country, zipcode, rate, _row_id#0] }
@@ -146,9 +146,9 @@
     create materialized view t as select * from s;
     select * from (select (country).city as c from t) as vv join t on (c).zipcode=(t.country).zipcode;
   logical_plan: |
-    LogicalProject { exprs: [$0, $1, $2, $3, $4], expr_alias: [c, id, country, zipcode, rate] }
+    LogicalProject { exprs: [$0, $1, $2, $3, $4], expr_alias: [ ,  ,  ,  ,  ] }
       LogicalJoin { type: Inner, on: (Field($0, 1:Int32) = Field($2, 2:Int32)) }
-        LogicalProject { exprs: [Field($1, 1:Int32)], expr_alias: [c] }
+        LogicalProject { exprs: [Field($1, 1:Int32)], expr_alias: [ ] }
           LogicalScan { table: t, columns: [id, country, zipcode, rate, _row_id#0] }
         LogicalScan { table: t, columns: [id, country, zipcode, rate, _row_id#0] }
   create_source:

--- a/src/frontend/test_runner/tests/testdata/subquery.yaml
+++ b/src/frontend/test_runner/tests/testdata/subquery.yaml
@@ -2,17 +2,17 @@
     create table t (v1 bigint, v2 double precision);
     select v1 from (select * from t) where v2 > 1;
   logical_plan: |
-    LogicalProject { exprs: [$0], expr_alias: [v1] }
+    LogicalProject { exprs: [$0], expr_alias: [ ] }
       LogicalFilter { predicate: ($1 > 1:Int32) }
-        LogicalProject { exprs: [$1, $2], expr_alias: [v1, v2] }
+        LogicalProject { exprs: [$1, $2], expr_alias: [ ,  ] }
           LogicalScan { table: t, columns: [_row_id#0, v1, v2] }
 - sql: |
     /* merge and then eliminate */
     create table t (v1 bigint, v2 double precision);
     select a1 as v1, a2 as v2 from (select v1 as a1, v2 as a2 from t);
   logical_plan: |
-    LogicalProject { exprs: [$0, $1], expr_alias: [v1, v2] }
-      LogicalProject { exprs: [$1, $2], expr_alias: [a1, a2] }
+    LogicalProject { exprs: [$0, $1], expr_alias: [ ,  ] }
+      LogicalProject { exprs: [$1, $2], expr_alias: [ ,  ] }
         LogicalScan { table: t, columns: [_row_id#0, v1, v2] }
   optimized_logical_plan: |
     LogicalScan { table: t, columns: [v1, v2] }
@@ -24,27 +24,27 @@
     create table t (v1 bigint, v2 double precision);
     select v3 from (select v2, v1 as v3 from t) where v2 > 1;
   logical_plan: |
-    LogicalProject { exprs: [$1], expr_alias: [v3] }
+    LogicalProject { exprs: [$1], expr_alias: [ ] }
       LogicalFilter { predicate: ($0 > 1:Int32) }
-        LogicalProject { exprs: [$2, $1], expr_alias: [v2, v3] }
+        LogicalProject { exprs: [$2, $1], expr_alias: [ ,  ] }
           LogicalScan { table: t, columns: [_row_id#0, v1, v2] }
 - sql: |
     /* consecutive projects are merged */
     create table t (v1 bigint, v2 double precision);
     select v1, 2 from (select v1, v2, 1 from t);
   logical_plan: |
-    LogicalProject { exprs: [$0, 2:Int32], expr_alias: [v1,  ] }
-      LogicalProject { exprs: [$1, $2, 1:Int32], expr_alias: [v1, v2,  ] }
+    LogicalProject { exprs: [$0, 2:Int32], expr_alias: [ ,  ] }
+      LogicalProject { exprs: [$1, $2, 1:Int32], expr_alias: [ ,  ,  ] }
         LogicalScan { table: t, columns: [_row_id#0, v1, v2] }
   optimized_logical_plan: |
-    LogicalProject { exprs: [$0, 2:Int32], expr_alias: [v1,  ] }
+    LogicalProject { exprs: [$0, 2:Int32], expr_alias: [ ,  ] }
       LogicalScan { table: t, columns: [v1] }
 - sql: |
     create table t (v1 bigint, v2 double precision);
     select * from (select * from t);
   logical_plan: |
-    LogicalProject { exprs: [$0, $1], expr_alias: [v1, v2] }
-      LogicalProject { exprs: [$1, $2], expr_alias: [v1, v2] }
+    LogicalProject { exprs: [$0, $1], expr_alias: [ ,  ] }
+      LogicalProject { exprs: [$1, $2], expr_alias: [ ,  ] }
         LogicalScan { table: t, columns: [_row_id#0, v1, v2] }
   optimized_logical_plan: |
     LogicalScan { table: t, columns: [v1, v2] }
@@ -53,9 +53,9 @@
     create table t (v1 bigint, v2 double precision);
     select * from (select * from t), t;
   logical_plan: |
-    LogicalProject { exprs: [$0, $1, $3, $4], expr_alias: [v1, v2, v1, v2] }
+    LogicalProject { exprs: [$0, $1, $3, $4], expr_alias: [ ,  ,  ,  ] }
       LogicalJoin { type: Inner, on: true }
-        LogicalProject { exprs: [$1, $2], expr_alias: [v1, v2] }
+        LogicalProject { exprs: [$1, $2], expr_alias: [ ,  ] }
           LogicalScan { table: t, columns: [_row_id#0, v1, v2] }
         LogicalScan { table: t, columns: [_row_id#0, v1, v2] }
 - sql: |
@@ -63,9 +63,9 @@
     create table t (v1 bigint, v2 double precision);
     select * from (select * from t) as tt join t on tt.v1=t.v1;
   logical_plan: |
-    LogicalProject { exprs: [$0, $1, $3, $4], expr_alias: [v1, v2, v1, v2] }
+    LogicalProject { exprs: [$0, $1, $3, $4], expr_alias: [ ,  ,  ,  ] }
       LogicalJoin { type: Inner, on: ($0 = $3) }
-        LogicalProject { exprs: [$1, $2], expr_alias: [v1, v2] }
+        LogicalProject { exprs: [$1, $2], expr_alias: [ ,  ] }
           LogicalScan { table: t, columns: [_row_id#0, v1, v2] }
         LogicalScan { table: t, columns: [_row_id#0, v1, v2] }
 - sql: |
@@ -73,9 +73,9 @@
     create table t (v1 bigint, v2 double precision);
     select * from (select * from t) as tt(a) join t on a=v1;
   logical_plan: |
-    LogicalProject { exprs: [$0, $1, $3, $4], expr_alias: [a, v2, v1, v2] }
+    LogicalProject { exprs: [$0, $1, $3, $4], expr_alias: [ ,  ,  ,  ] }
       LogicalJoin { type: Inner, on: ($0 = $3) }
-        LogicalProject { exprs: [$1, $2], expr_alias: [v1, v2] }
+        LogicalProject { exprs: [$1, $2], expr_alias: [ ,  ] }
           LogicalScan { table: t, columns: [_row_id#0, v1, v2] }
         LogicalScan { table: t, columns: [_row_id#0, v1, v2] }
 - sql: |

--- a/src/frontend/test_runner/tests/testdata/subquery_expr.yaml
+++ b/src/frontend/test_runner/tests/testdata/subquery_expr.yaml
@@ -13,7 +13,7 @@
     LogicalProject { exprs: [$2, 1:Int32], expr_alias: [ ,  ] }
       LogicalJoin { type: LeftOuter, on: true }
         LogicalScan { table: t, columns: [_row_id#0, x] }
-        LogicalProject { exprs: [$1], expr_alias: [x] }
+        LogicalProject { exprs: [$1], expr_alias: [ ] }
           LogicalScan { table: t, columns: [_row_id#0, x] }
 - sql: |
     create table t(x int);
@@ -22,7 +22,7 @@
     LogicalProject { exprs: [($2 + 1:Int32)], expr_alias: [ ] }
       LogicalJoin { type: LeftOuter, on: true }
         LogicalScan { table: t, columns: [_row_id#0, x] }
-        LogicalProject { exprs: [$1], expr_alias: [x] }
+        LogicalProject { exprs: [$1], expr_alias: [ ] }
           LogicalScan { table: t, columns: [_row_id#0, x] }
 - sql: |
     create table t(x int);
@@ -32,7 +32,7 @@
       LogicalJoin { type: LeftOuter, on: true }
         LogicalJoin { type: LeftOuter, on: true }
           LogicalValues { rows: [[]], schema: Schema { fields: [] } }
-          LogicalProject { exprs: [$1], expr_alias: [x] }
+          LogicalProject { exprs: [$1], expr_alias: [ ] }
             LogicalScan { table: t, columns: [_row_id#0, x] }
         LogicalProject { exprs: [1:Int32], expr_alias: [ ] }
           LogicalValues { rows: [[]], schema: Schema { fields: [] } }
@@ -40,13 +40,13 @@
     create table t(x int);
     select x + (select x + (select x as v1 from t) as v2 from t) as v3 from t;
   logical_plan: |
-    LogicalProject { exprs: [($1 + $2)], expr_alias: [v3] }
+    LogicalProject { exprs: [($1 + $2)], expr_alias: [ ] }
       LogicalJoin { type: LeftOuter, on: true }
         LogicalScan { table: t, columns: [_row_id#0, x] }
-        LogicalProject { exprs: [($1 + $2)], expr_alias: [v2] }
+        LogicalProject { exprs: [($1 + $2)], expr_alias: [ ] }
           LogicalJoin { type: LeftOuter, on: true }
             LogicalScan { table: t, columns: [_row_id#0, x] }
-            LogicalProject { exprs: [$1], expr_alias: [v1] }
+            LogicalProject { exprs: [$1], expr_alias: [ ] }
               LogicalScan { table: t, columns: [_row_id#0, x] }
 - sql: |
     select (select 1, 2);
@@ -58,7 +58,7 @@
     LogicalProject { exprs: [1:Int32], expr_alias: [ ] }
       LogicalJoin { type: LeftSemi, on: true }
         LogicalValues { rows: [[]], schema: Schema { fields: [] } }
-        LogicalProject { exprs: [$1], expr_alias: [x] }
+        LogicalProject { exprs: [$1], expr_alias: [ ] }
           LogicalScan { table: t, columns: [_row_id#0, x] }
   optimized_logical_plan: |
     LogicalProject { exprs: [1:Int32], expr_alias: [ ] }
@@ -72,7 +72,7 @@
     LogicalProject { exprs: [1:Int32], expr_alias: [ ] }
       LogicalJoin { type: LeftAnti, on: true }
         LogicalValues { rows: [[]], schema: Schema { fields: [] } }
-        LogicalProject { exprs: [$1], expr_alias: [x] }
+        LogicalProject { exprs: [$1], expr_alias: [ ] }
           LogicalScan { table: t, columns: [_row_id#0, x] }
   optimized_logical_plan: |
     LogicalProject { exprs: [1:Int32], expr_alias: [ ] }
@@ -84,30 +84,30 @@
     create table t2(x int);
     select x from t1 where exists (select x from t2);
   logical_plan: |
-    LogicalProject { exprs: [$1], expr_alias: [x] }
+    LogicalProject { exprs: [$1], expr_alias: [ ] }
       LogicalJoin { type: LeftSemi, on: true }
         LogicalScan { table: t1, columns: [_row_id#0, x] }
-        LogicalProject { exprs: [$1], expr_alias: [x] }
+        LogicalProject { exprs: [$1], expr_alias: [ ] }
           LogicalScan { table: t2, columns: [_row_id#0, x] }
 - sql: |
     create table t(x int);
     select x from t where exists (select * from t);
   logical_plan: |
-    LogicalProject { exprs: [$1], expr_alias: [x] }
+    LogicalProject { exprs: [$1], expr_alias: [ ] }
       LogicalJoin { type: LeftSemi, on: true }
         LogicalScan { table: t, columns: [_row_id#0, x] }
-        LogicalProject { exprs: [$1], expr_alias: [x] }
+        LogicalProject { exprs: [$1], expr_alias: [ ] }
           LogicalScan { table: t, columns: [_row_id#0, x] }
 - sql: |
     create table t1(x int);
     create table t2(x int);
     select x from t1 where x > (select x from t2)
   logical_plan: |
-    LogicalProject { exprs: [$1], expr_alias: [x] }
+    LogicalProject { exprs: [$1], expr_alias: [ ] }
       LogicalFilter { predicate: ($1 > $2) }
         LogicalJoin { type: LeftOuter, on: true }
           LogicalScan { table: t1, columns: [_row_id#0, x] }
-          LogicalProject { exprs: [$1], expr_alias: [x] }
+          LogicalProject { exprs: [$1], expr_alias: [ ] }
             LogicalScan { table: t2, columns: [_row_id#0, x] }
 - sql: |
     select 1 where 1>0 and exists (values (1))
@@ -137,18 +137,18 @@
     create table t2(x int, y int);
     select x from t1 where y in (select y from t2);
   logical_plan: |
-    LogicalProject { exprs: [$1], expr_alias: [x] }
+    LogicalProject { exprs: [$1], expr_alias: [ ] }
       LogicalJoin { type: LeftSemi, on: ($2 = $3) }
         LogicalScan { table: t1, columns: [_row_id#0, x, y] }
-        LogicalProject { exprs: [$2], expr_alias: [y] }
+        LogicalProject { exprs: [$2], expr_alias: [ ] }
           LogicalScan { table: t2, columns: [_row_id#0, x, y] }
 - sql: |
     create table t1(x int, y int);
     create table t2(x int, y int);
     select x from t1 where y not in (select y from t2);
   logical_plan: |
-    LogicalProject { exprs: [$1], expr_alias: [x] }
+    LogicalProject { exprs: [$1], expr_alias: [ ] }
       LogicalJoin { type: LeftAnti, on: ($2 = $3) }
         LogicalScan { table: t1, columns: [_row_id#0, x, y] }
-        LogicalProject { exprs: [$2], expr_alias: [y] }
+        LogicalProject { exprs: [$2], expr_alias: [ ] }
           LogicalScan { table: t2, columns: [_row_id#0, x, y] }

--- a/src/frontend/test_runner/tests/testdata/subquery_expr_correlated.yaml
+++ b/src/frontend/test_runner/tests/testdata/subquery_expr_correlated.yaml
@@ -3,7 +3,7 @@
     create table t2(x int, y int);
     select * from t1 where x > (select 1.5 * min(x) from t2 where t1.y=t2.y and t2.y = 1000)
   logical_plan: |
-    LogicalProject { exprs: [$1, $2], expr_alias: [x, y] }
+    LogicalProject { exprs: [$1, $2], expr_alias: [ ,  ] }
       LogicalFilter { predicate: ($1 > $3) }
         LogicalApply { type: LeftOuter, on: true }
           LogicalScan { table: t1, columns: [_row_id#0, x, y] }
@@ -13,7 +13,7 @@
                 LogicalFilter { predicate: (CorrelatedInputRef { index: 2, depth: 1 } = $2) AND ($2 = 1000:Int32) }
                   LogicalScan { table: t2, columns: [_row_id#0, x, y] }
   optimized_logical_plan: |
-    LogicalProject { exprs: [$0, $1], expr_alias: [x, y] }
+    LogicalProject { exprs: [$0, $1], expr_alias: [ ,  ] }
       LogicalFilter { predicate: ($0 > (1.5:Decimal * $2)) }
         LogicalProject { exprs: [$1, $2, $3], expr_alias: [ ,  ,  ] }
           LogicalAgg { group_keys: [0, 1, 2], agg_calls: [min($3)] }
@@ -27,7 +27,7 @@
     create table t2(x int, y int);
     select * from t1 where x>(select min(x) from t2 where t2.y = (select t1.y))
   logical_plan: |
-    LogicalProject { exprs: [$1, $2], expr_alias: [x, y] }
+    LogicalProject { exprs: [$1, $2], expr_alias: [ ,  ] }
       LogicalFilter { predicate: ($1 > $3) }
         LogicalApply { type: LeftOuter, on: true }
           LogicalScan { table: t1, columns: [_row_id#0, x, y] }
@@ -37,7 +37,7 @@
                 LogicalFilter { predicate: ($2 = $3) }
                   LogicalApply { type: LeftOuter, on: true }
                     LogicalScan { table: t2, columns: [_row_id#0, x, y] }
-                    LogicalProject { exprs: [CorrelatedInputRef { index: 2, depth: 2 }], expr_alias: [y] }
+                    LogicalProject { exprs: [CorrelatedInputRef { index: 2, depth: 2 }], expr_alias: [ ] }
                       LogicalValues { rows: [[]], schema: Schema { fields: [] } }
 - sql: |
     create table t1(x int, y int);
@@ -45,7 +45,7 @@
     create table t3(x int, y int);
     select * from t1 where x>(select min(x) from t2 where t1.y=t2.y and t1.x=(select max(x) from t3, (select 1) as dummy where t3.y=t1.y))
   logical_plan: |
-    LogicalProject { exprs: [$1, $2], expr_alias: [x, y] }
+    LogicalProject { exprs: [$1, $2], expr_alias: [ ,  ] }
       LogicalFilter { predicate: ($1 > $3) }
         LogicalApply { type: LeftOuter, on: true }
           LogicalScan { table: t1, columns: [_row_id#0, x, y] }
@@ -68,10 +68,10 @@
     create table t2(x int, y int);
     select * from t1 where exists(select * from t2 where y = 100 and t1.x = t2.x and x = 1000 and t1.y = t2.y);
   logical_plan: |
-    LogicalProject { exprs: [$1, $2], expr_alias: [x, y] }
+    LogicalProject { exprs: [$1, $2], expr_alias: [ ,  ] }
       LogicalApply { type: LeftSemi, on: true }
         LogicalScan { table: t1, columns: [_row_id#0, x, y] }
-        LogicalProject { exprs: [$1, $2], expr_alias: [x, y] }
+        LogicalProject { exprs: [$1, $2], expr_alias: [ ,  ] }
           LogicalFilter { predicate: ($2 = 100:Int32) AND (CorrelatedInputRef { index: 1, depth: 1 } = $1) AND ($1 = 1000:Int32) AND (CorrelatedInputRef { index: 2, depth: 1 } = $2) }
             LogicalScan { table: t2, columns: [_row_id#0, x, y] }
   optimized_logical_plan: |
@@ -84,7 +84,7 @@
     create table t2(x int, y int);
     select * from t1 where x > (select 1.5 * min(x) from t2 where t1.y = t2.y);
   logical_plan: |
-    LogicalProject { exprs: [$1, $2], expr_alias: [x, y] }
+    LogicalProject { exprs: [$1, $2], expr_alias: [ ,  ] }
       LogicalFilter { predicate: ($1 > $3) }
         LogicalApply { type: LeftOuter, on: true }
           LogicalScan { table: t1, columns: [_row_id#0, x, y] }
@@ -94,7 +94,7 @@
                 LogicalFilter { predicate: (CorrelatedInputRef { index: 2, depth: 1 } = $2) }
                   LogicalScan { table: t2, columns: [_row_id#0, x, y] }
   optimized_logical_plan: |
-    LogicalProject { exprs: [$0, $1], expr_alias: [x, y] }
+    LogicalProject { exprs: [$0, $1], expr_alias: [ ,  ] }
       LogicalFilter { predicate: ($0 > (1.5:Decimal * $2)) }
         LogicalProject { exprs: [$1, $2, $3], expr_alias: [ ,  ,  ] }
           LogicalAgg { group_keys: [0, 1, 2], agg_calls: [min($3)] }
@@ -107,7 +107,7 @@
     create table t2(x int, y int);
     select * from t1 where x > (select count(*) from t2 where t1.y = t2.y);
   logical_plan: |
-    LogicalProject { exprs: [$1, $2], expr_alias: [x, y] }
+    LogicalProject { exprs: [$1, $2], expr_alias: [ ,  ] }
       LogicalFilter { predicate: ($1 > $3) }
         LogicalApply { type: LeftOuter, on: true }
           LogicalScan { table: t1, columns: [_row_id#0, x, y] }
@@ -117,21 +117,21 @@
                 LogicalFilter { predicate: (CorrelatedInputRef { index: 2, depth: 1 } = $2) }
                   LogicalScan { table: t2, columns: [_row_id#0, x, y] }
   optimized_logical_plan: |
-    LogicalProject { exprs: [$0, $1], expr_alias: [x, y] }
+    LogicalProject { exprs: [$0, $1], expr_alias: [ ,  ] }
       LogicalFilter { predicate: ($0 > $2) }
         LogicalProject { exprs: [$1, $2, $3], expr_alias: [ ,  ,  ] }
           LogicalAgg { group_keys: [0, 1, 2], agg_calls: [count($3)] }
             LogicalProject { exprs: [$0, $1, $2, $3], expr_alias: [ ,  ,  ,  ] }
               LogicalJoin { type: LeftOuter, on: ($2 = $4) }
                 LogicalScan { table: t1, columns: [_row_id#0, x, y] }
-                LogicalProject { exprs: [1:Int32, $0], expr_alias: [1,  ] }
+                LogicalProject { exprs: [1:Int32, $0], expr_alias: [ ,  ] }
                   LogicalScan { table: t2, columns: [y] }
 - sql: |
     create table t1(x int, y int);
     create table t2(x int, y int);
     select * from t1 where x > (select count(*) + count(*) from t2 where t1.y = t2.y);
   logical_plan: |
-    LogicalProject { exprs: [$1, $2], expr_alias: [x, y] }
+    LogicalProject { exprs: [$1, $2], expr_alias: [ ,  ] }
       LogicalFilter { predicate: ($1 > $3) }
         LogicalApply { type: LeftOuter, on: true }
           LogicalScan { table: t1, columns: [_row_id#0, x, y] }
@@ -141,31 +141,31 @@
                 LogicalFilter { predicate: (CorrelatedInputRef { index: 2, depth: 1 } = $2) }
                   LogicalScan { table: t2, columns: [_row_id#0, x, y] }
   optimized_logical_plan: |
-    LogicalProject { exprs: [$0, $1], expr_alias: [x, y] }
+    LogicalProject { exprs: [$0, $1], expr_alias: [ ,  ] }
       LogicalFilter { predicate: ($0 > ($2 + $3)) }
         LogicalProject { exprs: [$1, $2, $3, $4], expr_alias: [ ,  ,  ,  ] }
           LogicalAgg { group_keys: [0, 1, 2], agg_calls: [count($3), count($3)] }
             LogicalProject { exprs: [$0, $1, $2, $3], expr_alias: [ ,  ,  ,  ] }
               LogicalJoin { type: LeftOuter, on: ($2 = $4) }
                 LogicalScan { table: t1, columns: [_row_id#0, x, y] }
-                LogicalProject { exprs: [1:Int32, $0], expr_alias: [1,  ] }
+                LogicalProject { exprs: [1:Int32, $0], expr_alias: [ ,  ] }
                   LogicalScan { table: t2, columns: [y] }
 - sql: |
     create table t1(x int, y int);
     create table t2(x int, y int);
     select x from t1 where y in (select y from t2 where t1.x = t2.x);
   logical_plan: |
-    LogicalProject { exprs: [$1], expr_alias: [x] }
+    LogicalProject { exprs: [$1], expr_alias: [ ] }
       LogicalApply { type: LeftSemi, on: ($2 = $3) }
         LogicalScan { table: t1, columns: [_row_id#0, x, y] }
-        LogicalProject { exprs: [$2], expr_alias: [y] }
+        LogicalProject { exprs: [$2], expr_alias: [ ] }
           LogicalFilter { predicate: (CorrelatedInputRef { index: 1, depth: 1 } = $1) }
             LogicalScan { table: t2, columns: [_row_id#0, x, y] }
   optimized_logical_plan: |
-    LogicalProject { exprs: [$0], expr_alias: [x] }
+    LogicalProject { exprs: [$0], expr_alias: [ ] }
       LogicalJoin { type: LeftSemi, on: ($1 = $2) AND ($0 = $3) }
         LogicalScan { table: t1, columns: [x, y] }
-        LogicalProject { exprs: [$1, $0], expr_alias: [y,  ] }
+        LogicalProject { exprs: [$1, $0], expr_alias: [ ,  ] }
           LogicalScan { table: t2, columns: [x, y] }
 - sql: |
     create table t1(x int, y int);
@@ -176,34 +176,34 @@
     create table t2(x int, y int);
     select x from t1 where y in (select y from t2 where t1.x + t2.x = 100 and t1.y = 1000);
   logical_plan: |
-    LogicalProject { exprs: [$1], expr_alias: [x] }
+    LogicalProject { exprs: [$1], expr_alias: [ ] }
       LogicalApply { type: LeftSemi, on: ($2 = $3) }
         LogicalScan { table: t1, columns: [_row_id#0, x, y] }
-        LogicalProject { exprs: [$2], expr_alias: [y] }
+        LogicalProject { exprs: [$2], expr_alias: [ ] }
           LogicalFilter { predicate: ((CorrelatedInputRef { index: 1, depth: 1 } + $1) = 100:Int32) AND (CorrelatedInputRef { index: 2, depth: 1 } = 1000:Int32) }
             LogicalScan { table: t2, columns: [_row_id#0, x, y] }
   optimized_logical_plan: |
-    LogicalProject { exprs: [$0], expr_alias: [x] }
+    LogicalProject { exprs: [$0], expr_alias: [ ] }
       LogicalJoin { type: LeftSemi, on: ($1 = $2) AND (($0 + $3) = 100:Int32) AND ($1 = 1000:Int32) }
         LogicalScan { table: t1, columns: [x, y] }
-        LogicalProject { exprs: [$1, $0], expr_alias: [y,  ] }
+        LogicalProject { exprs: [$1, $0], expr_alias: [ ,  ] }
           LogicalScan { table: t2, columns: [x, y] }
 - sql: |
     create table t1(x int, y int);
     create table t2(x int, y int);
     select x from t1 where y in (select y from t2 where t1.x > t2.x + 1000);
   logical_plan: |
-    LogicalProject { exprs: [$1], expr_alias: [x] }
+    LogicalProject { exprs: [$1], expr_alias: [ ] }
       LogicalApply { type: LeftSemi, on: ($2 = $3) }
         LogicalScan { table: t1, columns: [_row_id#0, x, y] }
-        LogicalProject { exprs: [$2], expr_alias: [y] }
+        LogicalProject { exprs: [$2], expr_alias: [ ] }
           LogicalFilter { predicate: (CorrelatedInputRef { index: 1, depth: 1 } > ($1 + 1000:Int32)) }
             LogicalScan { table: t2, columns: [_row_id#0, x, y] }
   optimized_logical_plan: |
-    LogicalProject { exprs: [$0], expr_alias: [x] }
+    LogicalProject { exprs: [$0], expr_alias: [ ] }
       LogicalJoin { type: LeftSemi, on: ($1 = $2) AND ($0 > ($3 + 1000:Int32)) }
         LogicalScan { table: t1, columns: [x, y] }
-        LogicalProject { exprs: [$1, $0], expr_alias: [y,  ] }
+        LogicalProject { exprs: [$1, $0], expr_alias: [ ,  ] }
           LogicalScan { table: t2, columns: [x, y] }
 - sql: |
     create table t1(x int, y int);
@@ -217,10 +217,10 @@
     create table t3(x int, y int);
     select x from t1 where y in (select x from t2 where t2.y = t1.y and x > (select min(x) from t3));
   logical_plan: |
-    LogicalProject { exprs: [$1], expr_alias: [x] }
+    LogicalProject { exprs: [$1], expr_alias: [ ] }
       LogicalApply { type: LeftSemi, on: ($2 = $3) }
         LogicalScan { table: t1, columns: [_row_id#0, x, y] }
-        LogicalProject { exprs: [$1], expr_alias: [x] }
+        LogicalProject { exprs: [$1], expr_alias: [ ] }
           LogicalFilter { predicate: ($2 = CorrelatedInputRef { index: 2, depth: 1 }) AND ($1 > $3) }
             LogicalJoin { type: LeftOuter, on: true }
               LogicalScan { table: t2, columns: [_row_id#0, x, y] }
@@ -235,13 +235,13 @@
     create table t3(x int, y int);
     select x from t1 where y in (select x from t2 where y in (select y from t3 where t1.y = t3.y));
   logical_plan: |
-    LogicalProject { exprs: [$1], expr_alias: [x] }
+    LogicalProject { exprs: [$1], expr_alias: [ ] }
       LogicalApply { type: LeftSemi, on: ($2 = $3) }
         LogicalScan { table: t1, columns: [_row_id#0, x, y] }
-        LogicalProject { exprs: [$1], expr_alias: [x] }
+        LogicalProject { exprs: [$1], expr_alias: [ ] }
           LogicalApply { type: LeftSemi, on: ($2 = $3) }
             LogicalScan { table: t2, columns: [_row_id#0, x, y] }
-            LogicalProject { exprs: [$2], expr_alias: [y] }
+            LogicalProject { exprs: [$2], expr_alias: [ ] }
               LogicalFilter { predicate: (CorrelatedInputRef { index: 2, depth: 2 } = $2) }
                 LogicalScan { table: t3, columns: [_row_id#0, x, y] }
 - sql: |
@@ -251,13 +251,13 @@
     create table t3(x int, y int);
     select x from t1 where y in (select x from t2 where y in (select y from t3 where t2.y = t3.y));
   logical_plan: |
-    LogicalProject { exprs: [$1], expr_alias: [x] }
+    LogicalProject { exprs: [$1], expr_alias: [ ] }
       LogicalJoin { type: LeftSemi, on: ($2 = $3) }
         LogicalScan { table: t1, columns: [_row_id#0, x, y] }
-        LogicalProject { exprs: [$1], expr_alias: [x] }
+        LogicalProject { exprs: [$1], expr_alias: [ ] }
           LogicalApply { type: LeftSemi, on: ($2 = $3) }
             LogicalScan { table: t2, columns: [_row_id#0, x, y] }
-            LogicalProject { exprs: [$2], expr_alias: [y] }
+            LogicalProject { exprs: [$2], expr_alias: [ ] }
               LogicalFilter { predicate: (CorrelatedInputRef { index: 2, depth: 1 } = $2) }
                 LogicalScan { table: t3, columns: [_row_id#0, x, y] }
 - sql: |

--- a/src/frontend/test_runner/tests/testdata/time_window.yaml
+++ b/src/frontend/test_runner/tests/testdata/time_window.yaml
@@ -2,12 +2,12 @@
     create table t1 (id int, created_at date);
     select * from tumble(t1, created_at, interval '3' day);
   logical_plan: |
-    LogicalProject { exprs: [$1, $2, $3, $4], expr_alias: [id, created_at, window_start, window_end] }
-      LogicalProject { exprs: [$0, $1, $2, TumbleStart($2, '3 days 00:00:00':Interval), (TumbleStart($2, '3 days 00:00:00':Interval) + '3 days 00:00:00':Interval)], expr_alias: [ ,  ,  , window_start, window_end] }
+    LogicalProject { exprs: [$1, $2, $3, $4], expr_alias: [ ,  ,  ,  ] }
+      LogicalProject { exprs: [$0, $1, $2, TumbleStart($2, '3 days 00:00:00':Interval), (TumbleStart($2, '3 days 00:00:00':Interval) + '3 days 00:00:00':Interval)], expr_alias: [ ,  ,  ,  ,  ] }
         LogicalScan { table: t1, columns: [_row_id#0, id, created_at] }
   batch_plan: |
     BatchExchange { order: [], dist: Single }
-      BatchProject { exprs: [$0, $1, TumbleStart($1, '3 days 00:00:00':Interval), (TumbleStart($1, '3 days 00:00:00':Interval) + '3 days 00:00:00':Interval)], expr_alias: [id, created_at, window_start, window_end] }
+      BatchProject { exprs: [$0, $1, TumbleStart($1, '3 days 00:00:00':Interval), (TumbleStart($1, '3 days 00:00:00':Interval) + '3 days 00:00:00':Interval)], expr_alias: [ ,  ,  ,  ] }
         BatchScan { table: t1, columns: [id, created_at] }
 - sql: |
     create materialized view t as select * from s;
@@ -39,7 +39,7 @@
     create table t1 (id int, created_at date);
     select * from hop(t1, created_at, interval '1' day, interval '3' day);
   logical_plan: |
-    LogicalProject { exprs: [$1, $2, $3, $4], expr_alias: [id, created_at, window_start, window_end] }
+    LogicalProject { exprs: [$1, $2, $3, $4], expr_alias: [ ,  ,  ,  ] }
       LogicalHopWindow { time_col: $2 slide: 1 day 00:00:00 size: 3 days 00:00:00 }
         LogicalScan { table: t1, columns: [_row_id#0, id, created_at] }
   stream_plan: |
@@ -51,43 +51,43 @@
     create table t1 (id int, created_at date);
     select id, created_at, window_start from hop(t1, created_at, interval '1' day, interval '3' day);
   logical_plan: |
-    LogicalProject { exprs: [$1, $2, $3], expr_alias: [id, created_at, window_start] }
+    LogicalProject { exprs: [$1, $2, $3], expr_alias: [ ,  ,  ] }
       LogicalHopWindow { time_col: $2 slide: 1 day 00:00:00 size: 3 days 00:00:00 }
         LogicalScan { table: t1, columns: [_row_id#0, id, created_at] }
   stream_plan: |
     StreamMaterialize { columns: [id, created_at, window_start, _row_id#0(hidden)], pk_columns: [_row_id#0, window_start] }
       StreamExchange { dist: HashShard([3, 2]) }
-        StreamProject { exprs: [$0, $1, $3, $2], expr_alias: [id, created_at, window_start,  ] }
+        StreamProject { exprs: [$0, $1, $3, $2], expr_alias: [ ,  ,  ,  ] }
           StreamHopWindow { time_col: $1 slide: 1 day 00:00:00 size: 3 days 00:00:00 }
             StreamTableScan { table: t1, columns: [id, created_at, _row_id#0], pk_indices: [2] }
 - sql: |
     create table t1 (id int, created_at date);
     select id, created_at, window_end from hop(t1, created_at, interval '1' day, interval '3' day);
   logical_plan: |
-    LogicalProject { exprs: [$1, $2, $4], expr_alias: [id, created_at, window_end] }
+    LogicalProject { exprs: [$1, $2, $4], expr_alias: [ ,  ,  ] }
       LogicalHopWindow { time_col: $2 slide: 1 day 00:00:00 size: 3 days 00:00:00 }
         LogicalScan { table: t1, columns: [_row_id#0, id, created_at] }
   stream_plan: |
     StreamMaterialize { columns: [id, created_at, window_end, _row_id#0(hidden), window_start(hidden)], pk_columns: [_row_id#0, window_start] }
       StreamExchange { dist: HashShard([3, 4]) }
-        StreamProject { exprs: [$0, $1, $4, $2, $3], expr_alias: [id, created_at, window_end,  ,  ] }
+        StreamProject { exprs: [$0, $1, $4, $2, $3], expr_alias: [ ,  ,  ,  ,  ] }
           StreamHopWindow { time_col: $1 slide: 1 day 00:00:00 size: 3 days 00:00:00 }
             StreamTableScan { table: t1, columns: [id, created_at, _row_id#0], pk_indices: [2] }
 - sql: |
     create table t1 (id int, created_at date);
     select id, created_at from hop(t1, created_at, interval '1' day, interval '3' day);
   logical_plan: |
-    LogicalProject { exprs: [$1, $2], expr_alias: [id, created_at] }
+    LogicalProject { exprs: [$1, $2], expr_alias: [ ,  ] }
       LogicalHopWindow { time_col: $2 slide: 1 day 00:00:00 size: 3 days 00:00:00 }
         LogicalScan { table: t1, columns: [_row_id#0, id, created_at] }
   batch_plan: |
     BatchExchange { order: [], dist: Single }
-      BatchProject { exprs: [$0, $1], expr_alias: [id, created_at] }
+      BatchProject { exprs: [$0, $1], expr_alias: [ ,  ] }
         BatchHopWindow { time_col: $1 slide: 1 day 00:00:00 size: 3 days 00:00:00 }
           BatchScan { table: t1, columns: [id, created_at] }
   stream_plan: |
     StreamMaterialize { columns: [id, created_at, _row_id#0(hidden), window_start(hidden)], pk_columns: [_row_id#0, window_start] }
       StreamExchange { dist: HashShard([2, 3]) }
-        StreamProject { exprs: [$0, $1, $2, $3], expr_alias: [id, created_at,  ,  ] }
+        StreamProject { exprs: [$0, $1, $2, $3], expr_alias: [ ,  ,  ,  ] }
           StreamHopWindow { time_col: $1 slide: 1 day 00:00:00 size: 3 days 00:00:00 }
             StreamTableScan { table: t1, columns: [id, created_at, _row_id#0], pk_indices: [2] }

--- a/src/frontend/test_runner/tests/testdata/tpch.yaml
+++ b/src/frontend/test_runner/tests/testdata/tpch.yaml
@@ -104,7 +104,7 @@
   batch_plan: |
     BatchExchange { order: [$0 ASC, $1 ASC], dist: Single }
       BatchSort { order: [$0 ASC, $1 ASC] }
-        BatchProject { exprs: [$0, $1, $2, $3, $4, $5, RoundDigit(($6 / $7), 4:Int32), RoundDigit(($8 / $9), 4:Int32), RoundDigit(($10 / $11), 4:Int32), $12], expr_alias: [l_returnflag, l_linestatus, sum_qty, sum_base_price, sum_disc_price, sum_charge, avg_qty, avg_price, avg_disc, count_order] }
+        BatchProject { exprs: [$0, $1, $2, $3, $4, $5, RoundDigit(($6 / $7), 4:Int32), RoundDigit(($8 / $9), 4:Int32), RoundDigit(($10 / $11), 4:Int32), $12], expr_alias: [ ,  ,  ,  ,  ,  ,  ,  ,  ,  ] }
           BatchHashAgg { group_keys: [$0, $1], aggs: [sum($2), sum($3), sum($4), sum($5), sum($2), count($2), sum($3), count($3), sum($6), count($6), count] }
             BatchProject { exprs: [$4, $5, $0, $1, ($1 * (1:Int32 - $2)), (($1 * (1:Int32 - $2)) * (1:Int32 + $3)), $2], expr_alias: [ ,  ,  ,  ,  ,  ,  ] }
               BatchExchange { order: [], dist: HashShard([4, 5]) }
@@ -112,7 +112,7 @@
                   BatchScan { table: lineitem, columns: [l_quantity, l_extendedprice, l_discount, l_tax, l_returnflag, l_linestatus, l_shipdate] }
   stream_plan: |
     StreamMaterialize { columns: [l_returnflag, l_linestatus, sum_qty, sum_base_price, sum_disc_price, sum_charge, avg_qty, avg_price, avg_disc, count_order], pk_columns: [l_returnflag, l_linestatus] }
-      StreamProject { exprs: [$0, $1, $3, $4, $5, $6, RoundDigit(($7 / $8), 4:Int32), RoundDigit(($9 / $10), 4:Int32), RoundDigit(($11 / $12), 4:Int32), $13], expr_alias: [l_returnflag, l_linestatus, sum_qty, sum_base_price, sum_disc_price, sum_charge, avg_qty, avg_price, avg_disc, count_order] }
+      StreamProject { exprs: [$0, $1, $3, $4, $5, $6, RoundDigit(($7 / $8), 4:Int32), RoundDigit(($9 / $10), 4:Int32), RoundDigit(($11 / $12), 4:Int32), $13], expr_alias: [ ,  ,  ,  ,  ,  ,  ,  ,  ,  ] }
         StreamHashAgg { group_keys: [$0, $1], aggs: [count, sum($2), sum($3), sum($4), sum($5), sum($2), count($2), sum($3), count($3), sum($6), count($6), count] }
           StreamProject { exprs: [$4, $5, $0, $1, ($1 * (1:Int32 - $2)), (($1 * (1:Int32 - $2)) * (1:Int32 + $3)), $2, $7], expr_alias: [ ,  ,  ,  ,  ,  ,  ,  ] }
             StreamExchange { dist: HashShard([4, 5]) }
@@ -171,7 +171,7 @@
   batch_plan: |
     BatchTopN { order: [$0 DESC, $2 ASC, $1 ASC, $3 ASC], limit: 100, offset: 0 }
       BatchExchange { order: [], dist: Single }
-        BatchProject { exprs: [$6, $3, $8, $1, $2, $4, $5, $7], expr_alias: [s_acctbal, s_name, n_name, p_partkey, p_mfgr, s_address, s_phone, s_comment] }
+        BatchProject { exprs: [$6, $3, $8, $1, $2, $4, $5, $7], expr_alias: [ ,  ,  ,  ,  ,  ,  ,  ] }
           BatchFilter { predicate: ($0 = $9) }
             BatchProject { exprs: [$4, $7, $9, $18, $19, $21, $22, $23, $26, $33], expr_alias: [ ,  ,  ,  ,  ,  ,  ,  ,  ,  ] }
               BatchHashAgg { group_keys: [$0, $1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16, $17, $18, $19, $20, $21, $22, $23, $24, $25, $26, $27, $28, $29, $30, $31, $32], aggs: [min($33)] }
@@ -221,7 +221,7 @@
     StreamMaterialize { columns: [s_acctbal, s_name, n_name, p_partkey, p_mfgr, s_address, s_phone, s_comment, _row_id#0(hidden), ps_partkey(hidden), ps_suppkey(hidden), ps_availqty(hidden), ps_supplycost(hidden), ps_comment(hidden), _row_id#1(hidden), p_name(hidden), p_brand(hidden), p_type(hidden), p_size(hidden), p_container(hidden), p_retailprice(hidden), p_comment(hidden), _row_id#2(hidden), s_suppkey(hidden), s_nationkey(hidden), _row_id#3(hidden), n_nationkey(hidden), n_regionkey(hidden), n_comment(hidden), _row_id#4(hidden), r_regionkey(hidden), r_name(hidden), r_comment(hidden)], pk_columns: [_row_id#0, ps_partkey, ps_suppkey, ps_availqty, ps_supplycost, ps_comment, _row_id#1, p_partkey, p_name, p_mfgr, p_brand, p_type, p_size, p_container, p_retailprice, p_comment, _row_id#2, s_suppkey, s_name, s_address, s_nationkey, s_phone, s_acctbal, s_comment, _row_id#3, n_nationkey, n_name, n_regionkey, n_comment, _row_id#4, r_regionkey, r_name, r_comment], order_descs: [s_acctbal, n_name, s_name, p_partkey, _row_id#0, ps_partkey, ps_suppkey, ps_availqty, ps_supplycost, ps_comment, _row_id#1, p_name, p_mfgr, p_brand, p_type, p_size, p_container, p_retailprice, p_comment, _row_id#2, s_suppkey, s_address, s_nationkey, s_phone, s_comment, _row_id#3, n_nationkey, n_regionkey, n_comment, _row_id#4, r_regionkey, r_name, r_comment] }
       StreamTopN { order: [$0 DESC, $2 ASC, $1 ASC, $3 ASC], limit: 100, offset: 0 }
         StreamExchange { dist: Single }
-          StreamProject { exprs: [$6, $3, $8, $1, $2, $4, $5, $7, $10, $11, $12, $13, $0, $14, $15, $16, $17, $18, $19, $20, $21, $22, $23, $24, $25, $26, $27, $28, $29, $30, $31, $32, $33], expr_alias: [s_acctbal, s_name, n_name, p_partkey, p_mfgr, s_address, s_phone, s_comment,  ,  ,  ,  ,  ,  ,  ,  ,  ,  ,  ,  ,  ,  ,  ,  ,  ,  ,  ,  ,  ,  ,  ,  ,  ] }
+          StreamProject { exprs: [$6, $3, $8, $1, $2, $4, $5, $7, $10, $11, $12, $13, $0, $14, $15, $16, $17, $18, $19, $20, $21, $22, $23, $24, $25, $26, $27, $28, $29, $30, $31, $32, $33], expr_alias: [ ,  ,  ,  ,  ,  ,  ,  ,  ,  ,  ,  ,  ,  ,  ,  ,  ,  ,  ,  ,  ,  ,  ,  ,  ,  ,  ,  ,  ,  ,  ,  ,  ] }
             StreamFilter { predicate: ($0 = $9) }
               StreamProject { exprs: [$4, $7, $9, $18, $19, $21, $22, $23, $26, $34, $0, $1, $2, $3, $5, $6, $8, $10, $11, $12, $13, $14, $15, $16, $17, $20, $24, $25, $27, $28, $29, $30, $31, $32], expr_alias: [ ,  ,  ,  ,  ,  ,  ,  ,  ,  ,  ,  ,  ,  ,  ,  ,  ,  ,  ,  ,  ,  ,  ,  ,  ,  ,  ,  ,  ,  ,  ,  ,  ,  ] }
                 StreamHashAgg { group_keys: [$0, $1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16, $17, $18, $19, $20, $21, $22, $23, $24, $25, $26, $27, $28, $29, $30, $31, $32], aggs: [count, min($33)] }
@@ -297,7 +297,7 @@
   batch_plan: |
     BatchTopN { order: [$1 DESC, $2 ASC], limit: 10, offset: 0 }
       BatchExchange { order: [], dist: Single }
-        BatchProject { exprs: [$0, $3, $1, $2], expr_alias: [l_orderkey, revenue, o_orderdate, o_shippriority] }
+        BatchProject { exprs: [$0, $3, $1, $2], expr_alias: [ ,  ,  ,  ] }
           BatchHashAgg { group_keys: [$0, $1, $2], aggs: [sum($3)] }
             BatchProject { exprs: [$3, $1, $2, ($4 * (1:Int32 - $5))], expr_alias: [ ,  ,  ,  ] }
               BatchExchange { order: [], dist: HashShard([3, 1, 2]) }
@@ -320,7 +320,7 @@
     StreamMaterialize { columns: [l_orderkey, revenue, o_orderdate, o_shippriority], pk_columns: [l_orderkey, o_orderdate, o_shippriority], order_descs: [revenue, o_orderdate, l_orderkey, o_shippriority] }
       StreamTopN { order: [$1 DESC, $2 ASC], limit: 10, offset: 0 }
         StreamExchange { dist: Single }
-          StreamProject { exprs: [$0, $4, $1, $2], expr_alias: [l_orderkey, revenue, o_orderdate, o_shippriority] }
+          StreamProject { exprs: [$0, $4, $1, $2], expr_alias: [ ,  ,  ,  ] }
             StreamHashAgg { group_keys: [$0, $1, $2], aggs: [count, sum($3)] }
               StreamProject { exprs: [$5, $1, $2, ($6 * (1:Int32 - $7)), $3, $4, $8], expr_alias: [ ,  ,  ,  ,  ,  ,  ] }
                 StreamExchange { dist: HashShard([5, 1, 2]) }
@@ -367,34 +367,32 @@
   batch_plan: |
     BatchExchange { order: [$0 ASC], dist: Single }
       BatchSort { order: [$0 ASC] }
-        BatchProject { exprs: [$0, $1], expr_alias: [o_orderpriority, order_count] }
-          BatchHashAgg { group_keys: [$0], aggs: [count] }
-            BatchProject { exprs: [$1], expr_alias: [ ] }
-              BatchExchange { order: [], dist: HashShard([1]) }
-                BatchHashJoin { type: LeftSemi, predicate: $0 = $2 }
-                  BatchProject { exprs: [$0, $2], expr_alias: [ ,  ] }
-                    BatchExchange { order: [], dist: HashShard([0]) }
-                      BatchFilter { predicate: ($1 >= '1997-07-01':Varchar::Date) AND ($1 < ('1997-07-01':Varchar::Date + '3 mons 00:00:00':Interval)) }
-                        BatchScan { table: orders, columns: [o_orderkey, o_orderdate, o_orderpriority] }
-                  BatchProject { exprs: [$0], expr_alias: [ ] }
-                    BatchExchange { order: [], dist: HashShard([0]) }
-                      BatchFilter { predicate: ($1 < $2) }
-                        BatchScan { table: lineitem, columns: [l_orderkey, l_commitdate, l_receiptdate] }
+        BatchHashAgg { group_keys: [$0], aggs: [count] }
+          BatchProject { exprs: [$1], expr_alias: [ ] }
+            BatchExchange { order: [], dist: HashShard([1]) }
+              BatchHashJoin { type: LeftSemi, predicate: $0 = $2 }
+                BatchProject { exprs: [$0, $2], expr_alias: [ ,  ] }
+                  BatchExchange { order: [], dist: HashShard([0]) }
+                    BatchFilter { predicate: ($1 >= '1997-07-01':Varchar::Date) AND ($1 < ('1997-07-01':Varchar::Date + '3 mons 00:00:00':Interval)) }
+                      BatchScan { table: orders, columns: [o_orderkey, o_orderdate, o_orderpriority] }
+                BatchProject { exprs: [$0], expr_alias: [ ] }
+                  BatchExchange { order: [], dist: HashShard([0]) }
+                    BatchFilter { predicate: ($1 < $2) }
+                      BatchScan { table: lineitem, columns: [l_orderkey, l_commitdate, l_receiptdate] }
   stream_plan: |
-    StreamMaterialize { columns: [o_orderpriority, order_count], pk_columns: [o_orderpriority] }
-      StreamProject { exprs: [$0, $2], expr_alias: [o_orderpriority, order_count] }
-        StreamHashAgg { group_keys: [$0], aggs: [count, count] }
-          StreamProject { exprs: [$1, $2], expr_alias: [ ,  ] }
-            StreamExchange { dist: HashShard([1]) }
-              StreamHashJoin { type: LeftSemi, predicate: $0 = $3 }
-                StreamProject { exprs: [$0, $2, $3], expr_alias: [ ,  ,  ] }
-                  StreamExchange { dist: HashShard([0]) }
-                    StreamFilter { predicate: ($1 >= '1997-07-01':Varchar::Date) AND ($1 < ('1997-07-01':Varchar::Date + '3 mons 00:00:00':Interval)) }
-                      StreamTableScan { table: orders, columns: [o_orderkey, o_orderdate, o_orderpriority, _row_id#0], pk_indices: [3] }
-                StreamProject { exprs: [$0, $3], expr_alias: [ ,  ] }
-                  StreamExchange { dist: HashShard([0]) }
-                    StreamFilter { predicate: ($1 < $2) }
-                      StreamTableScan { table: lineitem, columns: [l_orderkey, l_commitdate, l_receiptdate, _row_id#0], pk_indices: [3] }
+    StreamMaterialize { columns: [o_orderpriority, agg#0(hidden), order_count], pk_columns: [o_orderpriority] }
+      StreamHashAgg { group_keys: [$0], aggs: [count, count] }
+        StreamProject { exprs: [$1, $2], expr_alias: [ ,  ] }
+          StreamExchange { dist: HashShard([1]) }
+            StreamHashJoin { type: LeftSemi, predicate: $0 = $3 }
+              StreamProject { exprs: [$0, $2, $3], expr_alias: [ ,  ,  ] }
+                StreamExchange { dist: HashShard([0]) }
+                  StreamFilter { predicate: ($1 >= '1997-07-01':Varchar::Date) AND ($1 < ('1997-07-01':Varchar::Date + '3 mons 00:00:00':Interval)) }
+                    StreamTableScan { table: orders, columns: [o_orderkey, o_orderdate, o_orderpriority, _row_id#0], pk_indices: [3] }
+              StreamProject { exprs: [$0, $3], expr_alias: [ ,  ] }
+                StreamExchange { dist: HashShard([0]) }
+                  StreamFilter { predicate: ($1 < $2) }
+                    StreamTableScan { table: lineitem, columns: [l_orderkey, l_commitdate, l_receiptdate, _row_id#0], pk_indices: [3] }
 - id: tpch_q5
   before:
     - create_tables
@@ -426,74 +424,72 @@
   batch_plan: |
     BatchExchange { order: [$1 DESC], dist: Single }
       BatchSort { order: [$1 DESC] }
-        BatchProject { exprs: [$0, $1], expr_alias: [n_name, revenue] }
-          BatchHashAgg { group_keys: [$0], aggs: [sum($1)] }
-            BatchProject { exprs: [$2, ($0 * (1:Int32 - $1))], expr_alias: [ ,  ] }
-              BatchExchange { order: [], dist: HashShard([2]) }
-                BatchHashJoin { type: Inner, predicate: $3 = $4 }
-                  BatchProject { exprs: [$0, $1, $4, $5], expr_alias: [ ,  ,  ,  ] }
-                    BatchExchange { order: [], dist: HashShard([5]) }
-                      BatchHashJoin { type: Inner, predicate: $2 = $3 }
-                        BatchProject { exprs: [$2, $3, $5], expr_alias: [ ,  ,  ] }
-                          BatchExchange { order: [], dist: HashShard([5]) }
-                            BatchHashJoin { type: Inner, predicate: $1 = $4AND $0 = $5 }
-                              BatchProject { exprs: [$0, $3, $4, $5], expr_alias: [ ,  ,  ,  ] }
-                                BatchExchange { order: [], dist: HashShard([3, 0]) }
-                                  BatchHashJoin { type: Inner, predicate: $1 = $2 }
-                                    BatchProject { exprs: [$1, $2], expr_alias: [ ,  ] }
-                                      BatchExchange { order: [], dist: HashShard([2]) }
-                                        BatchHashJoin { type: Inner, predicate: $0 = $3 }
-                                          BatchExchange { order: [], dist: HashShard([0]) }
-                                            BatchScan { table: customer, columns: [c_custkey, c_nationkey] }
-                                          BatchProject { exprs: [$0, $1], expr_alias: [ ,  ] }
-                                            BatchExchange { order: [], dist: HashShard([1]) }
-                                              BatchFilter { predicate: ($2 >= '1994-01-01':Varchar::Date) AND ($2 < ('1994-01-01':Varchar::Date + '1 year 00:00:00':Interval)) }
-                                                BatchScan { table: orders, columns: [o_orderkey, o_custkey, o_orderdate] }
-                                    BatchExchange { order: [], dist: HashShard([0]) }
-                                      BatchScan { table: lineitem, columns: [l_orderkey, l_suppkey, l_extendedprice, l_discount] }
-                              BatchExchange { order: [], dist: HashShard([0, 1]) }
-                                BatchScan { table: supplier, columns: [s_suppkey, s_nationkey] }
-                        BatchExchange { order: [], dist: HashShard([0]) }
-                          BatchScan { table: nation, columns: [n_nationkey, n_name, n_regionkey] }
-                  BatchProject { exprs: [$0], expr_alias: [ ] }
-                    BatchExchange { order: [], dist: HashShard([0]) }
-                      BatchFilter { predicate: ($1 = 'MIDDLE EAST':Varchar) }
-                        BatchScan { table: region, columns: [r_regionkey, r_name] }
+        BatchHashAgg { group_keys: [$0], aggs: [sum($1)] }
+          BatchProject { exprs: [$2, ($0 * (1:Int32 - $1))], expr_alias: [ ,  ] }
+            BatchExchange { order: [], dist: HashShard([2]) }
+              BatchHashJoin { type: Inner, predicate: $3 = $4 }
+                BatchProject { exprs: [$0, $1, $4, $5], expr_alias: [ ,  ,  ,  ] }
+                  BatchExchange { order: [], dist: HashShard([5]) }
+                    BatchHashJoin { type: Inner, predicate: $2 = $3 }
+                      BatchProject { exprs: [$2, $3, $5], expr_alias: [ ,  ,  ] }
+                        BatchExchange { order: [], dist: HashShard([5]) }
+                          BatchHashJoin { type: Inner, predicate: $1 = $4AND $0 = $5 }
+                            BatchProject { exprs: [$0, $3, $4, $5], expr_alias: [ ,  ,  ,  ] }
+                              BatchExchange { order: [], dist: HashShard([3, 0]) }
+                                BatchHashJoin { type: Inner, predicate: $1 = $2 }
+                                  BatchProject { exprs: [$1, $2], expr_alias: [ ,  ] }
+                                    BatchExchange { order: [], dist: HashShard([2]) }
+                                      BatchHashJoin { type: Inner, predicate: $0 = $3 }
+                                        BatchExchange { order: [], dist: HashShard([0]) }
+                                          BatchScan { table: customer, columns: [c_custkey, c_nationkey] }
+                                        BatchProject { exprs: [$0, $1], expr_alias: [ ,  ] }
+                                          BatchExchange { order: [], dist: HashShard([1]) }
+                                            BatchFilter { predicate: ($2 >= '1994-01-01':Varchar::Date) AND ($2 < ('1994-01-01':Varchar::Date + '1 year 00:00:00':Interval)) }
+                                              BatchScan { table: orders, columns: [o_orderkey, o_custkey, o_orderdate] }
+                                  BatchExchange { order: [], dist: HashShard([0]) }
+                                    BatchScan { table: lineitem, columns: [l_orderkey, l_suppkey, l_extendedprice, l_discount] }
+                            BatchExchange { order: [], dist: HashShard([0, 1]) }
+                              BatchScan { table: supplier, columns: [s_suppkey, s_nationkey] }
+                      BatchExchange { order: [], dist: HashShard([0]) }
+                        BatchScan { table: nation, columns: [n_nationkey, n_name, n_regionkey] }
+                BatchProject { exprs: [$0], expr_alias: [ ] }
+                  BatchExchange { order: [], dist: HashShard([0]) }
+                    BatchFilter { predicate: ($1 = 'MIDDLE EAST':Varchar) }
+                      BatchScan { table: region, columns: [r_regionkey, r_name] }
   stream_plan: |
-    StreamMaterialize { columns: [n_name, revenue], pk_columns: [n_name], order_descs: [revenue, n_name] }
-      StreamProject { exprs: [$0, $2], expr_alias: [n_name, revenue] }
-        StreamHashAgg { group_keys: [$0], aggs: [count, sum($1)] }
-          StreamProject { exprs: [$2, ($0 * (1:Int32 - $1)), $4, $5, $6, $7, $8, $10], expr_alias: [ ,  ,  ,  ,  ,  ,  ,  ] }
-            StreamExchange { dist: HashShard([2]) }
-              StreamHashJoin { type: Inner, predicate: $3 = $9 }
-                StreamProject { exprs: [$0, $1, $8, $9, $3, $4, $5, $6, $10], expr_alias: [ ,  ,  ,  ,  ,  ,  ,  ,  ] }
-                  StreamExchange { dist: HashShard([9]) }
-                    StreamHashJoin { type: Inner, predicate: $2 = $7 }
-                      StreamProject { exprs: [$2, $3, $8, $4, $5, $6, $9], expr_alias: [ ,  ,  ,  ,  ,  ,  ] }
-                        StreamExchange { dist: HashShard([8]) }
-                          StreamHashJoin { type: Inner, predicate: $1 = $7AND $0 = $8 }
-                            StreamProject { exprs: [$0, $5, $6, $7, $2, $3, $8], expr_alias: [ ,  ,  ,  ,  ,  ,  ] }
-                              StreamExchange { dist: HashShard([5, 0]) }
-                                StreamHashJoin { type: Inner, predicate: $1 = $4 }
-                                  StreamProject { exprs: [$1, $3, $2, $5], expr_alias: [ ,  ,  ,  ] }
-                                    StreamExchange { dist: HashShard([3]) }
-                                      StreamHashJoin { type: Inner, predicate: $0 = $4 }
-                                        StreamExchange { dist: HashShard([0]) }
-                                          StreamTableScan { table: customer, columns: [c_custkey, c_nationkey, _row_id#0], pk_indices: [2] }
-                                        StreamProject { exprs: [$0, $1, $3], expr_alias: [ ,  ,  ] }
-                                          StreamExchange { dist: HashShard([1]) }
-                                            StreamFilter { predicate: ($2 >= '1994-01-01':Varchar::Date) AND ($2 < ('1994-01-01':Varchar::Date + '1 year 00:00:00':Interval)) }
-                                              StreamTableScan { table: orders, columns: [o_orderkey, o_custkey, o_orderdate, _row_id#0], pk_indices: [3] }
-                                  StreamExchange { dist: HashShard([0]) }
-                                    StreamTableScan { table: lineitem, columns: [l_orderkey, l_suppkey, l_extendedprice, l_discount, _row_id#0], pk_indices: [4] }
-                            StreamExchange { dist: HashShard([0, 1]) }
-                              StreamTableScan { table: supplier, columns: [s_suppkey, s_nationkey, _row_id#0], pk_indices: [2] }
-                      StreamExchange { dist: HashShard([0]) }
-                        StreamTableScan { table: nation, columns: [n_nationkey, n_name, n_regionkey, _row_id#0], pk_indices: [3] }
-                StreamProject { exprs: [$0, $2], expr_alias: [ ,  ] }
-                  StreamExchange { dist: HashShard([0]) }
-                    StreamFilter { predicate: ($1 = 'MIDDLE EAST':Varchar) }
-                      StreamTableScan { table: region, columns: [r_regionkey, r_name, _row_id#0], pk_indices: [2] }
+    StreamMaterialize { columns: [n_name, agg#0(hidden), revenue], pk_columns: [n_name], order_descs: [revenue, n_name] }
+      StreamHashAgg { group_keys: [$0], aggs: [count, sum($1)] }
+        StreamProject { exprs: [$2, ($0 * (1:Int32 - $1)), $4, $5, $6, $7, $8, $10], expr_alias: [ ,  ,  ,  ,  ,  ,  ,  ] }
+          StreamExchange { dist: HashShard([2]) }
+            StreamHashJoin { type: Inner, predicate: $3 = $9 }
+              StreamProject { exprs: [$0, $1, $8, $9, $3, $4, $5, $6, $10], expr_alias: [ ,  ,  ,  ,  ,  ,  ,  ,  ] }
+                StreamExchange { dist: HashShard([9]) }
+                  StreamHashJoin { type: Inner, predicate: $2 = $7 }
+                    StreamProject { exprs: [$2, $3, $8, $4, $5, $6, $9], expr_alias: [ ,  ,  ,  ,  ,  ,  ] }
+                      StreamExchange { dist: HashShard([8]) }
+                        StreamHashJoin { type: Inner, predicate: $1 = $7AND $0 = $8 }
+                          StreamProject { exprs: [$0, $5, $6, $7, $2, $3, $8], expr_alias: [ ,  ,  ,  ,  ,  ,  ] }
+                            StreamExchange { dist: HashShard([5, 0]) }
+                              StreamHashJoin { type: Inner, predicate: $1 = $4 }
+                                StreamProject { exprs: [$1, $3, $2, $5], expr_alias: [ ,  ,  ,  ] }
+                                  StreamExchange { dist: HashShard([3]) }
+                                    StreamHashJoin { type: Inner, predicate: $0 = $4 }
+                                      StreamExchange { dist: HashShard([0]) }
+                                        StreamTableScan { table: customer, columns: [c_custkey, c_nationkey, _row_id#0], pk_indices: [2] }
+                                      StreamProject { exprs: [$0, $1, $3], expr_alias: [ ,  ,  ] }
+                                        StreamExchange { dist: HashShard([1]) }
+                                          StreamFilter { predicate: ($2 >= '1994-01-01':Varchar::Date) AND ($2 < ('1994-01-01':Varchar::Date + '1 year 00:00:00':Interval)) }
+                                            StreamTableScan { table: orders, columns: [o_orderkey, o_custkey, o_orderdate, _row_id#0], pk_indices: [3] }
+                                StreamExchange { dist: HashShard([0]) }
+                                  StreamTableScan { table: lineitem, columns: [l_orderkey, l_suppkey, l_extendedprice, l_discount, _row_id#0], pk_indices: [4] }
+                          StreamExchange { dist: HashShard([0, 1]) }
+                            StreamTableScan { table: supplier, columns: [s_suppkey, s_nationkey, _row_id#0], pk_indices: [2] }
+                    StreamExchange { dist: HashShard([0]) }
+                      StreamTableScan { table: nation, columns: [n_nationkey, n_name, n_regionkey, _row_id#0], pk_indices: [3] }
+              StreamProject { exprs: [$0, $2], expr_alias: [ ,  ] }
+                StreamExchange { dist: HashShard([0]) }
+                  StreamFilter { predicate: ($1 = 'MIDDLE EAST':Varchar) }
+                    StreamTableScan { table: region, columns: [r_regionkey, r_name, _row_id#0], pk_indices: [2] }
 - id: tpch_q6
   before:
     - create_tables
@@ -508,20 +504,18 @@
       and l_discount between 0.08 - 0.01 and 0.08 + 0.01
       and l_quantity < 24;
   batch_plan: |
-    BatchProject { exprs: [$0], expr_alias: [revenue] }
-      BatchSimpleAgg { aggs: [sum($0)] }
-        BatchExchange { order: [], dist: Single }
-          BatchProject { exprs: [($1 * $2)], expr_alias: [ ] }
-            BatchFilter { predicate: ($3 >= '1994-01-01':Varchar::Date) AND ($3 < ('1994-01-01':Varchar::Date + '1 year 00:00:00':Interval)) AND ($2 >= (0.08:Decimal - 0.01:Decimal)) AND ($2 <= (0.08:Decimal + 0.01:Decimal)) AND ($0 < 24:Int32) }
-              BatchScan { table: lineitem, columns: [l_quantity, l_extendedprice, l_discount, l_shipdate] }
+    BatchSimpleAgg { aggs: [sum($0)] }
+      BatchExchange { order: [], dist: Single }
+        BatchProject { exprs: [($1 * $2)], expr_alias: [ ] }
+          BatchFilter { predicate: ($3 >= '1994-01-01':Varchar::Date) AND ($3 < ('1994-01-01':Varchar::Date + '1 year 00:00:00':Interval)) AND ($2 >= (0.08:Decimal - 0.01:Decimal)) AND ($2 <= (0.08:Decimal + 0.01:Decimal)) AND ($0 < 24:Int32) }
+            BatchScan { table: lineitem, columns: [l_quantity, l_extendedprice, l_discount, l_shipdate] }
   stream_plan: |
-    StreamMaterialize { columns: [revenue, agg#0(hidden)], pk_columns: [agg#0, revenue] }
-      StreamProject { exprs: [$1, $0], expr_alias: [revenue,  ] }
-        StreamSimpleAgg { aggs: [count, sum($0)] }
-          StreamExchange { dist: Single }
-            StreamProject { exprs: [($1 * $2), $4], expr_alias: [ ,  ] }
-              StreamFilter { predicate: ($3 >= '1994-01-01':Varchar::Date) AND ($3 < ('1994-01-01':Varchar::Date + '1 year 00:00:00':Interval)) AND ($2 >= (0.08:Decimal - 0.01:Decimal)) AND ($2 <= (0.08:Decimal + 0.01:Decimal)) AND ($0 < 24:Int32) }
-                StreamTableScan { table: lineitem, columns: [l_quantity, l_extendedprice, l_discount, l_shipdate, _row_id#0], pk_indices: [4] }
+    StreamMaterialize { columns: [agg#0(hidden), revenue], pk_columns: [agg#0, revenue] }
+      StreamSimpleAgg { aggs: [count, sum($0)] }
+        StreamExchange { dist: Single }
+          StreamProject { exprs: [($1 * $2), $4], expr_alias: [ ,  ] }
+            StreamFilter { predicate: ($3 >= '1994-01-01':Varchar::Date) AND ($3 < ('1994-01-01':Varchar::Date + '1 year 00:00:00':Interval)) AND ($2 >= (0.08:Decimal - 0.01:Decimal)) AND ($2 <= (0.08:Decimal + 0.01:Decimal)) AND ($0 < 24:Int32) }
+              StreamTableScan { table: lineitem, columns: [l_quantity, l_extendedprice, l_discount, l_shipdate, _row_id#0], pk_indices: [4] }
 - id: tpch_q7
   before:
     - create_tables
@@ -568,70 +562,68 @@
   batch_plan: |
     BatchExchange { order: [$0 ASC, $1 ASC, $2 ASC], dist: Single }
       BatchSort { order: [$0 ASC, $1 ASC, $2 ASC] }
-        BatchProject { exprs: [$0, $1, $2, $3], expr_alias: [supp_nation, cust_nation, l_year, revenue] }
-          BatchHashAgg { group_keys: [$0, $1, $2], aggs: [sum($3)] }
-            BatchExchange { order: [], dist: HashShard([0, 1, 2]) }
-              BatchProject { exprs: [$4, $6, Extract('YEAR':Varchar, $2), ($0 * (1:Int32 - $1))], expr_alias: [ ,  ,  ,  ] }
-                BatchFilter { predicate: ((($4 = 'ROMANIA':Varchar) AND ($6 = 'IRAN':Varchar)) OR (($4 = 'IRAN':Varchar) AND ($6 = 'ROMANIA':Varchar))) }
-                  BatchHashJoin { type: Inner, predicate: $3 = $5 }
-                    BatchProject { exprs: [$1, $2, $3, $4, $6], expr_alias: [ ,  ,  ,  ,  ] }
-                      BatchExchange { order: [], dist: HashShard([4]) }
-                        BatchHashJoin { type: Inner, predicate: $0 = $5 }
-                          BatchProject { exprs: [$0, $1, $2, $3, $6], expr_alias: [ ,  ,  ,  ,  ] }
-                            BatchExchange { order: [], dist: HashShard([0]) }
-                              BatchHashJoin { type: Inner, predicate: $4 = $5 }
-                                BatchProject { exprs: [$0, $2, $3, $4, $6], expr_alias: [ ,  ,  ,  ,  ] }
-                                  BatchExchange { order: [], dist: HashShard([6]) }
-                                    BatchHashJoin { type: Inner, predicate: $1 = $5 }
-                                      BatchProject { exprs: [$1, $2, $4, $5, $6], expr_alias: [ ,  ,  ,  ,  ] }
-                                        BatchExchange { order: [], dist: HashShard([2]) }
-                                          BatchHashJoin { type: Inner, predicate: $0 = $3 }
-                                            BatchExchange { order: [], dist: HashShard([0]) }
-                                              BatchScan { table: supplier, columns: [s_suppkey, s_nationkey] }
-                                            BatchExchange { order: [], dist: HashShard([1]) }
-                                              BatchFilter { predicate: ($4 >= '1983-01-01':Varchar::Date) AND ($4 <= '2000-12-31':Varchar::Date) }
-                                                BatchScan { table: lineitem, columns: [l_orderkey, l_suppkey, l_extendedprice, l_discount, l_shipdate] }
-                                      BatchExchange { order: [], dist: HashShard([0]) }
-                                        BatchScan { table: orders, columns: [o_orderkey, o_custkey] }
-                                BatchExchange { order: [], dist: HashShard([0]) }
-                                  BatchScan { table: customer, columns: [c_custkey, c_nationkey] }
+        BatchHashAgg { group_keys: [$0, $1, $2], aggs: [sum($3)] }
+          BatchExchange { order: [], dist: HashShard([0, 1, 2]) }
+            BatchProject { exprs: [$4, $6, Extract('YEAR':Varchar, $2), ($0 * (1:Int32 - $1))], expr_alias: [ ,  ,  ,  ] }
+              BatchFilter { predicate: ((($4 = 'ROMANIA':Varchar) AND ($6 = 'IRAN':Varchar)) OR (($4 = 'IRAN':Varchar) AND ($6 = 'ROMANIA':Varchar))) }
+                BatchHashJoin { type: Inner, predicate: $3 = $5 }
+                  BatchProject { exprs: [$1, $2, $3, $4, $6], expr_alias: [ ,  ,  ,  ,  ] }
+                    BatchExchange { order: [], dist: HashShard([4]) }
+                      BatchHashJoin { type: Inner, predicate: $0 = $5 }
+                        BatchProject { exprs: [$0, $1, $2, $3, $6], expr_alias: [ ,  ,  ,  ,  ] }
                           BatchExchange { order: [], dist: HashShard([0]) }
-                            BatchScan { table: nation, columns: [n_nationkey, n_name] }
-                    BatchExchange { order: [], dist: HashShard([0]) }
-                      BatchScan { table: nation, columns: [n_nationkey, n_name] }
+                            BatchHashJoin { type: Inner, predicate: $4 = $5 }
+                              BatchProject { exprs: [$0, $2, $3, $4, $6], expr_alias: [ ,  ,  ,  ,  ] }
+                                BatchExchange { order: [], dist: HashShard([6]) }
+                                  BatchHashJoin { type: Inner, predicate: $1 = $5 }
+                                    BatchProject { exprs: [$1, $2, $4, $5, $6], expr_alias: [ ,  ,  ,  ,  ] }
+                                      BatchExchange { order: [], dist: HashShard([2]) }
+                                        BatchHashJoin { type: Inner, predicate: $0 = $3 }
+                                          BatchExchange { order: [], dist: HashShard([0]) }
+                                            BatchScan { table: supplier, columns: [s_suppkey, s_nationkey] }
+                                          BatchExchange { order: [], dist: HashShard([1]) }
+                                            BatchFilter { predicate: ($4 >= '1983-01-01':Varchar::Date) AND ($4 <= '2000-12-31':Varchar::Date) }
+                                              BatchScan { table: lineitem, columns: [l_orderkey, l_suppkey, l_extendedprice, l_discount, l_shipdate] }
+                                    BatchExchange { order: [], dist: HashShard([0]) }
+                                      BatchScan { table: orders, columns: [o_orderkey, o_custkey] }
+                              BatchExchange { order: [], dist: HashShard([0]) }
+                                BatchScan { table: customer, columns: [c_custkey, c_nationkey] }
+                        BatchExchange { order: [], dist: HashShard([0]) }
+                          BatchScan { table: nation, columns: [n_nationkey, n_name] }
+                  BatchExchange { order: [], dist: HashShard([0]) }
+                    BatchScan { table: nation, columns: [n_nationkey, n_name] }
   stream_plan: |
-    StreamMaterialize { columns: [supp_nation, cust_nation, l_year, revenue], pk_columns: [supp_nation, cust_nation, l_year] }
-      StreamProject { exprs: [$0, $1, $2, $4], expr_alias: [supp_nation, cust_nation, l_year, revenue] }
-        StreamHashAgg { group_keys: [$0, $1, $2], aggs: [count, sum($3)] }
-          StreamExchange { dist: HashShard([0, 1, 2]) }
-            StreamProject { exprs: [$4, $11, Extract('YEAR':Varchar, $2), ($0 * (1:Int32 - $1)), $5, $6, $7, $8, $9, $12], expr_alias: [ ,  ,  ,  ,  ,  ,  ,  ,  ,  ] }
-              StreamFilter { predicate: ((($4 = 'ROMANIA':Varchar) AND ($11 = 'IRAN':Varchar)) OR (($4 = 'IRAN':Varchar) AND ($11 = 'ROMANIA':Varchar))) }
-                StreamHashJoin { type: Inner, predicate: $3 = $10 }
-                  StreamProject { exprs: [$1, $2, $3, $4, $10, $5, $6, $7, $8, $11], expr_alias: [ ,  ,  ,  ,  ,  ,  ,  ,  ,  ] }
-                    StreamExchange { dist: HashShard([4]) }
-                      StreamHashJoin { type: Inner, predicate: $0 = $9 }
-                        StreamProject { exprs: [$0, $1, $2, $3, $9, $5, $6, $7, $10], expr_alias: [ ,  ,  ,  ,  ,  ,  ,  ,  ] }
-                          StreamExchange { dist: HashShard([0]) }
-                            StreamHashJoin { type: Inner, predicate: $4 = $8 }
-                              StreamProject { exprs: [$0, $2, $3, $4, $8, $5, $6, $9], expr_alias: [ ,  ,  ,  ,  ,  ,  ,  ] }
-                                StreamExchange { dist: HashShard([8]) }
-                                  StreamHashJoin { type: Inner, predicate: $1 = $7 }
-                                    StreamProject { exprs: [$1, $3, $5, $6, $7, $2, $8], expr_alias: [ ,  ,  ,  ,  ,  ,  ] }
-                                      StreamExchange { dist: HashShard([3]) }
-                                        StreamHashJoin { type: Inner, predicate: $0 = $4 }
-                                          StreamExchange { dist: HashShard([0]) }
-                                            StreamTableScan { table: supplier, columns: [s_suppkey, s_nationkey, _row_id#0], pk_indices: [2] }
-                                          StreamExchange { dist: HashShard([1]) }
-                                            StreamFilter { predicate: ($4 >= '1983-01-01':Varchar::Date) AND ($4 <= '2000-12-31':Varchar::Date) }
-                                              StreamTableScan { table: lineitem, columns: [l_orderkey, l_suppkey, l_extendedprice, l_discount, l_shipdate, _row_id#0], pk_indices: [5] }
-                                    StreamExchange { dist: HashShard([0]) }
-                                      StreamTableScan { table: orders, columns: [o_orderkey, o_custkey, _row_id#0], pk_indices: [2] }
-                              StreamExchange { dist: HashShard([0]) }
-                                StreamTableScan { table: customer, columns: [c_custkey, c_nationkey, _row_id#0], pk_indices: [2] }
+    StreamMaterialize { columns: [supp_nation, cust_nation, l_year, agg#0(hidden), revenue], pk_columns: [supp_nation, cust_nation, l_year] }
+      StreamHashAgg { group_keys: [$0, $1, $2], aggs: [count, sum($3)] }
+        StreamExchange { dist: HashShard([0, 1, 2]) }
+          StreamProject { exprs: [$4, $11, Extract('YEAR':Varchar, $2), ($0 * (1:Int32 - $1)), $5, $6, $7, $8, $9, $12], expr_alias: [ ,  ,  ,  ,  ,  ,  ,  ,  ,  ] }
+            StreamFilter { predicate: ((($4 = 'ROMANIA':Varchar) AND ($11 = 'IRAN':Varchar)) OR (($4 = 'IRAN':Varchar) AND ($11 = 'ROMANIA':Varchar))) }
+              StreamHashJoin { type: Inner, predicate: $3 = $10 }
+                StreamProject { exprs: [$1, $2, $3, $4, $10, $5, $6, $7, $8, $11], expr_alias: [ ,  ,  ,  ,  ,  ,  ,  ,  ,  ] }
+                  StreamExchange { dist: HashShard([4]) }
+                    StreamHashJoin { type: Inner, predicate: $0 = $9 }
+                      StreamProject { exprs: [$0, $1, $2, $3, $9, $5, $6, $7, $10], expr_alias: [ ,  ,  ,  ,  ,  ,  ,  ,  ] }
                         StreamExchange { dist: HashShard([0]) }
-                          StreamTableScan { table: nation, columns: [n_nationkey, n_name, _row_id#0], pk_indices: [2] }
-                  StreamExchange { dist: HashShard([0]) }
-                    StreamTableScan { table: nation, columns: [n_nationkey, n_name, _row_id#0], pk_indices: [2] }
+                          StreamHashJoin { type: Inner, predicate: $4 = $8 }
+                            StreamProject { exprs: [$0, $2, $3, $4, $8, $5, $6, $9], expr_alias: [ ,  ,  ,  ,  ,  ,  ,  ] }
+                              StreamExchange { dist: HashShard([8]) }
+                                StreamHashJoin { type: Inner, predicate: $1 = $7 }
+                                  StreamProject { exprs: [$1, $3, $5, $6, $7, $2, $8], expr_alias: [ ,  ,  ,  ,  ,  ,  ] }
+                                    StreamExchange { dist: HashShard([3]) }
+                                      StreamHashJoin { type: Inner, predicate: $0 = $4 }
+                                        StreamExchange { dist: HashShard([0]) }
+                                          StreamTableScan { table: supplier, columns: [s_suppkey, s_nationkey, _row_id#0], pk_indices: [2] }
+                                        StreamExchange { dist: HashShard([1]) }
+                                          StreamFilter { predicate: ($4 >= '1983-01-01':Varchar::Date) AND ($4 <= '2000-12-31':Varchar::Date) }
+                                            StreamTableScan { table: lineitem, columns: [l_orderkey, l_suppkey, l_extendedprice, l_discount, l_shipdate, _row_id#0], pk_indices: [5] }
+                                  StreamExchange { dist: HashShard([0]) }
+                                    StreamTableScan { table: orders, columns: [o_orderkey, o_custkey, _row_id#0], pk_indices: [2] }
+                            StreamExchange { dist: HashShard([0]) }
+                              StreamTableScan { table: customer, columns: [c_custkey, c_nationkey, _row_id#0], pk_indices: [2] }
+                      StreamExchange { dist: HashShard([0]) }
+                        StreamTableScan { table: nation, columns: [n_nationkey, n_name, _row_id#0], pk_indices: [2] }
+                StreamExchange { dist: HashShard([0]) }
+                  StreamTableScan { table: nation, columns: [n_nationkey, n_name, _row_id#0], pk_indices: [2] }
 - id: tpch_q8
   before:
     - create_tables
@@ -678,7 +670,7 @@
   batch_plan: |
     BatchExchange { order: [$0 ASC], dist: Single }
       BatchSort { order: [$0 ASC] }
-        BatchProject { exprs: [$0, RoundDigit(($1 / $2), 6:Int32)], expr_alias: [o_year, mkt_share] }
+        BatchProject { exprs: [$0, RoundDigit(($1 / $2), 6:Int32)], expr_alias: [ ,  ] }
           BatchHashAgg { group_keys: [$0], aggs: [sum($1), sum($2)] }
             BatchExchange { order: [], dist: HashShard([0]) }
               BatchProject { exprs: [Extract('YEAR':Varchar, $2), Case(($4 = 'IRAN':Varchar), ($0 * (1:Int32 - $1)), 0:Int32::Decimal), ($0 * (1:Int32 - $1))], expr_alias: [ ,  ,  ] }
@@ -724,7 +716,7 @@
                         BatchScan { table: region, columns: [r_regionkey, r_name] }
   stream_plan: |
     StreamMaterialize { columns: [o_year, mkt_share], pk_columns: [o_year] }
-      StreamProject { exprs: [$0, RoundDigit(($2 / $3), 6:Int32)], expr_alias: [o_year, mkt_share] }
+      StreamProject { exprs: [$0, RoundDigit(($2 / $3), 6:Int32)], expr_alias: [ ,  ] }
         StreamHashAgg { group_keys: [$0], aggs: [count, sum($1), sum($2)] }
           StreamExchange { dist: HashShard([0]) }
             StreamProject { exprs: [Extract('YEAR':Varchar, $2), Case(($4 = 'IRAN':Varchar), ($0 * (1:Int32 - $1)), 0:Int32::Decimal), ($0 * (1:Int32 - $1)), $5, $6, $7, $8, $9, $10, $11, $13], expr_alias: [ ,  ,  ,  ,  ,  ,  ,  ,  ,  ,  ] }
@@ -809,7 +801,7 @@
   batch_plan: |
     BatchExchange { order: [$0 ASC, $1 DESC], dist: Single }
       BatchSort { order: [$0 ASC, $1 DESC] }
-        BatchProject { exprs: [$0, $1, RoundDigit($2, 2:Int32)], expr_alias: [nation, o_year, sum_profit] }
+        BatchProject { exprs: [$0, $1, RoundDigit($2, 2:Int32)], expr_alias: [ ,  ,  ] }
           BatchHashAgg { group_keys: [$0, $1], aggs: [sum($2)] }
             BatchExchange { order: [], dist: HashShard([0, 1]) }
               BatchProject { exprs: [$7, Extract('YEAR':Varchar, $5), (($1 * (1:Int32 - $2)) - ($4 * $0))], expr_alias: [ ,  ,  ] }
@@ -842,7 +834,7 @@
                     BatchScan { table: nation, columns: [n_nationkey, n_name] }
   stream_plan: |
     StreamMaterialize { columns: [nation, o_year, sum_profit], pk_columns: [nation, o_year] }
-      StreamProject { exprs: [$0, $1, RoundDigit($3, 2:Int32)], expr_alias: [nation, o_year, sum_profit] }
+      StreamProject { exprs: [$0, $1, RoundDigit($3, 2:Int32)], expr_alias: [ ,  ,  ] }
         StreamHashAgg { group_keys: [$0, $1], aggs: [count, sum($2)] }
           StreamExchange { dist: HashShard([0, 1]) }
             StreamProject { exprs: [$12, Extract('YEAR':Varchar, $5), (($1 * (1:Int32 - $2)) - ($4 * $0)), $6, $7, $8, $9, $10, $13], expr_alias: [ ,  ,  ,  ,  ,  ,  ,  ,  ] }
@@ -912,7 +904,7 @@
   batch_plan: |
     BatchTopN { order: [$2 DESC], limit: 20, offset: 0 }
       BatchExchange { order: [], dist: Single }
-        BatchProject { exprs: [$0, $1, $7, $2, $4, $5, $3, $6], expr_alias: [c_custkey, c_name, revenue, c_acctbal, n_name, c_address, c_phone, c_comment] }
+        BatchProject { exprs: [$0, $1, $7, $2, $4, $5, $3, $6], expr_alias: [ ,  ,  ,  ,  ,  ,  ,  ] }
           BatchHashAgg { group_keys: [$0, $1, $2, $3, $4, $5, $6], aggs: [sum($7)] }
             BatchProject { exprs: [$0, $1, $5, $4, $10, $2, $6, ($7 * (1.00:Decimal - $8))], expr_alias: [ ,  ,  ,  ,  ,  ,  ,  ] }
               BatchExchange { order: [], dist: HashShard([0, 1, 5, 4, 10, 2, 6]) }
@@ -939,7 +931,7 @@
     StreamMaterialize { columns: [c_custkey, c_name, revenue, c_acctbal, n_name, c_address, c_phone, c_comment], pk_columns: [c_custkey, c_name, c_acctbal, c_phone, n_name, c_address, c_comment], order_descs: [revenue, c_custkey, c_name, c_acctbal, c_phone, n_name, c_address, c_comment] }
       StreamTopN { order: [$2 DESC], limit: 20, offset: 0 }
         StreamExchange { dist: Single }
-          StreamProject { exprs: [$0, $1, $8, $2, $4, $5, $3, $6], expr_alias: [c_custkey, c_name, revenue, c_acctbal, n_name, c_address, c_phone, c_comment] }
+          StreamProject { exprs: [$0, $1, $8, $2, $4, $5, $3, $6], expr_alias: [ ,  ,  ,  ,  ,  ,  ,  ] }
             StreamHashAgg { group_keys: [$0, $1, $2, $3, $4, $5, $6], aggs: [count, sum($7)] }
               StreamProject { exprs: [$0, $1, $5, $4, $13, $2, $6, ($7 * (1.00:Decimal - $8)), $9, $10, $11, $14], expr_alias: [ ,  ,  ,  ,  ,  ,  ,  ,  ,  ,  ,  ] }
                 StreamExchange { dist: HashShard([0, 1, 5, 4, 13, 2, 6]) }
@@ -995,7 +987,7 @@
     order by
       value desc;
   logical_plan: |
-    LogicalProject { exprs: [$0, $1], expr_alias: [ps_partkey, value] }
+    LogicalProject { exprs: [$0, $1], expr_alias: [ ,  ] }
       LogicalFilter { predicate: ($2 > $3) }
         LogicalJoin { type: LeftOuter, on: true }
           LogicalAgg { group_keys: [0], agg_calls: [sum($1), sum($1)] }
@@ -1016,7 +1008,7 @@
                       LogicalScan { table: supplier, columns: [_row_id#0, s_suppkey, s_name, s_address, s_nationkey, s_phone, s_acctbal, s_comment] }
                     LogicalScan { table: nation, columns: [_row_id#0, n_nationkey, n_name, n_regionkey, n_comment] }
   optimized_logical_plan: |
-    LogicalProject { exprs: [$0, $1], expr_alias: [ps_partkey, value] }
+    LogicalProject { exprs: [$0, $1], expr_alias: [ ,  ] }
       LogicalJoin { type: Inner, on: ($2 > $3) }
         LogicalAgg { group_keys: [0], agg_calls: [sum($1), sum($1)] }
           LogicalProject { exprs: [$0, ($2 * $1)], expr_alias: [ ,  ] }
@@ -1041,7 +1033,7 @@
                     LogicalScan { table: nation, columns: [n_nationkey, n_name] }
   batch_plan: |
     BatchSort { order: [$1 DESC] }
-      BatchProject { exprs: [$0, $1], expr_alias: [ps_partkey, value] }
+      BatchProject { exprs: [$0, $1], expr_alias: [ ,  ] }
         BatchNestedLoopJoin { type: Inner, predicate: ($2 > $3) }
           BatchExchange { order: [], dist: Single }
             BatchHashAgg { group_keys: [$0], aggs: [sum($1), sum($1)] }
@@ -1110,30 +1102,28 @@
   batch_plan: |
     BatchExchange { order: [$0 ASC], dist: Single }
       BatchSort { order: [$0 ASC] }
-        BatchProject { exprs: [$0, $1, $2], expr_alias: [l_shipmode, high_line_count, low_line_count] }
-          BatchHashAgg { group_keys: [$0], aggs: [sum($1), sum($2)] }
-            BatchProject { exprs: [$3, Case((($1 = '1-URGENT':Varchar) OR ($1 = '2-HIGH':Varchar)), 1:Int32, 0:Int32), Case((($1 <> '1-URGENT':Varchar) AND ($1 <> '2-HIGH':Varchar)), 1:Int32, 0:Int32)], expr_alias: [ ,  ,  ] }
-              BatchExchange { order: [], dist: HashShard([3]) }
-                BatchHashJoin { type: Inner, predicate: $0 = $2 }
+        BatchHashAgg { group_keys: [$0], aggs: [sum($1), sum($2)] }
+          BatchProject { exprs: [$3, Case((($1 = '1-URGENT':Varchar) OR ($1 = '2-HIGH':Varchar)), 1:Int32, 0:Int32), Case((($1 <> '1-URGENT':Varchar) AND ($1 <> '2-HIGH':Varchar)), 1:Int32, 0:Int32)], expr_alias: [ ,  ,  ] }
+            BatchExchange { order: [], dist: HashShard([3]) }
+              BatchHashJoin { type: Inner, predicate: $0 = $2 }
+                BatchExchange { order: [], dist: HashShard([0]) }
+                  BatchScan { table: orders, columns: [o_orderkey, o_orderpriority] }
+                BatchProject { exprs: [$0, $4], expr_alias: [ ,  ] }
                   BatchExchange { order: [], dist: HashShard([0]) }
-                    BatchScan { table: orders, columns: [o_orderkey, o_orderpriority] }
-                  BatchProject { exprs: [$0, $4], expr_alias: [ ,  ] }
-                    BatchExchange { order: [], dist: HashShard([0]) }
-                      BatchFilter { predicate: In($4, 'FOB':Varchar, 'SHIP':Varchar) AND ($2 < $3) AND ($1 < $2) AND ($3 >= '1994-01-01':Varchar::Date) AND ($3 < ('1994-01-01':Varchar::Date + '1 year 00:00:00':Interval)) }
-                        BatchScan { table: lineitem, columns: [l_orderkey, l_shipdate, l_commitdate, l_receiptdate, l_shipmode] }
+                    BatchFilter { predicate: In($4, 'FOB':Varchar, 'SHIP':Varchar) AND ($2 < $3) AND ($1 < $2) AND ($3 >= '1994-01-01':Varchar::Date) AND ($3 < ('1994-01-01':Varchar::Date + '1 year 00:00:00':Interval)) }
+                      BatchScan { table: lineitem, columns: [l_orderkey, l_shipdate, l_commitdate, l_receiptdate, l_shipmode] }
   stream_plan: |
-    StreamMaterialize { columns: [l_shipmode, high_line_count, low_line_count], pk_columns: [l_shipmode] }
-      StreamProject { exprs: [$0, $2, $3], expr_alias: [l_shipmode, high_line_count, low_line_count] }
-        StreamHashAgg { group_keys: [$0], aggs: [count, sum($1), sum($2)] }
-          StreamProject { exprs: [$4, Case((($1 = '1-URGENT':Varchar) OR ($1 = '2-HIGH':Varchar)), 1:Int32, 0:Int32), Case((($1 <> '1-URGENT':Varchar) AND ($1 <> '2-HIGH':Varchar)), 1:Int32, 0:Int32), $2, $5], expr_alias: [ ,  ,  ,  ,  ] }
-            StreamExchange { dist: HashShard([4]) }
-              StreamHashJoin { type: Inner, predicate: $0 = $3 }
+    StreamMaterialize { columns: [l_shipmode, agg#0(hidden), high_line_count, low_line_count], pk_columns: [l_shipmode] }
+      StreamHashAgg { group_keys: [$0], aggs: [count, sum($1), sum($2)] }
+        StreamProject { exprs: [$4, Case((($1 = '1-URGENT':Varchar) OR ($1 = '2-HIGH':Varchar)), 1:Int32, 0:Int32), Case((($1 <> '1-URGENT':Varchar) AND ($1 <> '2-HIGH':Varchar)), 1:Int32, 0:Int32), $2, $5], expr_alias: [ ,  ,  ,  ,  ] }
+          StreamExchange { dist: HashShard([4]) }
+            StreamHashJoin { type: Inner, predicate: $0 = $3 }
+              StreamExchange { dist: HashShard([0]) }
+                StreamTableScan { table: orders, columns: [o_orderkey, o_orderpriority, _row_id#0], pk_indices: [2] }
+              StreamProject { exprs: [$0, $4, $5], expr_alias: [ ,  ,  ] }
                 StreamExchange { dist: HashShard([0]) }
-                  StreamTableScan { table: orders, columns: [o_orderkey, o_orderpriority, _row_id#0], pk_indices: [2] }
-                StreamProject { exprs: [$0, $4, $5], expr_alias: [ ,  ,  ] }
-                  StreamExchange { dist: HashShard([0]) }
-                    StreamFilter { predicate: In($4, 'FOB':Varchar, 'SHIP':Varchar) AND ($2 < $3) AND ($1 < $2) AND ($3 >= '1994-01-01':Varchar::Date) AND ($3 < ('1994-01-01':Varchar::Date + '1 year 00:00:00':Interval)) }
-                      StreamTableScan { table: lineitem, columns: [l_orderkey, l_shipdate, l_commitdate, l_receiptdate, l_shipmode, _row_id#0], pk_indices: [5] }
+                  StreamFilter { predicate: In($4, 'FOB':Varchar, 'SHIP':Varchar) AND ($2 < $3) AND ($1 < $2) AND ($3 >= '1994-01-01':Varchar::Date) AND ($3 < ('1994-01-01':Varchar::Date + '1 year 00:00:00':Interval)) }
+                    StreamTableScan { table: lineitem, columns: [l_orderkey, l_shipdate, l_commitdate, l_receiptdate, l_shipmode, _row_id#0], pk_indices: [5] }
 - id: tpch_q13
   before:
     - create_tables
@@ -1161,30 +1151,28 @@
   batch_plan: |
     BatchExchange { order: [$1 DESC, $0 DESC], dist: Single }
       BatchSort { order: [$1 DESC, $0 DESC] }
-        BatchProject { exprs: [$0, $1], expr_alias: [c_count, custdist] }
-          BatchHashAgg { group_keys: [$0], aggs: [count] }
-            BatchProject { exprs: [$1], expr_alias: [ ] }
-              BatchExchange { order: [], dist: HashShard([1]) }
-                BatchHashAgg { group_keys: [$0], aggs: [count($1)] }
-                  BatchProject { exprs: [$0, $1], expr_alias: [ ,  ] }
-                    BatchHashJoin { type: LeftOuter, predicate: $0 = $2AND Not(Like($3, '%:1%:2%':Varchar)) }
-                      BatchExchange { order: [], dist: HashShard([0]) }
-                        BatchScan { table: customer, columns: [c_custkey] }
-                      BatchExchange { order: [], dist: HashShard([1]) }
-                        BatchScan { table: orders, columns: [o_orderkey, o_custkey, o_comment] }
+        BatchHashAgg { group_keys: [$0], aggs: [count] }
+          BatchProject { exprs: [$1], expr_alias: [ ] }
+            BatchExchange { order: [], dist: HashShard([1]) }
+              BatchHashAgg { group_keys: [$0], aggs: [count($1)] }
+                BatchProject { exprs: [$0, $1], expr_alias: [ ,  ] }
+                  BatchHashJoin { type: LeftOuter, predicate: $0 = $2AND Not(Like($3, '%:1%:2%':Varchar)) }
+                    BatchExchange { order: [], dist: HashShard([0]) }
+                      BatchScan { table: customer, columns: [c_custkey] }
+                    BatchExchange { order: [], dist: HashShard([1]) }
+                      BatchScan { table: orders, columns: [o_orderkey, o_custkey, o_comment] }
   stream_plan: |
-    StreamMaterialize { columns: [c_count, custdist], pk_columns: [c_count], order_descs: [custdist, c_count] }
-      StreamProject { exprs: [$0, $2], expr_alias: [c_count, custdist] }
-        StreamHashAgg { group_keys: [$0], aggs: [count, count] }
-          StreamProject { exprs: [$2, $0], expr_alias: [ ,  ] }
-            StreamExchange { dist: HashShard([2]) }
-              StreamHashAgg { group_keys: [$0], aggs: [count, count($1)] }
-                StreamProject { exprs: [$0, $2, $1, $5], expr_alias: [ ,  ,  ,  ] }
-                  StreamHashJoin { type: LeftOuter, predicate: $0 = $3AND Not(Like($4, '%:1%:2%':Varchar)) }
-                    StreamExchange { dist: HashShard([0]) }
-                      StreamTableScan { table: customer, columns: [c_custkey, _row_id#0], pk_indices: [1] }
-                    StreamExchange { dist: HashShard([1]) }
-                      StreamTableScan { table: orders, columns: [o_orderkey, o_custkey, o_comment, _row_id#0], pk_indices: [3] }
+    StreamMaterialize { columns: [c_count, agg#0(hidden), custdist], pk_columns: [c_count], order_descs: [custdist, c_count] }
+      StreamHashAgg { group_keys: [$0], aggs: [count, count] }
+        StreamProject { exprs: [$2, $0], expr_alias: [ ,  ] }
+          StreamExchange { dist: HashShard([2]) }
+            StreamHashAgg { group_keys: [$0], aggs: [count, count($1)] }
+              StreamProject { exprs: [$0, $2, $1, $5], expr_alias: [ ,  ,  ,  ] }
+                StreamHashJoin { type: LeftOuter, predicate: $0 = $3AND Not(Like($4, '%:1%:2%':Varchar)) }
+                  StreamExchange { dist: HashShard([0]) }
+                    StreamTableScan { table: customer, columns: [c_custkey, _row_id#0], pk_indices: [1] }
+                  StreamExchange { dist: HashShard([1]) }
+                    StreamTableScan { table: orders, columns: [o_orderkey, o_custkey, o_comment, _row_id#0], pk_indices: [3] }
 - id: tpch_q14
   before:
     - create_tables
@@ -1203,7 +1191,7 @@
       and l_shipdate >= date '1995-09-01'
       and l_shipdate < date '1995-09-01' + interval '1' month;
   batch_plan: |
-    BatchProject { exprs: [((100.00:Decimal * $0) / $1)], expr_alias: [promo_revenue] }
+    BatchProject { exprs: [((100.00:Decimal * $0) / $1)], expr_alias: [ ] }
       BatchSimpleAgg { aggs: [sum($0), sum($1)] }
         BatchExchange { order: [], dist: Single }
           BatchProject { exprs: [Case(Like($4, 'PROMO%':Varchar), ($1 * (1:Int32 - $2)), 0:Int32::Decimal), ($1 * (1:Int32 - $2))], expr_alias: [ ,  ] }
@@ -1216,7 +1204,7 @@
                 BatchScan { table: part, columns: [p_partkey, p_type] }
   stream_plan: |
     StreamMaterialize { columns: [promo_revenue, agg#0(hidden), agg#1(hidden), agg#2(hidden)], pk_columns: [agg#0, agg#1, agg#2] }
-      StreamProject { exprs: [((100.00:Decimal * $1) / $2), $0, $1, $2], expr_alias: [promo_revenue,  ,  ,  ] }
+      StreamProject { exprs: [((100.00:Decimal * $1) / $2), $0, $1, $2], expr_alias: [ ,  ,  ,  ] }
         StreamSimpleAgg { aggs: [count, sum($0), sum($1)] }
           StreamExchange { dist: Single }
             StreamProject { exprs: [Case(Like($5, 'PROMO%':Varchar), ($1 * (1:Int32 - $2)), 0:Int32::Decimal), ($1 * (1:Int32 - $2)), $3, $6], expr_alias: [ ,  ,  ,  ] }
@@ -1275,55 +1263,51 @@
   batch_plan: |
     BatchExchange { order: [$0 ASC], dist: Single }
       BatchSort { order: [$0 ASC] }
-        BatchProject { exprs: [$0, $1, $2, $3, $4], expr_alias: [s_suppkey, s_name, s_address, s_phone, total_revenue] }
+        BatchProject { exprs: [$0, $1, $2, $3, $4], expr_alias: [ ,  ,  ,  ,  ] }
           BatchHashJoin { type: Inner, predicate: $4 = $5 }
             BatchProject { exprs: [$0, $1, $2, $3, $5], expr_alias: [ ,  ,  ,  ,  ] }
               BatchExchange { order: [], dist: HashShard([5]) }
                 BatchHashJoin { type: Inner, predicate: $0 = $4 }
                   BatchExchange { order: [], dist: HashShard([0]) }
                     BatchScan { table: supplier, columns: [s_suppkey, s_name, s_address, s_phone] }
-                  BatchProject { exprs: [$0, $1], expr_alias: [l_suppkey, total_revenue] }
+                  BatchHashAgg { group_keys: [$0], aggs: [sum($1)] }
+                    BatchProject { exprs: [$0, ($1 * (1:Int32 - $2))], expr_alias: [ ,  ] }
+                      BatchExchange { order: [], dist: HashShard([0]) }
+                        BatchFilter { predicate: ($3 >= '1993-01-01':Varchar::Date) AND ($3 < ('1993-01-01':Varchar::Date + '3 mons 00:00:00':Interval)) }
+                          BatchScan { table: lineitem, columns: [l_suppkey, l_extendedprice, l_discount, l_shipdate] }
+            BatchExchange { order: [], dist: HashShard([0]) }
+              BatchSimpleAgg { aggs: [max($0)] }
+                BatchExchange { order: [], dist: Single }
+                  BatchProject { exprs: [$1], expr_alias: [ ] }
                     BatchHashAgg { group_keys: [$0], aggs: [sum($1)] }
                       BatchProject { exprs: [$0, ($1 * (1:Int32 - $2))], expr_alias: [ ,  ] }
                         BatchExchange { order: [], dist: HashShard([0]) }
                           BatchFilter { predicate: ($3 >= '1993-01-01':Varchar::Date) AND ($3 < ('1993-01-01':Varchar::Date + '3 mons 00:00:00':Interval)) }
                             BatchScan { table: lineitem, columns: [l_suppkey, l_extendedprice, l_discount, l_shipdate] }
-            BatchProject { exprs: [$0], expr_alias: [max_revenue] }
-              BatchExchange { order: [], dist: HashShard([0]) }
-                BatchSimpleAgg { aggs: [max($0)] }
-                  BatchExchange { order: [], dist: Single }
-                    BatchProject { exprs: [$1], expr_alias: [ ] }
-                      BatchHashAgg { group_keys: [$0], aggs: [sum($1)] }
-                        BatchProject { exprs: [$0, ($1 * (1:Int32 - $2))], expr_alias: [ ,  ] }
-                          BatchExchange { order: [], dist: HashShard([0]) }
-                            BatchFilter { predicate: ($3 >= '1993-01-01':Varchar::Date) AND ($3 < ('1993-01-01':Varchar::Date + '3 mons 00:00:00':Interval)) }
-                              BatchScan { table: lineitem, columns: [l_suppkey, l_extendedprice, l_discount, l_shipdate] }
   stream_plan: |
-    StreamMaterialize { columns: [s_suppkey, s_name, s_address, s_phone, total_revenue, _row_id#0(hidden), l_suppkey(hidden), agg#0(hidden), max_revenue(hidden)], pk_columns: [_row_id#0, l_suppkey, agg#0, max_revenue], order_descs: [s_suppkey, _row_id#0, l_suppkey, agg#0, max_revenue] }
+    StreamMaterialize { columns: [s_suppkey, s_name, s_address, s_phone, total_revenue, _row_id#0(hidden), l_suppkey(hidden), agg#0(hidden), agg#1(hidden)], pk_columns: [_row_id#0, l_suppkey, agg#0, agg#1], order_descs: [s_suppkey, _row_id#0, l_suppkey, agg#0, agg#1] }
       StreamExchange { dist: HashShard([5, 6, 7, 8]) }
-        StreamProject { exprs: [$0, $1, $2, $3, $4, $5, $6, $8, $7], expr_alias: [s_suppkey, s_name, s_address, s_phone, total_revenue,  ,  ,  ,  ] }
-          StreamHashJoin { type: Inner, predicate: $4 = $7 }
-            StreamProject { exprs: [$0, $1, $2, $3, $6, $4, $5], expr_alias: [ ,  ,  ,  ,  ,  ,  ] }
-              StreamExchange { dist: HashShard([6]) }
+        StreamProject { exprs: [$0, $1, $2, $3, $4, $5, $6, $7, $8], expr_alias: [ ,  ,  ,  ,  ,  ,  ,  ,  ] }
+          StreamHashJoin { type: Inner, predicate: $4 = $8 }
+            StreamProject { exprs: [$0, $1, $2, $3, $7, $4, $5], expr_alias: [ ,  ,  ,  ,  ,  ,  ] }
+              StreamExchange { dist: HashShard([7]) }
                 StreamHashJoin { type: Inner, predicate: $0 = $5 }
                   StreamExchange { dist: HashShard([0]) }
                     StreamTableScan { table: supplier, columns: [s_suppkey, s_name, s_address, s_phone, _row_id#0], pk_indices: [4] }
-                  StreamProject { exprs: [$0, $2], expr_alias: [l_suppkey, total_revenue] }
+                  StreamHashAgg { group_keys: [$0], aggs: [count, sum($1)] }
+                    StreamProject { exprs: [$0, ($1 * (1:Int32 - $2)), $4], expr_alias: [ ,  ,  ] }
+                      StreamExchange { dist: HashShard([0]) }
+                        StreamFilter { predicate: ($3 >= '1993-01-01':Varchar::Date) AND ($3 < ('1993-01-01':Varchar::Date + '3 mons 00:00:00':Interval)) }
+                          StreamTableScan { table: lineitem, columns: [l_suppkey, l_extendedprice, l_discount, l_shipdate, _row_id#0], pk_indices: [4] }
+            StreamExchange { dist: HashShard([1]) }
+              StreamSimpleAgg { aggs: [count, max($0)] }
+                StreamExchange { dist: Single }
+                  StreamProject { exprs: [$2, $0], expr_alias: [ ,  ] }
                     StreamHashAgg { group_keys: [$0], aggs: [count, sum($1)] }
                       StreamProject { exprs: [$0, ($1 * (1:Int32 - $2)), $4], expr_alias: [ ,  ,  ] }
                         StreamExchange { dist: HashShard([0]) }
                           StreamFilter { predicate: ($3 >= '1993-01-01':Varchar::Date) AND ($3 < ('1993-01-01':Varchar::Date + '3 mons 00:00:00':Interval)) }
                             StreamTableScan { table: lineitem, columns: [l_suppkey, l_extendedprice, l_discount, l_shipdate, _row_id#0], pk_indices: [4] }
-            StreamProject { exprs: [$1, $0], expr_alias: [max_revenue,  ] }
-              StreamExchange { dist: HashShard([1]) }
-                StreamSimpleAgg { aggs: [count, max($0)] }
-                  StreamExchange { dist: Single }
-                    StreamProject { exprs: [$2, $0], expr_alias: [ ,  ] }
-                      StreamHashAgg { group_keys: [$0], aggs: [count, sum($1)] }
-                        StreamProject { exprs: [$0, ($1 * (1:Int32 - $2)), $4], expr_alias: [ ,  ,  ] }
-                          StreamExchange { dist: HashShard([0]) }
-                            StreamFilter { predicate: ($3 >= '1993-01-01':Varchar::Date) AND ($3 < ('1993-01-01':Varchar::Date + '3 mons 00:00:00':Interval)) }
-                              StreamTableScan { table: lineitem, columns: [l_suppkey, l_extendedprice, l_discount, l_shipdate, _row_id#0], pk_indices: [4] }
 - id: tpch_q16
   before:
     - create_tables
@@ -1359,7 +1343,7 @@
       p_type,
       p_size;
   logical_plan: |
-    LogicalProject { exprs: [$0, $1, $2, $3], expr_alias: [p_brand, p_type, p_size, supplier_cnt] }
+    LogicalProject { exprs: [$0, $1, $2, $3], expr_alias: [ ,  ,  ,  ] }
       LogicalAgg { group_keys: [0, 1, 2], agg_calls: [count($3)] }
         LogicalProject { exprs: [$10, $11, $12, $2], expr_alias: [ ,  ,  ,  ] }
           LogicalFilter { predicate: ($7 = $1) AND ($10 <> 'Brand#45':Varchar) AND Not(Like($11, 'SMALL PLATED%':Varchar)) AND In($12, 19:Int32, 17:Int32, 16:Int32, 23:Int32, 10:Int32, 4:Int32, 38:Int32, 11:Int32) }
@@ -1367,7 +1351,7 @@
               LogicalJoin { type: Inner, on: true }
                 LogicalScan { table: partsupp, columns: [_row_id#0, ps_partkey, ps_suppkey, ps_availqty, ps_supplycost, ps_comment] }
                 LogicalScan { table: part, columns: [_row_id#0, p_partkey, p_name, p_mfgr, p_brand, p_type, p_size, p_container, p_retailprice, p_comment] }
-              LogicalProject { exprs: [$1], expr_alias: [s_suppkey] }
+              LogicalProject { exprs: [$1], expr_alias: [ ] }
                 LogicalFilter { predicate: Like($7, '%Customer%Complaints%':Varchar) }
                   LogicalScan { table: supplier, columns: [_row_id#0, s_suppkey, s_name, s_address, s_nationkey, s_phone, s_acctbal, s_comment] }
 - id: tpch_q17
@@ -1392,7 +1376,7 @@
           l_partkey = p_partkey
       );
   batch_plan: |
-    BatchProject { exprs: [RoundDigit(($0 / 7.0:Decimal), 16:Int32)], expr_alias: [avg_yearly] }
+    BatchProject { exprs: [RoundDigit(($0 / 7.0:Decimal), 16:Int32)], expr_alias: [ ] }
       BatchSimpleAgg { aggs: [sum($0)] }
         BatchExchange { order: [], dist: Single }
           BatchProject { exprs: [$1], expr_alias: [ ] }
@@ -1414,7 +1398,7 @@
                             BatchScan { table: lineitem, columns: [l_partkey, l_quantity] }
   stream_plan: |
     StreamMaterialize { columns: [avg_yearly, agg#0(hidden), agg#1(hidden)], pk_columns: [agg#0, agg#1] }
-      StreamProject { exprs: [RoundDigit(($1 / 7.0:Decimal), 16:Int32), $0, $1], expr_alias: [avg_yearly,  ,  ] }
+      StreamProject { exprs: [RoundDigit(($1 / 7.0:Decimal), 16:Int32), $0, $1], expr_alias: [ ,  ,  ] }
         StreamSimpleAgg { aggs: [count, sum($0)] }
           StreamExchange { dist: Single }
             StreamProject { exprs: [$1, $4, $5, $6, $7, $8, $0, $9, $10, $11, $12, $13, $14, $15, $16, $17, $18, $19, $20, $21, $22, $23, $24, $25, $26, $27, $28], expr_alias: [ ,  ,  ,  ,  ,  ,  ,  ,  ,  ,  ,  ,  ,  ,  ,  ,  ,  ,  ,  ,  ,  ,  ,  ,  ,  ,  ] }
@@ -1475,52 +1459,50 @@
   batch_plan: |
     BatchTopN { order: [$4 DESC, $3 ASC], limit: 100, offset: 0 }
       BatchExchange { order: [], dist: Single }
-        BatchProject { exprs: [$0, $1, $2, $3, $4, $5], expr_alias: [c_name, c_custkey, o_orderkey, o_orderdate, o_totalprice, quantity] }
-          BatchHashAgg { group_keys: [$0, $1, $2, $3, $4], aggs: [sum($5)] }
-            BatchProject { exprs: [$1, $0, $2, $4, $3, $5], expr_alias: [ ,  ,  ,  ,  ,  ] }
-              BatchExchange { order: [], dist: HashShard([1, 0, 2, 4, 3]) }
-                BatchHashJoin { type: LeftSemi, predicate: $2 = $6 }
-                  BatchProject { exprs: [$0, $1, $2, $3, $4, $6], expr_alias: [ ,  ,  ,  ,  ,  ] }
-                    BatchHashJoin { type: Inner, predicate: $2 = $5 }
-                      BatchProject { exprs: [$0, $1, $2, $4, $5], expr_alias: [ ,  ,  ,  ,  ] }
-                        BatchExchange { order: [], dist: HashShard([2]) }
-                          BatchHashJoin { type: Inner, predicate: $0 = $3 }
-                            BatchExchange { order: [], dist: HashShard([0]) }
-                              BatchScan { table: customer, columns: [c_custkey, c_name] }
-                            BatchExchange { order: [], dist: HashShard([1]) }
-                              BatchScan { table: orders, columns: [o_orderkey, o_custkey, o_totalprice, o_orderdate] }
+        BatchHashAgg { group_keys: [$0, $1, $2, $3, $4], aggs: [sum($5)] }
+          BatchProject { exprs: [$1, $0, $2, $4, $3, $5], expr_alias: [ ,  ,  ,  ,  ,  ] }
+            BatchExchange { order: [], dist: HashShard([1, 0, 2, 4, 3]) }
+              BatchHashJoin { type: LeftSemi, predicate: $2 = $6 }
+                BatchProject { exprs: [$0, $1, $2, $3, $4, $6], expr_alias: [ ,  ,  ,  ,  ,  ] }
+                  BatchHashJoin { type: Inner, predicate: $2 = $5 }
+                    BatchProject { exprs: [$0, $1, $2, $4, $5], expr_alias: [ ,  ,  ,  ,  ] }
+                      BatchExchange { order: [], dist: HashShard([2]) }
+                        BatchHashJoin { type: Inner, predicate: $0 = $3 }
+                          BatchExchange { order: [], dist: HashShard([0]) }
+                            BatchScan { table: customer, columns: [c_custkey, c_name] }
+                          BatchExchange { order: [], dist: HashShard([1]) }
+                            BatchScan { table: orders, columns: [o_orderkey, o_custkey, o_totalprice, o_orderdate] }
+                    BatchExchange { order: [], dist: HashShard([0]) }
+                      BatchScan { table: lineitem, columns: [l_orderkey, l_quantity] }
+                BatchProject { exprs: [$0], expr_alias: [ ] }
+                  BatchFilter { predicate: ($1 > 1:Int32) }
+                    BatchHashAgg { group_keys: [$0], aggs: [sum($1)] }
                       BatchExchange { order: [], dist: HashShard([0]) }
                         BatchScan { table: lineitem, columns: [l_orderkey, l_quantity] }
-                  BatchProject { exprs: [$0], expr_alias: [l_orderkey] }
-                    BatchFilter { predicate: ($1 > 1:Int32) }
-                      BatchHashAgg { group_keys: [$0], aggs: [sum($1)] }
-                        BatchExchange { order: [], dist: HashShard([0]) }
-                          BatchScan { table: lineitem, columns: [l_orderkey, l_quantity] }
   stream_plan: |
-    StreamMaterialize { columns: [c_name, c_custkey, o_orderkey, o_orderdate, o_totalprice, quantity], pk_columns: [c_name, c_custkey, o_orderkey, o_orderdate, o_totalprice], order_descs: [o_totalprice, o_orderdate, c_name, c_custkey, o_orderkey] }
+    StreamMaterialize { columns: [c_name, c_custkey, o_orderkey, o_orderdate, o_totalprice, agg#0(hidden), quantity], pk_columns: [c_name, c_custkey, o_orderkey, o_orderdate, o_totalprice], order_descs: [o_totalprice, o_orderdate, c_name, c_custkey, o_orderkey] }
       StreamTopN { order: [$4 DESC, $3 ASC], limit: 100, offset: 0 }
         StreamExchange { dist: Single }
-          StreamProject { exprs: [$0, $1, $2, $3, $4, $6], expr_alias: [c_name, c_custkey, o_orderkey, o_orderdate, o_totalprice, quantity] }
-            StreamHashAgg { group_keys: [$0, $1, $2, $3, $4], aggs: [count, sum($5)] }
-              StreamProject { exprs: [$1, $0, $2, $4, $3, $5, $6, $7, $8], expr_alias: [ ,  ,  ,  ,  ,  ,  ,  ,  ] }
-                StreamExchange { dist: HashShard([1, 0, 2, 4, 3]) }
-                  StreamHashJoin { type: LeftSemi, predicate: $2 = $9 }
-                    StreamProject { exprs: [$0, $1, $2, $3, $4, $8, $5, $6, $9], expr_alias: [ ,  ,  ,  ,  ,  ,  ,  ,  ] }
-                      StreamHashJoin { type: Inner, predicate: $2 = $7 }
-                        StreamProject { exprs: [$0, $1, $3, $5, $6, $2, $7], expr_alias: [ ,  ,  ,  ,  ,  ,  ] }
-                          StreamExchange { dist: HashShard([3]) }
-                            StreamHashJoin { type: Inner, predicate: $0 = $4 }
-                              StreamExchange { dist: HashShard([0]) }
-                                StreamTableScan { table: customer, columns: [c_custkey, c_name, _row_id#0], pk_indices: [2] }
-                              StreamExchange { dist: HashShard([1]) }
-                                StreamTableScan { table: orders, columns: [o_orderkey, o_custkey, o_totalprice, o_orderdate, _row_id#0], pk_indices: [4] }
+          StreamHashAgg { group_keys: [$0, $1, $2, $3, $4], aggs: [count, sum($5)] }
+            StreamProject { exprs: [$1, $0, $2, $4, $3, $5, $6, $7, $8], expr_alias: [ ,  ,  ,  ,  ,  ,  ,  ,  ] }
+              StreamExchange { dist: HashShard([1, 0, 2, 4, 3]) }
+                StreamHashJoin { type: LeftSemi, predicate: $2 = $9 }
+                  StreamProject { exprs: [$0, $1, $2, $3, $4, $8, $5, $6, $9], expr_alias: [ ,  ,  ,  ,  ,  ,  ,  ,  ] }
+                    StreamHashJoin { type: Inner, predicate: $2 = $7 }
+                      StreamProject { exprs: [$0, $1, $3, $5, $6, $2, $7], expr_alias: [ ,  ,  ,  ,  ,  ,  ] }
+                        StreamExchange { dist: HashShard([3]) }
+                          StreamHashJoin { type: Inner, predicate: $0 = $4 }
+                            StreamExchange { dist: HashShard([0]) }
+                              StreamTableScan { table: customer, columns: [c_custkey, c_name, _row_id#0], pk_indices: [2] }
+                            StreamExchange { dist: HashShard([1]) }
+                              StreamTableScan { table: orders, columns: [o_orderkey, o_custkey, o_totalprice, o_orderdate, _row_id#0], pk_indices: [4] }
+                      StreamExchange { dist: HashShard([0]) }
+                        StreamTableScan { table: lineitem, columns: [l_orderkey, l_quantity, _row_id#0], pk_indices: [2] }
+                  StreamProject { exprs: [$0], expr_alias: [ ] }
+                    StreamFilter { predicate: ($2 > 1:Int32) }
+                      StreamHashAgg { group_keys: [$0], aggs: [count, sum($1)] }
                         StreamExchange { dist: HashShard([0]) }
                           StreamTableScan { table: lineitem, columns: [l_orderkey, l_quantity, _row_id#0], pk_indices: [2] }
-                    StreamProject { exprs: [$0], expr_alias: [l_orderkey] }
-                      StreamFilter { predicate: ($2 > 1:Int32) }
-                        StreamHashAgg { group_keys: [$0], aggs: [count, sum($1)] }
-                          StreamExchange { dist: HashShard([0]) }
-                            StreamTableScan { table: lineitem, columns: [l_orderkey, l_quantity, _row_id#0], pk_indices: [2] }
 - id: tpch_q19
   before:
     - create_tables
@@ -1561,34 +1543,32 @@
         and l_shipinstruct = 'DELIVER IN PERSON'
       );
   batch_plan: |
-    BatchProject { exprs: [$0], expr_alias: [revenue] }
-      BatchSimpleAgg { aggs: [sum($0)] }
-        BatchExchange { order: [], dist: Single }
-          BatchProject { exprs: [($2 * (1:Int32 - $3))], expr_alias: [ ] }
-            BatchFilter { predicate: ((((((($5 = 'Brand#52':Varchar) AND In($7, 'SM CASE':Varchar, 'SM BOX':Varchar, 'SM PACK':Varchar, 'SM PKG':Varchar)) AND ($1 >= 1:Int32)) AND ($1 <= 11:Int32)) AND ($6 <= 5:Int32)) OR ((((($5 = 'Brand#24':Varchar) AND In($7, 'MED BAG':Varchar, 'MED BOX':Varchar, 'MED PKG':Varchar, 'MED PACK':Varchar)) AND ($1 >= 30:Int32)) AND ($1 <= 40:Int32)) AND ($6 <= 10:Int32))) OR ((((($5 = 'Brand#32':Varchar) AND In($7, 'LG CASE':Varchar, 'LG BOX':Varchar, 'LG PACK':Varchar, 'LG PKG':Varchar)) AND ($1 >= 10:Int32)) AND ($1 <= 20:Int32)) AND ($6 <= 15:Int32))) }
-              BatchHashJoin { type: Inner, predicate: $0 = $4 }
-                BatchProject { exprs: [$0, $1, $2, $3], expr_alias: [ ,  ,  ,  ] }
-                  BatchExchange { order: [], dist: HashShard([0]) }
-                    BatchFilter { predicate: In($5, 'AIR':Varchar, 'AIR REG':Varchar) AND ($4 = 'DELIVER IN PERSON':Varchar) }
-                      BatchScan { table: lineitem, columns: [l_partkey, l_quantity, l_extendedprice, l_discount, l_shipinstruct, l_shipmode] }
+    BatchSimpleAgg { aggs: [sum($0)] }
+      BatchExchange { order: [], dist: Single }
+        BatchProject { exprs: [($2 * (1:Int32 - $3))], expr_alias: [ ] }
+          BatchFilter { predicate: ((((((($5 = 'Brand#52':Varchar) AND In($7, 'SM CASE':Varchar, 'SM BOX':Varchar, 'SM PACK':Varchar, 'SM PKG':Varchar)) AND ($1 >= 1:Int32)) AND ($1 <= 11:Int32)) AND ($6 <= 5:Int32)) OR ((((($5 = 'Brand#24':Varchar) AND In($7, 'MED BAG':Varchar, 'MED BOX':Varchar, 'MED PKG':Varchar, 'MED PACK':Varchar)) AND ($1 >= 30:Int32)) AND ($1 <= 40:Int32)) AND ($6 <= 10:Int32))) OR ((((($5 = 'Brand#32':Varchar) AND In($7, 'LG CASE':Varchar, 'LG BOX':Varchar, 'LG PACK':Varchar, 'LG PKG':Varchar)) AND ($1 >= 10:Int32)) AND ($1 <= 20:Int32)) AND ($6 <= 15:Int32))) }
+            BatchHashJoin { type: Inner, predicate: $0 = $4 }
+              BatchProject { exprs: [$0, $1, $2, $3], expr_alias: [ ,  ,  ,  ] }
                 BatchExchange { order: [], dist: HashShard([0]) }
-                  BatchFilter { predicate: ($2 >= 1:Int32) }
-                    BatchScan { table: part, columns: [p_partkey, p_brand, p_size, p_container] }
+                  BatchFilter { predicate: In($5, 'AIR':Varchar, 'AIR REG':Varchar) AND ($4 = 'DELIVER IN PERSON':Varchar) }
+                    BatchScan { table: lineitem, columns: [l_partkey, l_quantity, l_extendedprice, l_discount, l_shipinstruct, l_shipmode] }
+              BatchExchange { order: [], dist: HashShard([0]) }
+                BatchFilter { predicate: ($2 >= 1:Int32) }
+                  BatchScan { table: part, columns: [p_partkey, p_brand, p_size, p_container] }
   stream_plan: |
-    StreamMaterialize { columns: [revenue, agg#0(hidden)], pk_columns: [agg#0, revenue] }
-      StreamProject { exprs: [$1, $0], expr_alias: [revenue,  ] }
-        StreamSimpleAgg { aggs: [count, sum($0)] }
-          StreamExchange { dist: Single }
-            StreamProject { exprs: [($2 * (1:Int32 - $3)), $4, $9], expr_alias: [ ,  ,  ] }
-              StreamFilter { predicate: ((((((($6 = 'Brand#52':Varchar) AND In($8, 'SM CASE':Varchar, 'SM BOX':Varchar, 'SM PACK':Varchar, 'SM PKG':Varchar)) AND ($1 >= 1:Int32)) AND ($1 <= 11:Int32)) AND ($7 <= 5:Int32)) OR ((((($6 = 'Brand#24':Varchar) AND In($8, 'MED BAG':Varchar, 'MED BOX':Varchar, 'MED PKG':Varchar, 'MED PACK':Varchar)) AND ($1 >= 30:Int32)) AND ($1 <= 40:Int32)) AND ($7 <= 10:Int32))) OR ((((($6 = 'Brand#32':Varchar) AND In($8, 'LG CASE':Varchar, 'LG BOX':Varchar, 'LG PACK':Varchar, 'LG PKG':Varchar)) AND ($1 >= 10:Int32)) AND ($1 <= 20:Int32)) AND ($7 <= 15:Int32))) }
-                StreamHashJoin { type: Inner, predicate: $0 = $5 }
-                  StreamProject { exprs: [$0, $1, $2, $3, $6], expr_alias: [ ,  ,  ,  ,  ] }
-                    StreamExchange { dist: HashShard([0]) }
-                      StreamFilter { predicate: In($5, 'AIR':Varchar, 'AIR REG':Varchar) AND ($4 = 'DELIVER IN PERSON':Varchar) }
-                        StreamTableScan { table: lineitem, columns: [l_partkey, l_quantity, l_extendedprice, l_discount, l_shipinstruct, l_shipmode, _row_id#0], pk_indices: [6] }
+    StreamMaterialize { columns: [agg#0(hidden), revenue], pk_columns: [agg#0, revenue] }
+      StreamSimpleAgg { aggs: [count, sum($0)] }
+        StreamExchange { dist: Single }
+          StreamProject { exprs: [($2 * (1:Int32 - $3)), $4, $9], expr_alias: [ ,  ,  ] }
+            StreamFilter { predicate: ((((((($6 = 'Brand#52':Varchar) AND In($8, 'SM CASE':Varchar, 'SM BOX':Varchar, 'SM PACK':Varchar, 'SM PKG':Varchar)) AND ($1 >= 1:Int32)) AND ($1 <= 11:Int32)) AND ($7 <= 5:Int32)) OR ((((($6 = 'Brand#24':Varchar) AND In($8, 'MED BAG':Varchar, 'MED BOX':Varchar, 'MED PKG':Varchar, 'MED PACK':Varchar)) AND ($1 >= 30:Int32)) AND ($1 <= 40:Int32)) AND ($7 <= 10:Int32))) OR ((((($6 = 'Brand#32':Varchar) AND In($8, 'LG CASE':Varchar, 'LG BOX':Varchar, 'LG PACK':Varchar, 'LG PKG':Varchar)) AND ($1 >= 10:Int32)) AND ($1 <= 20:Int32)) AND ($7 <= 15:Int32))) }
+              StreamHashJoin { type: Inner, predicate: $0 = $5 }
+                StreamProject { exprs: [$0, $1, $2, $3, $6], expr_alias: [ ,  ,  ,  ,  ] }
                   StreamExchange { dist: HashShard([0]) }
-                    StreamFilter { predicate: ($2 >= 1:Int32) }
-                      StreamTableScan { table: part, columns: [p_partkey, p_brand, p_size, p_container, _row_id#0], pk_indices: [4] }
+                    StreamFilter { predicate: In($5, 'AIR':Varchar, 'AIR REG':Varchar) AND ($4 = 'DELIVER IN PERSON':Varchar) }
+                      StreamTableScan { table: lineitem, columns: [l_partkey, l_quantity, l_extendedprice, l_discount, l_shipinstruct, l_shipmode, _row_id#0], pk_indices: [6] }
+                StreamExchange { dist: HashShard([0]) }
+                  StreamFilter { predicate: ($2 >= 1:Int32) }
+                    StreamTableScan { table: part, columns: [p_partkey, p_brand, p_size, p_container, _row_id#0], pk_indices: [4] }
 - id: tpch_q20
   before:
     - create_tables
@@ -1633,7 +1613,7 @@
   batch_plan: |
     BatchExchange { order: [$0 ASC], dist: Single }
       BatchSort { order: [$0 ASC] }
-        BatchProject { exprs: [$1, $2], expr_alias: [s_name, s_address] }
+        BatchProject { exprs: [$1, $2], expr_alias: [ ,  ] }
           BatchHashJoin { type: LeftSemi, predicate: $0 = $3 }
             BatchProject { exprs: [$0, $1, $2], expr_alias: [ ,  ,  ] }
               BatchExchange { order: [], dist: HashShard([0]) }
@@ -1644,7 +1624,7 @@
                     BatchExchange { order: [], dist: HashShard([0]) }
                       BatchFilter { predicate: ($1 = 'KENYA':Varchar) }
                         BatchScan { table: nation, columns: [n_nationkey, n_name] }
-            BatchProject { exprs: [$0], expr_alias: [ps_suppkey] }
+            BatchProject { exprs: [$0], expr_alias: [ ] }
               BatchExchange { order: [], dist: HashShard([0]) }
                 BatchFilter { predicate: ($1 > (0.5:Decimal * $2)) }
                   BatchProject { exprs: [$2, $3, $6], expr_alias: [ ,  ,  ] }
@@ -1656,7 +1636,7 @@
                               BatchHashJoin { type: LeftSemi, predicate: $1 = $6 }
                                 BatchExchange { order: [], dist: HashShard([1]) }
                                   BatchScan { table: partsupp, columns: [_row_id#0, ps_partkey, ps_suppkey, ps_availqty, ps_supplycost, ps_comment] }
-                                BatchProject { exprs: [$0], expr_alias: [p_partkey] }
+                                BatchProject { exprs: [$0], expr_alias: [ ] }
                                   BatchExchange { order: [], dist: HashShard([0]) }
                                     BatchFilter { predicate: Like($1, 'forest%':Varchar) }
                                       BatchScan { table: part, columns: [p_partkey, p_name] }
@@ -1667,7 +1647,7 @@
   stream_plan: |
     StreamMaterialize { columns: [s_name, s_address, _row_id#0(hidden), _row_id#1(hidden)], pk_columns: [_row_id#0, _row_id#1], order_descs: [s_name, _row_id#0, _row_id#1] }
       StreamExchange { dist: HashShard([2, 3]) }
-        StreamProject { exprs: [$1, $2, $3, $4], expr_alias: [s_name, s_address,  ,  ] }
+        StreamProject { exprs: [$1, $2, $3, $4], expr_alias: [ ,  ,  ,  ] }
           StreamHashJoin { type: LeftSemi, predicate: $0 = $5 }
             StreamProject { exprs: [$0, $1, $2, $4, $6], expr_alias: [ ,  ,  ,  ,  ] }
               StreamExchange { dist: HashShard([0]) }
@@ -1678,7 +1658,7 @@
                     StreamExchange { dist: HashShard([0]) }
                       StreamFilter { predicate: ($1 = 'KENYA':Varchar) }
                         StreamTableScan { table: nation, columns: [n_nationkey, n_name, _row_id#0], pk_indices: [2] }
-            StreamProject { exprs: [$0, $3, $4, $1, $5, $6], expr_alias: [ps_suppkey,  ,  ,  ,  ,  ] }
+            StreamProject { exprs: [$0, $3, $4, $1, $5, $6], expr_alias: [ ,  ,  ,  ,  ,  ] }
               StreamFilter { predicate: ($1 > (0.5:Decimal * $2)) }
                 StreamProject { exprs: [$2, $3, $7, $0, $1, $4, $5], expr_alias: [ ,  ,  ,  ,  ,  ,  ] }
                   StreamHashAgg { group_keys: [$0, $1, $2, $3, $4, $5], aggs: [count, sum($6)] }
@@ -1689,7 +1669,7 @@
                             StreamHashJoin { type: LeftSemi, predicate: $1 = $6 }
                               StreamExchange { dist: HashShard([1]) }
                                 StreamTableScan { table: partsupp, columns: [_row_id#0, ps_partkey, ps_suppkey, ps_availqty, ps_supplycost, ps_comment], pk_indices: [0] }
-                              StreamProject { exprs: [$0, $2], expr_alias: [p_partkey,  ] }
+                              StreamProject { exprs: [$0, $2], expr_alias: [ ,  ] }
                                 StreamExchange { dist: HashShard([0]) }
                                   StreamFilter { predicate: Like($1, 'forest%':Varchar) }
                                     StreamTableScan { table: part, columns: [p_partkey, p_name, _row_id#0], pk_indices: [2] }
@@ -1743,7 +1723,7 @@
     LIMIT 100;
   logical_plan: |
     LogicalTopN { order: [$1 DESC, $0 ASC], limit: 100, offset: 0 }
-      LogicalProject { exprs: [$0, $1], expr_alias: [s_name, numwait] }
+      LogicalProject { exprs: [$0, $1], expr_alias: [ ,  ] }
         LogicalAgg { group_keys: [0], agg_calls: [count] }
           LogicalProject { exprs: [$2], expr_alias: [ ] }
             LogicalFilter { predicate: ($1 = $11) AND ($26 = $9) AND ($28 = 'F':Varchar) AND ($21 > $20) AND ($4 = $36) AND ($37 = 'GERMANY':Varchar) }
@@ -1756,10 +1736,10 @@
                         LogicalScan { table: lineitem, columns: [_row_id#0, l_orderkey, l_partkey, l_suppkey, l_linenumber, l_quantity, l_extendedprice, l_discount, l_tax, l_returnflag, l_linestatus, l_shipdate, l_commitdate, l_receiptdate, l_shipinstruct, l_shipmode, l_comment] }
                       LogicalScan { table: orders, columns: [_row_id#0, o_orderkey, o_custkey, o_orderstatus, o_totalprice, o_orderdate, o_orderpriority, o_clerk, o_shippriority, o_comment] }
                     LogicalScan { table: nation, columns: [_row_id#0, n_nationkey, n_name, n_regionkey, n_comment] }
-                  LogicalProject { exprs: [$1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16], expr_alias: [l_orderkey, l_partkey, l_suppkey, l_linenumber, l_quantity, l_extendedprice, l_discount, l_tax, l_returnflag, l_linestatus, l_shipdate, l_commitdate, l_receiptdate, l_shipinstruct, l_shipmode, l_comment] }
+                  LogicalProject { exprs: [$1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16], expr_alias: [ ,  ,  ,  ,  ,  ,  ,  ,  ,  ,  ,  ,  ,  ,  ,  ] }
                     LogicalFilter { predicate: ($1 = CorrelatedInputRef { index: 9, depth: 1 }) AND ($3 <> CorrelatedInputRef { index: 11, depth: 1 }) }
                       LogicalScan { table: lineitem, columns: [_row_id#0, l_orderkey, l_partkey, l_suppkey, l_linenumber, l_quantity, l_extendedprice, l_discount, l_tax, l_returnflag, l_linestatus, l_shipdate, l_commitdate, l_receiptdate, l_shipinstruct, l_shipmode, l_comment] }
-                LogicalProject { exprs: [$1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16], expr_alias: [l_orderkey, l_partkey, l_suppkey, l_linenumber, l_quantity, l_extendedprice, l_discount, l_tax, l_returnflag, l_linestatus, l_shipdate, l_commitdate, l_receiptdate, l_shipinstruct, l_shipmode, l_comment] }
+                LogicalProject { exprs: [$1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16], expr_alias: [ ,  ,  ,  ,  ,  ,  ,  ,  ,  ,  ,  ,  ,  ,  ,  ] }
                   LogicalFilter { predicate: ($1 = CorrelatedInputRef { index: 9, depth: 1 }) AND ($3 <> CorrelatedInputRef { index: 11, depth: 1 }) AND ($13 > $12) }
                     LogicalScan { table: lineitem, columns: [_row_id#0, l_orderkey, l_partkey, l_suppkey, l_linenumber, l_quantity, l_extendedprice, l_discount, l_tax, l_returnflag, l_linestatus, l_shipdate, l_commitdate, l_receiptdate, l_shipinstruct, l_shipmode, l_comment] }
 - id: tpch_q22


### PR DESCRIPTION
## What's changed and what's your intention?

NOTE this PR is only a preview / test. The actual refactor will be split in 2 PRs:
* Materialized view and batch query read output column aliases from binder/PlanRoot. This would contain the core refactoring logic, with all tests still passing without change.
* Remove `aliases` from `LogicalProject` and update massive planner tests. This would contain no critical logic change, but a lot of test update.

#1433 `LogicalProject` used to take `aliases` as input and cannot be eliminated when there is only naming change. The management of output column aliases should be the job of binder/PlanRoot and general plan nodes should be unaware of them. The schema field names on each plan node are for debugging only.

## Checklist

- [ ] I have written necessary docs and comments
- [ ] I have added necessary unit tests and integration tests

## Refer to a related PR or issue link (optional)
