### PR TITLE
fix(meta): dashboard node type and stateful fragment rule

### DIFF
--- a/src/meta/src/dashboard/index.html
+++ b/src/meta/src/dashboard/index.html
@@ -125,6 +125,8 @@
   let currentMvs = new Set
   let showAssociateMv = false
 
+  const types = new Set(["source", "project", "filter", "materialize", "localSimpleAgg", "globalSimpleAgg", "hashAgg", "appendOnlyTopN", "hashJoin", "topN", "hopWindow", "merge", "exchange", "chain", "batchPlan", "lookup", "arrange", "lookupUnion", "union", "deltaIndexJoin"]);
+
   const cluster = (type, cluster) => `
 <div class="p-6 max-w bg-white rounded-xl shadow-md flex flex-col space-y-1">
   <div class="flex flex-row items-center">
@@ -166,7 +168,8 @@
   /// Transform a single actor to a d3.hierarchy
   const hierarchyActor = (actor) => {
     /// Find a key ends with `Node`
-    const findTitle = (actorNode) => Object.keys(actorNode).find(x => x.endsWith("Node"))
+
+    const findTitle = (actorNode) => Object.keys(actorNode).find(x => types.has(x))
 
     /// Transform an actor node to a struct that can be parsed by d3.hierarchy
     const hierarchyActorNode = (node) => {
@@ -331,8 +334,8 @@
       actors.forEach(actor => {
         const fragmentId = fragmentIdOf(actor)
 
-        if (actor.nodes.chainNode) {
-          let upstreamActorIds = actor.nodes.input[0].mergeNode.upstreamActorId
+        if (actor.nodes.chain) {
+          let upstreamActorIds = actor.nodes.input[0].merge.upstreamActorId
           if (upstreamActorIds.length != 0) {
             let upstreamFragmentId = fragmentIdOf(actorMap.get(upstreamActorIds[0]))
             actorNodes.get(upstreamFragmentId).parents.push(fragmentId)

--- a/src/meta/src/stream/fragmenter/graph/stream_graph.rs
+++ b/src/meta/src/stream/fragmenter/graph/stream_graph.rs
@@ -457,7 +457,7 @@ impl StreamGraphBuilder {
         let table_id_offset = ctx.table_id_offset;
         match stream_node.get_node_body()? {
             NodeBody::Exchange(_) => {
-                panic!("ExchangeNode should be eliminated from the top of the plan node when converting fragments to actors")
+                panic!("ExchangeNode should be eliminated from the top of the plan node when converting fragments to actors: {:#?}", stream_node)
             }
             NodeBody::Chain(_) => self.resolve_chain_node(ctx, stream_node, actor_id),
             _ => {

--- a/src/meta/src/stream/fragmenter/mod.rs
+++ b/src/meta/src/stream/fragmenter/mod.rs
@@ -287,7 +287,12 @@ impl StreamFragmenter {
                         self.rewrite_stream_node_inner(state, child_node, true)?
                     }
                 }
-                _ => child_node,
+                // For exchanges, reset the flag.
+                NodeBody::Exchange(_) => {
+                    self.rewrite_stream_node_inner(state, child_node, false)?
+                }
+                // Otherwise, recursively visit the children.
+                _ => self.rewrite_stream_node_inner(state, child_node, insert_exchange_flag)?,
             };
             inputs.push(input);
         }


### PR DESCRIPTION
Signed-off-by: Alex Chi <iskyzh@gmail.com>

## What's changed and what's your intention?

* Dashboard can now correctly show texts.
* If there are projection between two stateful executors, now they will be split into two actors.

Note that the distribution issue is still not fixed in https://github.com/singularity-data/risingwave/issues/2442

<img width="1145" alt="image" src="https://user-images.githubusercontent.com/4198311/167994829-b33b9a19-fe18-4d68-ba21-da3b92792a75.png">

## Checklist

- [x] I have written necessary docs and comments
- [x] I have added necessary unit tests and integration tests

## Refer to a related PR or issue link (optional)

fix https://github.com/singularity-data/risingwave/issues/2446
fix https://github.com/singularity-data/risingwave/issues/2448