### PR TITLE
feat(meta): add logical part for epoch to avoid backwards

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3475,6 +3475,7 @@ dependencies = [
  "tonic",
  "tower",
  "tower-http",
+ "tracing",
  "twox-hash",
  "value-encoding",
  "workspace-hack",

--- a/src/common/Cargo.toml
+++ b/src/common/Cargo.toml
@@ -36,6 +36,7 @@ toml = "0.5"
 tonic = "0.7"
 tower = { version = "0.4", features = ["util", "load-shed"] }
 tower-http = { version = "0.3", features = ["add-extension", "cors"] }
+tracing = { version = "0.1" }
 twox-hash = "1"
 value-encoding = { path = "../utils/value-encoding" }
 workspace-hack = { version = "0.1", path = "../workspace-hack" }

--- a/src/common/src/util/epoch.rs
+++ b/src/common/src/util/epoch.rs
@@ -34,7 +34,8 @@ impl Epoch {
         Self(Self::physical_now() << EPOCH_PHYSICAL_SHIFT_BITS)
     }
 
-    pub fn next(&self) -> Epoch {
+    #[must_use]
+    pub fn next(self) -> Self {
         let physical_now = Epoch::physical_now();
         let prev_physical_time = self.physical_time();
         match physical_now.cmp(&prev_physical_time) {

--- a/src/common/src/util/epoch.rs
+++ b/src/common/src/util/epoch.rs
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 use core::fmt;
+use std::cmp::Ordering;
 use std::time::{Duration, SystemTime};
 
 lazy_static::lazy_static! {
@@ -26,13 +27,38 @@ pub struct Epoch(pub u64);
 /// `INVALID_EPOCH` defines the invalid epoch value.
 pub const INVALID_EPOCH: u64 = 0;
 
+const EPOCH_PHYSICAL_SHIFT_BITS: u8 = 16;
+
 impl Epoch {
     pub fn now() -> Self {
-        Self(Self::physical_now())
+        Self(Self::physical_now() << EPOCH_PHYSICAL_SHIFT_BITS)
     }
 
-    // TODO: use a monotonic library to replace SystemTime.
-    pub fn physical_now() -> u64 {
+    pub fn next(&self) -> Epoch {
+        let physical_now = Epoch::physical_now();
+        let prev_physical_time = self.physical_time();
+        match physical_now.cmp(&prev_physical_time) {
+            Ordering::Greater => Epoch(physical_now << EPOCH_PHYSICAL_SHIFT_BITS),
+            Ordering::Equal => {
+                tracing::warn!("New generate epoch is too close to the previous one.");
+                Epoch(self.0 + 1)
+            }
+            Ordering::Less => {
+                tracing::warn!(
+                    "Clock goes backwards when calling Epoch::next(): prev={}, curr={}",
+                    prev_physical_time,
+                    physical_now
+                );
+                Epoch(self.0 + 1)
+            }
+        }
+    }
+
+    pub fn physical_time(&self) -> u64 {
+        self.0 >> EPOCH_PHYSICAL_SHIFT_BITS
+    }
+
+    fn physical_now() -> u64 {
         UNIX_SINGULARITY_DATE_EPOCH
             .elapsed()
             .expect("system clock set earlier than singularity date!")
@@ -41,7 +67,7 @@ impl Epoch {
 
     /// Returns the epoch in real system time.
     pub fn as_system_time(&self) -> SystemTime {
-        *UNIX_SINGULARITY_DATE_EPOCH + Duration::from_millis(self.0)
+        *UNIX_SINGULARITY_DATE_EPOCH + Duration::from_millis(self.physical_time())
     }
 }
 
@@ -69,5 +95,15 @@ mod tests {
         let singularity_dt = Local.from_utc_datetime(&utc.naive_utc());
         let singularity_st = SystemTime::from(singularity_dt);
         assert_eq!(singularity_st, *UNIX_SINGULARITY_DATE_EPOCH);
+    }
+
+    #[test]
+    fn test_epoch_generate() {
+        let mut prev_epoch = Epoch::now();
+        for _ in 0..1000 {
+            let epoch = prev_epoch.next();
+            assert!(epoch > prev_epoch);
+            prev_epoch = epoch;
+        }
     }
 }

--- a/src/meta/src/barrier/mod.rs
+++ b/src/meta/src/barrier/mod.rs
@@ -21,7 +21,7 @@ use futures::future::try_join_all;
 use itertools::Itertools;
 use risingwave_common::catalog::TableId;
 use risingwave_common::error::{ErrorCode, Result, RwError, ToRwResult};
-use risingwave_common::util::epoch::{Epoch, INVALID_EPOCH};
+use risingwave_common::util::epoch::INVALID_EPOCH;
 use risingwave_hummock_sdk::HummockEpoch;
 use risingwave_pb::common::worker_node::State::Running;
 use risingwave_pb::common::WorkerType;
@@ -213,7 +213,7 @@ where
         if self.enable_recovery {
             // handle init, here we simply trigger a recovery process to achieve the consistency. We
             // may need to avoid this when we have more state persisted in meta store.
-            let new_epoch = Epoch::now();
+            let new_epoch = state.prev_epoch.next();
             assert!(new_epoch > state.prev_epoch);
             state.prev_epoch = new_epoch;
 
@@ -254,7 +254,7 @@ where
                 notifiers.iter_mut().for_each(Notifier::notify_collected);
                 continue;
             }
-            let new_epoch = Epoch::now();
+            let new_epoch = state.prev_epoch.next();
             assert!(new_epoch > state.prev_epoch);
             let command_ctx = CommandContext::new(
                 self.fragment_manager.clone(),

--- a/src/meta/src/barrier/recovery.rs
+++ b/src/meta/src/barrier/recovery.rs
@@ -64,7 +64,7 @@ where
         let retry_strategy = Self::get_retry_strategy();
         let (new_epoch, responses) = tokio_retry::Retry::spawn(retry_strategy, || async {
             let info = self.resolve_actor_info(None).await;
-            let mut new_epoch = Epoch::now();
+            let mut new_epoch = prev_epoch.next();
 
             // Reset all compute nodes, stop and drop existing actors.
             self.reset_compute_nodes(&info, &prev_epoch, &new_epoch)
@@ -87,7 +87,7 @@ where
             }
 
             let prev_epoch = new_epoch;
-            new_epoch = Epoch::now();
+            new_epoch = prev_epoch.next();
             // checkpoint, used as init barrier to initialize all executors.
             let command_ctx = CommandContext::new(
                 self.fragment_manager.clone(),


### PR DESCRIPTION
## What's changed and what's your intention?

As title, the epoch will never goes backwards during Meta serving. Since committed epoch in cluster is persistent in MetaStore, it also works after reboot and recovery. Besides add some warning when two epoch generated are too close and clock goes backwards.

Please explain **IN DETAIL** what the changes are in this PR and why they are needed:

- Summarize your change (**mandatory**)
- How does this PR work? Need a brief introduction for the changed logic (optional)
- Describe clearly one logical change and avoid lazy messages (optional)
- Describe any limitations of the current code (optional)

## Checklist

- [x] I have written necessary docs and comments
- [x] I have added necessary unit tests and integration tests

## Refer to a related PR or issue link (optional)
Close https://github.com/singularity-data/risingwave/issues/2011