### PR TITLE
feat(relational-state): use relational state for value state

### DIFF
--- a/src/stream/src/executor/global_simple_agg.rs
+++ b/src/stream/src/executor/global_simple_agg.rs
@@ -19,13 +19,16 @@ use futures_async_stream::try_stream;
 use itertools::Itertools;
 use risingwave_common::array::column::Column;
 use risingwave_common::array::StreamChunk;
-use risingwave_common::catalog::Schema;
+use risingwave_common::catalog::{ColumnDesc, ColumnId, Schema};
 use risingwave_common::error::Result;
+use risingwave_common::util::sort_util::OrderType;
+use risingwave_storage::table::state_table::StateTable;
 use risingwave_storage::{Keyspace, StateStore};
 
 use super::*;
 use crate::executor::aggregation::{
-    agg_input_array_refs, generate_agg_schema, generate_managed_agg_state, AggCall, AggState,
+    agg_input_array_refs, generate_agg_schema, generate_managed_agg_state, get_key_len, AggCall,
+    AggState,
 };
 use crate::executor::error::StreamExecutorError;
 use crate::executor::{BoxedMessageStream, Message, PkIndices};
@@ -64,6 +67,10 @@ pub struct SimpleAggExecutor<S: StateStore> {
     /// An operator will support multiple aggregation calls.
     agg_calls: Vec<AggCall>,
 
+    /// Relational state tables used by this executor.
+    /// One-to-one map with AggCall.
+    state_tables: Vec<StateTable<S>>,
+
     #[allow(dead_code)]
     /// Indices of the columns on which key distribution depends.
     key_indices: Vec<usize>,
@@ -99,6 +106,21 @@ impl<S: StateStore> SimpleAggExecutor<S> {
         let input_info = input.info();
         let schema = generate_agg_schema(input.as_ref(), &agg_calls, None);
 
+        // Create state tables for each agg call.
+        let mut state_tables = Vec::with_capacity(agg_calls.len());
+        for (agg_call, ks) in agg_calls.iter().zip_eq(&keyspace) {
+            let state_table = StateTable::new(
+                ks.clone(),
+                vec![ColumnDesc::unnamed(
+                    ColumnId::new(0),
+                    agg_call.return_type.clone(),
+                )],
+                // Primary key do not includes group key.
+                vec![OrderType::Descending; get_key_len(agg_call)],
+            );
+            state_tables.push(state_table);
+        }
+
         Ok(Self {
             input,
             info: ExecutorInfo {
@@ -112,9 +134,11 @@ impl<S: StateStore> SimpleAggExecutor<S> {
             states: None,
             agg_calls,
             key_indices,
+            state_tables,
         })
     }
 
+    #[allow(clippy::too_many_arguments)]
     async fn apply_chunk(
         agg_calls: &[AggCall],
         input_pk_indices: &[usize],
@@ -123,6 +147,7 @@ impl<S: StateStore> SimpleAggExecutor<S> {
         keyspace: &[Keyspace<S>],
         chunk: StreamChunk,
         epoch: u64,
+        state_tables: &[StateTable<S>],
     ) -> StreamExecutorResult<()> {
         let (ops, columns, visibility) = chunk.into_inner();
 
@@ -153,6 +178,7 @@ impl<S: StateStore> SimpleAggExecutor<S> {
                 input_pk_data_types,
                 epoch,
                 None,
+                state_tables,
             )
             .await?;
             *states = Some(state);
@@ -181,6 +207,7 @@ impl<S: StateStore> SimpleAggExecutor<S> {
         states: &mut Option<AggState<S>>,
         keyspace: &[Keyspace<S>],
         epoch: u64,
+        state_tables: &mut [StateTable<S>],
     ) -> StreamExecutorResult<Option<StreamChunk>> {
         // The state store of each keyspace is the same so just need the first.
         let store = keyspace[0].state_store();
@@ -194,15 +221,25 @@ impl<S: StateStore> SimpleAggExecutor<S> {
         };
 
         let mut write_batch = store.start_write_batch();
-        for state in &mut states.managed_states {
+        for (state, state_table) in states
+            .managed_states
+            .iter_mut()
+            .zip_eq(state_tables.iter_mut())
+        {
             state
-                .flush(&mut write_batch)
+                .flush(&mut write_batch, state_table)
+                .await
                 .map_err(StreamExecutorError::agg_state_error)?;
         }
         write_batch
             .ingest(epoch)
             .await
             .map_err(StreamExecutorError::agg_state_error)?;
+
+        // Batch commit state tables.
+        for state_table in state_tables.iter_mut() {
+            state_table.commit(epoch).await?;
+        }
 
         // --- Create array builders ---
         // As the datatype is retrieved from schema, it contains both group key and aggregation
@@ -240,6 +277,7 @@ impl<S: StateStore> SimpleAggExecutor<S> {
             mut states,
             agg_calls,
             key_indices: _,
+            mut state_tables,
         } = self;
         let mut input = input.execute();
 
@@ -260,13 +298,20 @@ impl<S: StateStore> SimpleAggExecutor<S> {
                         &keyspace,
                         chunk,
                         epoch,
+                        &state_tables,
                     )
                     .await?;
                 }
                 Message::Barrier(barrier) => {
                     let next_epoch = barrier.epoch.curr;
-                    if let Some(chunk) =
-                        Self::flush_data(&info.schema, &mut states, &keyspace, epoch).await?
+                    if let Some(chunk) = Self::flush_data(
+                        &info.schema,
+                        &mut states,
+                        &keyspace,
+                        epoch,
+                        &mut state_tables,
+                    )
+                    .await?
                     {
                         assert_eq!(epoch, barrier.epoch.prev);
                         yield Message::Chunk(chunk);

--- a/src/stream/src/executor/global_simple_agg.rs
+++ b/src/stream/src/executor/global_simple_agg.rs
@@ -117,6 +117,7 @@ impl<S: StateStore> SimpleAggExecutor<S> {
                 )],
                 // Primary key do not includes group key.
                 vec![OrderType::Descending; get_key_len(agg_call)],
+                None,
             );
             state_tables.push(state_table);
         }

--- a/src/stream/src/executor/hash_agg.rs
+++ b/src/stream/src/executor/hash_agg.rs
@@ -23,11 +23,13 @@ use madsim::collections::HashMap;
 use risingwave_common::array::column::Column;
 use risingwave_common::array::StreamChunk;
 use risingwave_common::buffer::Bitmap;
-use risingwave_common::catalog::Schema;
+use risingwave_common::catalog::{ColumnDesc, ColumnId, Schema};
 use risingwave_common::collection::evictable::EvictableHashMap;
 use risingwave_common::error::{Result, RwError};
 use risingwave_common::hash::{HashCode, HashKey};
 use risingwave_common::util::hash_util::CRC32FastBuilder;
+use risingwave_common::util::sort_util::OrderType;
+use risingwave_storage::table::state_table::StateTable;
 use risingwave_storage::{Keyspace, StateStore};
 
 use super::{
@@ -35,7 +37,8 @@ use super::{
     StreamExecutorResult,
 };
 use crate::executor::aggregation::{
-    agg_input_arrays, generate_agg_schema, generate_managed_agg_state, AggCall, AggState,
+    agg_input_arrays, generate_agg_schema, generate_managed_agg_state, get_key_len, AggCall,
+    AggState,
 };
 use crate::executor::error::StreamExecutorError;
 use crate::executor::{BoxedMessageStream, Message, PkIndices, PROCESSING_WINDOW_SIZE};
@@ -83,6 +86,8 @@ struct HashAggExecutorExtra<S: StateStore> {
     /// Indices of the columns
     /// all of the aggregation functions in this executor should depend on same group of keys
     key_indices: Vec<usize>,
+
+    state_tables: Vec<StateTable<S>>,
 }
 
 impl<K: HashKey, S: StateStore> Executor for HashAggExecutor<K, S> {
@@ -115,6 +120,20 @@ impl<K: HashKey, S: StateStore> HashAggExecutor<K, S> {
         let input_info = input.info();
         let schema = generate_agg_schema(input.as_ref(), &agg_calls, Some(&key_indices));
 
+        let mut state_tables = Vec::with_capacity(agg_calls.len());
+        for (agg_call, ks) in agg_calls.iter().zip_eq(&keyspace) {
+            let state_table = StateTable::new(
+                ks.clone(),
+                vec![ColumnDesc::unnamed(
+                    ColumnId::new(0),
+                    agg_call.return_type.clone(),
+                )],
+                // Primary key includes group key.
+                vec![OrderType::Descending; key_indices.len() + get_key_len(agg_call)],
+            );
+            state_tables.push(state_table);
+        }
+
         Ok(Self {
             input,
             extra: HashAggExecutorExtra {
@@ -126,6 +145,7 @@ impl<K: HashKey, S: StateStore> HashAggExecutor<K, S> {
                 keyspace,
                 agg_calls,
                 key_indices,
+                state_tables,
             },
             _phantom: PhantomData,
         })
@@ -190,6 +210,7 @@ impl<K: HashKey, S: StateStore> HashAggExecutor<K, S> {
             ref input_schema,
             ref keyspace,
             ref schema,
+            ref state_tables,
             ..
         }: &HashAggExecutorExtra<S>,
         state_map: &mut EvictableHashMap<K, Option<Box<AggState<S>>>>,
@@ -259,6 +280,7 @@ impl<K: HashKey, S: StateStore> HashAggExecutor<K, S> {
                                 input_pk_data_types.clone(),
                                 epoch,
                                 Some(hash_code),
+                                state_tables,
                             )
                             .await?,
                         ),
@@ -297,12 +319,13 @@ impl<K: HashKey, S: StateStore> HashAggExecutor<K, S> {
 
     #[try_stream(ok = StreamChunk, error = StreamExecutorError)]
     async fn flush_data<'a>(
-        &HashAggExecutorExtra::<S> {
+        &mut HashAggExecutorExtra::<S> {
             ref key_indices,
             ref keyspace,
             ref schema,
+            ref mut state_tables,
             ..
-        }: &'a HashAggExecutorExtra<S>,
+        }: &'a mut HashAggExecutorExtra<S>,
         state_map: &'a mut EvictableHashMap<K, Option<Box<AggState<S>>>>,
         epoch: u64,
     ) {
@@ -318,13 +341,26 @@ impl<K: HashKey, S: StateStore> HashAggExecutor<K, S> {
             for states in state_map.values_mut() {
                 if states.as_ref().unwrap().is_dirty() {
                     dirty_cnt += 1;
-                    for state in &mut states.as_mut().unwrap().managed_states {
+                    for (state, state_table) in states
+                        .as_mut()
+                        .unwrap()
+                        .managed_states
+                        .iter_mut()
+                        .zip_eq(state_tables.iter_mut())
+                    {
                         state
-                            .flush(&mut write_batch)
+                            .flush(&mut write_batch, state_table)
+                            .await
                             .map_err(StreamExecutorError::agg_state_error)?;
                     }
                 }
             }
+
+            // Batch commit state table.
+            for state_table in state_tables.iter_mut() {
+                state_table.commit(epoch).await?;
+            }
+
             (write_batch, dirty_cnt)
         };
 
@@ -390,7 +426,9 @@ impl<K: HashKey, S: StateStore> HashAggExecutor<K, S> {
 
     #[try_stream(ok = Message, error = StreamExecutorError)]
     async fn execute_inner(self) {
-        let HashAggExecutor { input, extra, .. } = self;
+        let HashAggExecutor {
+            input, mut extra, ..
+        } = self;
 
         // The cached states. `HashKey -> (prev_value, value)`.
         let mut state_map = EvictableHashMap::new(1 << 16);
@@ -412,7 +450,7 @@ impl<K: HashKey, S: StateStore> HashAggExecutor<K, S> {
                     assert_eq!(epoch, barrier.epoch.prev);
 
                     #[for_await]
-                    for chunk in Self::flush_data(&extra, &mut state_map, epoch) {
+                    for chunk in Self::flush_data(&mut extra, &mut state_map, epoch) {
                         yield Message::Chunk(chunk?);
                     }
 

--- a/src/stream/src/executor/hash_agg.rs
+++ b/src/stream/src/executor/hash_agg.rs
@@ -130,6 +130,7 @@ impl<K: HashKey, S: StateStore> HashAggExecutor<K, S> {
                 )],
                 // Primary key includes group key.
                 vec![OrderType::Descending; key_indices.len() + get_key_len(agg_call)],
+                Some(key_indices.clone()),
             );
             state_tables.push(state_table);
         }

--- a/src/stream/src/executor/managed_state/aggregation/value.rs
+++ b/src/stream/src/executor/managed_state/aggregation/value.rs
@@ -150,6 +150,7 @@ mod tests {
             keyspace.clone(),
             vec![ColumnDesc::unnamed(ColumnId::new(0), DataType::Int64)],
             vec![],
+            None,
         );
         let mut managed_state =
             ManagedValueState::new(create_test_count_state(), Some(0), None, &state_table)
@@ -212,6 +213,7 @@ mod tests {
             keyspace.clone(),
             vec![ColumnDesc::unnamed(ColumnId::new(0), DataType::Int64)],
             vec![],
+            None,
         );
         let mut managed_state = ManagedValueState::new(
             create_test_max_agg_append_only(),

--- a/src/stream/src/executor/managed_state/aggregation/value.rs
+++ b/src/stream/src/executor/managed_state/aggregation/value.rs
@@ -13,52 +13,51 @@
 // limitations under the License.
 
 use risingwave_common::array::stream_chunk::Ops;
-use risingwave_common::array::ArrayImpl;
+use risingwave_common::array::{ArrayImpl, Row};
 use risingwave_common::buffer::Bitmap;
 use risingwave_common::error::Result;
 use risingwave_common::types::Datum;
-use risingwave_common::util::value_encoding::{deserialize_cell, serialize_cell};
-use risingwave_storage::storage_value::StorageValue;
+use risingwave_storage::table::state_table::StateTable;
 use risingwave_storage::write_batch::WriteBatch;
-use risingwave_storage::{Keyspace, StateStore};
+use risingwave_storage::StateStore;
 
 use crate::executor::aggregation::{create_streaming_agg_state, AggCall, StreamingAggStateImpl};
 
 /// A wrapper around [`StreamingAggStateImpl`], which fetches data from the state store and helps
 /// update the state. We don't use any trait to wrap around all `ManagedXxxState`, so as to reduce
 /// the overhead of creating boxed async future.
-pub struct ManagedValueState<S: StateStore> {
+pub struct ManagedValueState {
     /// The internal single-value state.
     state: Box<dyn StreamingAggStateImpl>,
-
-    /// The keyspace to operate on.
-    keyspace: Keyspace<S>,
 
     /// Indicates whether this managed state is dirty. If this state is dirty, we cannot evict the
     /// state from memory.
     is_dirty: bool,
+
+    /// Primary key to look up in relational table. For value state, there is only one row.
+    /// If None, the pk is empty vector (simple agg). If not None, the pk is group key (hash agg).
+    pk: Option<Row>,
 }
 
-impl<S: StateStore> ManagedValueState<S> {
+impl ManagedValueState {
     /// Create a single-value managed state based on `AggCall` and `Keyspace`.
-    pub async fn new(
+    pub async fn new<S: StateStore>(
         agg_call: AggCall,
-        keyspace: Keyspace<S>,
         row_count: Option<usize>,
+        pk: Option<&Row>,
+        state_table: &StateTable<S>,
     ) -> Result<Self> {
         let data = if row_count != Some(0) {
             // TODO: use the correct epoch
             let epoch = u64::MAX;
-            // View the keyspace as a single-value space, and get the value.
-            let raw_data = keyspace.value(epoch).await?;
 
-            // Decode the Datum from the value.
-            if let Some(mut raw_data) = raw_data {
-                // let mut deserializer = value_encoding::Deserializer::new(raw_data);
-                Some(deserialize_cell(&mut raw_data, &agg_call.return_type)?)
-            } else {
-                None
-            }
+            // View the state table as single-value table, and get the value via empty primary key
+            // or group key.
+            let raw_data = state_table
+                .get_row(pk.unwrap_or(&Row(vec![])), epoch)
+                .await?;
+
+            raw_data.and_then(|row| row.values().next().cloned())
         } else {
             None
         };
@@ -72,7 +71,7 @@ impl<S: StateStore> ManagedValueState<S> {
                 data,
             )?,
             is_dirty: false,
-            keyspace,
+            pk: pk.cloned(),
         })
     }
 
@@ -102,15 +101,23 @@ impl<S: StateStore> ManagedValueState<S> {
     }
 
     /// Flush the internal state to a write batch.
-    pub fn flush(&mut self, write_batch: &mut WriteBatch<S>) -> Result<()> {
+    pub async fn flush<S: StateStore>(
+        &mut self,
+        _write_batch: &mut WriteBatch<S>,
+        state_table: &mut StateTable<S>,
+    ) -> Result<()> {
         // If the managed state is not dirty, the caller should not flush. But forcing a flush won't
         // cause incorrect result: it will only produce more I/O.
         debug_assert!(self.is_dirty());
 
-        let mut local = write_batch.prefixify(&self.keyspace);
+        // Persist value into relational table.
         let v = self.state.get_output()?;
         // TODO(Yuanxin): Implement value meta
-        local.put_single(StorageValue::new_default_put(serialize_cell(&v)?));
+        state_table.insert(
+            self.pk.as_ref().cloned().unwrap_or(Row(vec![])),
+            Row(vec![v]),
+        )?;
+
         self.is_dirty = false;
         Ok(())
     }
@@ -119,7 +126,9 @@ impl<S: StateStore> ManagedValueState<S> {
 #[cfg(test)]
 mod tests {
     use risingwave_common::array::{I64Array, Op};
+    use risingwave_common::catalog::{ColumnDesc, ColumnId};
     use risingwave_common::types::{DataType, ScalarImpl};
+    use risingwave_storage::table::state_table::StateTable;
 
     use super::*;
     use crate::executor::aggregation::AggArgs;
@@ -137,8 +146,13 @@ mod tests {
     #[tokio::test]
     async fn test_managed_value_state() {
         let keyspace = create_in_memory_keyspace();
+        let mut state_table = StateTable::new(
+            keyspace.clone(),
+            vec![ColumnDesc::unnamed(ColumnId::new(0), DataType::Int64)],
+            vec![],
+        );
         let mut managed_state =
-            ManagedValueState::new(create_test_count_state(), keyspace.clone(), Some(0))
+            ManagedValueState::new(create_test_count_state(), Some(0), None, &state_table)
                 .await
                 .unwrap();
         assert!(!managed_state.is_dirty());
@@ -159,8 +173,11 @@ mod tests {
         // flush to write batch and write to state store
         let epoch: u64 = 0;
         let mut write_batch = keyspace.state_store().start_write_batch();
-        managed_state.flush(&mut write_batch).unwrap();
-        write_batch.ingest(epoch).await.unwrap();
+        managed_state
+            .flush(&mut write_batch, &mut state_table)
+            .await
+            .unwrap();
+        state_table.commit(epoch).await.unwrap();
 
         // get output
         assert_eq!(
@@ -169,9 +186,10 @@ mod tests {
         );
 
         // reload the state and check the output
-        let mut managed_state = ManagedValueState::new(create_test_count_state(), keyspace, None)
-            .await
-            .unwrap();
+        let mut managed_state =
+            ManagedValueState::new(create_test_count_state(), None, None, &state_table)
+                .await
+                .unwrap();
         assert_eq!(
             managed_state.get_output().await.unwrap(),
             Some(ScalarImpl::Int64(3))
@@ -190,10 +208,19 @@ mod tests {
     #[tokio::test]
     async fn test_managed_value_state_append_only() {
         let keyspace = create_in_memory_keyspace();
-        let mut managed_state =
-            ManagedValueState::new(create_test_max_agg_append_only(), keyspace.clone(), Some(0))
-                .await
-                .unwrap();
+        let mut state_table = StateTable::new(
+            keyspace.clone(),
+            vec![ColumnDesc::unnamed(ColumnId::new(0), DataType::Int64)],
+            vec![],
+        );
+        let mut managed_state = ManagedValueState::new(
+            create_test_max_agg_append_only(),
+            Some(0),
+            None,
+            &state_table,
+        )
+        .await
+        .unwrap();
         assert!(!managed_state.is_dirty());
 
         // apply a batch and get the output
@@ -214,8 +241,11 @@ mod tests {
         // flush to write batch and write to state store
         let epoch: u64 = 0;
         let mut write_batch = keyspace.state_store().start_write_batch();
-        managed_state.flush(&mut write_batch).unwrap();
-        write_batch.ingest(epoch).await.unwrap();
+        managed_state
+            .flush(&mut write_batch, &mut state_table)
+            .await
+            .unwrap();
+        state_table.commit(epoch).await.unwrap();
 
         // get output
         assert_eq!(
@@ -225,7 +255,7 @@ mod tests {
 
         // reload the state and check the output
         let mut managed_state =
-            ManagedValueState::new(create_test_max_agg_append_only(), keyspace, None)
+            ManagedValueState::new(create_test_max_agg_append_only(), None, None, &state_table)
                 .await
                 .unwrap();
         assert_eq!(

--- a/src/stream/src/executor/managed_state/aggregation/value.rs
+++ b/src/stream/src/executor/managed_state/aggregation/value.rs
@@ -112,7 +112,6 @@ impl ManagedValueState {
 
         // Persist value into relational table.
         let v = self.state.get_output()?;
-        // TODO(Yuanxin): Implement value meta
         state_table.insert(
             self.pk.as_ref().cloned().unwrap_or(Row(vec![])),
             Row(vec![v]),


### PR DESCRIPTION
## What's changed and what's your intention?
Use relational state for hash agg/simple agg that use `ManagedValueState`. 

For each AggCall, there is a relational table state correspond. For simple agg, the primary key in table state is empty `vec![]` (Down to the keyspace encoding it is just `table_id/`). For hash agg, the primary key in table state is `group_key` (Keyspace encoding `table_id/group_key`). 

For code, my design principle is to only let `AggState` to aware of `StateTable` or `Keyspace` or `WriteBatch`. In the future, if we apply relational states to all, then all executors do not need to start write batch/use keyspace to scan, it only need to access the `ManagedState`.

~~* Because different `AggState` may share one `StateTable`, so I wrap a `Arc<Mutex<>>`. The Mutex seems can only be tokio::sync::Mutex, though I'm a little scared about the dead lock.~~
* The flush of `AggState` will eventually remove WriteBatch after refactor ExtremeState, only accept epoch is enough.
* To new a StateTable, we need `OrderType` of primary key, and `ColumnDesc` of value. It is generated in CN runtime execution. This is different from `Materialize`, which read this info from proto plan node (generated via frontend).


## Checklist

- [x] I have written necessary docs and comments
- [x] I have added necessary unit tests and integration tests

## Refer to a related PR or issue link (optional)
