### PR TITLE
refactor(optimizer): remove aliases from LogicalProject

### DIFF
--- a/src/frontend/src/optimizer/plan_node/logical_agg.rs
+++ b/src/frontend/src/optimizer/plan_node/logical_agg.rs
@@ -363,8 +363,7 @@ impl LogicalAgg {
             .transpose()?;
 
         // This LogicalProject focuses on the exprs in aggregates and GROUP BY clause.
-        let expr_alias = vec![None; expr_handler.project.len()];
-        let logical_project = LogicalProject::create(input, expr_handler.project, expr_alias);
+        let logical_project = LogicalProject::create(input, expr_handler.project);
 
         // This LogicalAgg focuses on calculating the aggregates and grouping.
         let logical_agg = LogicalAgg::new(expr_handler.agg_calls, group_keys, logical_project);

--- a/src/frontend/src/optimizer/plan_node/logical_project.rs
+++ b/src/frontend/src/optimizer/plan_node/logical_project.rs
@@ -24,9 +24,7 @@ use super::{
     BatchProject, ColPrunable, PlanBase, PlanNode, PlanRef, PlanTreeNodeUnary, StreamProject,
     ToBatch, ToStream,
 };
-use crate::expr::{
-    as_alias_display, assert_input_ref, Expr, ExprImpl, ExprRewriter, ExprVisitor, InputRef,
-};
+use crate::expr::{assert_input_ref, Expr, ExprImpl, ExprRewriter, ExprVisitor, InputRef};
 use crate::optimizer::plan_node::CollectInputRef;
 use crate::optimizer::property::{Distribution, Order};
 use crate::utils::ColIndexMapping;

--- a/src/frontend/src/optimizer/plan_node/logical_project.rs
+++ b/src/frontend/src/optimizer/plan_node/logical_project.rs
@@ -36,14 +36,13 @@ use crate::utils::ColIndexMapping;
 pub struct LogicalProject {
     pub base: PlanBase,
     exprs: Vec<ExprImpl>,
-    expr_alias: Vec<Option<String>>,
     input: PlanRef,
 }
 
 impl LogicalProject {
-    pub fn new(input: PlanRef, exprs: Vec<ExprImpl>, expr_alias: Vec<Option<String>>) -> Self {
+    pub fn new(input: PlanRef, exprs: Vec<ExprImpl>) -> Self {
         let ctx = input.ctx();
-        let schema = Self::derive_schema(&exprs, &expr_alias, input.schema());
+        let schema = Self::derive_schema(&exprs, input.schema());
         let pk_indices = Self::derive_pk(input.schema(), input.pk_indices(), &exprs);
         for expr in &exprs {
             assert_input_ref!(expr, input.schema().fields().len());
@@ -51,12 +50,7 @@ impl LogicalProject {
             assert!(!expr.has_agg_call());
         }
         let base = PlanBase::new_logical(ctx, schema, pk_indices);
-        LogicalProject {
-            base,
-            exprs,
-            expr_alias,
-            input,
-        }
+        LogicalProject { base, exprs, input }
     }
 
     /// get the Mapping of columnIndex from output column index to input column index
@@ -85,12 +79,8 @@ impl LogicalProject {
         Self::i2o_col_mapping_inner(self.input.schema().len(), self.exprs())
     }
 
-    pub fn create(
-        input: PlanRef,
-        exprs: Vec<ExprImpl>,
-        expr_alias: Vec<Option<String>>,
-    ) -> PlanRef {
-        Self::new(input, exprs, expr_alias).into()
+    pub fn create(input: PlanRef, exprs: Vec<ExprImpl>) -> PlanRef {
+        Self::new(input, exprs).into()
     }
 
     /// Creates a `LogicalProject` which select some columns from the input.
@@ -124,30 +114,23 @@ impl LogicalProject {
             .map(|i| InputRef::new(i, input_schema.fields()[i].data_type()).into())
             .collect();
 
-        let alias = vec![None; exprs.len()];
-        LogicalProject::new(input, exprs, alias).into()
+        LogicalProject::new(input, exprs).into()
     }
 
-    fn derive_schema(
-        exprs: &[ExprImpl],
-        expr_alias: &[Option<String>],
-        input_schema: &Schema,
-    ) -> Schema {
+    fn derive_schema(exprs: &[ExprImpl], input_schema: &Schema) -> Schema {
         let o2i = Self::o2i_col_mapping_inner(input_schema.len(), exprs);
         let fields = exprs
             .iter()
-            .zip_eq(expr_alias.iter())
             .enumerate()
-            .map(|(id, (expr, alias))| {
+            .map(|(id, expr)| {
                 // Get field info from o2i.
-                let (default_name, sub_fields, type_name) = match o2i.try_map(id) {
+                let (name, sub_fields, type_name) = match o2i.try_map(id) {
                     Some(input_idx) => {
                         let field = input_schema.fields()[input_idx].clone();
                         (field.name, field.sub_fields, field.type_name)
                     }
                     None => (format!("expr#{}", id), vec![], String::new()),
                 };
-                let name = alias.clone().unwrap_or(default_name);
                 Field::with_struct(expr.return_type(), name, sub_fields, type_name)
             })
             .collect();
@@ -167,23 +150,8 @@ impl LogicalProject {
         &self.exprs
     }
 
-    /// Get a reference to the logical project's expr alias.
-    pub fn expr_alias(&self) -> &[Option<String>] {
-        self.expr_alias.as_ref()
-    }
-
     pub(super) fn fmt_with_name(&self, f: &mut fmt::Formatter, name: &str) -> fmt::Result {
-        f.debug_struct(name)
-            .field("exprs", self.exprs())
-            .field(
-                "expr_alias",
-                &self
-                    .expr_alias()
-                    .iter()
-                    .map(as_alias_display)
-                    .collect::<Vec<_>>(),
-            )
-            .finish()
+        f.debug_struct(name).field("exprs", self.exprs()).finish()
     }
 
     pub fn is_identity(&self) -> bool {
@@ -191,17 +159,15 @@ impl LogicalProject {
             && self
                 .exprs
                 .iter()
-                .zip_eq(self.expr_alias.iter())
                 .zip_eq(self.input.schema().fields())
                 .enumerate()
-                .all(|(i, ((expr, alias), field))| {
-                    alias.as_ref().map(|alias| alias == &field.name).unwrap_or(true) &&
+                .all(|(i, (expr, field))| {
                     matches!(expr, ExprImpl::InputRef(input_ref) if **input_ref == InputRef::new(i, field.data_type()))
                 })
     }
 
-    pub fn decompose(self) -> (Vec<ExprImpl>, Vec<Option<String>>, PlanRef) {
-        (self.exprs, self.expr_alias, self.input)
+    pub fn decompose(self) -> (Vec<ExprImpl>, PlanRef) {
+        (self.exprs, self.input)
     }
 }
 
@@ -211,7 +177,7 @@ impl PlanTreeNodeUnary for LogicalProject {
     }
 
     fn clone_with_input(&self, input: PlanRef) -> Self {
-        Self::new(input, self.exprs.clone(), self.expr_alias().to_vec())
+        Self::new(input, self.exprs.clone())
     }
 
     fn rewrite_with_input(
@@ -225,7 +191,7 @@ impl PlanTreeNodeUnary for LogicalProject {
             .into_iter()
             .map(|expr| input_col_change.rewrite_expr(expr))
             .collect();
-        let proj = Self::new(input, exprs, self.expr_alias().to_vec());
+        let proj = Self::new(input, exprs);
         // change the input columns index will not change the output column index
         let out_col_change = ColIndexMapping::identity(self.schema().len());
         (proj, out_col_change)
@@ -255,23 +221,13 @@ impl ColPrunable for LogicalProject {
         let mut mapping = ColIndexMapping::with_remaining_columns(&child_required_cols);
 
         // Rewrite each InputRef with new index.
-        let (exprs, expr_alias) = required_cols
+        let exprs = required_cols
             .ones()
-            .map(|id| {
-                (
-                    mapping.rewrite_expr(self.exprs[id].clone()),
-                    self.expr_alias[id].clone(),
-                )
-            })
-            .unzip();
+            .map(|id| mapping.rewrite_expr(self.exprs[id].clone()))
+            .collect();
 
         // Reconstruct the LogicalProject.
-        LogicalProject::new(
-            self.input.prune_col(&child_required_cols),
-            exprs,
-            expr_alias,
-        )
-        .into()
+        LogicalProject::new(self.input.prune_col(&child_required_cols), exprs).into()
     }
 }
 
@@ -310,20 +266,15 @@ impl ToStream for LogicalProject {
         let i2o = Self::i2o_col_mapping_inner(input.schema().len(), proj.exprs());
         let col_need_to_add = input_pk.iter().cloned().filter(|i| i2o.try_map(*i) == None);
         let input_schema = input.schema();
-        let (exprs, expr_alias) = proj
-            .exprs()
-            .iter()
-            .cloned()
-            .zip_eq(proj.expr_alias().iter().cloned())
-            .map(|(a, b)| (a, b))
-            .chain(col_need_to_add.map(|idx| {
-                (
-                    InputRef::new(idx, input_schema.fields[idx].data_type.clone()).into(),
-                    None,
-                )
-            }))
-            .unzip();
-        let proj = Self::new(input, exprs, expr_alias);
+        let exprs =
+            proj.exprs()
+                .iter()
+                .cloned()
+                .chain(col_need_to_add.map(|idx| {
+                    InputRef::new(idx, input_schema.fields[idx].data_type.clone()).into()
+                }))
+                .collect();
+        let proj = Self::new(input, exprs);
         // the added columns is at the end, so it will not change the exists column index
         Ok((proj.into(), out_col_change))
     }
@@ -382,7 +333,6 @@ mod tests {
                     .unwrap(),
                 )),
             ],
-            vec![None; 3],
         );
 
         // Perform the prune

--- a/src/frontend/src/optimizer/rule/project_merge.rs
+++ b/src/frontend/src/optimizer/rule/project_merge.rs
@@ -34,14 +34,7 @@ impl Rule for ProjectMergeRule {
             .cloned()
             .map(|expr| subst.rewrite_expr(expr))
             .collect();
-        Some(
-            LogicalProject::new(
-                inner_project.input(),
-                exprs,
-                outer_project.expr_alias().to_owned(),
-            )
-            .into(),
-        )
+        Some(LogicalProject::new(inner_project.input(), exprs).into())
     }
 }
 

--- a/src/frontend/src/optimizer/rule/pull_up_correlated_predicate.rs
+++ b/src/frontend/src/optimizer/rule/pull_up_correlated_predicate.rs
@@ -35,7 +35,7 @@ impl Rule for PullUpCorrelatedPredicate {
         }
 
         let project = apply_right.as_logical_project()?;
-        let (mut proj_exprs, mut proj_expr_alias, _) = project.clone().decompose();
+        let (mut proj_exprs, _) = project.clone().decompose();
 
         let input = project.input();
         let filter = input.as_logical_filter()?;
@@ -60,7 +60,6 @@ impl Rule for PullUpCorrelatedPredicate {
                 });
         // Append `InputRef`s in the predicate expression to be pulled to the project, so that they
         // are accessible by the expression after it is pulled.
-        proj_expr_alias.extend(vec![None; rewriter.input_refs.len()].into_iter());
         proj_exprs.extend(
             rewriter
                 .input_refs
@@ -75,7 +74,7 @@ impl Rule for PullUpCorrelatedPredicate {
             },
         );
 
-        let project = LogicalProject::new(filter, proj_exprs, proj_expr_alias);
+        let project = LogicalProject::new(filter, proj_exprs);
 
         // Merge these expressions with LogicalApply into LogicalJoin.
         let on = apply_on.and(Condition {

--- a/src/frontend/src/planner/insert.rs
+++ b/src/frontend/src/planner/insert.rs
@@ -25,8 +25,7 @@ impl Planner {
     pub(super) fn plan_insert(&mut self, insert: BoundInsert) -> Result<PlanRoot> {
         let mut input = self.plan_query(insert.source)?.as_subplan();
         if !insert.cast_exprs.is_empty() {
-            let aliases = vec![None; insert.cast_exprs.len()];
-            input = LogicalProject::create(input, insert.cast_exprs, aliases);
+            input = LogicalProject::create(input, insert.cast_exprs);
         }
         // `columns` not used by backend yet.
         let plan: PlanRef = LogicalInsert::create(

--- a/src/frontend/src/planner/relation.rs
+++ b/src/frontend/src/planner/relation.rs
@@ -151,10 +151,8 @@ impl Planner {
         match (args.next(), args.next()) {
             (Some(window_size @ ExprImpl::Literal(_)), None) => {
                 let mut exprs = Vec::with_capacity(cols.len() + 2);
-                let mut expr_aliases = Vec::with_capacity(cols.len() + 2);
                 for (idx, col) in cols.iter().enumerate() {
                     exprs.push(InputRef::new(idx, col.data_type().clone()).into());
-                    expr_aliases.push(None);
                 }
                 let window_start: ExprImpl = FunctionCall::new(
                     ExprType::TumbleStart,
@@ -169,10 +167,8 @@ impl Planner {
                         .into();
                 exprs.push(window_start);
                 exprs.push(window_end);
-                expr_aliases.push(Some("window_start".to_string()));
-                expr_aliases.push(Some("window_end".to_string()));
                 let base = self.plan_relation(input)?;
-                let project = LogicalProject::create(base, exprs, expr_aliases);
+                let project = LogicalProject::create(base, exprs);
                 Ok(project)
             }
             _ => Err(ErrorCode::BindError(

--- a/src/frontend/src/planner/select.rs
+++ b/src/frontend/src/planner/select.rs
@@ -37,7 +37,6 @@ impl Planner {
             mut select_items,
             group_by,
             mut having,
-            mut aliases,
             distinct,
             ..
         }: BoundSelect,
@@ -50,7 +49,6 @@ impl Planner {
             )
             .into());
         }
-        aliases.extend(vec![None; extra_order_exprs.len()]);
         select_items.extend(extra_order_exprs);
 
         // Plan the FROM clause.
@@ -77,7 +75,7 @@ impl Planner {
         if select_items.iter().any(|e| e.has_subquery()) {
             (root, select_items) = self.substitute_subqueries(root, select_items)?;
         }
-        root = LogicalProject::create(root, select_items, aliases);
+        root = LogicalProject::create(root, select_items);
 
         if distinct {
             let group_keys = (0..root.schema().fields().len()).collect();
@@ -105,11 +103,7 @@ impl Planner {
             ],
         )
         .unwrap();
-        Ok(LogicalProject::create(
-            count_star.into(),
-            vec![ge.into()],
-            vec![None],
-        ))
+        Ok(LogicalProject::create(count_star.into(), vec![ge.into()]))
     }
 
     /// For `(NOT) EXISTS subquery` or `(NOT) IN subquery`, we can plan it as

--- a/src/frontend/test_runner/tests/testdata/agg.yaml
+++ b/src/frontend/test_runner/tests/testdata/agg.yaml
@@ -19,13 +19,13 @@
     select v1, min(v2) + max(v3) * count(v1) as agg from t group by v1;
   batch_plan: |
     BatchExchange { order: [], dist: Single }
-      BatchProject { exprs: [$0, ($1 + ($2 * $3))], expr_alias: [v1, agg] }
+      BatchProject { exprs: [$0, ($1 + ($2 * $3))] }
         BatchHashAgg { group_keys: [$0], aggs: [min($1), max($2), count($0)] }
           BatchExchange { order: [], dist: HashShard([0]) }
             BatchScan { table: t, columns: [v1, v2, v3] }
   stream_plan: |
     StreamMaterialize { columns: [v1, agg], pk_columns: [v1] }
-      StreamProject { exprs: [$0, ($2 + ($3 * $4))], expr_alias: [v1, agg] }
+      StreamProject { exprs: [$0, ($2 + ($3 * $4))] }
         StreamHashAgg { group_keys: [$0], aggs: [count, min($1), max($2), count($0)] }
           StreamExchange { dist: HashShard([0]) }
             StreamTableScan { table: t, columns: [v1, v2, v3, _row_id#0], pk_indices: [3] }
@@ -33,13 +33,13 @@
     create table t(v1 int, v2 int, v3 int);
     select min(v1) + max(v2) * count(v3) as agg from t;
   batch_plan: |
-    BatchProject { exprs: [($0 + ($1 * $2))], expr_alias: [agg] }
+    BatchProject { exprs: [($0 + ($1 * $2))] }
       BatchSimpleAgg { aggs: [min($0), max($1), count($2)] }
         BatchExchange { order: [], dist: Single }
           BatchScan { table: t, columns: [v1, v2, v3] }
   stream_plan: |
     StreamMaterialize { columns: [agg, agg#0(hidden), agg#1(hidden), agg#2(hidden), agg#3(hidden)], pk_columns: [agg#0, agg#1, agg#2, agg#3] }
-      StreamProject { exprs: [($1 + ($2 * $3)), $0, $1, $2, $3], expr_alias: [agg,  ,  ,  ,  ] }
+      StreamProject { exprs: [($1 + ($2 * $3)), $0, $1, $2, $3] }
         StreamSimpleAgg { aggs: [count, min($0), max($1), count($2)] }
           StreamExchange { dist: Single }
             StreamTableScan { table: t, columns: [v1, v2, v3, _row_id#0], pk_indices: [3] }
@@ -56,16 +56,16 @@
     select v3, min(v1) * avg(v1+v2) as agg from t group by v3;
   batch_plan: |
     BatchExchange { order: [], dist: Single }
-      BatchProject { exprs: [$0, ($1 * ($2::Decimal / $3))], expr_alias: [v3, agg] }
+      BatchProject { exprs: [$0, ($1 * ($2::Decimal / $3))] }
         BatchHashAgg { group_keys: [$0], aggs: [min($1), sum($2), count($2)] }
-          BatchProject { exprs: [$2, $0, ($0 + $1)], expr_alias: [ ,  ,  ] }
+          BatchProject { exprs: [$2, $0, ($0 + $1)] }
             BatchExchange { order: [], dist: HashShard([2]) }
               BatchScan { table: t, columns: [v1, v2, v3] }
   stream_plan: |
     StreamMaterialize { columns: [v3, agg], pk_columns: [v3] }
-      StreamProject { exprs: [$0, ($2 * ($3::Decimal / $4))], expr_alias: [v3, agg] }
+      StreamProject { exprs: [$0, ($2 * ($3::Decimal / $4))] }
         StreamHashAgg { group_keys: [$0], aggs: [count, min($1), sum($2), count($2)] }
-          StreamProject { exprs: [$2, $0, ($0 + $1), $3], expr_alias: [ ,  ,  ,  ] }
+          StreamProject { exprs: [$2, $0, ($0 + $1), $3] }
             StreamExchange { dist: HashShard([2]) }
               StreamTableScan { table: t, columns: [v1, v2, v3, _row_id#0], pk_indices: [3] }
 - sql: |
@@ -73,27 +73,27 @@
     create table t(v1 int, v2 int);
     select min(v1), sum(v1 + v2) from t group by v1 + v2;
   logical_plan: |
-    LogicalProject { exprs: [$1, $2], expr_alias: [ ,  ] }
+    LogicalProject { exprs: [$1, $2] }
       LogicalAgg { group_keys: [0], agg_calls: [min($1), sum($0)] }
-        LogicalProject { exprs: [($1 + $2), $1], expr_alias: [ ,  ] }
+        LogicalProject { exprs: [($1 + $2), $1] }
           LogicalScan { table: t, columns: [_row_id#0, v1, v2] }
 - sql: |
     /* test logical_agg with complex group expression */
     create table t(v1 int, v2 int, v3 int);
     select v1, sum(v1 * v2) as sum from t group by (v1 + v2) / v3, v1;
   logical_plan: |
-    LogicalProject { exprs: [$1, $2], expr_alias: [v1, sum] }
+    LogicalProject { exprs: [$1, $2] }
       LogicalAgg { group_keys: [0, 1], agg_calls: [sum($2)] }
-        LogicalProject { exprs: [(($1 + $2) / $3), $1, ($1 * $2)], expr_alias: [ ,  ,  ] }
+        LogicalProject { exprs: [(($1 + $2) / $3), $1, ($1 * $2)] }
           LogicalScan { table: t, columns: [_row_id#0, v1, v2, v3] }
 - sql: |
     /* test logical_agg with complex group expression */
     create table t(v1 int, v2 int);
     select v1 + v2 from t group by v1 + v2;
   logical_plan: |
-    LogicalProject { exprs: [$0], expr_alias: [ ] }
+    LogicalProject { exprs: [$0] }
       LogicalAgg { group_keys: [0], agg_calls: [] }
-        LogicalProject { exprs: [($1 + $2)], expr_alias: [ ] }
+        LogicalProject { exprs: [($1 + $2)] }
           LogicalScan { table: t, columns: [_row_id#0, v1, v2] }
 - sql: |
     /* test logical_agg with complex group expression */
@@ -106,9 +106,9 @@
     create table t(v1 int, v2 int);
     select v1 + v2 from t group by v1, v2;
   logical_plan: |
-    LogicalProject { exprs: [($0 + $1)], expr_alias: [ ] }
+    LogicalProject { exprs: [($0 + $1)] }
       LogicalAgg { group_keys: [0, 1], agg_calls: [] }
-        LogicalProject { exprs: [$1, $2], expr_alias: [ ,  ] }
+        LogicalProject { exprs: [$1, $2] }
           LogicalScan { table: t, columns: [_row_id#0, v1, v2] }
 - sql: |
     create table t(v1 int, v2 int);
@@ -118,33 +118,31 @@
     create table t(v1 int, v2 int);
     select count(v1 + v2) as cnt, sum(v1 + v2) as sum from t;
   batch_plan: |
-    BatchProject { exprs: [$0, $1], expr_alias: [cnt, sum] }
-      BatchSimpleAgg { aggs: [count($0), sum($0)] }
-        BatchExchange { order: [], dist: Single }
-          BatchProject { exprs: [($0 + $1)], expr_alias: [ ] }
-            BatchScan { table: t, columns: [v1, v2] }
+    BatchSimpleAgg { aggs: [count($0), sum($0)] }
+      BatchExchange { order: [], dist: Single }
+        BatchProject { exprs: [($0 + $1)] }
+          BatchScan { table: t, columns: [v1, v2] }
   stream_plan: |
-    StreamMaterialize { columns: [cnt, sum, agg#0(hidden)], pk_columns: [agg#0, cnt, sum] }
-      StreamProject { exprs: [$1, $2, $0], expr_alias: [cnt, sum,  ] }
-        StreamSimpleAgg { aggs: [count, count($0), sum($0)] }
-          StreamExchange { dist: Single }
-            StreamProject { exprs: [($0 + $1), $2], expr_alias: [ ,  ] }
-              StreamTableScan { table: t, columns: [v1, v2, _row_id#0], pk_indices: [2] }
+    StreamMaterialize { columns: [agg#0(hidden), cnt, sum], pk_columns: [agg#0, cnt, sum] }
+      StreamSimpleAgg { aggs: [count, count($0), sum($0)] }
+        StreamExchange { dist: Single }
+          StreamProject { exprs: [($0 + $1), $2] }
+            StreamTableScan { table: t, columns: [v1, v2, _row_id#0], pk_indices: [2] }
 - sql: |
     create table t(v1 int, v2 int, v3 int);
     select v1, sum(v2 + v3) / count(v2 + v3) + max(v1) as agg from t group by v1;
   batch_plan: |
     BatchExchange { order: [], dist: Single }
-      BatchProject { exprs: [$0, (($1 / $2) + $3)], expr_alias: [v1, agg] }
+      BatchProject { exprs: [$0, (($1 / $2) + $3)] }
         BatchHashAgg { group_keys: [$0], aggs: [sum($1), count($1), max($0)] }
-          BatchProject { exprs: [$0, ($1 + $2)], expr_alias: [ ,  ] }
+          BatchProject { exprs: [$0, ($1 + $2)] }
             BatchExchange { order: [], dist: HashShard([0]) }
               BatchScan { table: t, columns: [v1, v2, v3] }
   stream_plan: |
     StreamMaterialize { columns: [v1, agg], pk_columns: [v1] }
-      StreamProject { exprs: [$0, (($2 / $3) + $4)], expr_alias: [v1, agg] }
+      StreamProject { exprs: [$0, (($2 / $3) + $4)] }
         StreamHashAgg { group_keys: [$0], aggs: [count, sum($1), count($1), max($0)] }
-          StreamProject { exprs: [$0, ($1 + $2), $3], expr_alias: [ ,  ,  ] }
+          StreamProject { exprs: [$0, ($1 + $2), $3] }
             StreamExchange { dist: HashShard([0]) }
               StreamTableScan { table: t, columns: [v1, v2, v3, _row_id#0], pk_indices: [3] }
 - sql: |
@@ -167,7 +165,7 @@
     create table t (v1 real not null);
     select 1 from t having sum(v1) > 5;
   batch_plan: |
-    BatchProject { exprs: [1:Int32], expr_alias: [ ] }
+    BatchProject { exprs: [1:Int32] }
       BatchFilter { predicate: ($0 > 5:Int32) }
         BatchSimpleAgg { aggs: [sum($0)] }
           BatchExchange { order: [], dist: Single }
@@ -177,10 +175,10 @@
     create table t (v1 real not null);
     select 1 from t group by v1 having v1 > 5;
   logical_plan: |
-    LogicalProject { exprs: [1:Int32], expr_alias: [ ] }
+    LogicalProject { exprs: [1:Int32] }
       LogicalFilter { predicate: ($0 > 5:Int32) }
         LogicalAgg { group_keys: [0], agg_calls: [] }
-          LogicalProject { exprs: [$1], expr_alias: [ ] }
+          LogicalProject { exprs: [$1] }
             LogicalScan { table: t, columns: [_row_id#0, v1] }
 - sql: |
     /* having with non-group column */
@@ -193,7 +191,7 @@
     select distinct v1 from t;
   logical_plan: |
     LogicalAgg { group_keys: [0], agg_calls: [] }
-      LogicalProject { exprs: [$1], expr_alias: [v1] }
+      LogicalProject { exprs: [$1] }
         LogicalScan { table: t, columns: [_row_id#0, v1, v2] }
 - sql: |
     /* distinct with agg */
@@ -201,7 +199,7 @@
     select distinct sum(v1) from t group by v2;
   logical_plan: |
     LogicalAgg { group_keys: [0], agg_calls: [] }
-      LogicalProject { exprs: [$1], expr_alias: [ ] }
+      LogicalProject { exprs: [$1] }
         LogicalAgg { group_keys: [0], agg_calls: [sum($1)] }
-          LogicalProject { exprs: [$2, $1], expr_alias: [ ,  ] }
+          LogicalProject { exprs: [$2, $1] }
             LogicalScan { table: t, columns: [_row_id#0, v1, v2] }

--- a/src/frontend/test_runner/tests/testdata/basic_query.yaml
+++ b/src/frontend/test_runner/tests/testdata/basic_query.yaml
@@ -67,7 +67,7 @@
     create table t(a Boolean);
     select * from t where (NULL IS NULL) IS TRUE AND FALSE IS FALSE AND a;
   logical_plan: |
-    LogicalProject { exprs: [$1], expr_alias: [a] }
+    LogicalProject { exprs: [$1] }
       LogicalFilter { predicate: $1 }
         LogicalScan { table: t, columns: [_row_id#0, a] }
 - sql: |
@@ -75,7 +75,7 @@
     create table t(a Boolean);
     select * from t where (NULL IS NOT TRUE) IS NOT FALSE AND a IS NOT TRUE;
   logical_plan: |
-    LogicalProject { exprs: [$1], expr_alias: [a] }
+    LogicalProject { exprs: [$1] }
       LogicalFilter { predicate: IsNotTrue($1) }
         LogicalScan { table: t, columns: [_row_id#0, a] }
 - sql: |
@@ -83,7 +83,7 @@
     create table t(a double precision);
     select * from t where (a IS NOT NULL AND 3.14 IS NOT NULL) OR (NULL IS NOT NULL);
   logical_plan: |
-    LogicalProject { exprs: [$1], expr_alias: [a] }
+    LogicalProject { exprs: [$1] }
       LogicalFilter { predicate: IsNotNull($1) }
         LogicalScan { table: t, columns: [_row_id#0, a] }
 - sql: |
@@ -97,15 +97,14 @@
       StreamTableScan { table: t, columns: [v1, _row_id#0], pk_indices: [1] }
 - sql: select 1
   batch_plan: |
-    BatchProject { exprs: [1:Int32], expr_alias: [ ] }
+    BatchProject { exprs: [1:Int32] }
       BatchValues { rows: [[]] }
 - sql: |
     create table t (v1 bigint, v2 double precision);
     select a from t as t2(a);
   batch_plan: |
     BatchExchange { order: [], dist: Single }
-      BatchProject { exprs: [$0], expr_alias: [a] }
-        BatchScan { table: t, columns: [v1] }
+      BatchScan { table: t, columns: [v1] }
 - sql: |
     create table t (v1 int, v2 int);
     delete from t;

--- a/src/frontend/test_runner/tests/testdata/column_pruning.yaml
+++ b/src/frontend/test_runner/tests/testdata/column_pruning.yaml
@@ -2,7 +2,7 @@
     create table t (v1 bigint, v2 double precision);
     select v1 from t
   logical_plan: |
-    LogicalProject { exprs: [$1], expr_alias: [v1] }
+    LogicalProject { exprs: [$1] }
       LogicalScan { table: t, columns: [_row_id#0, v1, v2] }
   optimized_logical_plan: |
     LogicalScan { table: t, columns: [v1] }
@@ -11,11 +11,11 @@
     create table t (v1 bigint, v2 double precision, v3 int);
     select v1 from t where v2 > 2
   logical_plan: |
-    LogicalProject { exprs: [$1], expr_alias: [v1] }
+    LogicalProject { exprs: [$1] }
       LogicalFilter { predicate: ($2 > 2:Int32) }
         LogicalScan { table: t, columns: [_row_id#0, v1, v2, v3] }
   optimized_logical_plan: |
-    LogicalProject { exprs: [$0], expr_alias: [v1] }
+    LogicalProject { exprs: [$0] }
       LogicalFilter { predicate: ($1 > 2:Int32) }
         LogicalScan { table: t, columns: [v1, v2] }
 - sql: |
@@ -24,12 +24,12 @@
     create table t2 (v1 int not null, v2 int not null, v3 int);
     select t1.v1, t2.v1 from t1 join t2 on t1.v2 = t2.v2;
   logical_plan: |
-    LogicalProject { exprs: [$1, $5], expr_alias: [v1, v1] }
+    LogicalProject { exprs: [$1, $5] }
       LogicalJoin { type: Inner, on: ($2 = $6) }
         LogicalScan { table: t1, columns: [_row_id#0, v1, v2, v3] }
         LogicalScan { table: t2, columns: [_row_id#0, v1, v2, v3] }
   optimized_logical_plan: |
-    LogicalProject { exprs: [$0, $2], expr_alias: [v1, v1] }
+    LogicalProject { exprs: [$0, $2] }
       LogicalJoin { type: Inner, on: ($1 = $3) }
         LogicalScan { table: t1, columns: [v1, v2] }
         LogicalScan { table: t2, columns: [v1, v2] }
@@ -38,14 +38,14 @@
     create table t (v1 bigint, v2 double precision, v3 int);
     select count(v1) from t where v2 > 2
   logical_plan: |
-    LogicalProject { exprs: [$0], expr_alias: [ ] }
+    LogicalProject { exprs: [$0] }
       LogicalAgg { group_keys: [], agg_calls: [count($0)] }
-        LogicalProject { exprs: [$1], expr_alias: [ ] }
+        LogicalProject { exprs: [$1] }
           LogicalFilter { predicate: ($2 > 2:Int32) }
             LogicalScan { table: t, columns: [_row_id#0, v1, v2, v3] }
   optimized_logical_plan: |
     LogicalAgg { group_keys: [], agg_calls: [count($0)] }
-      LogicalProject { exprs: [$0], expr_alias: [ ] }
+      LogicalProject { exprs: [$0] }
         LogicalFilter { predicate: ($1 > 2:Int32) }
           LogicalScan { table: t, columns: [v1, v2] }
 - sql: |
@@ -53,21 +53,21 @@
     create table t (v1 bigint, v2 double precision, v3 int);
     select 1 from t
   logical_plan: |
-    LogicalProject { exprs: [1:Int32], expr_alias: [ ] }
+    LogicalProject { exprs: [1:Int32] }
       LogicalScan { table: t, columns: [_row_id#0, v1, v2, v3] }
   optimized_logical_plan: |
-    LogicalProject { exprs: [1:Int32], expr_alias: [ ] }
+    LogicalProject { exprs: [1:Int32] }
       LogicalScan { table: t, columns: [] }
 - sql: |
     /* constant + filter */
     create table t (v1 bigint, v2 double precision, v3 int);
     select 1 from t where v2>1
   logical_plan: |
-    LogicalProject { exprs: [1:Int32], expr_alias: [ ] }
+    LogicalProject { exprs: [1:Int32] }
       LogicalFilter { predicate: ($2 > 1:Int32) }
         LogicalScan { table: t, columns: [_row_id#0, v1, v2, v3] }
   optimized_logical_plan: |
-    LogicalProject { exprs: [1:Int32], expr_alias: [ ] }
+    LogicalProject { exprs: [1:Int32] }
       LogicalFilter { predicate: ($0 > 1:Int32) }
         LogicalScan { table: t, columns: [v2] }
 - sql: |
@@ -75,27 +75,27 @@
     create table t (v1 bigint, v2 double precision, v3 int);
     select count(1) from t
   logical_plan: |
-    LogicalProject { exprs: [$0], expr_alias: [ ] }
+    LogicalProject { exprs: [$0] }
       LogicalAgg { group_keys: [], agg_calls: [count($0)] }
-        LogicalProject { exprs: [1:Int32], expr_alias: [ ] }
+        LogicalProject { exprs: [1:Int32] }
           LogicalScan { table: t, columns: [_row_id#0, v1, v2, v3] }
   optimized_logical_plan: |
     LogicalAgg { group_keys: [], agg_calls: [count($0)] }
-      LogicalProject { exprs: [1:Int32], expr_alias: [ ] }
+      LogicalProject { exprs: [1:Int32] }
         LogicalScan { table: t, columns: [] }
 - sql: |
     /* constant agg + filter */
     create table t (v1 bigint, v2 double precision, v3 int);
     select count(1) from t where v2>1
   logical_plan: |
-    LogicalProject { exprs: [$0], expr_alias: [ ] }
+    LogicalProject { exprs: [$0] }
       LogicalAgg { group_keys: [], agg_calls: [count($0)] }
-        LogicalProject { exprs: [1:Int32], expr_alias: [ ] }
+        LogicalProject { exprs: [1:Int32] }
           LogicalFilter { predicate: ($2 > 1:Int32) }
             LogicalScan { table: t, columns: [_row_id#0, v1, v2, v3] }
   optimized_logical_plan: |
     LogicalAgg { group_keys: [], agg_calls: [count($0)] }
-      LogicalProject { exprs: [1:Int32], expr_alias: [ ] }
+      LogicalProject { exprs: [1:Int32] }
         LogicalFilter { predicate: ($0 > 1:Int32) }
           LogicalScan { table: t, columns: [v2] }
 - sql: |
@@ -104,15 +104,15 @@
     create table t2 (v1 int not null, v2 int not null, v3 int);
     select t1.v1, t2.v1 from t1 join t2 on t1.v2 = t2.v2 where t1.v3 < 1;
   logical_plan: |
-    LogicalProject { exprs: [$1, $5], expr_alias: [v1, v1] }
+    LogicalProject { exprs: [$1, $5] }
       LogicalFilter { predicate: ($3 < 1:Int32) }
         LogicalJoin { type: Inner, on: ($2 = $6) }
           LogicalScan { table: t1, columns: [_row_id#0, v1, v2, v3] }
           LogicalScan { table: t2, columns: [_row_id#0, v1, v2, v3] }
   optimized_logical_plan: |
-    LogicalProject { exprs: [$0, $2], expr_alias: [v1, v1] }
+    LogicalProject { exprs: [$0, $2] }
       LogicalJoin { type: Inner, on: ($1 = $3) }
-        LogicalProject { exprs: [$0, $1], expr_alias: [ ,  ] }
+        LogicalProject { exprs: [$0, $1] }
           LogicalFilter { predicate: ($2 < 1:Int32) }
             LogicalScan { table: t1, columns: [v1, v2, v3] }
         LogicalScan { table: t2, columns: [v1, v2] }
@@ -121,14 +121,14 @@
     create table t (v1 bigint, v2 double precision, v3 int);
     select count(1), count(v1) from t where v2>1
   logical_plan: |
-    LogicalProject { exprs: [$0, $1], expr_alias: [ ,  ] }
+    LogicalProject { exprs: [$0, $1] }
       LogicalAgg { group_keys: [], agg_calls: [count($0), count($1)] }
-        LogicalProject { exprs: [1:Int32, $1], expr_alias: [ ,  ] }
+        LogicalProject { exprs: [1:Int32, $1] }
           LogicalFilter { predicate: ($2 > 1:Int32) }
             LogicalScan { table: t, columns: [_row_id#0, v1, v2, v3] }
   optimized_logical_plan: |
     LogicalAgg { group_keys: [], agg_calls: [count($0), count($1)] }
-      LogicalProject { exprs: [1:Int32, $0], expr_alias: [ ,  ] }
+      LogicalProject { exprs: [1:Int32, $0] }
         LogicalFilter { predicate: ($1 > 1:Int32) }
           LogicalScan { table: t, columns: [v1, v2] }
 - sql: |
@@ -136,10 +136,10 @@
     create table t1 (a int, b int, created_at timestamp);
     select a, window_end from hop(t1, created_at, interval '15' minute, interval '30' minute)
   logical_plan: |
-    LogicalProject { exprs: [$1, $5], expr_alias: [a, window_end] }
+    LogicalProject { exprs: [$1, $5] }
       LogicalHopWindow { time_col: $3 slide: 00:15:00 size: 00:30:00 }
         LogicalScan { table: t1, columns: [_row_id#0, a, b, created_at] }
   optimized_logical_plan: |
-    LogicalProject { exprs: [$0, $3], expr_alias: [a, window_end] }
+    LogicalProject { exprs: [$0, $3] }
       LogicalHopWindow { time_col: $1 slide: 00:15:00 size: 00:30:00 }
         LogicalScan { table: t1, columns: [a, created_at] }

--- a/src/frontend/test_runner/tests/testdata/distribution_derive.yaml
+++ b/src/frontend/test_runner/tests/testdata/distribution_derive.yaml
@@ -11,18 +11,18 @@
     group by a;
   batch_plan: |
     BatchExchange { order: [], dist: Single }
-      BatchProject { exprs: [$1, $0], expr_alias: [max_num, a] }
+      BatchProject { exprs: [$1, $0] }
         BatchHashAgg { group_keys: [$0], aggs: [max($1)] }
-          BatchProject { exprs: [$0, $2], expr_alias: [ ,  ] }
+          BatchProject { exprs: [$0, $2] }
             BatchExchange { order: [], dist: HashShard([0]) }
               BatchHashAgg { group_keys: [$0, $1], aggs: [count] }
                 BatchExchange { order: [], dist: HashShard([0, 1]) }
                   BatchScan { table: t, columns: [a, b] }
   stream_plan: |
     StreamMaterialize { columns: [max_num, a], pk_columns: [a] }
-      StreamProject { exprs: [$2, $0], expr_alias: [max_num, a] }
+      StreamProject { exprs: [$2, $0] }
         StreamHashAgg { group_keys: [$0], aggs: [count, max($1)] }
-          StreamProject { exprs: [$0, $3, $1], expr_alias: [ ,  ,  ] }
+          StreamProject { exprs: [$0, $3, $1] }
             StreamExchange { dist: HashShard([0]) }
               StreamHashAgg { group_keys: [$0, $1], aggs: [count, count] }
                 StreamExchange { dist: HashShard([0, 1]) }

--- a/src/frontend/test_runner/tests/testdata/expr.yaml
+++ b/src/frontend/test_runner/tests/testdata/expr.yaml
@@ -2,13 +2,13 @@
     /* bind typed literal */
     select int '1';
   logical_plan: |
-    LogicalProject { exprs: ['1':Varchar::Int32], expr_alias: [ ] }
+    LogicalProject { exprs: ['1':Varchar::Int32] }
       LogicalValues { rows: [[]], schema: Schema { fields: [] } }
 - sql: |
     /* bind typed literal */
     SELECT bool 't'
   logical_plan: |
-    LogicalProject { exprs: ['t':Varchar::Boolean], expr_alias: [ ] }
+    LogicalProject { exprs: ['t':Varchar::Boolean] }
       LogicalValues { rows: [[]], schema: Schema { fields: [] } }
 - sql: |
     values(must_be_unimplemented_func(1));
@@ -26,25 +26,25 @@
     select (((((false is not true) is true) is not false) is false) is not null) is null from t;
   batch_plan: |
     BatchExchange { order: [], dist: Single }
-      BatchProject { exprs: [IsNull(IsNotNull(IsFalse(IsNotFalse(IsTrue(IsNotTrue(false:Boolean))))))], expr_alias: [ ] }
+      BatchProject { exprs: [IsNull(IsNotNull(IsFalse(IsNotFalse(IsTrue(IsNotTrue(false:Boolean))))))] }
         BatchScan { table: t, columns: [] }
 - sql: |
     /* bind between */
     SELECT 1 between 2 and 3
   logical_plan: |
-    LogicalProject { exprs: [((1:Int32 >= 2:Int32) AND (1:Int32 <= 3:Int32))], expr_alias: [ ] }
+    LogicalProject { exprs: [((1:Int32 >= 2:Int32) AND (1:Int32 <= 3:Int32))] }
       LogicalValues { rows: [[]], schema: Schema { fields: [] } }
 - sql: |
     /* in-list with aligned types */
     SELECT 1::real in (3, 1.0, 2);
   batch_plan: |
-    BatchProject { exprs: [In(1:Int32::Float32, 3:Int32::Float32, 1.0:Decimal::Float32, 2:Int32::Float32)], expr_alias: [ ] }
+    BatchProject { exprs: [In(1:Int32::Float32, 3:Int32::Float32, 1.0:Decimal::Float32, 2:Int32::Float32)] }
       BatchValues { rows: [[]] }
 - sql: |
     /* not in-list with aligned types */
     SELECT 1::real not in (3, 1.0, 2);
   batch_plan: |
-    BatchProject { exprs: [Not(In(1:Int32::Float32, 3:Int32::Float32, 1.0:Decimal::Float32, 2:Int32::Float32))], expr_alias: [ ] }
+    BatchProject { exprs: [Not(In(1:Int32::Float32, 3:Int32::Float32, 1.0:Decimal::Float32, 2:Int32::Float32))] }
       BatchValues { rows: [[]] }
 - sql: |
     /* in-list with misaligned types */
@@ -53,7 +53,7 @@
 - sql: |
     select +1.0, -2.0;
   batch_plan: |
-    BatchProject { exprs: [1.0:Decimal, Neg(2.0:Decimal)], expr_alias: [ ,  ] }
+    BatchProject { exprs: [1.0:Decimal, Neg(2.0:Decimal)] }
       BatchValues { rows: [[]] }
 - sql: |
     values(round(42.4382, 2));
@@ -80,12 +80,12 @@
 - sql: |
     select length(trim(trailing '1' from '12'))+length(trim(leading '2' from '23'))+length(trim(both '3' from '34'));
   batch_plan: |
-    BatchProject { exprs: [((Length(Rtrim('12':Varchar, '1':Varchar)) + Length(Ltrim('23':Varchar, '2':Varchar))) + Length(Trim('34':Varchar, '3':Varchar)))], expr_alias: [ ] }
+    BatchProject { exprs: [((Length(Rtrim('12':Varchar, '1':Varchar)) + Length(Ltrim('23':Varchar, '2':Varchar))) + Length(Trim('34':Varchar, '3':Varchar)))] }
       BatchValues { rows: [[]] }
 - sql: |
     select position(replace('1','1','2'),'123') where '12' like '%1';
   batch_plan: |
-    BatchProject { exprs: [Position(Replace('1':Varchar, '1':Varchar, '2':Varchar), '123':Varchar)], expr_alias: [ ] }
+    BatchProject { exprs: [Position(Replace('1':Varchar, '1':Varchar, '2':Varchar), '123':Varchar)] }
       BatchFilter { predicate: Like('12':Varchar, '%1':Varchar) }
         BatchValues { rows: [[]] }
 - sql: |
@@ -94,11 +94,11 @@
     select (case when v1=1 then 1 when v1=2 then 2 else 0.0 end) as expr from t;
   batch_plan: |
     BatchExchange { order: [], dist: Single }
-      BatchProject { exprs: [Case(($0 = 1:Int32), 1:Int32::Decimal, ($0 = 2:Int32), 2:Int32::Decimal, 0.0:Decimal)], expr_alias: [expr] }
+      BatchProject { exprs: [Case(($0 = 1:Int32), 1:Int32::Decimal, ($0 = 2:Int32), 2:Int32::Decimal, 0.0:Decimal)] }
         BatchScan { table: t, columns: [v1] }
   stream_plan: |
     StreamMaterialize { columns: [expr, _row_id#0(hidden)], pk_columns: [_row_id#0] }
-      StreamProject { exprs: [Case(($0 = 1:Int32), 1:Int32::Decimal, ($0 = 2:Int32), 2:Int32::Decimal, 0.0:Decimal), $1], expr_alias: [expr,  ] }
+      StreamProject { exprs: [Case(($0 = 1:Int32), 1:Int32::Decimal, ($0 = 2:Int32), 2:Int32::Decimal, 0.0:Decimal), $1] }
         StreamTableScan { table: t, columns: [v1, _row_id#0], pk_indices: [1] }
 - sql: |
     /* case searched form without else */
@@ -106,7 +106,7 @@
     select (case when v1=1 then 1 when v1=2 then 2.1 end) from t;
   batch_plan: |
     BatchExchange { order: [], dist: Single }
-      BatchProject { exprs: [Case(($0 = 1:Int32), 1:Int32::Decimal, ($0 = 2:Int32), 2.1:Decimal)], expr_alias: [ ] }
+      BatchProject { exprs: [Case(($0 = 1:Int32), 1:Int32::Decimal, ($0 = 2:Int32), 2.1:Decimal)] }
         BatchScan { table: t, columns: [v1] }
 - sql: |
     /* case simple form */
@@ -114,7 +114,7 @@
     select (case v1 when 1 then 1 when 2.0 then 2 else 0.0 end) from t;
   batch_plan: |
     BatchExchange { order: [], dist: Single }
-      BatchProject { exprs: [Case(($0 = 1:Int32), 1:Int32::Decimal, ($0 = 2.0:Decimal), 2:Int32::Decimal, 0.0:Decimal)], expr_alias: [ ] }
+      BatchProject { exprs: [Case(($0 = 1:Int32), 1:Int32::Decimal, ($0 = 2.0:Decimal), 2:Int32::Decimal, 0.0:Decimal)] }
         BatchScan { table: t, columns: [v1] }
 - sql: |
     /* case misaligned result types */
@@ -131,11 +131,11 @@
     select nullif(v1, 1) as expr from t;
   batch_plan: |
     BatchExchange { order: [], dist: Single }
-      BatchProject { exprs: [Case(($0 = 1:Int32), null:Int32, $0)], expr_alias: [expr] }
+      BatchProject { exprs: [Case(($0 = 1:Int32), null:Int32, $0)] }
         BatchScan { table: t, columns: [v1] }
   stream_plan: |
     StreamMaterialize { columns: [expr, _row_id#0(hidden)], pk_columns: [_row_id#0] }
-      StreamProject { exprs: [Case(($0 = 1:Int32), null:Int32, $0), $1], expr_alias: [expr,  ] }
+      StreamProject { exprs: [Case(($0 = 1:Int32), null:Int32, $0), $1] }
         StreamTableScan { table: t, columns: [v1, _row_id#0], pk_indices: [1] }
 - sql: |
     create table t (v1 int);
@@ -150,18 +150,18 @@
     select coalesce(v1, 1) as expr from t;
   batch_plan: |
     BatchExchange { order: [], dist: Single }
-      BatchProject { exprs: [Coalesce($0, 1:Int32)], expr_alias: [expr] }
+      BatchProject { exprs: [Coalesce($0, 1:Int32)] }
         BatchScan { table: t, columns: [v1] }
   stream_plan: |
     StreamMaterialize { columns: [expr, _row_id#0(hidden)], pk_columns: [_row_id#0] }
-      StreamProject { exprs: [Coalesce($0, 1:Int32), $1], expr_alias: [expr,  ] }
+      StreamProject { exprs: [Coalesce($0, 1:Int32), $1] }
         StreamTableScan { table: t, columns: [v1, _row_id#0], pk_indices: [1] }
 - sql: |
     create table t (v1 int);
     select coalesce(v1, 1.2) from t;
   batch_plan: |
     BatchExchange { order: [], dist: Single }
-      BatchProject { exprs: [Coalesce($0::Decimal, 1.2:Decimal)], expr_alias: [ ] }
+      BatchProject { exprs: [Coalesce($0::Decimal, 1.2:Decimal)] }
         BatchScan { table: t, columns: [v1] }
 - sql: |
     create table t (v1 int);

--- a/src/frontend/test_runner/tests/testdata/index.yaml
+++ b/src/frontend/test_runner/tests/testdata/index.yaml
@@ -36,7 +36,7 @@
   stream_plan: |
     StreamMaterialize { columns: [v4, _row_id#0(hidden), _row_id#1(hidden)], pk_columns: [_row_id#0, _row_id#1] }
       StreamExchange { dist: HashShard([1, 2]) }
-        StreamProject { exprs: [$3, $1, $4], expr_alias: [v4,  ,  ] }
+        StreamProject { exprs: [$3, $1, $4] }
           StreamDeltaJoin { type: Inner, predicate: $0 = $2 }
             StreamIndexScan { index: iii_index_1, columns: [v1, _row_id#0], pk_indices: [1] }
             StreamIndexScan { index: iii_index_2, columns: [v3, v4, _row_id#0], pk_indices: [2] }

--- a/src/frontend/test_runner/tests/testdata/insert.yaml
+++ b/src/frontend/test_runner/tests/testdata/insert.yaml
@@ -73,7 +73,7 @@
     insert into t select timestamp '2020-01-01 01:02:03', 11, 4.5 from t;
   batch_plan: |
     BatchInsert { table: t }
-      BatchProject { exprs: ['2020-01-01 01:02:03':Varchar::Timestamp::Time, 11:Int32, 4.5:Decimal::Float32], expr_alias: [ ,  ,  ] }
+      BatchProject { exprs: ['2020-01-01 01:02:03':Varchar::Timestamp::Time, 11:Int32, 4.5:Decimal::Float32] }
         BatchScan { table: t, columns: [] }
 - sql: |
     /* insert into select with cast error */

--- a/src/frontend/test_runner/tests/testdata/join.yaml
+++ b/src/frontend/test_runner/tests/testdata/join.yaml
@@ -4,7 +4,7 @@
     create table t3 (v5 int, v6 int);
     select * from t1, t2, t3 where t1.v1 = t2.v3 and t1.v1 = t3.v5;
   logical_plan: |
-    LogicalProject { exprs: [$1, $2, $4, $5, $7, $8], expr_alias: [v1, v2, v3, v4, v5, v6] }
+    LogicalProject { exprs: [$1, $2, $4, $5, $7, $8] }
       LogicalFilter { predicate: ($1 = $4) AND ($1 = $7) }
         LogicalJoin { type: Inner, on: true }
           LogicalJoin { type: Inner, on: true }
@@ -27,19 +27,18 @@
     create table t (v1 int, v2 int);
     select t1.v1 as t1v1, t2.v1 as t2v1 from t t1 join t t2 on t1.v1 = t2.v1;
   logical_plan: |
-    LogicalProject { exprs: [$1, $4], expr_alias: [t1v1, t2v1] }
+    LogicalProject { exprs: [$1, $4] }
       LogicalJoin { type: Inner, on: ($1 = $4) }
         LogicalScan { table: t, columns: [_row_id#0, v1, v2] }
         LogicalScan { table: t, columns: [_row_id#0, v1, v2] }
   stream_plan: |
-    StreamMaterialize { columns: [t1v1, t2v1, _row_id#0(hidden), _row_id#1(hidden)], pk_columns: [_row_id#0, _row_id#1] }
-      StreamExchange { dist: HashShard([2, 3]) }
-        StreamProject { exprs: [$0, $2, $1, $3], expr_alias: [t1v1, t2v1,  ,  ] }
-          StreamHashJoin { type: Inner, predicate: $0 = $2 }
-            StreamExchange { dist: HashShard([0]) }
-              StreamTableScan { table: t, columns: [v1, _row_id#0], pk_indices: [1] }
-            StreamExchange { dist: HashShard([0]) }
-              StreamTableScan { table: t, columns: [v1, _row_id#0], pk_indices: [1] }
+    StreamMaterialize { columns: [t1v1, _row_id#0(hidden), t2v1, _row_id#1(hidden)], pk_columns: [_row_id#0, _row_id#1] }
+      StreamExchange { dist: HashShard([1, 3]) }
+        StreamHashJoin { type: Inner, predicate: $0 = $2 }
+          StreamExchange { dist: HashShard([0]) }
+            StreamTableScan { table: t, columns: [v1, _row_id#0], pk_indices: [1] }
+          StreamExchange { dist: HashShard([0]) }
+            StreamTableScan { table: t, columns: [v1, _row_id#0], pk_indices: [1] }
 - sql: |
     create table t1 (v1 int, v2 int);
     create table t2 (v1 int, v2 int);
@@ -47,36 +46,34 @@
     select t1.v1 as t1_v1, t1.v2 as t1_v2, t2.v1 as t2_v1, t2.v2 as t2_v2, t3.v1 as t3_v1, t3.v2 as t3_v2 from t1 join t2 on (t1.v1 = t2.v1) join t3 on (t2.v2 = t3.v2);
   batch_plan: |
     BatchExchange { order: [], dist: Single }
-      BatchProject { exprs: [$0, $1, $2, $3, $4, $5], expr_alias: [t1_v1, t1_v2, t2_v1, t2_v2, t3_v1, t3_v2] }
-        BatchHashJoin { type: Inner, predicate: $3 = $5 }
-          BatchExchange { order: [], dist: HashShard([3]) }
-            BatchHashJoin { type: Inner, predicate: $0 = $2 }
-              BatchExchange { order: [], dist: HashShard([0]) }
-                BatchScan { table: t1, columns: [v1, v2] }
-              BatchExchange { order: [], dist: HashShard([0]) }
-                BatchScan { table: t2, columns: [v1, v2] }
-          BatchExchange { order: [], dist: HashShard([1]) }
-            BatchScan { table: t3, columns: [v1, v2] }
+      BatchHashJoin { type: Inner, predicate: $3 = $5 }
+        BatchExchange { order: [], dist: HashShard([3]) }
+          BatchHashJoin { type: Inner, predicate: $0 = $2 }
+            BatchExchange { order: [], dist: HashShard([0]) }
+              BatchScan { table: t1, columns: [v1, v2] }
+            BatchExchange { order: [], dist: HashShard([0]) }
+              BatchScan { table: t2, columns: [v1, v2] }
+        BatchExchange { order: [], dist: HashShard([1]) }
+          BatchScan { table: t3, columns: [v1, v2] }
   stream_plan: |
-    StreamMaterialize { columns: [t1_v1, t1_v2, t2_v1, t2_v2, t3_v1, t3_v2, _row_id#0(hidden), _row_id#1(hidden), _row_id#2(hidden)], pk_columns: [_row_id#0, _row_id#1, _row_id#2] }
-      StreamExchange { dist: HashShard([6, 7, 8]) }
-        StreamProject { exprs: [$0, $1, $3, $4, $6, $7, $2, $5, $8], expr_alias: [t1_v1, t1_v2, t2_v1, t2_v2, t3_v1, t3_v2,  ,  ,  ] }
-          StreamHashJoin { type: Inner, predicate: $4 = $7 }
-            StreamExchange { dist: HashShard([4]) }
-              StreamHashJoin { type: Inner, predicate: $0 = $3 }
-                StreamExchange { dist: HashShard([0]) }
-                  StreamTableScan { table: t1, columns: [v1, v2, _row_id#0], pk_indices: [2] }
-                StreamExchange { dist: HashShard([0]) }
-                  StreamTableScan { table: t2, columns: [v1, v2, _row_id#0], pk_indices: [2] }
-            StreamExchange { dist: HashShard([1]) }
-              StreamTableScan { table: t3, columns: [v1, v2, _row_id#0], pk_indices: [2] }
+    StreamMaterialize { columns: [t1_v1, t1_v2, _row_id#0(hidden), t2_v1, t2_v2, _row_id#1(hidden), t3_v1, t3_v2, _row_id#2(hidden)], pk_columns: [_row_id#0, _row_id#1, _row_id#2] }
+      StreamExchange { dist: HashShard([2, 5, 8]) }
+        StreamHashJoin { type: Inner, predicate: $4 = $7 }
+          StreamExchange { dist: HashShard([4]) }
+            StreamHashJoin { type: Inner, predicate: $0 = $3 }
+              StreamExchange { dist: HashShard([0]) }
+                StreamTableScan { table: t1, columns: [v1, v2, _row_id#0], pk_indices: [2] }
+              StreamExchange { dist: HashShard([0]) }
+                StreamTableScan { table: t2, columns: [v1, v2, _row_id#0], pk_indices: [2] }
+          StreamExchange { dist: HashShard([1]) }
+            StreamTableScan { table: t3, columns: [v1, v2, _row_id#0], pk_indices: [2] }
 - sql: |
     create table t1 (v1 int not null, v2 int not null);
     create table t2 (v1 int not null, v2 int not null);
     select t1.v2 as t1_v2, t2.v2 as t2_v2 from t1 join t2 on t1.v1 = t2.v1;
   batch_plan: |
     BatchExchange { order: [], dist: Single }
-      BatchProject { exprs: [$1, $3], expr_alias: [t1_v2, t2_v2] }
+      BatchProject { exprs: [$1, $3] }
         BatchHashJoin { type: Inner, predicate: $0 = $2 }
           BatchExchange { order: [], dist: HashShard([0]) }
             BatchScan { table: t1, columns: [v1, v2] }
@@ -85,7 +82,7 @@
   stream_plan: |
     StreamMaterialize { columns: [t1_v2, t2_v2, _row_id#0(hidden), _row_id#1(hidden)], pk_columns: [_row_id#0, _row_id#1] }
       StreamExchange { dist: HashShard([2, 3]) }
-        StreamProject { exprs: [$1, $4, $2, $5], expr_alias: [t1_v2, t2_v2,  ,  ] }
+        StreamProject { exprs: [$1, $4, $2, $5] }
           StreamHashJoin { type: Inner, predicate: $0 = $3 }
             StreamExchange { dist: HashShard([0]) }
               StreamTableScan { table: t1, columns: [v1, v2, _row_id#0], pk_indices: [2] }
@@ -96,7 +93,7 @@
     create table t2 (v1 int not null, v2 int not null);
     select t1.v2 as t1_v2, t2.v2 as t2_v2 from t1 join t2 on t1.v1 > t2.v1 and t1.v2 < 10;
   batch_plan: |
-    BatchProject { exprs: [$1, $3], expr_alias: [t1_v2, t2_v2] }
+    BatchProject { exprs: [$1, $3] }
       BatchNestedLoopJoin { type: Inner, predicate: ($0 > $2) AND ($1 < 10:Int32) }
         BatchExchange { order: [], dist: Single }
           BatchScan { table: t1, columns: [v1, v2] }

--- a/src/frontend/test_runner/tests/testdata/limit.yaml
+++ b/src/frontend/test_runner/tests/testdata/limit.yaml
@@ -3,21 +3,21 @@
     select * from t limit 4;
   logical_plan: |
     LogicalLimit { limit: 4, offset: 0 }
-      LogicalProject { exprs: [$1], expr_alias: [v] }
+      LogicalProject { exprs: [$1] }
         LogicalScan { table: t, columns: [_row_id#0, v] }
 - sql: |
     create table t (v int not null);
     select * from t offset 4;
   logical_plan: |
     LogicalLimit { limit: 9223372036854775807, offset: 4 }
-      LogicalProject { exprs: [$1], expr_alias: [v] }
+      LogicalProject { exprs: [$1] }
         LogicalScan { table: t, columns: [_row_id#0, v] }
 - sql: |
     create table t (v int not null);
     select * from ( select * from t limit 5 ) limit 4;
   logical_plan: |
     LogicalLimit { limit: 4, offset: 0 }
-      LogicalProject { exprs: [$0], expr_alias: [v] }
+      LogicalProject { exprs: [$0] }
         LogicalLimit { limit: 5, offset: 0 }
-          LogicalProject { exprs: [$1], expr_alias: [v] }
+          LogicalProject { exprs: [$1] }
             LogicalScan { table: t, columns: [_row_id#0, v] }

--- a/src/frontend/test_runner/tests/testdata/mv_on_mv.yaml
+++ b/src/frontend/test_runner/tests/testdata/mv_on_mv.yaml
@@ -10,11 +10,10 @@
   sql: |
     select m1.v1 as m1v1, m1.v2 as m1v2, m2.v1 as m2v1, m2.v2 as m2v2 from m1 join m2 on m1.v1 = m2.v1;
   stream_plan: |
-    StreamMaterialize { columns: [m1v1, m1v2, m2v1, m2v2, _row_id#0(hidden), _row_id#1(hidden)], pk_columns: [_row_id#0, _row_id#1] }
-      StreamExchange { dist: HashShard([4, 5]) }
-        StreamProject { exprs: [$0, $1, $3, $4, $2, $5], expr_alias: [m1v1, m1v2, m2v1, m2v2,  ,  ] }
-          StreamHashJoin { type: Inner, predicate: $0 = $3 }
-            StreamExchange { dist: HashShard([0]) }
-              StreamTableScan { table: m1, columns: [v1, v2, _row_id#0], pk_indices: [2] }
-            StreamExchange { dist: HashShard([0]) }
-              StreamTableScan { table: m2, columns: [v1, v2, _row_id#0], pk_indices: [2] }
+    StreamMaterialize { columns: [m1v1, m1v2, _row_id#0(hidden), m2v1, m2v2, _row_id#1(hidden)], pk_columns: [_row_id#0, _row_id#1] }
+      StreamExchange { dist: HashShard([2, 5]) }
+        StreamHashJoin { type: Inner, predicate: $0 = $3 }
+          StreamExchange { dist: HashShard([0]) }
+            StreamTableScan { table: m1, columns: [v1, v2, _row_id#0], pk_indices: [2] }
+          StreamExchange { dist: HashShard([0]) }
+            StreamTableScan { table: m2, columns: [v1, v2, _row_id#0], pk_indices: [2] }

--- a/src/frontend/test_runner/tests/testdata/nexmark.yaml
+++ b/src/frontend/test_runner/tests/testdata/nexmark.yaml
@@ -60,11 +60,11 @@
     FROM bid;
   batch_plan: |
     BatchExchange { order: [], dist: Single }
-      BatchProject { exprs: [$0, $1, (0.908:Decimal * $2), $3], expr_alias: [auction, bidder, price, dateTime] }
+      BatchProject { exprs: [$0, $1, (0.908:Decimal * $2), $3] }
         BatchScan { table: bid, columns: [auction, bidder, price, dateTime] }
   stream_plan: |
     StreamMaterialize { columns: [auction, bidder, price, dateTime, _row_id#0(hidden)], pk_columns: [_row_id#0] }
-      StreamProject { exprs: [$0, $1, (0.908:Decimal * $2), $3, $4], expr_alias: [auction, bidder, price, dateTime,  ] }
+      StreamProject { exprs: [$0, $1, (0.908:Decimal * $2), $3, $4] }
         StreamTableScan { table: bid, columns: [auction, bidder, price, dateTime, _row_id#0], pk_indices: [4] }
 - id: nexmark_q2
   before:
@@ -90,9 +90,9 @@
         A.category = 10 and (P.state = 'or' OR P.state = 'id' OR P.state = 'ca');
   batch_plan: |
     BatchExchange { order: [], dist: Single }
-      BatchProject { exprs: [$3, $4, $5, $0], expr_alias: [name, city, state, id] }
+      BatchProject { exprs: [$3, $4, $5, $0] }
         BatchHashJoin { type: Inner, predicate: $1 = $2 }
-          BatchProject { exprs: [$0, $1], expr_alias: [ ,  ] }
+          BatchProject { exprs: [$0, $1] }
             BatchExchange { order: [], dist: HashShard([1]) }
               BatchFilter { predicate: ($2 = 10:Int32) }
                 BatchScan { table: auction, columns: [id, seller, category] }
@@ -102,9 +102,9 @@
   stream_plan: |
     StreamMaterialize { columns: [name, city, state, id, _row_id#0(hidden), _row_id#1(hidden)], pk_columns: [_row_id#0, _row_id#1] }
       StreamExchange { dist: HashShard([4, 5]) }
-        StreamProject { exprs: [$4, $5, $6, $0, $2, $7], expr_alias: [name, city, state, id,  ,  ] }
+        StreamProject { exprs: [$4, $5, $6, $0, $2, $7] }
           StreamHashJoin { type: Inner, predicate: $1 = $3 }
-            StreamProject { exprs: [$0, $1, $3], expr_alias: [ ,  ,  ] }
+            StreamProject { exprs: [$0, $1, $3] }
               StreamExchange { dist: HashShard([1]) }
                 StreamFilter { predicate: ($2 = 10:Int32) }
                   StreamTableScan { table: auction, columns: [id, seller, category, _row_id#0], pk_indices: [3] }
@@ -127,12 +127,12 @@
     GROUP BY Q.category;
   batch_plan: |
     BatchExchange { order: [], dist: Single }
-      BatchProject { exprs: [$0, ($1 / $2)], expr_alias: [category, avg] }
+      BatchProject { exprs: [$0, ($1 / $2)] }
         BatchHashAgg { group_keys: [$0], aggs: [sum($1), count($1)] }
-          BatchProject { exprs: [$1, $2], expr_alias: [ ,  ] }
+          BatchProject { exprs: [$1, $2] }
             BatchExchange { order: [], dist: HashShard([1]) }
               BatchHashAgg { group_keys: [$0, $1], aggs: [max($2)] }
-                BatchProject { exprs: [$0, $3, $5], expr_alias: [ ,  ,  ] }
+                BatchProject { exprs: [$0, $3, $5] }
                   BatchFilter { predicate: ($6 >= $1) AND ($6 <= $2) }
                     BatchHashJoin { type: Inner, predicate: $0 = $4 }
                       BatchExchange { order: [], dist: HashShard([0]) }
@@ -141,12 +141,12 @@
                         BatchScan { table: bid, columns: [auction, price, dateTime] }
   stream_plan: |
     StreamMaterialize { columns: [category, avg], pk_columns: [category] }
-      StreamProject { exprs: [$0, ($2 / $3)], expr_alias: [category, avg] }
+      StreamProject { exprs: [$0, ($2 / $3)] }
         StreamHashAgg { group_keys: [$0], aggs: [count, sum($1), count($1)] }
-          StreamProject { exprs: [$1, $3, $0], expr_alias: [ ,  ,  ] }
+          StreamProject { exprs: [$1, $3, $0] }
             StreamExchange { dist: HashShard([1]) }
               StreamHashAgg { group_keys: [$0, $1], aggs: [count, max($2)] }
-                StreamProject { exprs: [$0, $3, $6, $4, $8], expr_alias: [ ,  ,  ,  ,  ] }
+                StreamProject { exprs: [$0, $3, $6, $4, $8] }
                   StreamFilter { predicate: ($7 >= $1) AND ($7 <= $2) }
                     StreamHashJoin { type: Inner, predicate: $0 = $5 }
                       StreamExchange { dist: HashShard([0]) }

--- a/src/frontend/test_runner/tests/testdata/order_by.yaml
+++ b/src/frontend/test_runner/tests/testdata/order_by.yaml
@@ -21,7 +21,7 @@
   batch_plan: |
     BatchExchange { order: [$0 ASC], dist: Single }
       BatchSort { order: [$0 ASC] }
-        BatchProject { exprs: [$0, ($0 + 1:Int32)], expr_alias: [v1,  ] }
+        BatchProject { exprs: [$0, ($0 + 1:Int32)] }
           BatchScan { table: t, columns: [v1] }
 - sql: |
     create table t (v1 bigint, v2 double precision);
@@ -36,20 +36,19 @@
   batch_plan: |
     BatchExchange { order: [$0 ASC], dist: Single }
       BatchSort { order: [$0 ASC] }
-        BatchProject { exprs: [$0], expr_alias: [a1] }
-          BatchScan { table: t, columns: [v1] }
+        BatchScan { table: t, columns: [v1] }
 - sql: |
     create table t (v1 bigint, v2 double precision);
     select * from t order by 1+1;
   batch_plan: |
-    BatchProject { exprs: [$0, $1], expr_alias: [v1, v2] }
+    BatchProject { exprs: [$0, $1] }
       BatchExchange { order: [$2 ASC], dist: Single }
         BatchSort { order: [$2 ASC] }
-          BatchProject { exprs: [$0, $1, (1:Int32 + 1:Int32)], expr_alias: [v1, v2,  ] }
+          BatchProject { exprs: [$0, $1, (1:Int32 + 1:Int32)] }
             BatchScan { table: t, columns: [v1, v2] }
   stream_plan: |
     StreamMaterialize { columns: [v1, v2, expr#2(hidden), _row_id#0(hidden)], pk_columns: [_row_id#0], order_descs: [expr#2, _row_id#0] }
-      StreamProject { exprs: [$0, $1, (1:Int32 + 1:Int32), $2], expr_alias: [v1, v2,  ,  ] }
+      StreamProject { exprs: [$0, $1, (1:Int32 + 1:Int32), $2] }
         StreamTableScan { table: t, columns: [v1, v2, _row_id#0], pk_indices: [2] }
 - sql: |
     create table t (v1 bigint, v2 double precision);
@@ -84,17 +83,17 @@
     create table t (x int, y int, z int);
     select x, y from t order by x + y, z;
   optimized_logical_plan: |
-    LogicalProject { exprs: [$0, $1, ($0 + $1), $2], expr_alias: [x, y,  ,  ] }
+    LogicalProject { exprs: [$0, $1, ($0 + $1), $2] }
       LogicalScan { table: t, columns: [x, y, z] }
   batch_plan: |
-    BatchProject { exprs: [$0, $1], expr_alias: [x, y] }
+    BatchProject { exprs: [$0, $1] }
       BatchExchange { order: [$2 ASC, $3 ASC], dist: Single }
         BatchSort { order: [$2 ASC, $3 ASC] }
-          BatchProject { exprs: [$0, $1, ($0 + $1), $2], expr_alias: [x, y,  ,  ] }
+          BatchProject { exprs: [$0, $1, ($0 + $1), $2] }
             BatchScan { table: t, columns: [x, y, z] }
   stream_plan: |
     StreamMaterialize { columns: [x, y, expr#2(hidden), z(hidden), _row_id#0(hidden)], pk_columns: [_row_id#0], order_descs: [expr#2, z, _row_id#0] }
-      StreamProject { exprs: [$0, $1, ($0 + $1), $2, $3], expr_alias: [x, y,  ,  ,  ] }
+      StreamProject { exprs: [$0, $1, ($0 + $1), $2, $3] }
         StreamTableScan { table: t, columns: [x, y, z, _row_id#0], pk_indices: [3] }
 - sql: |
     /* order by the number of an output column */

--- a/src/frontend/test_runner/tests/testdata/predicate_pushdown.yaml
+++ b/src/frontend/test_runner/tests/testdata/predicate_pushdown.yaml
@@ -3,7 +3,7 @@
     create table t2 (v1 int, v2 int, v3 int);
     select * from t1 join t2 on t1.v1=t2.v2 and t1.v1>1 where t2.v2>2;
   logical_plan: |
-    LogicalProject { exprs: [$1, $2, $3, $5, $6, $7], expr_alias: [v1, v2, v3, v1, v2, v3] }
+    LogicalProject { exprs: [$1, $2, $3, $5, $6, $7] }
       LogicalFilter { predicate: ($6 > 2:Int32) }
         LogicalJoin { type: Inner, on: ($1 = $6) AND ($1 > 1:Int32) }
           LogicalScan { table: t1, columns: [_row_id#0, v1, v2, v3] }
@@ -18,9 +18,9 @@
     create table t (v1 bigint, v2 double precision);
     select * from (select * from t) where v2 > 1;
   logical_plan: |
-    LogicalProject { exprs: [$0, $1], expr_alias: [v1, v2] }
+    LogicalProject { exprs: [$0, $1] }
       LogicalFilter { predicate: ($1 > 1:Int32) }
-        LogicalProject { exprs: [$1, $2], expr_alias: [v1, v2] }
+        LogicalProject { exprs: [$1, $2] }
           LogicalScan { table: t, columns: [_row_id#0, v1, v2] }
   optimized_logical_plan: |
     LogicalFilter { predicate: ($1 > 1:Int32) }
@@ -29,40 +29,39 @@
     create table t (v1 bigint, v2 double precision);
     select v1 from (select v2, v1 from t) where v2 > 1;
   logical_plan: |
-    LogicalProject { exprs: [$1], expr_alias: [v1] }
+    LogicalProject { exprs: [$1] }
       LogicalFilter { predicate: ($0 > 1:Int32) }
-        LogicalProject { exprs: [$2, $1], expr_alias: [v2, v1] }
+        LogicalProject { exprs: [$2, $1] }
           LogicalScan { table: t, columns: [_row_id#0, v1, v2] }
   optimized_logical_plan: |
-    LogicalProject { exprs: [$0], expr_alias: [v1] }
+    LogicalProject { exprs: [$0] }
       LogicalFilter { predicate: ($1 > 1:Int32) }
         LogicalScan { table: t, columns: [v1, v2] }
 - sql: |
     create table t (v1 bigint, v2 double precision);
     select v1 from (select v2 as a2, v1 from t where v1 > 2) where a2 > 1;
   logical_plan: |
-    LogicalProject { exprs: [$1], expr_alias: [v1] }
+    LogicalProject { exprs: [$1] }
       LogicalFilter { predicate: ($0 > 1:Int32) }
-        LogicalProject { exprs: [$2, $1], expr_alias: [a2, v1] }
+        LogicalProject { exprs: [$2, $1] }
           LogicalFilter { predicate: ($1 > 2:Int32) }
             LogicalScan { table: t, columns: [_row_id#0, v1, v2] }
   optimized_logical_plan: |
-    LogicalProject { exprs: [$0], expr_alias: [v1] }
+    LogicalProject { exprs: [$0] }
       LogicalFilter { predicate: ($1 > 1:Int32) AND ($0 > 2:Int32) }
         LogicalScan { table: t, columns: [v1, v2] }
 - sql: |
     create table t(v1 int, v2 int, v3 int, v4 int);
     select * from (select v1, min(v2) as min from t group by v1) where v1 > 1 and min > 1 and 1 > 0 and v1 > min;
   logical_plan: |
-    LogicalProject { exprs: [$0, $1], expr_alias: [v1, min] }
+    LogicalProject { exprs: [$0, $1] }
       LogicalFilter { predicate: ($0 > 1:Int32) AND ($1 > 1:Int32) AND (1:Int32 > 0:Int32) AND ($0 > $1) }
-        LogicalProject { exprs: [$0, $1], expr_alias: [v1, min] }
+        LogicalProject { exprs: [$0, $1] }
           LogicalAgg { group_keys: [0], agg_calls: [min($1)] }
-            LogicalProject { exprs: [$1, $2], expr_alias: [ ,  ] }
+            LogicalProject { exprs: [$1, $2] }
               LogicalScan { table: t, columns: [_row_id#0, v1, v2, v3, v4] }
   optimized_logical_plan: |
-    LogicalProject { exprs: [$0, $1], expr_alias: [v1, min] }
-      LogicalFilter { predicate: ($1 > 1:Int32) AND ($0 > $1) }
-        LogicalAgg { group_keys: [0], agg_calls: [min($1)] }
-          LogicalFilter { predicate: ($0 > 1:Int32) AND (1:Int32 > 0:Int32) }
-            LogicalScan { table: t, columns: [v1, v2] }
+    LogicalFilter { predicate: ($1 > 1:Int32) AND ($0 > $1) }
+      LogicalAgg { group_keys: [0], agg_calls: [min($1)] }
+        LogicalFilter { predicate: ($0 > 1:Int32) AND (1:Int32 > 0:Int32) }
+          LogicalScan { table: t, columns: [v1, v2] }

--- a/src/frontend/test_runner/tests/testdata/stream_proto.yaml
+++ b/src/frontend/test_runner/tests/testdata/stream_proto.yaml
@@ -346,52 +346,25 @@
       - input:
           - input:
               - input:
-                  - input:
-                      - merge: {}
-                      - pkIndices:
-                          - 1
-                        appendOnly: true
-                        batchPlan:
-                          tableRefId:
-                            tableId: 2
-                          columnDescs:
-                            - columnType:
-                                typeName: INT32
-                                isNullable: true
-                              columnId: 1
-                              name: v1
-                            - columnType:
-                                typeName: INT64
-                                isNullable: true
-                              name: "_row_id#0"
-                          distributionKeys:
-                            - 1
-                    pkIndices:
+                  - merge: {}
+                  - pkIndices:
                       - 1
-                    fields:
-                      - dataType:
-                          typeName: INT32
-                          isNullable: true
-                        name: v1
-                      - dataType:
-                          typeName: INT64
-                          isNullable: true
-                        name: "_row_id#0"
-                    chain:
+                    appendOnly: true
+                    batchPlan:
                       tableRefId:
                         tableId: 2
-                      upstreamFields:
-                        - dataType:
+                      columnDescs:
+                        - columnType:
+                            typeName: INT32
+                            isNullable: true
+                          columnId: 1
+                          name: v1
+                        - columnType:
                             typeName: INT64
                             isNullable: true
                           name: "_row_id#0"
-                        - dataType:
-                            typeName: INT32
-                            isNullable: true
-                          name: v1
-                      columnIds:
+                      distributionKeys:
                         - 1
-                        - 0
                 pkIndices:
                   - 1
                 fields:
@@ -403,83 +376,84 @@
                       typeName: INT64
                       isNullable: true
                     name: "_row_id#0"
-                exchange:
-                  strategy:
-                    type: SIMPLE
+                chain:
+                  tableRefId:
+                    tableId: 2
+                  upstreamFields:
+                    - dataType:
+                        typeName: INT64
+                        isNullable: true
+                      name: "_row_id#0"
+                    - dataType:
+                        typeName: INT32
+                        isNullable: true
+                      name: v1
+                  columnIds:
+                    - 1
+                    - 0
             pkIndices:
-              - 0
               - 1
             fields:
               - dataType:
-                  typeName: INT64
+                  typeName: INT32
                   isNullable: true
-                name: "agg#0"
+                name: v1
               - dataType:
                   typeName: INT64
                   isNullable: true
-                name: "agg#1"
-            globalSimpleAgg:
-              aggCalls:
-                - type: COUNT
-                  returnType:
-                    typeName: INT64
-                    isNullable: true
-                - type: SUM
-                  args:
-                    - input: {}
-                      type:
-                        typeName: INT32
-                        isNullable: true
-                  returnType:
-                    typeName: INT64
-                    isNullable: true
+                name: "_row_id#0"
+            exchange:
+              strategy:
+                type: SIMPLE
         pkIndices:
-          - 1
           - 0
+          - 1
         fields:
           - dataType:
               typeName: INT64
               isNullable: true
-            name: sum
+            name: "agg#0"
           - dataType:
               typeName: INT64
               isNullable: true
-            name: "agg#0"
-        project:
-          selectList:
-            - exprType: INPUT_REF
+            name: "agg#1"
+        globalSimpleAgg:
+          aggCalls:
+            - type: COUNT
               returnType:
                 typeName: INT64
                 isNullable: true
-              inputRef:
-                columnIdx: 1
-            - exprType: INPUT_REF
+            - type: SUM
+              args:
+                - input: {}
+                  type:
+                    typeName: INT32
+                    isNullable: true
               returnType:
                 typeName: INT64
                 isNullable: true
-              inputRef: {}
     pkIndices:
-      - 1
       - 0
+      - 1
     fields:
       - dataType:
           typeName: INT64
           isNullable: true
-        name: sum
+        name: "agg#0"
       - dataType:
           typeName: INT64
           isNullable: true
-        name: "agg#0"
+        name: "agg#1"
     materialize:
       columnOrders:
         - orderType: ASCENDING
-          inputRef:
-            columnIdx: 1
+          inputRef: {}
           returnType:
             typeName: INT64
             isNullable: true
         - orderType: ASCENDING
-          inputRef: {}
+          inputRef:
+            columnIdx: 1
           returnType:
             typeName: INT64
             isNullable: true
@@ -494,23 +468,23 @@
           columnType:
             typeName: INT64
             isNullable: true
-          name: sum
+          name: "agg#0"
+        isHidden: true
       - columnDesc:
           columnType:
             typeName: INT64
             isNullable: true
           columnId: 1
-          name: "agg#0"
-        isHidden: true
+          name: sum
     orderColumnIds:
-      - 1
       - 0
+      - 1
     orders:
       - ASCENDING
       - ASCENDING
     pk:
-      - 1
       - 0
+      - 1
 - sql: |
     /* test simple agg */
     create table t (v1 int, v2 int);
@@ -675,7 +649,7 @@
           - dataType:
               typeName: INT64
               isNullable: true
-            name: sum_v1
+            name: "agg#1"
           - dataType:
               typeName: INT32
               isNullable: true
@@ -699,7 +673,7 @@
       - dataType:
           typeName: INT64
           isNullable: true
-        name: sum_v1
+        name: "agg#1"
       - dataType:
           typeName: INT32
           isNullable: true

--- a/src/frontend/test_runner/tests/testdata/struct_query.yaml
+++ b/src/frontend/test_runner/tests/testdata/struct_query.yaml
@@ -32,7 +32,7 @@
     create materialized view t as select * from s;
     select (t).country.city,(t).country,(country).city.address from t;
   logical_plan: |
-    LogicalProject { exprs: [Field($1, 1:Int32), $1, Field(Field($1, 1:Int32), 0:Int32)], expr_alias: [city, country, address] }
+    LogicalProject { exprs: [Field($1, 1:Int32), $1, Field(Field($1, 1:Int32), 0:Int32)] }
       LogicalScan { table: t, columns: [id, country, zipcode, rate, _row_id#0] }
   create_source:
     row_format: protobuf
@@ -59,7 +59,7 @@
     create materialized view t as select * from s;
     select (t).country1.city.*,(t.country2).*,(country3).city.* from t;
   logical_plan: |
-    LogicalProject { exprs: [Field(Field($1, 1:Int32), 0:Int32), Field(Field($1, 1:Int32), 1:Int32), Field($2, 0:Int32), Field($2, 1:Int32), Field($2, 2:Int32), Field(Field($3, 1:Int32), 0:Int32), Field(Field($3, 1:Int32), 1:Int32)], expr_alias: [address, zipcode, address, city, zipcode, address, zipcode] }
+    LogicalProject { exprs: [Field(Field($1, 1:Int32), 0:Int32), Field(Field($1, 1:Int32), 1:Int32), Field($2, 0:Int32), Field($2, 1:Int32), Field($2, 2:Int32), Field(Field($3, 1:Int32), 0:Int32), Field(Field($3, 1:Int32), 1:Int32)] }
       LogicalScan { table: t, columns: [id, country1, country2, country3, zipcode, rate, _row_id#0] }
   create_source:
     row_format: protobuf
@@ -88,8 +88,8 @@
     create materialized view t as select * from s;
     select (c).zipcode from (select (t).country.city as c from t);
   logical_plan: |
-    LogicalProject { exprs: [Field($0, 1:Int32)], expr_alias: [zipcode] }
-      LogicalProject { exprs: [Field($1, 1:Int32)], expr_alias: [c] }
+    LogicalProject { exprs: [Field($0, 1:Int32)] }
+      LogicalProject { exprs: [Field($1, 1:Int32)] }
         LogicalScan { table: t, columns: [id, country, zipcode, rate, _row_id#0] }
   create_source:
     row_format: protobuf
@@ -116,10 +116,10 @@
     create materialized view t as select * from s;
     select (c).zipcode from (select min((t).country.city) as c from t);
   logical_plan: |
-    LogicalProject { exprs: [Field($0, 1:Int32)], expr_alias: [zipcode] }
-      LogicalProject { exprs: [$0], expr_alias: [c] }
+    LogicalProject { exprs: [Field($0, 1:Int32)] }
+      LogicalProject { exprs: [$0] }
         LogicalAgg { group_keys: [], agg_calls: [min($0)] }
-          LogicalProject { exprs: [Field($1, 1:Int32)], expr_alias: [ ] }
+          LogicalProject { exprs: [Field($1, 1:Int32)] }
             LogicalScan { table: t, columns: [id, country, zipcode, rate, _row_id#0] }
   create_source:
     row_format: protobuf
@@ -146,9 +146,9 @@
     create materialized view t as select * from s;
     select * from (select (country).city as c from t) as vv join t on (c).zipcode=(t.country).zipcode;
   logical_plan: |
-    LogicalProject { exprs: [$0, $1, $2, $3, $4], expr_alias: [c, id, country, zipcode, rate] }
+    LogicalProject { exprs: [$0, $1, $2, $3, $4] }
       LogicalJoin { type: Inner, on: (Field($0, 1:Int32) = Field($2, 2:Int32)) }
-        LogicalProject { exprs: [Field($1, 1:Int32)], expr_alias: [c] }
+        LogicalProject { exprs: [Field($1, 1:Int32)] }
           LogicalScan { table: t, columns: [id, country, zipcode, rate, _row_id#0] }
         LogicalScan { table: t, columns: [id, country, zipcode, rate, _row_id#0] }
   create_source:
@@ -176,9 +176,9 @@
     create materialized view t as select * from s;
     select min((t.country).city.address) + max((t.country).city.address) * count(zipcode) from t;
   logical_plan: |
-    LogicalProject { exprs: [($0 + ($1 * $2))], expr_alias: [ ] }
+    LogicalProject { exprs: [($0 + ($1 * $2))] }
       LogicalAgg { group_keys: [], agg_calls: [min($0), max($0), count($1)] }
-        LogicalProject { exprs: [Field(Field($1, 1:Int32), 0:Int32), $2], expr_alias: [ ,  ] }
+        LogicalProject { exprs: [Field(Field($1, 1:Int32), 0:Int32), $2] }
           LogicalScan { table: t, columns: [id, country, zipcode, rate, _row_id#0] }
   create_source:
     row_format: protobuf
@@ -205,9 +205,9 @@
     create materialized view t as select * from s;
     select count(1), count((country).city.zipcode) from t where (country).city.address>1;
   logical_plan: |
-    LogicalProject { exprs: [$0, $1], expr_alias: [ ,  ] }
+    LogicalProject { exprs: [$0, $1] }
       LogicalAgg { group_keys: [], agg_calls: [count($0), count($1)] }
-        LogicalProject { exprs: [1:Int32, Field(Field($1, 1:Int32), 1:Int32)], expr_alias: [ ,  ] }
+        LogicalProject { exprs: [1:Int32, Field(Field($1, 1:Int32), 1:Int32)] }
           LogicalFilter { predicate: (Field(Field($1, 1:Int32), 0:Int32) > 1:Int32) }
             LogicalScan { table: t, columns: [id, country, zipcode, rate, _row_id#0] }
   create_source:
@@ -345,7 +345,7 @@
 - sql: |
     select * from s where s.v3 = (1,2,(1,2,3));
   logical_plan: |
-    LogicalProject { exprs: [$1, $2, $3], expr_alias: [v1, v2, v3] }
+    LogicalProject { exprs: [$1, $2, $3] }
       LogicalFilter { predicate: ($3 = {Some(Int32(1)), Some(Int32(2)), Some(Struct(StructValue { fields: [Some(Int32(1)), Some(Int32(2)), Some(Int32(3))] }))}:Struct { fields: [Int32, Int32, Struct { fields: [Int32, Int32, Int32] }] }) }
         LogicalScan { table: s, columns: [_row_id#0, v1, v2, v3] }
   create_source:

--- a/src/frontend/test_runner/tests/testdata/subquery.yaml
+++ b/src/frontend/test_runner/tests/testdata/subquery.yaml
@@ -2,17 +2,17 @@
     create table t (v1 bigint, v2 double precision);
     select v1 from (select * from t) where v2 > 1;
   logical_plan: |
-    LogicalProject { exprs: [$0], expr_alias: [v1] }
+    LogicalProject { exprs: [$0] }
       LogicalFilter { predicate: ($1 > 1:Int32) }
-        LogicalProject { exprs: [$1, $2], expr_alias: [v1, v2] }
+        LogicalProject { exprs: [$1, $2] }
           LogicalScan { table: t, columns: [_row_id#0, v1, v2] }
 - sql: |
     /* merge and then eliminate */
     create table t (v1 bigint, v2 double precision);
     select a1 as v1, a2 as v2 from (select v1 as a1, v2 as a2 from t);
   logical_plan: |
-    LogicalProject { exprs: [$0, $1], expr_alias: [v1, v2] }
-      LogicalProject { exprs: [$1, $2], expr_alias: [a1, a2] }
+    LogicalProject { exprs: [$0, $1] }
+      LogicalProject { exprs: [$1, $2] }
         LogicalScan { table: t, columns: [_row_id#0, v1, v2] }
   optimized_logical_plan: |
     LogicalScan { table: t, columns: [v1, v2] }
@@ -24,27 +24,27 @@
     create table t (v1 bigint, v2 double precision);
     select v3 from (select v2, v1 as v3 from t) where v2 > 1;
   logical_plan: |
-    LogicalProject { exprs: [$1], expr_alias: [v3] }
+    LogicalProject { exprs: [$1] }
       LogicalFilter { predicate: ($0 > 1:Int32) }
-        LogicalProject { exprs: [$2, $1], expr_alias: [v2, v3] }
+        LogicalProject { exprs: [$2, $1] }
           LogicalScan { table: t, columns: [_row_id#0, v1, v2] }
 - sql: |
     /* consecutive projects are merged */
     create table t (v1 bigint, v2 double precision);
     select v1, 2 from (select v1, v2, 1 from t);
   logical_plan: |
-    LogicalProject { exprs: [$0, 2:Int32], expr_alias: [v1,  ] }
-      LogicalProject { exprs: [$1, $2, 1:Int32], expr_alias: [v1, v2,  ] }
+    LogicalProject { exprs: [$0, 2:Int32] }
+      LogicalProject { exprs: [$1, $2, 1:Int32] }
         LogicalScan { table: t, columns: [_row_id#0, v1, v2] }
   optimized_logical_plan: |
-    LogicalProject { exprs: [$0, 2:Int32], expr_alias: [v1,  ] }
+    LogicalProject { exprs: [$0, 2:Int32] }
       LogicalScan { table: t, columns: [v1] }
 - sql: |
     create table t (v1 bigint, v2 double precision);
     select * from (select * from t);
   logical_plan: |
-    LogicalProject { exprs: [$0, $1], expr_alias: [v1, v2] }
-      LogicalProject { exprs: [$1, $2], expr_alias: [v1, v2] }
+    LogicalProject { exprs: [$0, $1] }
+      LogicalProject { exprs: [$1, $2] }
         LogicalScan { table: t, columns: [_row_id#0, v1, v2] }
   optimized_logical_plan: |
     LogicalScan { table: t, columns: [v1, v2] }
@@ -53,9 +53,9 @@
     create table t (v1 bigint, v2 double precision);
     select * from (select * from t), t;
   logical_plan: |
-    LogicalProject { exprs: [$0, $1, $3, $4], expr_alias: [v1, v2, v1, v2] }
+    LogicalProject { exprs: [$0, $1, $3, $4] }
       LogicalJoin { type: Inner, on: true }
-        LogicalProject { exprs: [$1, $2], expr_alias: [v1, v2] }
+        LogicalProject { exprs: [$1, $2] }
           LogicalScan { table: t, columns: [_row_id#0, v1, v2] }
         LogicalScan { table: t, columns: [_row_id#0, v1, v2] }
 - sql: |
@@ -63,9 +63,9 @@
     create table t (v1 bigint, v2 double precision);
     select * from (select * from t) as tt join t on tt.v1=t.v1;
   logical_plan: |
-    LogicalProject { exprs: [$0, $1, $3, $4], expr_alias: [v1, v2, v1, v2] }
+    LogicalProject { exprs: [$0, $1, $3, $4] }
       LogicalJoin { type: Inner, on: ($0 = $3) }
-        LogicalProject { exprs: [$1, $2], expr_alias: [v1, v2] }
+        LogicalProject { exprs: [$1, $2] }
           LogicalScan { table: t, columns: [_row_id#0, v1, v2] }
         LogicalScan { table: t, columns: [_row_id#0, v1, v2] }
 - sql: |
@@ -73,9 +73,9 @@
     create table t (v1 bigint, v2 double precision);
     select * from (select * from t) as tt(a) join t on a=v1;
   logical_plan: |
-    LogicalProject { exprs: [$0, $1, $3, $4], expr_alias: [a, v2, v1, v2] }
+    LogicalProject { exprs: [$0, $1, $3, $4] }
       LogicalJoin { type: Inner, on: ($0 = $3) }
-        LogicalProject { exprs: [$1, $2], expr_alias: [v1, v2] }
+        LogicalProject { exprs: [$1, $2] }
           LogicalScan { table: t, columns: [_row_id#0, v1, v2] }
         LogicalScan { table: t, columns: [_row_id#0, v1, v2] }
 - sql: |

--- a/src/frontend/test_runner/tests/testdata/subquery_expr.yaml
+++ b/src/frontend/test_runner/tests/testdata/subquery_expr.yaml
@@ -1,52 +1,52 @@
 - sql: |
     select (select 1);
   logical_plan: |
-    LogicalProject { exprs: [$0], expr_alias: [ ] }
+    LogicalProject { exprs: [$0] }
       LogicalJoin { type: LeftOuter, on: true }
         LogicalValues { rows: [[]], schema: Schema { fields: [] } }
-        LogicalProject { exprs: [1:Int32], expr_alias: [ ] }
+        LogicalProject { exprs: [1:Int32] }
           LogicalValues { rows: [[]], schema: Schema { fields: [] } }
 - sql: |
     create table t(x int);
     select (select x from t), 1 from t;
   logical_plan: |
-    LogicalProject { exprs: [$2, 1:Int32], expr_alias: [ ,  ] }
+    LogicalProject { exprs: [$2, 1:Int32] }
       LogicalJoin { type: LeftOuter, on: true }
         LogicalScan { table: t, columns: [_row_id#0, x] }
-        LogicalProject { exprs: [$1], expr_alias: [x] }
+        LogicalProject { exprs: [$1] }
           LogicalScan { table: t, columns: [_row_id#0, x] }
 - sql: |
     create table t(x int);
     select (select x from t) + 1 from t;
   logical_plan: |
-    LogicalProject { exprs: [($2 + 1:Int32)], expr_alias: [ ] }
+    LogicalProject { exprs: [($2 + 1:Int32)] }
       LogicalJoin { type: LeftOuter, on: true }
         LogicalScan { table: t, columns: [_row_id#0, x] }
-        LogicalProject { exprs: [$1], expr_alias: [x] }
+        LogicalProject { exprs: [$1] }
           LogicalScan { table: t, columns: [_row_id#0, x] }
 - sql: |
     create table t(x int);
     select (select x from t), (select 1);
   logical_plan: |
-    LogicalProject { exprs: [$0, $1], expr_alias: [ ,  ] }
+    LogicalProject { exprs: [$0, $1] }
       LogicalJoin { type: LeftOuter, on: true }
         LogicalJoin { type: LeftOuter, on: true }
           LogicalValues { rows: [[]], schema: Schema { fields: [] } }
-          LogicalProject { exprs: [$1], expr_alias: [x] }
+          LogicalProject { exprs: [$1] }
             LogicalScan { table: t, columns: [_row_id#0, x] }
-        LogicalProject { exprs: [1:Int32], expr_alias: [ ] }
+        LogicalProject { exprs: [1:Int32] }
           LogicalValues { rows: [[]], schema: Schema { fields: [] } }
 - sql: |
     create table t(x int);
     select x + (select x + (select x as v1 from t) as v2 from t) as v3 from t;
   logical_plan: |
-    LogicalProject { exprs: [($1 + $2)], expr_alias: [v3] }
+    LogicalProject { exprs: [($1 + $2)] }
       LogicalJoin { type: LeftOuter, on: true }
         LogicalScan { table: t, columns: [_row_id#0, x] }
-        LogicalProject { exprs: [($1 + $2)], expr_alias: [v2] }
+        LogicalProject { exprs: [($1 + $2)] }
           LogicalJoin { type: LeftOuter, on: true }
             LogicalScan { table: t, columns: [_row_id#0, x] }
-            LogicalProject { exprs: [$1], expr_alias: [v1] }
+            LogicalProject { exprs: [$1] }
               LogicalScan { table: t, columns: [_row_id#0, x] }
 - sql: |
     select (select 1, 2);
@@ -55,13 +55,13 @@
     create table t(x int);
     select 1 where exists (select * from t);
   logical_plan: |
-    LogicalProject { exprs: [1:Int32], expr_alias: [ ] }
+    LogicalProject { exprs: [1:Int32] }
       LogicalJoin { type: LeftSemi, on: true }
         LogicalValues { rows: [[]], schema: Schema { fields: [] } }
-        LogicalProject { exprs: [$1], expr_alias: [x] }
+        LogicalProject { exprs: [$1] }
           LogicalScan { table: t, columns: [_row_id#0, x] }
   optimized_logical_plan: |
-    LogicalProject { exprs: [1:Int32], expr_alias: [ ] }
+    LogicalProject { exprs: [1:Int32] }
       LogicalJoin { type: LeftSemi, on: true }
         LogicalValues { rows: [[]], schema: Schema { fields: [] } }
         LogicalScan { table: t, columns: [] }
@@ -69,13 +69,13 @@
     create table t(x int);
     select 1 where not exists (select * from t);
   logical_plan: |
-    LogicalProject { exprs: [1:Int32], expr_alias: [ ] }
+    LogicalProject { exprs: [1:Int32] }
       LogicalJoin { type: LeftAnti, on: true }
         LogicalValues { rows: [[]], schema: Schema { fields: [] } }
-        LogicalProject { exprs: [$1], expr_alias: [x] }
+        LogicalProject { exprs: [$1] }
           LogicalScan { table: t, columns: [_row_id#0, x] }
   optimized_logical_plan: |
-    LogicalProject { exprs: [1:Int32], expr_alias: [ ] }
+    LogicalProject { exprs: [1:Int32] }
       LogicalJoin { type: LeftAnti, on: true }
         LogicalValues { rows: [[]], schema: Schema { fields: [] } }
         LogicalScan { table: t, columns: [] }
@@ -84,35 +84,35 @@
     create table t2(x int);
     select x from t1 where exists (select x from t2);
   logical_plan: |
-    LogicalProject { exprs: [$1], expr_alias: [x] }
+    LogicalProject { exprs: [$1] }
       LogicalJoin { type: LeftSemi, on: true }
         LogicalScan { table: t1, columns: [_row_id#0, x] }
-        LogicalProject { exprs: [$1], expr_alias: [x] }
+        LogicalProject { exprs: [$1] }
           LogicalScan { table: t2, columns: [_row_id#0, x] }
 - sql: |
     create table t(x int);
     select x from t where exists (select * from t);
   logical_plan: |
-    LogicalProject { exprs: [$1], expr_alias: [x] }
+    LogicalProject { exprs: [$1] }
       LogicalJoin { type: LeftSemi, on: true }
         LogicalScan { table: t, columns: [_row_id#0, x] }
-        LogicalProject { exprs: [$1], expr_alias: [x] }
+        LogicalProject { exprs: [$1] }
           LogicalScan { table: t, columns: [_row_id#0, x] }
 - sql: |
     create table t1(x int);
     create table t2(x int);
     select x from t1 where x > (select x from t2)
   logical_plan: |
-    LogicalProject { exprs: [$1], expr_alias: [x] }
+    LogicalProject { exprs: [$1] }
       LogicalFilter { predicate: ($1 > $2) }
         LogicalJoin { type: LeftOuter, on: true }
           LogicalScan { table: t1, columns: [_row_id#0, x] }
-          LogicalProject { exprs: [$1], expr_alias: [x] }
+          LogicalProject { exprs: [$1] }
             LogicalScan { table: t2, columns: [_row_id#0, x] }
 - sql: |
     select 1 where 1>0 and exists (values (1))
   logical_plan: |
-    LogicalProject { exprs: [1:Int32], expr_alias: [ ] }
+    LogicalProject { exprs: [1:Int32] }
       LogicalFilter { predicate: (1:Int32 > 0:Int32) }
         LogicalJoin { type: LeftSemi, on: true }
           LogicalValues { rows: [[]], schema: Schema { fields: [] } }
@@ -120,13 +120,13 @@
 - sql: |
     select 1 where (not exists (values (1))) and (1>0 or exists (values (1)))
   logical_plan: |
-    LogicalProject { exprs: [1:Int32], expr_alias: [ ] }
+    LogicalProject { exprs: [1:Int32] }
       LogicalFilter { predicate: ((1:Int32 > 0:Int32) OR $0) }
         LogicalJoin { type: LeftOuter, on: true }
           LogicalJoin { type: LeftAnti, on: true }
             LogicalValues { rows: [[]], schema: Schema { fields: [] } }
             LogicalValues { rows: [[1:Int32]], schema: Schema { fields: [:Int32] } }
-          LogicalProject { exprs: [($0 >= 1:Int32)], expr_alias: [ ] }
+          LogicalProject { exprs: [($0 >= 1:Int32)] }
             LogicalAgg { group_keys: [], agg_calls: [count] }
               LogicalValues { rows: [[1:Int32]], schema: Schema { fields: [:Int32] } }
 - sql: |
@@ -137,18 +137,18 @@
     create table t2(x int, y int);
     select x from t1 where y in (select y from t2);
   logical_plan: |
-    LogicalProject { exprs: [$1], expr_alias: [x] }
+    LogicalProject { exprs: [$1] }
       LogicalJoin { type: LeftSemi, on: ($2 = $3) }
         LogicalScan { table: t1, columns: [_row_id#0, x, y] }
-        LogicalProject { exprs: [$2], expr_alias: [y] }
+        LogicalProject { exprs: [$2] }
           LogicalScan { table: t2, columns: [_row_id#0, x, y] }
 - sql: |
     create table t1(x int, y int);
     create table t2(x int, y int);
     select x from t1 where y not in (select y from t2);
   logical_plan: |
-    LogicalProject { exprs: [$1], expr_alias: [x] }
+    LogicalProject { exprs: [$1] }
       LogicalJoin { type: LeftAnti, on: ($2 = $3) }
         LogicalScan { table: t1, columns: [_row_id#0, x, y] }
-        LogicalProject { exprs: [$2], expr_alias: [y] }
+        LogicalProject { exprs: [$2] }
           LogicalScan { table: t2, columns: [_row_id#0, x, y] }

--- a/src/frontend/test_runner/tests/testdata/subquery_expr_correlated.yaml
+++ b/src/frontend/test_runner/tests/testdata/subquery_expr_correlated.yaml
@@ -3,21 +3,21 @@
     create table t2(x int, y int);
     select * from t1 where x > (select 1.5 * min(x) from t2 where t1.y=t2.y and t2.y = 1000)
   logical_plan: |
-    LogicalProject { exprs: [$1, $2], expr_alias: [x, y] }
+    LogicalProject { exprs: [$1, $2] }
       LogicalFilter { predicate: ($1 > $3) }
         LogicalApply { type: LeftOuter, on: true }
           LogicalScan { table: t1, columns: [_row_id#0, x, y] }
-          LogicalProject { exprs: [(1.5:Decimal * $0)], expr_alias: [ ] }
+          LogicalProject { exprs: [(1.5:Decimal * $0)] }
             LogicalAgg { group_keys: [], agg_calls: [min($0)] }
-              LogicalProject { exprs: [$1], expr_alias: [ ] }
+              LogicalProject { exprs: [$1] }
                 LogicalFilter { predicate: (CorrelatedInputRef { index: 2, depth: 1 } = $2) AND ($2 = 1000:Int32) }
                   LogicalScan { table: t2, columns: [_row_id#0, x, y] }
   optimized_logical_plan: |
-    LogicalProject { exprs: [$0, $1], expr_alias: [x, y] }
+    LogicalProject { exprs: [$0, $1] }
       LogicalFilter { predicate: ($0 > (1.5:Decimal * $2)) }
-        LogicalProject { exprs: [$1, $2, $3], expr_alias: [ ,  ,  ] }
+        LogicalProject { exprs: [$1, $2, $3] }
           LogicalAgg { group_keys: [0, 1, 2], agg_calls: [min($3)] }
-            LogicalProject { exprs: [$0, $1, $2, $3], expr_alias: [ ,  ,  ,  ] }
+            LogicalProject { exprs: [$0, $1, $2, $3] }
               LogicalJoin { type: LeftOuter, on: ($2 = $4) }
                 LogicalScan { table: t1, columns: [_row_id#0, x, y] }
                 LogicalFilter { predicate: ($1 = 1000:Int32) }
@@ -27,17 +27,17 @@
     create table t2(x int, y int);
     select * from t1 where x>(select min(x) from t2 where t2.y = (select t1.y))
   logical_plan: |
-    LogicalProject { exprs: [$1, $2], expr_alias: [x, y] }
+    LogicalProject { exprs: [$1, $2] }
       LogicalFilter { predicate: ($1 > $3) }
         LogicalApply { type: LeftOuter, on: true }
           LogicalScan { table: t1, columns: [_row_id#0, x, y] }
-          LogicalProject { exprs: [$0], expr_alias: [ ] }
+          LogicalProject { exprs: [$0] }
             LogicalAgg { group_keys: [], agg_calls: [min($0)] }
-              LogicalProject { exprs: [$1], expr_alias: [ ] }
+              LogicalProject { exprs: [$1] }
                 LogicalFilter { predicate: ($2 = $3) }
                   LogicalApply { type: LeftOuter, on: true }
                     LogicalScan { table: t2, columns: [_row_id#0, x, y] }
-                    LogicalProject { exprs: [CorrelatedInputRef { index: 2, depth: 2 }], expr_alias: [y] }
+                    LogicalProject { exprs: [CorrelatedInputRef { index: 2, depth: 2 }] }
                       LogicalValues { rows: [[]], schema: Schema { fields: [] } }
 - sql: |
     create table t1(x int, y int);
@@ -45,33 +45,33 @@
     create table t3(x int, y int);
     select * from t1 where x>(select min(x) from t2 where t1.y=t2.y and t1.x=(select max(x) from t3, (select 1) as dummy where t3.y=t1.y))
   logical_plan: |
-    LogicalProject { exprs: [$1, $2], expr_alias: [x, y] }
+    LogicalProject { exprs: [$1, $2] }
       LogicalFilter { predicate: ($1 > $3) }
         LogicalApply { type: LeftOuter, on: true }
           LogicalScan { table: t1, columns: [_row_id#0, x, y] }
-          LogicalProject { exprs: [$0], expr_alias: [ ] }
+          LogicalProject { exprs: [$0] }
             LogicalAgg { group_keys: [], agg_calls: [min($0)] }
-              LogicalProject { exprs: [$1], expr_alias: [ ] }
+              LogicalProject { exprs: [$1] }
                 LogicalFilter { predicate: (CorrelatedInputRef { index: 2, depth: 1 } = $2) AND (CorrelatedInputRef { index: 1, depth: 1 } = $3) }
                   LogicalApply { type: LeftOuter, on: true }
                     LogicalScan { table: t2, columns: [_row_id#0, x, y] }
-                    LogicalProject { exprs: [$0], expr_alias: [ ] }
+                    LogicalProject { exprs: [$0] }
                       LogicalAgg { group_keys: [], agg_calls: [max($0)] }
-                        LogicalProject { exprs: [$1], expr_alias: [ ] }
+                        LogicalProject { exprs: [$1] }
                           LogicalFilter { predicate: ($2 = CorrelatedInputRef { index: 2, depth: 2 }) }
                             LogicalJoin { type: Inner, on: true }
                               LogicalScan { table: t3, columns: [_row_id#0, x, y] }
-                              LogicalProject { exprs: [1:Int32], expr_alias: [ ] }
+                              LogicalProject { exprs: [1:Int32] }
                                 LogicalValues { rows: [[]], schema: Schema { fields: [] } }
 - sql: |
     create table t1(x int, y int);
     create table t2(x int, y int);
     select * from t1 where exists(select * from t2 where y = 100 and t1.x = t2.x and x = 1000 and t1.y = t2.y);
   logical_plan: |
-    LogicalProject { exprs: [$1, $2], expr_alias: [x, y] }
+    LogicalProject { exprs: [$1, $2] }
       LogicalApply { type: LeftSemi, on: true }
         LogicalScan { table: t1, columns: [_row_id#0, x, y] }
-        LogicalProject { exprs: [$1, $2], expr_alias: [x, y] }
+        LogicalProject { exprs: [$1, $2] }
           LogicalFilter { predicate: ($2 = 100:Int32) AND (CorrelatedInputRef { index: 1, depth: 1 } = $1) AND ($1 = 1000:Int32) AND (CorrelatedInputRef { index: 2, depth: 1 } = $2) }
             LogicalScan { table: t2, columns: [_row_id#0, x, y] }
   optimized_logical_plan: |
@@ -84,21 +84,21 @@
     create table t2(x int, y int);
     select * from t1 where x > (select 1.5 * min(x) from t2 where t1.y = t2.y);
   logical_plan: |
-    LogicalProject { exprs: [$1, $2], expr_alias: [x, y] }
+    LogicalProject { exprs: [$1, $2] }
       LogicalFilter { predicate: ($1 > $3) }
         LogicalApply { type: LeftOuter, on: true }
           LogicalScan { table: t1, columns: [_row_id#0, x, y] }
-          LogicalProject { exprs: [(1.5:Decimal * $0)], expr_alias: [ ] }
+          LogicalProject { exprs: [(1.5:Decimal * $0)] }
             LogicalAgg { group_keys: [], agg_calls: [min($0)] }
-              LogicalProject { exprs: [$1], expr_alias: [ ] }
+              LogicalProject { exprs: [$1] }
                 LogicalFilter { predicate: (CorrelatedInputRef { index: 2, depth: 1 } = $2) }
                   LogicalScan { table: t2, columns: [_row_id#0, x, y] }
   optimized_logical_plan: |
-    LogicalProject { exprs: [$0, $1], expr_alias: [x, y] }
+    LogicalProject { exprs: [$0, $1] }
       LogicalFilter { predicate: ($0 > (1.5:Decimal * $2)) }
-        LogicalProject { exprs: [$1, $2, $3], expr_alias: [ ,  ,  ] }
+        LogicalProject { exprs: [$1, $2, $3] }
           LogicalAgg { group_keys: [0, 1, 2], agg_calls: [min($3)] }
-            LogicalProject { exprs: [$0, $1, $2, $3], expr_alias: [ ,  ,  ,  ] }
+            LogicalProject { exprs: [$0, $1, $2, $3] }
               LogicalJoin { type: LeftOuter, on: ($2 = $4) }
                 LogicalScan { table: t1, columns: [_row_id#0, x, y] }
                 LogicalScan { table: t2, columns: [x, y] }
@@ -107,65 +107,65 @@
     create table t2(x int, y int);
     select * from t1 where x > (select count(*) from t2 where t1.y = t2.y);
   logical_plan: |
-    LogicalProject { exprs: [$1, $2], expr_alias: [x, y] }
+    LogicalProject { exprs: [$1, $2] }
       LogicalFilter { predicate: ($1 > $3) }
         LogicalApply { type: LeftOuter, on: true }
           LogicalScan { table: t1, columns: [_row_id#0, x, y] }
-          LogicalProject { exprs: [$0], expr_alias: [ ] }
+          LogicalProject { exprs: [$0] }
             LogicalAgg { group_keys: [], agg_calls: [count] }
-              LogicalProject { exprs: [], expr_alias: [] }
+              LogicalProject { exprs: [] }
                 LogicalFilter { predicate: (CorrelatedInputRef { index: 2, depth: 1 } = $2) }
                   LogicalScan { table: t2, columns: [_row_id#0, x, y] }
   optimized_logical_plan: |
-    LogicalProject { exprs: [$0, $1], expr_alias: [x, y] }
+    LogicalProject { exprs: [$0, $1] }
       LogicalFilter { predicate: ($0 > $2) }
-        LogicalProject { exprs: [$1, $2, $3], expr_alias: [ ,  ,  ] }
+        LogicalProject { exprs: [$1, $2, $3] }
           LogicalAgg { group_keys: [0, 1, 2], agg_calls: [count($3)] }
-            LogicalProject { exprs: [$0, $1, $2, $3], expr_alias: [ ,  ,  ,  ] }
+            LogicalProject { exprs: [$0, $1, $2, $3] }
               LogicalJoin { type: LeftOuter, on: ($2 = $4) }
                 LogicalScan { table: t1, columns: [_row_id#0, x, y] }
-                LogicalProject { exprs: [1:Int32, $0], expr_alias: [1,  ] }
+                LogicalProject { exprs: [1:Int32, $0] }
                   LogicalScan { table: t2, columns: [y] }
 - sql: |
     create table t1(x int, y int);
     create table t2(x int, y int);
     select * from t1 where x > (select count(*) + count(*) from t2 where t1.y = t2.y);
   logical_plan: |
-    LogicalProject { exprs: [$1, $2], expr_alias: [x, y] }
+    LogicalProject { exprs: [$1, $2] }
       LogicalFilter { predicate: ($1 > $3) }
         LogicalApply { type: LeftOuter, on: true }
           LogicalScan { table: t1, columns: [_row_id#0, x, y] }
-          LogicalProject { exprs: [($0 + $1)], expr_alias: [ ] }
+          LogicalProject { exprs: [($0 + $1)] }
             LogicalAgg { group_keys: [], agg_calls: [count, count] }
-              LogicalProject { exprs: [], expr_alias: [] }
+              LogicalProject { exprs: [] }
                 LogicalFilter { predicate: (CorrelatedInputRef { index: 2, depth: 1 } = $2) }
                   LogicalScan { table: t2, columns: [_row_id#0, x, y] }
   optimized_logical_plan: |
-    LogicalProject { exprs: [$0, $1], expr_alias: [x, y] }
+    LogicalProject { exprs: [$0, $1] }
       LogicalFilter { predicate: ($0 > ($2 + $3)) }
-        LogicalProject { exprs: [$1, $2, $3, $4], expr_alias: [ ,  ,  ,  ] }
+        LogicalProject { exprs: [$1, $2, $3, $4] }
           LogicalAgg { group_keys: [0, 1, 2], agg_calls: [count($3), count($3)] }
-            LogicalProject { exprs: [$0, $1, $2, $3], expr_alias: [ ,  ,  ,  ] }
+            LogicalProject { exprs: [$0, $1, $2, $3] }
               LogicalJoin { type: LeftOuter, on: ($2 = $4) }
                 LogicalScan { table: t1, columns: [_row_id#0, x, y] }
-                LogicalProject { exprs: [1:Int32, $0], expr_alias: [1,  ] }
+                LogicalProject { exprs: [1:Int32, $0] }
                   LogicalScan { table: t2, columns: [y] }
 - sql: |
     create table t1(x int, y int);
     create table t2(x int, y int);
     select x from t1 where y in (select y from t2 where t1.x = t2.x);
   logical_plan: |
-    LogicalProject { exprs: [$1], expr_alias: [x] }
+    LogicalProject { exprs: [$1] }
       LogicalApply { type: LeftSemi, on: ($2 = $3) }
         LogicalScan { table: t1, columns: [_row_id#0, x, y] }
-        LogicalProject { exprs: [$2], expr_alias: [y] }
+        LogicalProject { exprs: [$2] }
           LogicalFilter { predicate: (CorrelatedInputRef { index: 1, depth: 1 } = $1) }
             LogicalScan { table: t2, columns: [_row_id#0, x, y] }
   optimized_logical_plan: |
-    LogicalProject { exprs: [$0], expr_alias: [x] }
+    LogicalProject { exprs: [$0] }
       LogicalJoin { type: LeftSemi, on: ($1 = $2) AND ($0 = $3) }
         LogicalScan { table: t1, columns: [x, y] }
-        LogicalProject { exprs: [$1, $0], expr_alias: [y,  ] }
+        LogicalProject { exprs: [$1, $0] }
           LogicalScan { table: t2, columns: [x, y] }
 - sql: |
     create table t1(x int, y int);
@@ -176,34 +176,34 @@
     create table t2(x int, y int);
     select x from t1 where y in (select y from t2 where t1.x + t2.x = 100 and t1.y = 1000);
   logical_plan: |
-    LogicalProject { exprs: [$1], expr_alias: [x] }
+    LogicalProject { exprs: [$1] }
       LogicalApply { type: LeftSemi, on: ($2 = $3) }
         LogicalScan { table: t1, columns: [_row_id#0, x, y] }
-        LogicalProject { exprs: [$2], expr_alias: [y] }
+        LogicalProject { exprs: [$2] }
           LogicalFilter { predicate: ((CorrelatedInputRef { index: 1, depth: 1 } + $1) = 100:Int32) AND (CorrelatedInputRef { index: 2, depth: 1 } = 1000:Int32) }
             LogicalScan { table: t2, columns: [_row_id#0, x, y] }
   optimized_logical_plan: |
-    LogicalProject { exprs: [$0], expr_alias: [x] }
+    LogicalProject { exprs: [$0] }
       LogicalJoin { type: LeftSemi, on: ($1 = $2) AND (($0 + $3) = 100:Int32) AND ($1 = 1000:Int32) }
         LogicalScan { table: t1, columns: [x, y] }
-        LogicalProject { exprs: [$1, $0], expr_alias: [y,  ] }
+        LogicalProject { exprs: [$1, $0] }
           LogicalScan { table: t2, columns: [x, y] }
 - sql: |
     create table t1(x int, y int);
     create table t2(x int, y int);
     select x from t1 where y in (select y from t2 where t1.x > t2.x + 1000);
   logical_plan: |
-    LogicalProject { exprs: [$1], expr_alias: [x] }
+    LogicalProject { exprs: [$1] }
       LogicalApply { type: LeftSemi, on: ($2 = $3) }
         LogicalScan { table: t1, columns: [_row_id#0, x, y] }
-        LogicalProject { exprs: [$2], expr_alias: [y] }
+        LogicalProject { exprs: [$2] }
           LogicalFilter { predicate: (CorrelatedInputRef { index: 1, depth: 1 } > ($1 + 1000:Int32)) }
             LogicalScan { table: t2, columns: [_row_id#0, x, y] }
   optimized_logical_plan: |
-    LogicalProject { exprs: [$0], expr_alias: [x] }
+    LogicalProject { exprs: [$0] }
       LogicalJoin { type: LeftSemi, on: ($1 = $2) AND ($0 > ($3 + 1000:Int32)) }
         LogicalScan { table: t1, columns: [x, y] }
-        LogicalProject { exprs: [$1, $0], expr_alias: [y,  ] }
+        LogicalProject { exprs: [$1, $0] }
           LogicalScan { table: t2, columns: [x, y] }
 - sql: |
     create table t1(x int, y int);
@@ -217,16 +217,16 @@
     create table t3(x int, y int);
     select x from t1 where y in (select x from t2 where t2.y = t1.y and x > (select min(x) from t3));
   logical_plan: |
-    LogicalProject { exprs: [$1], expr_alias: [x] }
+    LogicalProject { exprs: [$1] }
       LogicalApply { type: LeftSemi, on: ($2 = $3) }
         LogicalScan { table: t1, columns: [_row_id#0, x, y] }
-        LogicalProject { exprs: [$1], expr_alias: [x] }
+        LogicalProject { exprs: [$1] }
           LogicalFilter { predicate: ($2 = CorrelatedInputRef { index: 2, depth: 1 }) AND ($1 > $3) }
             LogicalJoin { type: LeftOuter, on: true }
               LogicalScan { table: t2, columns: [_row_id#0, x, y] }
-              LogicalProject { exprs: [$0], expr_alias: [ ] }
+              LogicalProject { exprs: [$0] }
                 LogicalAgg { group_keys: [], agg_calls: [min($0)] }
-                  LogicalProject { exprs: [$1], expr_alias: [ ] }
+                  LogicalProject { exprs: [$1] }
                     LogicalScan { table: t3, columns: [_row_id#0, x, y] }
 - sql: |
     /* correlated inner subquery with depth = 2 */
@@ -235,13 +235,13 @@
     create table t3(x int, y int);
     select x from t1 where y in (select x from t2 where y in (select y from t3 where t1.y = t3.y));
   logical_plan: |
-    LogicalProject { exprs: [$1], expr_alias: [x] }
+    LogicalProject { exprs: [$1] }
       LogicalApply { type: LeftSemi, on: ($2 = $3) }
         LogicalScan { table: t1, columns: [_row_id#0, x, y] }
-        LogicalProject { exprs: [$1], expr_alias: [x] }
+        LogicalProject { exprs: [$1] }
           LogicalApply { type: LeftSemi, on: ($2 = $3) }
             LogicalScan { table: t2, columns: [_row_id#0, x, y] }
-            LogicalProject { exprs: [$2], expr_alias: [y] }
+            LogicalProject { exprs: [$2] }
               LogicalFilter { predicate: (CorrelatedInputRef { index: 2, depth: 2 } = $2) }
                 LogicalScan { table: t3, columns: [_row_id#0, x, y] }
 - sql: |
@@ -251,13 +251,13 @@
     create table t3(x int, y int);
     select x from t1 where y in (select x from t2 where y in (select y from t3 where t2.y = t3.y));
   logical_plan: |
-    LogicalProject { exprs: [$1], expr_alias: [x] }
+    LogicalProject { exprs: [$1] }
       LogicalJoin { type: LeftSemi, on: ($2 = $3) }
         LogicalScan { table: t1, columns: [_row_id#0, x, y] }
-        LogicalProject { exprs: [$1], expr_alias: [x] }
+        LogicalProject { exprs: [$1] }
           LogicalApply { type: LeftSemi, on: ($2 = $3) }
             LogicalScan { table: t2, columns: [_row_id#0, x, y] }
-            LogicalProject { exprs: [$2], expr_alias: [y] }
+            LogicalProject { exprs: [$2] }
               LogicalFilter { predicate: (CorrelatedInputRef { index: 2, depth: 1 } = $2) }
                 LogicalScan { table: t3, columns: [_row_id#0, x, y] }
 - sql: |

--- a/src/frontend/test_runner/tests/testdata/time_window.yaml
+++ b/src/frontend/test_runner/tests/testdata/time_window.yaml
@@ -2,12 +2,12 @@
     create table t1 (id int, created_at date);
     select * from tumble(t1, created_at, interval '3' day);
   logical_plan: |
-    LogicalProject { exprs: [$1, $2, $3, $4], expr_alias: [id, created_at, window_start, window_end] }
-      LogicalProject { exprs: [$0, $1, $2, TumbleStart($2, '3 days 00:00:00':Interval), (TumbleStart($2, '3 days 00:00:00':Interval) + '3 days 00:00:00':Interval)], expr_alias: [ ,  ,  , window_start, window_end] }
+    LogicalProject { exprs: [$1, $2, $3, $4] }
+      LogicalProject { exprs: [$0, $1, $2, TumbleStart($2, '3 days 00:00:00':Interval), (TumbleStart($2, '3 days 00:00:00':Interval) + '3 days 00:00:00':Interval)] }
         LogicalScan { table: t1, columns: [_row_id#0, id, created_at] }
   batch_plan: |
     BatchExchange { order: [], dist: Single }
-      BatchProject { exprs: [$0, $1, TumbleStart($1, '3 days 00:00:00':Interval), (TumbleStart($1, '3 days 00:00:00':Interval) + '3 days 00:00:00':Interval)], expr_alias: [id, created_at, window_start, window_end] }
+      BatchProject { exprs: [$0, $1, TumbleStart($1, '3 days 00:00:00':Interval), (TumbleStart($1, '3 days 00:00:00':Interval) + '3 days 00:00:00':Interval)] }
         BatchScan { table: t1, columns: [id, created_at] }
 - sql: |
     create materialized view t as select * from s;
@@ -39,7 +39,7 @@
     create table t1 (id int, created_at date);
     select * from hop(t1, created_at, interval '1' day, interval '3' day);
   logical_plan: |
-    LogicalProject { exprs: [$1, $2, $3, $4], expr_alias: [id, created_at, window_start, window_end] }
+    LogicalProject { exprs: [$1, $2, $3, $4] }
       LogicalHopWindow { time_col: $2 slide: 1 day 00:00:00 size: 3 days 00:00:00 }
         LogicalScan { table: t1, columns: [_row_id#0, id, created_at] }
   stream_plan: |
@@ -50,40 +50,40 @@
     create table t1 (id int, created_at date);
     select id, created_at, window_start from hop(t1, created_at, interval '1' day, interval '3' day);
   logical_plan: |
-    LogicalProject { exprs: [$1, $2, $3], expr_alias: [id, created_at, window_start] }
+    LogicalProject { exprs: [$1, $2, $3] }
       LogicalHopWindow { time_col: $2 slide: 1 day 00:00:00 size: 3 days 00:00:00 }
         LogicalScan { table: t1, columns: [_row_id#0, id, created_at] }
   stream_plan: |
     StreamMaterialize { columns: [id, created_at, window_start, _row_id#0(hidden)], pk_columns: [_row_id#0, window_start] }
-      StreamProject { exprs: [$0, $1, $3, $2], expr_alias: [id, created_at, window_start,  ] }
+      StreamProject { exprs: [$0, $1, $3, $2] }
         StreamHopWindow { time_col: $1 slide: 1 day 00:00:00 size: 3 days 00:00:00 }
           StreamTableScan { table: t1, columns: [id, created_at, _row_id#0], pk_indices: [2] }
 - sql: |
     create table t1 (id int, created_at date);
     select id, created_at, window_end from hop(t1, created_at, interval '1' day, interval '3' day);
   logical_plan: |
-    LogicalProject { exprs: [$1, $2, $4], expr_alias: [id, created_at, window_end] }
+    LogicalProject { exprs: [$1, $2, $4] }
       LogicalHopWindow { time_col: $2 slide: 1 day 00:00:00 size: 3 days 00:00:00 }
         LogicalScan { table: t1, columns: [_row_id#0, id, created_at] }
   stream_plan: |
     StreamMaterialize { columns: [id, created_at, window_end, _row_id#0(hidden), window_start(hidden)], pk_columns: [_row_id#0, window_start] }
-      StreamProject { exprs: [$0, $1, $4, $2, $3], expr_alias: [id, created_at, window_end,  ,  ] }
+      StreamProject { exprs: [$0, $1, $4, $2, $3] }
         StreamHopWindow { time_col: $1 slide: 1 day 00:00:00 size: 3 days 00:00:00 }
           StreamTableScan { table: t1, columns: [id, created_at, _row_id#0], pk_indices: [2] }
 - sql: |
     create table t1 (id int, created_at date);
     select id, created_at from hop(t1, created_at, interval '1' day, interval '3' day);
   logical_plan: |
-    LogicalProject { exprs: [$1, $2], expr_alias: [id, created_at] }
+    LogicalProject { exprs: [$1, $2] }
       LogicalHopWindow { time_col: $2 slide: 1 day 00:00:00 size: 3 days 00:00:00 }
         LogicalScan { table: t1, columns: [_row_id#0, id, created_at] }
   batch_plan: |
     BatchExchange { order: [], dist: Single }
-      BatchProject { exprs: [$0, $1], expr_alias: [id, created_at] }
+      BatchProject { exprs: [$0, $1] }
         BatchHopWindow { time_col: $1 slide: 1 day 00:00:00 size: 3 days 00:00:00 }
           BatchScan { table: t1, columns: [id, created_at] }
   stream_plan: |
     StreamMaterialize { columns: [id, created_at, _row_id#0(hidden), window_start(hidden)], pk_columns: [_row_id#0, window_start] }
-      StreamProject { exprs: [$0, $1, $2, $3], expr_alias: [id, created_at,  ,  ] }
+      StreamProject { exprs: [$0, $1, $2, $3] }
         StreamHopWindow { time_col: $1 slide: 1 day 00:00:00 size: 3 days 00:00:00 }
           StreamTableScan { table: t1, columns: [id, created_at, _row_id#0], pk_indices: [2] }

--- a/src/frontend/test_runner/tests/testdata/tpch.yaml
+++ b/src/frontend/test_runner/tests/testdata/tpch.yaml
@@ -104,17 +104,17 @@
   batch_plan: |
     BatchExchange { order: [$0 ASC, $1 ASC], dist: Single }
       BatchSort { order: [$0 ASC, $1 ASC] }
-        BatchProject { exprs: [$0, $1, $2, $3, $4, $5, RoundDigit(($6 / $7), 4:Int32), RoundDigit(($8 / $9), 4:Int32), RoundDigit(($10 / $11), 4:Int32), $12], expr_alias: [l_returnflag, l_linestatus, sum_qty, sum_base_price, sum_disc_price, sum_charge, avg_qty, avg_price, avg_disc, count_order] }
+        BatchProject { exprs: [$0, $1, $2, $3, $4, $5, RoundDigit(($6 / $7), 4:Int32), RoundDigit(($8 / $9), 4:Int32), RoundDigit(($10 / $11), 4:Int32), $12] }
           BatchHashAgg { group_keys: [$0, $1], aggs: [sum($2), sum($3), sum($4), sum($5), sum($2), count($2), sum($3), count($3), sum($6), count($6), count] }
-            BatchProject { exprs: [$4, $5, $0, $1, ($1 * (1:Int32 - $2)), (($1 * (1:Int32 - $2)) * (1:Int32 + $3)), $2], expr_alias: [ ,  ,  ,  ,  ,  ,  ] }
+            BatchProject { exprs: [$4, $5, $0, $1, ($1 * (1:Int32 - $2)), (($1 * (1:Int32 - $2)) * (1:Int32 + $3)), $2] }
               BatchExchange { order: [], dist: HashShard([4, 5]) }
                 BatchFilter { predicate: ($6 <= ('1998-12-01':Varchar::Date - '71 days 00:00:00':Interval)) }
                   BatchScan { table: lineitem, columns: [l_quantity, l_extendedprice, l_discount, l_tax, l_returnflag, l_linestatus, l_shipdate] }
   stream_plan: |
     StreamMaterialize { columns: [l_returnflag, l_linestatus, sum_qty, sum_base_price, sum_disc_price, sum_charge, avg_qty, avg_price, avg_disc, count_order], pk_columns: [l_returnflag, l_linestatus] }
-      StreamProject { exprs: [$0, $1, $3, $4, $5, $6, RoundDigit(($7 / $8), 4:Int32), RoundDigit(($9 / $10), 4:Int32), RoundDigit(($11 / $12), 4:Int32), $13], expr_alias: [l_returnflag, l_linestatus, sum_qty, sum_base_price, sum_disc_price, sum_charge, avg_qty, avg_price, avg_disc, count_order] }
+      StreamProject { exprs: [$0, $1, $3, $4, $5, $6, RoundDigit(($7 / $8), 4:Int32), RoundDigit(($9 / $10), 4:Int32), RoundDigit(($11 / $12), 4:Int32), $13] }
         StreamHashAgg { group_keys: [$0, $1], aggs: [count, sum($2), sum($3), sum($4), sum($5), sum($2), count($2), sum($3), count($3), sum($6), count($6), count] }
-          StreamProject { exprs: [$4, $5, $0, $1, ($1 * (1:Int32 - $2)), (($1 * (1:Int32 - $2)) * (1:Int32 + $3)), $2, $7], expr_alias: [ ,  ,  ,  ,  ,  ,  ,  ] }
+          StreamProject { exprs: [$4, $5, $0, $1, ($1 * (1:Int32 - $2)), (($1 * (1:Int32 - $2)) * (1:Int32 + $3)), $2, $7] }
             StreamExchange { dist: HashShard([4, 5]) }
               StreamFilter { predicate: ($6 <= ('1998-12-01':Varchar::Date - '71 days 00:00:00':Interval)) }
                 StreamTableScan { table: lineitem, columns: [l_quantity, l_extendedprice, l_discount, l_tax, l_returnflag, l_linestatus, l_shipdate, _row_id#0], pk_indices: [7] }
@@ -171,11 +171,11 @@
   batch_plan: |
     BatchTopN { order: [$0 DESC, $2 ASC, $1 ASC, $3 ASC], limit: 100, offset: 0 }
       BatchExchange { order: [], dist: Single }
-        BatchProject { exprs: [$6, $3, $8, $1, $2, $4, $5, $7], expr_alias: [s_acctbal, s_name, n_name, p_partkey, p_mfgr, s_address, s_phone, s_comment] }
+        BatchProject { exprs: [$6, $3, $8, $1, $2, $4, $5, $7] }
           BatchFilter { predicate: ($0 = $9) }
-            BatchProject { exprs: [$4, $7, $9, $18, $19, $21, $22, $23, $26, $33], expr_alias: [ ,  ,  ,  ,  ,  ,  ,  ,  ,  ] }
+            BatchProject { exprs: [$4, $7, $9, $18, $19, $21, $22, $23, $26, $33] }
               BatchHashAgg { group_keys: [$0, $1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16, $17, $18, $19, $20, $21, $22, $23, $24, $25, $26, $27, $28, $29, $30, $31, $32], aggs: [min($33)] }
-                BatchProject { exprs: [$0, $1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16, $17, $18, $19, $20, $21, $22, $23, $24, $25, $26, $27, $28, $29, $30, $31, $32, $33], expr_alias: [ ,  ,  ,  ,  ,  ,  ,  ,  ,  ,  ,  ,  ,  ,  ,  ,  ,  ,  ,  ,  ,  ,  ,  ,  ,  ,  ,  ,  ,  ,  ,  ,  ,  ] }
+                BatchProject { exprs: [$0, $1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16, $17, $18, $19, $20, $21, $22, $23, $24, $25, $26, $27, $28, $29, $30, $31, $32, $33] }
                   BatchHashJoin { type: LeftOuter, predicate: $7 = $34 }
                     BatchExchange { order: [], dist: HashShard([7]) }
                       BatchHashJoin { type: Inner, predicate: $27 = $30 }
@@ -197,13 +197,13 @@
                         BatchExchange { order: [], dist: HashShard([1]) }
                           BatchFilter { predicate: ($2 = 'AFRICA':Varchar) }
                             BatchScan { table: region, columns: [_row_id#0, r_regionkey, r_name, r_comment] }
-                    BatchProject { exprs: [$1, $0], expr_alias: [ ,  ] }
+                    BatchProject { exprs: [$1, $0] }
                       BatchExchange { order: [], dist: HashShard([0]) }
                         BatchHashJoin { type: Inner, predicate: $2 = $3 }
-                          BatchProject { exprs: [$0, $1, $4], expr_alias: [ ,  ,  ] }
+                          BatchProject { exprs: [$0, $1, $4] }
                             BatchExchange { order: [], dist: HashShard([4]) }
                               BatchHashJoin { type: Inner, predicate: $2 = $3 }
-                                BatchProject { exprs: [$0, $2, $4], expr_alias: [ ,  ,  ] }
+                                BatchProject { exprs: [$0, $2, $4] }
                                   BatchExchange { order: [], dist: HashShard([4]) }
                                     BatchHashJoin { type: Inner, predicate: $1 = $3 }
                                       BatchExchange { order: [], dist: HashShard([1]) }
@@ -212,7 +212,7 @@
                                         BatchScan { table: supplier, columns: [s_suppkey, s_nationkey] }
                                 BatchExchange { order: [], dist: HashShard([0]) }
                                   BatchScan { table: nation, columns: [n_nationkey, n_regionkey] }
-                          BatchProject { exprs: [$0], expr_alias: [ ] }
+                          BatchProject { exprs: [$0] }
                             BatchExchange { order: [], dist: HashShard([0]) }
                               BatchFilter { predicate: ($1 = 'AFRICA':Varchar) }
                                 BatchScan { table: region, columns: [r_regionkey, r_name] }
@@ -220,11 +220,11 @@
     StreamMaterialize { columns: [s_acctbal, s_name, n_name, p_partkey, p_mfgr, s_address, s_phone, s_comment, _row_id#0(hidden), ps_partkey(hidden), ps_suppkey(hidden), ps_availqty(hidden), ps_supplycost(hidden), ps_comment(hidden), _row_id#1(hidden), p_name(hidden), p_brand(hidden), p_type(hidden), p_size(hidden), p_container(hidden), p_retailprice(hidden), p_comment(hidden), _row_id#2(hidden), s_suppkey(hidden), s_nationkey(hidden), _row_id#3(hidden), n_nationkey(hidden), n_regionkey(hidden), n_comment(hidden), _row_id#4(hidden), r_regionkey(hidden), r_name(hidden), r_comment(hidden)], pk_columns: [_row_id#0, ps_partkey, ps_suppkey, ps_availqty, ps_supplycost, ps_comment, _row_id#1, p_partkey, p_name, p_mfgr, p_brand, p_type, p_size, p_container, p_retailprice, p_comment, _row_id#2, s_suppkey, s_name, s_address, s_nationkey, s_phone, s_acctbal, s_comment, _row_id#3, n_nationkey, n_name, n_regionkey, n_comment, _row_id#4, r_regionkey, r_name, r_comment], order_descs: [s_acctbal, n_name, s_name, p_partkey, _row_id#0, ps_partkey, ps_suppkey, ps_availqty, ps_supplycost, ps_comment, _row_id#1, p_name, p_mfgr, p_brand, p_type, p_size, p_container, p_retailprice, p_comment, _row_id#2, s_suppkey, s_address, s_nationkey, s_phone, s_comment, _row_id#3, n_nationkey, n_regionkey, n_comment, _row_id#4, r_regionkey, r_name, r_comment] }
       StreamTopN { order: [$0 DESC, $2 ASC, $1 ASC, $3 ASC], limit: 100, offset: 0 }
         StreamExchange { dist: Single }
-          StreamProject { exprs: [$6, $3, $8, $1, $2, $4, $5, $7, $10, $11, $12, $13, $0, $14, $15, $16, $17, $18, $19, $20, $21, $22, $23, $24, $25, $26, $27, $28, $29, $30, $31, $32, $33], expr_alias: [s_acctbal, s_name, n_name, p_partkey, p_mfgr, s_address, s_phone, s_comment,  ,  ,  ,  ,  ,  ,  ,  ,  ,  ,  ,  ,  ,  ,  ,  ,  ,  ,  ,  ,  ,  ,  ,  ,  ] }
+          StreamProject { exprs: [$6, $3, $8, $1, $2, $4, $5, $7, $10, $11, $12, $13, $0, $14, $15, $16, $17, $18, $19, $20, $21, $22, $23, $24, $25, $26, $27, $28, $29, $30, $31, $32, $33] }
             StreamFilter { predicate: ($0 = $9) }
-              StreamProject { exprs: [$4, $7, $9, $18, $19, $21, $22, $23, $26, $34, $0, $1, $2, $3, $5, $6, $8, $10, $11, $12, $13, $14, $15, $16, $17, $20, $24, $25, $27, $28, $29, $30, $31, $32], expr_alias: [ ,  ,  ,  ,  ,  ,  ,  ,  ,  ,  ,  ,  ,  ,  ,  ,  ,  ,  ,  ,  ,  ,  ,  ,  ,  ,  ,  ,  ,  ,  ,  ,  ,  ] }
+              StreamProject { exprs: [$4, $7, $9, $18, $19, $21, $22, $23, $26, $34, $0, $1, $2, $3, $5, $6, $8, $10, $11, $12, $13, $14, $15, $16, $17, $20, $24, $25, $27, $28, $29, $30, $31, $32] }
                 StreamHashAgg { group_keys: [$0, $1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16, $17, $18, $19, $20, $21, $22, $23, $24, $25, $26, $27, $28, $29, $30, $31, $32], aggs: [count, min($33)] }
-                  StreamProject { exprs: [$0, $1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16, $17, $18, $19, $20, $21, $22, $23, $24, $25, $26, $27, $28, $29, $30, $31, $32, $33, $35, $36, $37, $38], expr_alias: [ ,  ,  ,  ,  ,  ,  ,  ,  ,  ,  ,  ,  ,  ,  ,  ,  ,  ,  ,  ,  ,  ,  ,  ,  ,  ,  ,  ,  ,  ,  ,  ,  ,  ,  ,  ,  ,  ] }
+                  StreamProject { exprs: [$0, $1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16, $17, $18, $19, $20, $21, $22, $23, $24, $25, $26, $27, $28, $29, $30, $31, $32, $33, $35, $36, $37, $38] }
                     StreamHashJoin { type: LeftOuter, predicate: $7 = $34 }
                       StreamExchange { dist: HashShard([7]) }
                         StreamHashJoin { type: Inner, predicate: $27 = $30 }
@@ -246,13 +246,13 @@
                           StreamExchange { dist: HashShard([1]) }
                             StreamFilter { predicate: ($2 = 'AFRICA':Varchar) }
                               StreamTableScan { table: region, columns: [_row_id#0, r_regionkey, r_name, r_comment], pk_indices: [0] }
-                      StreamProject { exprs: [$1, $0, $3, $4, $5, $7], expr_alias: [ ,  ,  ,  ,  ,  ] }
+                      StreamProject { exprs: [$1, $0, $3, $4, $5, $7] }
                         StreamExchange { dist: HashShard([0]) }
                           StreamHashJoin { type: Inner, predicate: $2 = $6 }
-                            StreamProject { exprs: [$0, $1, $6, $3, $4, $7], expr_alias: [ ,  ,  ,  ,  ,  ] }
+                            StreamProject { exprs: [$0, $1, $6, $3, $4, $7] }
                               StreamExchange { dist: HashShard([6]) }
                                 StreamHashJoin { type: Inner, predicate: $2 = $5 }
-                                  StreamProject { exprs: [$0, $2, $5, $3, $6], expr_alias: [ ,  ,  ,  ,  ] }
+                                  StreamProject { exprs: [$0, $2, $5, $3, $6] }
                                     StreamExchange { dist: HashShard([5]) }
                                       StreamHashJoin { type: Inner, predicate: $1 = $4 }
                                         StreamExchange { dist: HashShard([1]) }
@@ -261,7 +261,7 @@
                                           StreamTableScan { table: supplier, columns: [s_suppkey, s_nationkey, _row_id#0], pk_indices: [2] }
                                   StreamExchange { dist: HashShard([0]) }
                                     StreamTableScan { table: nation, columns: [n_nationkey, n_regionkey, _row_id#0], pk_indices: [2] }
-                            StreamProject { exprs: [$0, $2], expr_alias: [ ,  ] }
+                            StreamProject { exprs: [$0, $2] }
                               StreamExchange { dist: HashShard([0]) }
                                 StreamFilter { predicate: ($1 = 'AFRICA':Varchar) }
                                   StreamTableScan { table: region, columns: [r_regionkey, r_name, _row_id#0], pk_indices: [2] }
@@ -295,22 +295,22 @@
   batch_plan: |
     BatchTopN { order: [$1 DESC, $2 ASC], limit: 10, offset: 0 }
       BatchExchange { order: [], dist: Single }
-        BatchProject { exprs: [$0, $3, $1, $2], expr_alias: [l_orderkey, revenue, o_orderdate, o_shippriority] }
+        BatchProject { exprs: [$0, $3, $1, $2] }
           BatchHashAgg { group_keys: [$0, $1, $2], aggs: [sum($3)] }
-            BatchProject { exprs: [$3, $1, $2, ($4 * (1:Int32 - $5))], expr_alias: [ ,  ,  ,  ] }
+            BatchProject { exprs: [$3, $1, $2, ($4 * (1:Int32 - $5))] }
               BatchExchange { order: [], dist: HashShard([3, 1, 2]) }
                 BatchHashJoin { type: Inner, predicate: $0 = $3 }
-                  BatchProject { exprs: [$1, $3, $4], expr_alias: [ ,  ,  ] }
+                  BatchProject { exprs: [$1, $3, $4] }
                     BatchExchange { order: [], dist: HashShard([1]) }
                       BatchHashJoin { type: Inner, predicate: $0 = $2 }
-                        BatchProject { exprs: [$0], expr_alias: [ ] }
+                        BatchProject { exprs: [$0] }
                           BatchExchange { order: [], dist: HashShard([0]) }
                             BatchFilter { predicate: ($1 = 'FURNITURE':Varchar) }
                               BatchScan { table: customer, columns: [c_custkey, c_mktsegment] }
                         BatchExchange { order: [], dist: HashShard([1]) }
                           BatchFilter { predicate: ($2 < '1995-03-29':Varchar::Date) }
                             BatchScan { table: orders, columns: [o_orderkey, o_custkey, o_orderdate, o_shippriority] }
-                  BatchProject { exprs: [$0, $1, $2], expr_alias: [ ,  ,  ] }
+                  BatchProject { exprs: [$0, $1, $2] }
                     BatchExchange { order: [], dist: HashShard([0]) }
                       BatchFilter { predicate: ($3 > '1995-03-29':Varchar::Date) }
                         BatchScan { table: lineitem, columns: [l_orderkey, l_extendedprice, l_discount, l_shipdate] }
@@ -318,22 +318,22 @@
     StreamMaterialize { columns: [l_orderkey, revenue, o_orderdate, o_shippriority], pk_columns: [l_orderkey, o_orderdate, o_shippriority], order_descs: [revenue, o_orderdate, l_orderkey, o_shippriority] }
       StreamTopN { order: [$1 DESC, $2 ASC], limit: 10, offset: 0 }
         StreamExchange { dist: Single }
-          StreamProject { exprs: [$0, $4, $1, $2], expr_alias: [l_orderkey, revenue, o_orderdate, o_shippriority] }
+          StreamProject { exprs: [$0, $4, $1, $2] }
             StreamHashAgg { group_keys: [$0, $1, $2], aggs: [count, sum($3)] }
-              StreamProject { exprs: [$5, $1, $2, ($6 * (1:Int32 - $7)), $3, $4, $8], expr_alias: [ ,  ,  ,  ,  ,  ,  ] }
+              StreamProject { exprs: [$5, $1, $2, ($6 * (1:Int32 - $7)), $3, $4, $8] }
                 StreamExchange { dist: HashShard([5, 1, 2]) }
                   StreamHashJoin { type: Inner, predicate: $0 = $5 }
-                    StreamProject { exprs: [$2, $4, $5, $1, $6], expr_alias: [ ,  ,  ,  ,  ] }
+                    StreamProject { exprs: [$2, $4, $5, $1, $6] }
                       StreamExchange { dist: HashShard([2]) }
                         StreamHashJoin { type: Inner, predicate: $0 = $3 }
-                          StreamProject { exprs: [$0, $2], expr_alias: [ ,  ] }
+                          StreamProject { exprs: [$0, $2] }
                             StreamExchange { dist: HashShard([0]) }
                               StreamFilter { predicate: ($1 = 'FURNITURE':Varchar) }
                                 StreamTableScan { table: customer, columns: [c_custkey, c_mktsegment, _row_id#0], pk_indices: [2] }
                           StreamExchange { dist: HashShard([1]) }
                             StreamFilter { predicate: ($2 < '1995-03-29':Varchar::Date) }
                               StreamTableScan { table: orders, columns: [o_orderkey, o_custkey, o_orderdate, o_shippriority, _row_id#0], pk_indices: [4] }
-                    StreamProject { exprs: [$0, $1, $2, $4], expr_alias: [ ,  ,  ,  ] }
+                    StreamProject { exprs: [$0, $1, $2, $4] }
                       StreamExchange { dist: HashShard([0]) }
                         StreamFilter { predicate: ($3 > '1995-03-29':Varchar::Date) }
                           StreamTableScan { table: lineitem, columns: [l_orderkey, l_extendedprice, l_discount, l_shipdate, _row_id#0], pk_indices: [4] }
@@ -365,34 +365,32 @@
   batch_plan: |
     BatchExchange { order: [$0 ASC], dist: Single }
       BatchSort { order: [$0 ASC] }
-        BatchProject { exprs: [$0, $1], expr_alias: [o_orderpriority, order_count] }
-          BatchHashAgg { group_keys: [$0], aggs: [count] }
-            BatchProject { exprs: [$1], expr_alias: [ ] }
-              BatchExchange { order: [], dist: HashShard([1]) }
-                BatchHashJoin { type: LeftSemi, predicate: $0 = $2 }
-                  BatchProject { exprs: [$0, $2], expr_alias: [ ,  ] }
-                    BatchExchange { order: [], dist: HashShard([0]) }
-                      BatchFilter { predicate: ($1 >= '1997-07-01':Varchar::Date) AND ($1 < ('1997-07-01':Varchar::Date + '3 mons 00:00:00':Interval)) }
-                        BatchScan { table: orders, columns: [o_orderkey, o_orderdate, o_orderpriority] }
-                  BatchProject { exprs: [$0], expr_alias: [ ] }
-                    BatchExchange { order: [], dist: HashShard([0]) }
-                      BatchFilter { predicate: ($1 < $2) }
-                        BatchScan { table: lineitem, columns: [l_orderkey, l_commitdate, l_receiptdate] }
+        BatchHashAgg { group_keys: [$0], aggs: [count] }
+          BatchProject { exprs: [$1] }
+            BatchExchange { order: [], dist: HashShard([1]) }
+              BatchHashJoin { type: LeftSemi, predicate: $0 = $2 }
+                BatchProject { exprs: [$0, $2] }
+                  BatchExchange { order: [], dist: HashShard([0]) }
+                    BatchFilter { predicate: ($1 >= '1997-07-01':Varchar::Date) AND ($1 < ('1997-07-01':Varchar::Date + '3 mons 00:00:00':Interval)) }
+                      BatchScan { table: orders, columns: [o_orderkey, o_orderdate, o_orderpriority] }
+                BatchProject { exprs: [$0] }
+                  BatchExchange { order: [], dist: HashShard([0]) }
+                    BatchFilter { predicate: ($1 < $2) }
+                      BatchScan { table: lineitem, columns: [l_orderkey, l_commitdate, l_receiptdate] }
   stream_plan: |
-    StreamMaterialize { columns: [o_orderpriority, order_count], pk_columns: [o_orderpriority] }
-      StreamProject { exprs: [$0, $2], expr_alias: [o_orderpriority, order_count] }
-        StreamHashAgg { group_keys: [$0], aggs: [count, count] }
-          StreamProject { exprs: [$1, $2], expr_alias: [ ,  ] }
-            StreamExchange { dist: HashShard([1]) }
-              StreamHashJoin { type: LeftSemi, predicate: $0 = $3 }
-                StreamProject { exprs: [$0, $2, $3], expr_alias: [ ,  ,  ] }
-                  StreamExchange { dist: HashShard([0]) }
-                    StreamFilter { predicate: ($1 >= '1997-07-01':Varchar::Date) AND ($1 < ('1997-07-01':Varchar::Date + '3 mons 00:00:00':Interval)) }
-                      StreamTableScan { table: orders, columns: [o_orderkey, o_orderdate, o_orderpriority, _row_id#0], pk_indices: [3] }
-                StreamProject { exprs: [$0, $3], expr_alias: [ ,  ] }
-                  StreamExchange { dist: HashShard([0]) }
-                    StreamFilter { predicate: ($1 < $2) }
-                      StreamTableScan { table: lineitem, columns: [l_orderkey, l_commitdate, l_receiptdate, _row_id#0], pk_indices: [3] }
+    StreamMaterialize { columns: [o_orderpriority, agg#0(hidden), order_count], pk_columns: [o_orderpriority] }
+      StreamHashAgg { group_keys: [$0], aggs: [count, count] }
+        StreamProject { exprs: [$1, $2] }
+          StreamExchange { dist: HashShard([1]) }
+            StreamHashJoin { type: LeftSemi, predicate: $0 = $3 }
+              StreamProject { exprs: [$0, $2, $3] }
+                StreamExchange { dist: HashShard([0]) }
+                  StreamFilter { predicate: ($1 >= '1997-07-01':Varchar::Date) AND ($1 < ('1997-07-01':Varchar::Date + '3 mons 00:00:00':Interval)) }
+                    StreamTableScan { table: orders, columns: [o_orderkey, o_orderdate, o_orderpriority, _row_id#0], pk_indices: [3] }
+              StreamProject { exprs: [$0, $3] }
+                StreamExchange { dist: HashShard([0]) }
+                  StreamFilter { predicate: ($1 < $2) }
+                    StreamTableScan { table: lineitem, columns: [l_orderkey, l_commitdate, l_receiptdate, _row_id#0], pk_indices: [3] }
 - id: tpch_q5
   before:
     - create_tables
@@ -424,74 +422,72 @@
   batch_plan: |
     BatchExchange { order: [$1 DESC], dist: Single }
       BatchSort { order: [$1 DESC] }
-        BatchProject { exprs: [$0, $1], expr_alias: [n_name, revenue] }
-          BatchHashAgg { group_keys: [$0], aggs: [sum($1)] }
-            BatchProject { exprs: [$2, ($0 * (1:Int32 - $1))], expr_alias: [ ,  ] }
-              BatchExchange { order: [], dist: HashShard([2]) }
-                BatchHashJoin { type: Inner, predicate: $3 = $4 }
-                  BatchProject { exprs: [$0, $1, $4, $5], expr_alias: [ ,  ,  ,  ] }
-                    BatchExchange { order: [], dist: HashShard([5]) }
-                      BatchHashJoin { type: Inner, predicate: $2 = $3 }
-                        BatchProject { exprs: [$2, $3, $5], expr_alias: [ ,  ,  ] }
-                          BatchExchange { order: [], dist: HashShard([5]) }
-                            BatchHashJoin { type: Inner, predicate: $1 = $4 AND $0 = $5 }
-                              BatchProject { exprs: [$0, $3, $4, $5], expr_alias: [ ,  ,  ,  ] }
-                                BatchExchange { order: [], dist: HashShard([3, 0]) }
-                                  BatchHashJoin { type: Inner, predicate: $1 = $2 }
-                                    BatchProject { exprs: [$1, $2], expr_alias: [ ,  ] }
-                                      BatchExchange { order: [], dist: HashShard([2]) }
-                                        BatchHashJoin { type: Inner, predicate: $0 = $3 }
-                                          BatchExchange { order: [], dist: HashShard([0]) }
-                                            BatchScan { table: customer, columns: [c_custkey, c_nationkey] }
-                                          BatchProject { exprs: [$0, $1], expr_alias: [ ,  ] }
-                                            BatchExchange { order: [], dist: HashShard([1]) }
-                                              BatchFilter { predicate: ($2 >= '1994-01-01':Varchar::Date) AND ($2 < ('1994-01-01':Varchar::Date + '1 year 00:00:00':Interval)) }
-                                                BatchScan { table: orders, columns: [o_orderkey, o_custkey, o_orderdate] }
-                                    BatchExchange { order: [], dist: HashShard([0]) }
-                                      BatchScan { table: lineitem, columns: [l_orderkey, l_suppkey, l_extendedprice, l_discount] }
-                              BatchExchange { order: [], dist: HashShard([0, 1]) }
-                                BatchScan { table: supplier, columns: [s_suppkey, s_nationkey] }
-                        BatchExchange { order: [], dist: HashShard([0]) }
-                          BatchScan { table: nation, columns: [n_nationkey, n_name, n_regionkey] }
-                  BatchProject { exprs: [$0], expr_alias: [ ] }
-                    BatchExchange { order: [], dist: HashShard([0]) }
-                      BatchFilter { predicate: ($1 = 'MIDDLE EAST':Varchar) }
-                        BatchScan { table: region, columns: [r_regionkey, r_name] }
+        BatchHashAgg { group_keys: [$0], aggs: [sum($1)] }
+          BatchProject { exprs: [$2, ($0 * (1:Int32 - $1))] }
+            BatchExchange { order: [], dist: HashShard([2]) }
+              BatchHashJoin { type: Inner, predicate: $3 = $4 }
+                BatchProject { exprs: [$0, $1, $4, $5] }
+                  BatchExchange { order: [], dist: HashShard([5]) }
+                    BatchHashJoin { type: Inner, predicate: $2 = $3 }
+                      BatchProject { exprs: [$2, $3, $5] }
+                        BatchExchange { order: [], dist: HashShard([5]) }
+                          BatchHashJoin { type: Inner, predicate: $1 = $4 AND $0 = $5 }
+                            BatchProject { exprs: [$0, $3, $4, $5] }
+                              BatchExchange { order: [], dist: HashShard([3, 0]) }
+                                BatchHashJoin { type: Inner, predicate: $1 = $2 }
+                                  BatchProject { exprs: [$1, $2] }
+                                    BatchExchange { order: [], dist: HashShard([2]) }
+                                      BatchHashJoin { type: Inner, predicate: $0 = $3 }
+                                        BatchExchange { order: [], dist: HashShard([0]) }
+                                          BatchScan { table: customer, columns: [c_custkey, c_nationkey] }
+                                        BatchProject { exprs: [$0, $1] }
+                                          BatchExchange { order: [], dist: HashShard([1]) }
+                                            BatchFilter { predicate: ($2 >= '1994-01-01':Varchar::Date) AND ($2 < ('1994-01-01':Varchar::Date + '1 year 00:00:00':Interval)) }
+                                              BatchScan { table: orders, columns: [o_orderkey, o_custkey, o_orderdate] }
+                                  BatchExchange { order: [], dist: HashShard([0]) }
+                                    BatchScan { table: lineitem, columns: [l_orderkey, l_suppkey, l_extendedprice, l_discount] }
+                            BatchExchange { order: [], dist: HashShard([0, 1]) }
+                              BatchScan { table: supplier, columns: [s_suppkey, s_nationkey] }
+                      BatchExchange { order: [], dist: HashShard([0]) }
+                        BatchScan { table: nation, columns: [n_nationkey, n_name, n_regionkey] }
+                BatchProject { exprs: [$0] }
+                  BatchExchange { order: [], dist: HashShard([0]) }
+                    BatchFilter { predicate: ($1 = 'MIDDLE EAST':Varchar) }
+                      BatchScan { table: region, columns: [r_regionkey, r_name] }
   stream_plan: |
-    StreamMaterialize { columns: [n_name, revenue], pk_columns: [n_name], order_descs: [revenue, n_name] }
-      StreamProject { exprs: [$0, $2], expr_alias: [n_name, revenue] }
-        StreamHashAgg { group_keys: [$0], aggs: [count, sum($1)] }
-          StreamProject { exprs: [$2, ($0 * (1:Int32 - $1)), $4, $5, $6, $7, $8, $10], expr_alias: [ ,  ,  ,  ,  ,  ,  ,  ] }
-            StreamExchange { dist: HashShard([2]) }
-              StreamHashJoin { type: Inner, predicate: $3 = $9 }
-                StreamProject { exprs: [$0, $1, $8, $9, $3, $4, $5, $6, $10], expr_alias: [ ,  ,  ,  ,  ,  ,  ,  ,  ] }
-                  StreamExchange { dist: HashShard([9]) }
-                    StreamHashJoin { type: Inner, predicate: $2 = $7 }
-                      StreamProject { exprs: [$2, $3, $8, $4, $5, $6, $9], expr_alias: [ ,  ,  ,  ,  ,  ,  ] }
-                        StreamExchange { dist: HashShard([8]) }
-                          StreamHashJoin { type: Inner, predicate: $1 = $7 AND $0 = $8 }
-                            StreamProject { exprs: [$0, $5, $6, $7, $2, $3, $8], expr_alias: [ ,  ,  ,  ,  ,  ,  ] }
-                              StreamExchange { dist: HashShard([5, 0]) }
-                                StreamHashJoin { type: Inner, predicate: $1 = $4 }
-                                  StreamProject { exprs: [$1, $3, $2, $5], expr_alias: [ ,  ,  ,  ] }
-                                    StreamExchange { dist: HashShard([3]) }
-                                      StreamHashJoin { type: Inner, predicate: $0 = $4 }
-                                        StreamExchange { dist: HashShard([0]) }
-                                          StreamTableScan { table: customer, columns: [c_custkey, c_nationkey, _row_id#0], pk_indices: [2] }
-                                        StreamProject { exprs: [$0, $1, $3], expr_alias: [ ,  ,  ] }
-                                          StreamExchange { dist: HashShard([1]) }
-                                            StreamFilter { predicate: ($2 >= '1994-01-01':Varchar::Date) AND ($2 < ('1994-01-01':Varchar::Date + '1 year 00:00:00':Interval)) }
-                                              StreamTableScan { table: orders, columns: [o_orderkey, o_custkey, o_orderdate, _row_id#0], pk_indices: [3] }
-                                  StreamExchange { dist: HashShard([0]) }
-                                    StreamTableScan { table: lineitem, columns: [l_orderkey, l_suppkey, l_extendedprice, l_discount, _row_id#0], pk_indices: [4] }
-                            StreamExchange { dist: HashShard([0, 1]) }
-                              StreamTableScan { table: supplier, columns: [s_suppkey, s_nationkey, _row_id#0], pk_indices: [2] }
-                      StreamExchange { dist: HashShard([0]) }
-                        StreamTableScan { table: nation, columns: [n_nationkey, n_name, n_regionkey, _row_id#0], pk_indices: [3] }
-                StreamProject { exprs: [$0, $2], expr_alias: [ ,  ] }
-                  StreamExchange { dist: HashShard([0]) }
-                    StreamFilter { predicate: ($1 = 'MIDDLE EAST':Varchar) }
-                      StreamTableScan { table: region, columns: [r_regionkey, r_name, _row_id#0], pk_indices: [2] }
+    StreamMaterialize { columns: [n_name, agg#0(hidden), revenue], pk_columns: [n_name], order_descs: [revenue, n_name] }
+      StreamHashAgg { group_keys: [$0], aggs: [count, sum($1)] }
+        StreamProject { exprs: [$2, ($0 * (1:Int32 - $1)), $4, $5, $6, $7, $8, $10] }
+          StreamExchange { dist: HashShard([2]) }
+            StreamHashJoin { type: Inner, predicate: $3 = $9 }
+              StreamProject { exprs: [$0, $1, $8, $9, $3, $4, $5, $6, $10] }
+                StreamExchange { dist: HashShard([9]) }
+                  StreamHashJoin { type: Inner, predicate: $2 = $7 }
+                    StreamProject { exprs: [$2, $3, $8, $4, $5, $6, $9] }
+                      StreamExchange { dist: HashShard([8]) }
+                        StreamHashJoin { type: Inner, predicate: $1 = $7 AND $0 = $8 }
+                          StreamProject { exprs: [$0, $5, $6, $7, $2, $3, $8] }
+                            StreamExchange { dist: HashShard([5, 0]) }
+                              StreamHashJoin { type: Inner, predicate: $1 = $4 }
+                                StreamProject { exprs: [$1, $3, $2, $5] }
+                                  StreamExchange { dist: HashShard([3]) }
+                                    StreamHashJoin { type: Inner, predicate: $0 = $4 }
+                                      StreamExchange { dist: HashShard([0]) }
+                                        StreamTableScan { table: customer, columns: [c_custkey, c_nationkey, _row_id#0], pk_indices: [2] }
+                                      StreamProject { exprs: [$0, $1, $3] }
+                                        StreamExchange { dist: HashShard([1]) }
+                                          StreamFilter { predicate: ($2 >= '1994-01-01':Varchar::Date) AND ($2 < ('1994-01-01':Varchar::Date + '1 year 00:00:00':Interval)) }
+                                            StreamTableScan { table: orders, columns: [o_orderkey, o_custkey, o_orderdate, _row_id#0], pk_indices: [3] }
+                                StreamExchange { dist: HashShard([0]) }
+                                  StreamTableScan { table: lineitem, columns: [l_orderkey, l_suppkey, l_extendedprice, l_discount, _row_id#0], pk_indices: [4] }
+                          StreamExchange { dist: HashShard([0, 1]) }
+                            StreamTableScan { table: supplier, columns: [s_suppkey, s_nationkey, _row_id#0], pk_indices: [2] }
+                    StreamExchange { dist: HashShard([0]) }
+                      StreamTableScan { table: nation, columns: [n_nationkey, n_name, n_regionkey, _row_id#0], pk_indices: [3] }
+              StreamProject { exprs: [$0, $2] }
+                StreamExchange { dist: HashShard([0]) }
+                  StreamFilter { predicate: ($1 = 'MIDDLE EAST':Varchar) }
+                    StreamTableScan { table: region, columns: [r_regionkey, r_name, _row_id#0], pk_indices: [2] }
 - id: tpch_q6
   before:
     - create_tables
@@ -506,20 +502,18 @@
       and l_discount between 0.08 - 0.01 and 0.08 + 0.01
       and l_quantity < 24;
   batch_plan: |
-    BatchProject { exprs: [$0], expr_alias: [revenue] }
-      BatchSimpleAgg { aggs: [sum($0)] }
-        BatchExchange { order: [], dist: Single }
-          BatchProject { exprs: [($1 * $2)], expr_alias: [ ] }
-            BatchFilter { predicate: ($3 >= '1994-01-01':Varchar::Date) AND ($3 < ('1994-01-01':Varchar::Date + '1 year 00:00:00':Interval)) AND ($2 >= (0.08:Decimal - 0.01:Decimal)) AND ($2 <= (0.08:Decimal + 0.01:Decimal)) AND ($0 < 24:Int32) }
-              BatchScan { table: lineitem, columns: [l_quantity, l_extendedprice, l_discount, l_shipdate] }
+    BatchSimpleAgg { aggs: [sum($0)] }
+      BatchExchange { order: [], dist: Single }
+        BatchProject { exprs: [($1 * $2)] }
+          BatchFilter { predicate: ($3 >= '1994-01-01':Varchar::Date) AND ($3 < ('1994-01-01':Varchar::Date + '1 year 00:00:00':Interval)) AND ($2 >= (0.08:Decimal - 0.01:Decimal)) AND ($2 <= (0.08:Decimal + 0.01:Decimal)) AND ($0 < 24:Int32) }
+            BatchScan { table: lineitem, columns: [l_quantity, l_extendedprice, l_discount, l_shipdate] }
   stream_plan: |
-    StreamMaterialize { columns: [revenue, agg#0(hidden)], pk_columns: [agg#0, revenue] }
-      StreamProject { exprs: [$1, $0], expr_alias: [revenue,  ] }
-        StreamSimpleAgg { aggs: [count, sum($0)] }
-          StreamExchange { dist: Single }
-            StreamProject { exprs: [($1 * $2), $4], expr_alias: [ ,  ] }
-              StreamFilter { predicate: ($3 >= '1994-01-01':Varchar::Date) AND ($3 < ('1994-01-01':Varchar::Date + '1 year 00:00:00':Interval)) AND ($2 >= (0.08:Decimal - 0.01:Decimal)) AND ($2 <= (0.08:Decimal + 0.01:Decimal)) AND ($0 < 24:Int32) }
-                StreamTableScan { table: lineitem, columns: [l_quantity, l_extendedprice, l_discount, l_shipdate, _row_id#0], pk_indices: [4] }
+    StreamMaterialize { columns: [agg#0(hidden), revenue], pk_columns: [agg#0, revenue] }
+      StreamSimpleAgg { aggs: [count, sum($0)] }
+        StreamExchange { dist: Single }
+          StreamProject { exprs: [($1 * $2), $4] }
+            StreamFilter { predicate: ($3 >= '1994-01-01':Varchar::Date) AND ($3 < ('1994-01-01':Varchar::Date + '1 year 00:00:00':Interval)) AND ($2 >= (0.08:Decimal - 0.01:Decimal)) AND ($2 <= (0.08:Decimal + 0.01:Decimal)) AND ($0 < 24:Int32) }
+              StreamTableScan { table: lineitem, columns: [l_quantity, l_extendedprice, l_discount, l_shipdate, _row_id#0], pk_indices: [4] }
 - id: tpch_q7
   before:
     - create_tables
@@ -566,70 +560,68 @@
   batch_plan: |
     BatchExchange { order: [$0 ASC, $1 ASC, $2 ASC], dist: Single }
       BatchSort { order: [$0 ASC, $1 ASC, $2 ASC] }
-        BatchProject { exprs: [$0, $1, $2, $3], expr_alias: [supp_nation, cust_nation, l_year, revenue] }
-          BatchHashAgg { group_keys: [$0, $1, $2], aggs: [sum($3)] }
-            BatchExchange { order: [], dist: HashShard([0, 1, 2]) }
-              BatchProject { exprs: [$4, $6, Extract('YEAR':Varchar, $2), ($0 * (1:Int32 - $1))], expr_alias: [ ,  ,  ,  ] }
-                BatchFilter { predicate: ((($4 = 'ROMANIA':Varchar) AND ($6 = 'IRAN':Varchar)) OR (($4 = 'IRAN':Varchar) AND ($6 = 'ROMANIA':Varchar))) }
-                  BatchHashJoin { type: Inner, predicate: $3 = $5 }
-                    BatchProject { exprs: [$1, $2, $3, $4, $6], expr_alias: [ ,  ,  ,  ,  ] }
-                      BatchExchange { order: [], dist: HashShard([4]) }
-                        BatchHashJoin { type: Inner, predicate: $0 = $5 }
-                          BatchProject { exprs: [$0, $1, $2, $3, $6], expr_alias: [ ,  ,  ,  ,  ] }
-                            BatchExchange { order: [], dist: HashShard([0]) }
-                              BatchHashJoin { type: Inner, predicate: $4 = $5 }
-                                BatchProject { exprs: [$0, $2, $3, $4, $6], expr_alias: [ ,  ,  ,  ,  ] }
-                                  BatchExchange { order: [], dist: HashShard([6]) }
-                                    BatchHashJoin { type: Inner, predicate: $1 = $5 }
-                                      BatchProject { exprs: [$1, $2, $4, $5, $6], expr_alias: [ ,  ,  ,  ,  ] }
-                                        BatchExchange { order: [], dist: HashShard([2]) }
-                                          BatchHashJoin { type: Inner, predicate: $0 = $3 }
-                                            BatchExchange { order: [], dist: HashShard([0]) }
-                                              BatchScan { table: supplier, columns: [s_suppkey, s_nationkey] }
-                                            BatchExchange { order: [], dist: HashShard([1]) }
-                                              BatchFilter { predicate: ($4 >= '1983-01-01':Varchar::Date) AND ($4 <= '2000-12-31':Varchar::Date) }
-                                                BatchScan { table: lineitem, columns: [l_orderkey, l_suppkey, l_extendedprice, l_discount, l_shipdate] }
-                                      BatchExchange { order: [], dist: HashShard([0]) }
-                                        BatchScan { table: orders, columns: [o_orderkey, o_custkey] }
-                                BatchExchange { order: [], dist: HashShard([0]) }
-                                  BatchScan { table: customer, columns: [c_custkey, c_nationkey] }
+        BatchHashAgg { group_keys: [$0, $1, $2], aggs: [sum($3)] }
+          BatchExchange { order: [], dist: HashShard([0, 1, 2]) }
+            BatchProject { exprs: [$4, $6, Extract('YEAR':Varchar, $2), ($0 * (1:Int32 - $1))] }
+              BatchFilter { predicate: ((($4 = 'ROMANIA':Varchar) AND ($6 = 'IRAN':Varchar)) OR (($4 = 'IRAN':Varchar) AND ($6 = 'ROMANIA':Varchar))) }
+                BatchHashJoin { type: Inner, predicate: $3 = $5 }
+                  BatchProject { exprs: [$1, $2, $3, $4, $6] }
+                    BatchExchange { order: [], dist: HashShard([4]) }
+                      BatchHashJoin { type: Inner, predicate: $0 = $5 }
+                        BatchProject { exprs: [$0, $1, $2, $3, $6] }
                           BatchExchange { order: [], dist: HashShard([0]) }
-                            BatchScan { table: nation, columns: [n_nationkey, n_name] }
-                    BatchExchange { order: [], dist: HashShard([0]) }
-                      BatchScan { table: nation, columns: [n_nationkey, n_name] }
+                            BatchHashJoin { type: Inner, predicate: $4 = $5 }
+                              BatchProject { exprs: [$0, $2, $3, $4, $6] }
+                                BatchExchange { order: [], dist: HashShard([6]) }
+                                  BatchHashJoin { type: Inner, predicate: $1 = $5 }
+                                    BatchProject { exprs: [$1, $2, $4, $5, $6] }
+                                      BatchExchange { order: [], dist: HashShard([2]) }
+                                        BatchHashJoin { type: Inner, predicate: $0 = $3 }
+                                          BatchExchange { order: [], dist: HashShard([0]) }
+                                            BatchScan { table: supplier, columns: [s_suppkey, s_nationkey] }
+                                          BatchExchange { order: [], dist: HashShard([1]) }
+                                            BatchFilter { predicate: ($4 >= '1983-01-01':Varchar::Date) AND ($4 <= '2000-12-31':Varchar::Date) }
+                                              BatchScan { table: lineitem, columns: [l_orderkey, l_suppkey, l_extendedprice, l_discount, l_shipdate] }
+                                    BatchExchange { order: [], dist: HashShard([0]) }
+                                      BatchScan { table: orders, columns: [o_orderkey, o_custkey] }
+                              BatchExchange { order: [], dist: HashShard([0]) }
+                                BatchScan { table: customer, columns: [c_custkey, c_nationkey] }
+                        BatchExchange { order: [], dist: HashShard([0]) }
+                          BatchScan { table: nation, columns: [n_nationkey, n_name] }
+                  BatchExchange { order: [], dist: HashShard([0]) }
+                    BatchScan { table: nation, columns: [n_nationkey, n_name] }
   stream_plan: |
-    StreamMaterialize { columns: [supp_nation, cust_nation, l_year, revenue], pk_columns: [supp_nation, cust_nation, l_year] }
-      StreamProject { exprs: [$0, $1, $2, $4], expr_alias: [supp_nation, cust_nation, l_year, revenue] }
-        StreamHashAgg { group_keys: [$0, $1, $2], aggs: [count, sum($3)] }
-          StreamExchange { dist: HashShard([0, 1, 2]) }
-            StreamProject { exprs: [$4, $11, Extract('YEAR':Varchar, $2), ($0 * (1:Int32 - $1)), $5, $6, $7, $8, $9, $12], expr_alias: [ ,  ,  ,  ,  ,  ,  ,  ,  ,  ] }
-              StreamFilter { predicate: ((($4 = 'ROMANIA':Varchar) AND ($11 = 'IRAN':Varchar)) OR (($4 = 'IRAN':Varchar) AND ($11 = 'ROMANIA':Varchar))) }
-                StreamHashJoin { type: Inner, predicate: $3 = $10 }
-                  StreamProject { exprs: [$1, $2, $3, $4, $10, $5, $6, $7, $8, $11], expr_alias: [ ,  ,  ,  ,  ,  ,  ,  ,  ,  ] }
-                    StreamExchange { dist: HashShard([4]) }
-                      StreamHashJoin { type: Inner, predicate: $0 = $9 }
-                        StreamProject { exprs: [$0, $1, $2, $3, $9, $5, $6, $7, $10], expr_alias: [ ,  ,  ,  ,  ,  ,  ,  ,  ] }
-                          StreamExchange { dist: HashShard([0]) }
-                            StreamHashJoin { type: Inner, predicate: $4 = $8 }
-                              StreamProject { exprs: [$0, $2, $3, $4, $8, $5, $6, $9], expr_alias: [ ,  ,  ,  ,  ,  ,  ,  ] }
-                                StreamExchange { dist: HashShard([8]) }
-                                  StreamHashJoin { type: Inner, predicate: $1 = $7 }
-                                    StreamProject { exprs: [$1, $3, $5, $6, $7, $2, $8], expr_alias: [ ,  ,  ,  ,  ,  ,  ] }
-                                      StreamExchange { dist: HashShard([3]) }
-                                        StreamHashJoin { type: Inner, predicate: $0 = $4 }
-                                          StreamExchange { dist: HashShard([0]) }
-                                            StreamTableScan { table: supplier, columns: [s_suppkey, s_nationkey, _row_id#0], pk_indices: [2] }
-                                          StreamExchange { dist: HashShard([1]) }
-                                            StreamFilter { predicate: ($4 >= '1983-01-01':Varchar::Date) AND ($4 <= '2000-12-31':Varchar::Date) }
-                                              StreamTableScan { table: lineitem, columns: [l_orderkey, l_suppkey, l_extendedprice, l_discount, l_shipdate, _row_id#0], pk_indices: [5] }
-                                    StreamExchange { dist: HashShard([0]) }
-                                      StreamTableScan { table: orders, columns: [o_orderkey, o_custkey, _row_id#0], pk_indices: [2] }
-                              StreamExchange { dist: HashShard([0]) }
-                                StreamTableScan { table: customer, columns: [c_custkey, c_nationkey, _row_id#0], pk_indices: [2] }
+    StreamMaterialize { columns: [supp_nation, cust_nation, l_year, agg#0(hidden), revenue], pk_columns: [supp_nation, cust_nation, l_year] }
+      StreamHashAgg { group_keys: [$0, $1, $2], aggs: [count, sum($3)] }
+        StreamExchange { dist: HashShard([0, 1, 2]) }
+          StreamProject { exprs: [$4, $11, Extract('YEAR':Varchar, $2), ($0 * (1:Int32 - $1)), $5, $6, $7, $8, $9, $12] }
+            StreamFilter { predicate: ((($4 = 'ROMANIA':Varchar) AND ($11 = 'IRAN':Varchar)) OR (($4 = 'IRAN':Varchar) AND ($11 = 'ROMANIA':Varchar))) }
+              StreamHashJoin { type: Inner, predicate: $3 = $10 }
+                StreamProject { exprs: [$1, $2, $3, $4, $10, $5, $6, $7, $8, $11] }
+                  StreamExchange { dist: HashShard([4]) }
+                    StreamHashJoin { type: Inner, predicate: $0 = $9 }
+                      StreamProject { exprs: [$0, $1, $2, $3, $9, $5, $6, $7, $10] }
                         StreamExchange { dist: HashShard([0]) }
-                          StreamTableScan { table: nation, columns: [n_nationkey, n_name, _row_id#0], pk_indices: [2] }
-                  StreamExchange { dist: HashShard([0]) }
-                    StreamTableScan { table: nation, columns: [n_nationkey, n_name, _row_id#0], pk_indices: [2] }
+                          StreamHashJoin { type: Inner, predicate: $4 = $8 }
+                            StreamProject { exprs: [$0, $2, $3, $4, $8, $5, $6, $9] }
+                              StreamExchange { dist: HashShard([8]) }
+                                StreamHashJoin { type: Inner, predicate: $1 = $7 }
+                                  StreamProject { exprs: [$1, $3, $5, $6, $7, $2, $8] }
+                                    StreamExchange { dist: HashShard([3]) }
+                                      StreamHashJoin { type: Inner, predicate: $0 = $4 }
+                                        StreamExchange { dist: HashShard([0]) }
+                                          StreamTableScan { table: supplier, columns: [s_suppkey, s_nationkey, _row_id#0], pk_indices: [2] }
+                                        StreamExchange { dist: HashShard([1]) }
+                                          StreamFilter { predicate: ($4 >= '1983-01-01':Varchar::Date) AND ($4 <= '2000-12-31':Varchar::Date) }
+                                            StreamTableScan { table: lineitem, columns: [l_orderkey, l_suppkey, l_extendedprice, l_discount, l_shipdate, _row_id#0], pk_indices: [5] }
+                                  StreamExchange { dist: HashShard([0]) }
+                                    StreamTableScan { table: orders, columns: [o_orderkey, o_custkey, _row_id#0], pk_indices: [2] }
+                            StreamExchange { dist: HashShard([0]) }
+                              StreamTableScan { table: customer, columns: [c_custkey, c_nationkey, _row_id#0], pk_indices: [2] }
+                      StreamExchange { dist: HashShard([0]) }
+                        StreamTableScan { table: nation, columns: [n_nationkey, n_name, _row_id#0], pk_indices: [2] }
+                StreamExchange { dist: HashShard([0]) }
+                  StreamTableScan { table: nation, columns: [n_nationkey, n_name, _row_id#0], pk_indices: [2] }
 - id: tpch_q8
   before:
     - create_tables
@@ -676,32 +668,32 @@
   batch_plan: |
     BatchExchange { order: [$0 ASC], dist: Single }
       BatchSort { order: [$0 ASC] }
-        BatchProject { exprs: [$0, RoundDigit(($1 / $2), 6:Int32)], expr_alias: [o_year, mkt_share] }
+        BatchProject { exprs: [$0, RoundDigit(($1 / $2), 6:Int32)] }
           BatchHashAgg { group_keys: [$0], aggs: [sum($1), sum($2)] }
             BatchExchange { order: [], dist: HashShard([0]) }
-              BatchProject { exprs: [Extract('YEAR':Varchar, $2), Case(($4 = 'IRAN':Varchar), ($0 * (1:Int32 - $1)), 0:Int32::Decimal), ($0 * (1:Int32 - $1))], expr_alias: [ ,  ,  ] }
+              BatchProject { exprs: [Extract('YEAR':Varchar, $2), Case(($4 = 'IRAN':Varchar), ($0 * (1:Int32 - $1)), 0:Int32::Decimal), ($0 * (1:Int32 - $1))] }
                 BatchHashJoin { type: Inner, predicate: $3 = $5 }
-                  BatchProject { exprs: [$0, $1, $3, $4, $6], expr_alias: [ ,  ,  ,  ,  ] }
+                  BatchProject { exprs: [$0, $1, $3, $4, $6] }
                     BatchExchange { order: [], dist: HashShard([4]) }
                       BatchHashJoin { type: Inner, predicate: $2 = $5 }
-                        BatchProject { exprs: [$0, $1, $2, $3, $6], expr_alias: [ ,  ,  ,  ,  ] }
+                        BatchProject { exprs: [$0, $1, $2, $3, $6] }
                           BatchExchange { order: [], dist: HashShard([2]) }
                             BatchHashJoin { type: Inner, predicate: $4 = $5 }
-                              BatchProject { exprs: [$0, $1, $2, $4, $6], expr_alias: [ ,  ,  ,  ,  ] }
+                              BatchProject { exprs: [$0, $1, $2, $4, $6] }
                                 BatchExchange { order: [], dist: HashShard([6]) }
                                   BatchHashJoin { type: Inner, predicate: $3 = $5 }
-                                    BatchProject { exprs: [$1, $2, $3, $5, $6], expr_alias: [ ,  ,  ,  ,  ] }
+                                    BatchProject { exprs: [$1, $2, $3, $5, $6] }
                                       BatchExchange { order: [], dist: HashShard([5]) }
                                         BatchHashJoin { type: Inner, predicate: $0 = $4 }
-                                          BatchProject { exprs: [$0, $2, $3, $5], expr_alias: [ ,  ,  ,  ] }
+                                          BatchProject { exprs: [$0, $2, $3, $5] }
                                             BatchExchange { order: [], dist: HashShard([0]) }
                                               BatchHashJoin { type: Inner, predicate: $1 = $4 }
-                                                BatchProject { exprs: [$0, $2, $3, $4], expr_alias: [ ,  ,  ,  ] }
+                                                BatchProject { exprs: [$0, $2, $3, $4] }
                                                   BatchExchange { order: [], dist: HashShard([2]) }
                                                     BatchHashJoin { type: Inner, predicate: $1 = $5 }
                                                       BatchExchange { order: [], dist: HashShard([1]) }
                                                         BatchScan { table: lineitem, columns: [l_orderkey, l_partkey, l_suppkey, l_extendedprice, l_discount] }
-                                                      BatchProject { exprs: [$0], expr_alias: [ ] }
+                                                      BatchProject { exprs: [$0] }
                                                         BatchExchange { order: [], dist: HashShard([0]) }
                                                           BatchFilter { predicate: ($1 = 'PROMO ANODIZED STEEL':Varchar) }
                                                             BatchScan { table: part, columns: [p_partkey, p_type] }
@@ -716,38 +708,38 @@
                                 BatchScan { table: nation, columns: [n_nationkey, n_regionkey] }
                         BatchExchange { order: [], dist: HashShard([0]) }
                           BatchScan { table: nation, columns: [n_nationkey, n_name] }
-                  BatchProject { exprs: [$0], expr_alias: [ ] }
+                  BatchProject { exprs: [$0] }
                     BatchExchange { order: [], dist: HashShard([0]) }
                       BatchFilter { predicate: ($1 = 'ASIA':Varchar) }
                         BatchScan { table: region, columns: [r_regionkey, r_name] }
   stream_plan: |
     StreamMaterialize { columns: [o_year, mkt_share], pk_columns: [o_year] }
-      StreamProject { exprs: [$0, RoundDigit(($2 / $3), 6:Int32)], expr_alias: [o_year, mkt_share] }
+      StreamProject { exprs: [$0, RoundDigit(($2 / $3), 6:Int32)] }
         StreamHashAgg { group_keys: [$0], aggs: [count, sum($1), sum($2)] }
           StreamExchange { dist: HashShard([0]) }
-            StreamProject { exprs: [Extract('YEAR':Varchar, $2), Case(($4 = 'IRAN':Varchar), ($0 * (1:Int32 - $1)), 0:Int32::Decimal), ($0 * (1:Int32 - $1)), $5, $6, $7, $8, $9, $10, $11, $13], expr_alias: [ ,  ,  ,  ,  ,  ,  ,  ,  ,  ,  ] }
+            StreamProject { exprs: [Extract('YEAR':Varchar, $2), Case(($4 = 'IRAN':Varchar), ($0 * (1:Int32 - $1)), 0:Int32::Decimal), ($0 * (1:Int32 - $1)), $5, $6, $7, $8, $9, $10, $11, $13] }
               StreamHashJoin { type: Inner, predicate: $3 = $12 }
-                StreamProject { exprs: [$0, $1, $3, $4, $12, $5, $6, $7, $8, $9, $10, $13], expr_alias: [ ,  ,  ,  ,  ,  ,  ,  ,  ,  ,  ,  ] }
+                StreamProject { exprs: [$0, $1, $3, $4, $12, $5, $6, $7, $8, $9, $10, $13] }
                   StreamExchange { dist: HashShard([4]) }
                     StreamHashJoin { type: Inner, predicate: $2 = $11 }
-                      StreamProject { exprs: [$0, $1, $2, $3, $11, $5, $6, $7, $8, $9, $12], expr_alias: [ ,  ,  ,  ,  ,  ,  ,  ,  ,  ,  ] }
+                      StreamProject { exprs: [$0, $1, $2, $3, $11, $5, $6, $7, $8, $9, $12] }
                         StreamExchange { dist: HashShard([2]) }
                           StreamHashJoin { type: Inner, predicate: $4 = $10 }
-                            StreamProject { exprs: [$0, $1, $2, $4, $10, $5, $6, $7, $8, $11], expr_alias: [ ,  ,  ,  ,  ,  ,  ,  ,  ,  ] }
+                            StreamProject { exprs: [$0, $1, $2, $4, $10, $5, $6, $7, $8, $11] }
                               StreamExchange { dist: HashShard([10]) }
                                 StreamHashJoin { type: Inner, predicate: $3 = $9 }
-                                  StreamProject { exprs: [$1, $2, $3, $8, $9, $4, $5, $6, $10], expr_alias: [ ,  ,  ,  ,  ,  ,  ,  ,  ] }
+                                  StreamProject { exprs: [$1, $2, $3, $8, $9, $4, $5, $6, $10] }
                                     StreamExchange { dist: HashShard([8]) }
                                       StreamHashJoin { type: Inner, predicate: $0 = $7 }
-                                        StreamProject { exprs: [$0, $2, $3, $7, $4, $5, $8], expr_alias: [ ,  ,  ,  ,  ,  ,  ] }
+                                        StreamProject { exprs: [$0, $2, $3, $7, $4, $5, $8] }
                                           StreamExchange { dist: HashShard([0]) }
                                             StreamHashJoin { type: Inner, predicate: $1 = $6 }
-                                              StreamProject { exprs: [$0, $2, $3, $4, $5, $7], expr_alias: [ ,  ,  ,  ,  ,  ] }
+                                              StreamProject { exprs: [$0, $2, $3, $4, $5, $7] }
                                                 StreamExchange { dist: HashShard([2]) }
                                                   StreamHashJoin { type: Inner, predicate: $1 = $6 }
                                                     StreamExchange { dist: HashShard([1]) }
                                                       StreamTableScan { table: lineitem, columns: [l_orderkey, l_partkey, l_suppkey, l_extendedprice, l_discount, _row_id#0], pk_indices: [5] }
-                                                    StreamProject { exprs: [$0, $2], expr_alias: [ ,  ] }
+                                                    StreamProject { exprs: [$0, $2] }
                                                       StreamExchange { dist: HashShard([0]) }
                                                         StreamFilter { predicate: ($1 = 'PROMO ANODIZED STEEL':Varchar) }
                                                           StreamTableScan { table: part, columns: [p_partkey, p_type, _row_id#0], pk_indices: [2] }
@@ -762,7 +754,7 @@
                               StreamTableScan { table: nation, columns: [n_nationkey, n_regionkey, _row_id#0], pk_indices: [2] }
                       StreamExchange { dist: HashShard([0]) }
                         StreamTableScan { table: nation, columns: [n_nationkey, n_name, _row_id#0], pk_indices: [2] }
-                StreamProject { exprs: [$0, $2], expr_alias: [ ,  ] }
+                StreamProject { exprs: [$0, $2] }
                   StreamExchange { dist: HashShard([0]) }
                     StreamFilter { predicate: ($1 = 'ASIA':Varchar) }
                       StreamTableScan { table: region, columns: [r_regionkey, r_name, _row_id#0], pk_indices: [2] }
@@ -807,26 +799,26 @@
   batch_plan: |
     BatchExchange { order: [$0 ASC, $1 DESC], dist: Single }
       BatchSort { order: [$0 ASC, $1 DESC] }
-        BatchProject { exprs: [$0, $1, RoundDigit($2, 2:Int32)], expr_alias: [nation, o_year, sum_profit] }
+        BatchProject { exprs: [$0, $1, RoundDigit($2, 2:Int32)] }
           BatchHashAgg { group_keys: [$0, $1], aggs: [sum($2)] }
             BatchExchange { order: [], dist: HashShard([0, 1]) }
-              BatchProject { exprs: [$7, Extract('YEAR':Varchar, $5), (($1 * (1:Int32 - $2)) - ($4 * $0))], expr_alias: [ ,  ,  ] }
+              BatchProject { exprs: [$7, Extract('YEAR':Varchar, $5), (($1 * (1:Int32 - $2)) - ($4 * $0))] }
                 BatchHashJoin { type: Inner, predicate: $3 = $6 }
-                  BatchProject { exprs: [$1, $2, $3, $4, $5, $7], expr_alias: [ ,  ,  ,  ,  ,  ] }
+                  BatchProject { exprs: [$1, $2, $3, $4, $5, $7] }
                     BatchExchange { order: [], dist: HashShard([4]) }
                       BatchHashJoin { type: Inner, predicate: $0 = $6 }
-                        BatchProject { exprs: [$0, $3, $4, $5, $6, $9], expr_alias: [ ,  ,  ,  ,  ,  ] }
+                        BatchProject { exprs: [$0, $3, $4, $5, $6, $9] }
                           BatchExchange { order: [], dist: HashShard([0]) }
                             BatchHashJoin { type: Inner, predicate: $2 = $8 AND $1 = $7 }
                               BatchExchange { order: [], dist: HashShard([2, 1]) }
-                                BatchProject { exprs: [$0, $1, $2, $3, $4, $5, $7], expr_alias: [ ,  ,  ,  ,  ,  ,  ] }
+                                BatchProject { exprs: [$0, $1, $2, $3, $4, $5, $7] }
                                   BatchHashJoin { type: Inner, predicate: $2 = $6 }
-                                    BatchProject { exprs: [$0, $1, $2, $3, $4, $5], expr_alias: [ ,  ,  ,  ,  ,  ] }
+                                    BatchProject { exprs: [$0, $1, $2, $3, $4, $5] }
                                       BatchExchange { order: [], dist: HashShard([2]) }
                                         BatchHashJoin { type: Inner, predicate: $1 = $6 }
                                           BatchExchange { order: [], dist: HashShard([1]) }
                                             BatchScan { table: lineitem, columns: [l_orderkey, l_partkey, l_suppkey, l_quantity, l_extendedprice, l_discount] }
-                                          BatchProject { exprs: [$0], expr_alias: [ ] }
+                                          BatchProject { exprs: [$0] }
                                             BatchExchange { order: [], dist: HashShard([0]) }
                                               BatchFilter { predicate: Like($1, '%yellow%':Varchar) }
                                                 BatchScan { table: part, columns: [p_partkey, p_name] }
@@ -840,26 +832,26 @@
                     BatchScan { table: nation, columns: [n_nationkey, n_name] }
   stream_plan: |
     StreamMaterialize { columns: [nation, o_year, sum_profit], pk_columns: [nation, o_year] }
-      StreamProject { exprs: [$0, $1, RoundDigit($3, 2:Int32)], expr_alias: [nation, o_year, sum_profit] }
+      StreamProject { exprs: [$0, $1, RoundDigit($3, 2:Int32)] }
         StreamHashAgg { group_keys: [$0, $1], aggs: [count, sum($2)] }
           StreamExchange { dist: HashShard([0, 1]) }
-            StreamProject { exprs: [$12, Extract('YEAR':Varchar, $5), (($1 * (1:Int32 - $2)) - ($4 * $0)), $6, $7, $8, $9, $10, $13], expr_alias: [ ,  ,  ,  ,  ,  ,  ,  ,  ] }
+            StreamProject { exprs: [$12, Extract('YEAR':Varchar, $5), (($1 * (1:Int32 - $2)) - ($4 * $0)), $6, $7, $8, $9, $10, $13] }
               StreamHashJoin { type: Inner, predicate: $3 = $11 }
-                StreamProject { exprs: [$1, $2, $3, $4, $5, $11, $6, $7, $8, $9, $12], expr_alias: [ ,  ,  ,  ,  ,  ,  ,  ,  ,  ,  ] }
+                StreamProject { exprs: [$1, $2, $3, $4, $5, $11, $6, $7, $8, $9, $12] }
                   StreamExchange { dist: HashShard([4]) }
                     StreamHashJoin { type: Inner, predicate: $0 = $10 }
-                      StreamProject { exprs: [$0, $3, $4, $5, $6, $12, $7, $8, $9, $13], expr_alias: [ ,  ,  ,  ,  ,  ,  ,  ,  ,  ] }
+                      StreamProject { exprs: [$0, $3, $4, $5, $6, $12, $7, $8, $9, $13] }
                         StreamExchange { dist: HashShard([0]) }
                           StreamHashJoin { type: Inner, predicate: $2 = $11 AND $1 = $10 }
                             StreamExchange { dist: HashShard([2, 1]) }
-                              StreamProject { exprs: [$0, $1, $2, $3, $4, $5, $9, $6, $7, $10], expr_alias: [ ,  ,  ,  ,  ,  ,  ,  ,  ,  ] }
+                              StreamProject { exprs: [$0, $1, $2, $3, $4, $5, $9, $6, $7, $10] }
                                 StreamHashJoin { type: Inner, predicate: $2 = $8 }
-                                  StreamProject { exprs: [$0, $1, $2, $3, $4, $5, $6, $8], expr_alias: [ ,  ,  ,  ,  ,  ,  ,  ] }
+                                  StreamProject { exprs: [$0, $1, $2, $3, $4, $5, $6, $8] }
                                     StreamExchange { dist: HashShard([2]) }
                                       StreamHashJoin { type: Inner, predicate: $1 = $7 }
                                         StreamExchange { dist: HashShard([1]) }
                                           StreamTableScan { table: lineitem, columns: [l_orderkey, l_partkey, l_suppkey, l_quantity, l_extendedprice, l_discount, _row_id#0], pk_indices: [6] }
-                                        StreamProject { exprs: [$0, $2], expr_alias: [ ,  ] }
+                                        StreamProject { exprs: [$0, $2] }
                                           StreamExchange { dist: HashShard([0]) }
                                             StreamFilter { predicate: Like($1, '%yellow%':Varchar) }
                                               StreamTableScan { table: part, columns: [p_partkey, p_name, _row_id#0], pk_indices: [2] }
@@ -910,24 +902,24 @@
   batch_plan: |
     BatchTopN { order: [$2 DESC], limit: 20, offset: 0 }
       BatchExchange { order: [], dist: Single }
-        BatchProject { exprs: [$0, $1, $7, $2, $4, $5, $3, $6], expr_alias: [c_custkey, c_name, revenue, c_acctbal, n_name, c_address, c_phone, c_comment] }
+        BatchProject { exprs: [$0, $1, $7, $2, $4, $5, $3, $6] }
           BatchHashAgg { group_keys: [$0, $1, $2, $3, $4, $5, $6], aggs: [sum($7)] }
-            BatchProject { exprs: [$0, $1, $5, $4, $10, $2, $6, ($7 * (1.00:Decimal - $8))], expr_alias: [ ,  ,  ,  ,  ,  ,  ,  ] }
+            BatchProject { exprs: [$0, $1, $5, $4, $10, $2, $6, ($7 * (1.00:Decimal - $8))] }
               BatchExchange { order: [], dist: HashShard([0, 1, 5, 4, 10, 2, 6]) }
                 BatchHashJoin { type: Inner, predicate: $3 = $9 }
-                  BatchProject { exprs: [$0, $1, $2, $3, $4, $5, $6, $9, $10], expr_alias: [ ,  ,  ,  ,  ,  ,  ,  ,  ] }
+                  BatchProject { exprs: [$0, $1, $2, $3, $4, $5, $6, $9, $10] }
                     BatchExchange { order: [], dist: HashShard([3]) }
                       BatchHashJoin { type: Inner, predicate: $7 = $8 }
-                        BatchProject { exprs: [$0, $1, $2, $3, $4, $5, $6, $7], expr_alias: [ ,  ,  ,  ,  ,  ,  ,  ] }
+                        BatchProject { exprs: [$0, $1, $2, $3, $4, $5, $6, $7] }
                           BatchExchange { order: [], dist: HashShard([7]) }
                             BatchHashJoin { type: Inner, predicate: $0 = $8 }
                               BatchExchange { order: [], dist: HashShard([0]) }
                                 BatchScan { table: customer, columns: [c_custkey, c_name, c_address, c_nationkey, c_phone, c_acctbal, c_comment] }
-                              BatchProject { exprs: [$0, $1], expr_alias: [ ,  ] }
+                              BatchProject { exprs: [$0, $1] }
                                 BatchExchange { order: [], dist: HashShard([1]) }
                                   BatchFilter { predicate: ($2 >= '1994-01-01':Varchar::Date) AND ($2 < ('1994-01-01':Varchar::Date + '3 mons 00:00:00':Interval)) }
                                     BatchScan { table: orders, columns: [o_orderkey, o_custkey, o_orderdate] }
-                        BatchProject { exprs: [$0, $1, $2], expr_alias: [ ,  ,  ] }
+                        BatchProject { exprs: [$0, $1, $2] }
                           BatchExchange { order: [], dist: HashShard([0]) }
                             BatchFilter { predicate: ($3 = 'R':Varchar) }
                               BatchScan { table: lineitem, columns: [l_orderkey, l_extendedprice, l_discount, l_returnflag] }
@@ -937,24 +929,24 @@
     StreamMaterialize { columns: [c_custkey, c_name, revenue, c_acctbal, n_name, c_address, c_phone, c_comment], pk_columns: [c_custkey, c_name, c_acctbal, c_phone, n_name, c_address, c_comment], order_descs: [revenue, c_custkey, c_name, c_acctbal, c_phone, n_name, c_address, c_comment] }
       StreamTopN { order: [$2 DESC], limit: 20, offset: 0 }
         StreamExchange { dist: Single }
-          StreamProject { exprs: [$0, $1, $8, $2, $4, $5, $3, $6], expr_alias: [c_custkey, c_name, revenue, c_acctbal, n_name, c_address, c_phone, c_comment] }
+          StreamProject { exprs: [$0, $1, $8, $2, $4, $5, $3, $6] }
             StreamHashAgg { group_keys: [$0, $1, $2, $3, $4, $5, $6], aggs: [count, sum($7)] }
-              StreamProject { exprs: [$0, $1, $5, $4, $13, $2, $6, ($7 * (1.00:Decimal - $8)), $9, $10, $11, $14], expr_alias: [ ,  ,  ,  ,  ,  ,  ,  ,  ,  ,  ,  ] }
+              StreamProject { exprs: [$0, $1, $5, $4, $13, $2, $6, ($7 * (1.00:Decimal - $8)), $9, $10, $11, $14] }
                 StreamExchange { dist: HashShard([0, 1, 5, 4, 13, 2, 6]) }
                   StreamHashJoin { type: Inner, predicate: $3 = $12 }
-                    StreamProject { exprs: [$0, $1, $2, $3, $4, $5, $6, $11, $12, $8, $9, $13], expr_alias: [ ,  ,  ,  ,  ,  ,  ,  ,  ,  ,  ,  ] }
+                    StreamProject { exprs: [$0, $1, $2, $3, $4, $5, $6, $11, $12, $8, $9, $13] }
                       StreamExchange { dist: HashShard([3]) }
                         StreamHashJoin { type: Inner, predicate: $7 = $10 }
-                          StreamProject { exprs: [$0, $1, $2, $3, $4, $5, $6, $8, $7, $10], expr_alias: [ ,  ,  ,  ,  ,  ,  ,  ,  ,  ] }
+                          StreamProject { exprs: [$0, $1, $2, $3, $4, $5, $6, $8, $7, $10] }
                             StreamExchange { dist: HashShard([8]) }
                               StreamHashJoin { type: Inner, predicate: $0 = $9 }
                                 StreamExchange { dist: HashShard([0]) }
                                   StreamTableScan { table: customer, columns: [c_custkey, c_name, c_address, c_nationkey, c_phone, c_acctbal, c_comment, _row_id#0], pk_indices: [7] }
-                                StreamProject { exprs: [$0, $1, $3], expr_alias: [ ,  ,  ] }
+                                StreamProject { exprs: [$0, $1, $3] }
                                   StreamExchange { dist: HashShard([1]) }
                                     StreamFilter { predicate: ($2 >= '1994-01-01':Varchar::Date) AND ($2 < ('1994-01-01':Varchar::Date + '3 mons 00:00:00':Interval)) }
                                       StreamTableScan { table: orders, columns: [o_orderkey, o_custkey, o_orderdate, _row_id#0], pk_indices: [3] }
-                          StreamProject { exprs: [$0, $1, $2, $4], expr_alias: [ ,  ,  ,  ] }
+                          StreamProject { exprs: [$0, $1, $2, $4] }
                             StreamExchange { dist: HashShard([0]) }
                               StreamFilter { predicate: ($3 = 'R':Varchar) }
                                 StreamTableScan { table: lineitem, columns: [l_orderkey, l_extendedprice, l_discount, l_returnflag, _row_id#0], pk_indices: [4] }
@@ -993,20 +985,20 @@
     order by
       value desc;
   logical_plan: |
-    LogicalProject { exprs: [$0, $1], expr_alias: [ps_partkey, value] }
+    LogicalProject { exprs: [$0, $1] }
       LogicalFilter { predicate: ($2 > $3) }
         LogicalJoin { type: LeftOuter, on: true }
           LogicalAgg { group_keys: [0], agg_calls: [sum($1), sum($1)] }
-            LogicalProject { exprs: [$1, ($4 * $3)], expr_alias: [ ,  ] }
+            LogicalProject { exprs: [$1, ($4 * $3)] }
               LogicalFilter { predicate: ($2 = $7) AND ($10 = $15) AND ($16 = 'ARGENTINA':Varchar) }
                 LogicalJoin { type: Inner, on: true }
                   LogicalJoin { type: Inner, on: true }
                     LogicalScan { table: partsupp, columns: [_row_id#0, ps_partkey, ps_suppkey, ps_availqty, ps_supplycost, ps_comment] }
                     LogicalScan { table: supplier, columns: [_row_id#0, s_suppkey, s_name, s_address, s_nationkey, s_phone, s_acctbal, s_comment] }
                   LogicalScan { table: nation, columns: [_row_id#0, n_nationkey, n_name, n_regionkey, n_comment] }
-          LogicalProject { exprs: [($0 * 0.0001000000:Decimal)], expr_alias: [ ] }
+          LogicalProject { exprs: [($0 * 0.0001000000:Decimal)] }
             LogicalAgg { group_keys: [], agg_calls: [sum($0)] }
-              LogicalProject { exprs: [($4 * $3)], expr_alias: [ ] }
+              LogicalProject { exprs: [($4 * $3)] }
                 LogicalFilter { predicate: ($2 = $7) AND ($10 = $15) AND ($16 = 'ARGENTINA':Varchar) }
                   LogicalJoin { type: Inner, on: true }
                     LogicalJoin { type: Inner, on: true }
@@ -1014,62 +1006,62 @@
                       LogicalScan { table: supplier, columns: [_row_id#0, s_suppkey, s_name, s_address, s_nationkey, s_phone, s_acctbal, s_comment] }
                     LogicalScan { table: nation, columns: [_row_id#0, n_nationkey, n_name, n_regionkey, n_comment] }
   optimized_logical_plan: |
-    LogicalProject { exprs: [$0, $1], expr_alias: [ps_partkey, value] }
+    LogicalProject { exprs: [$0, $1] }
       LogicalJoin { type: Inner, on: ($2 > $3) }
         LogicalAgg { group_keys: [0], agg_calls: [sum($1), sum($1)] }
-          LogicalProject { exprs: [$0, ($2 * $1)], expr_alias: [ ,  ] }
+          LogicalProject { exprs: [$0, ($2 * $1)] }
             LogicalJoin { type: Inner, on: ($3 = $4) }
-              LogicalProject { exprs: [$0, $2, $3, $5], expr_alias: [ ,  ,  ,  ] }
+              LogicalProject { exprs: [$0, $2, $3, $5] }
                 LogicalJoin { type: Inner, on: ($1 = $4) }
                   LogicalScan { table: partsupp, columns: [ps_partkey, ps_suppkey, ps_availqty, ps_supplycost] }
                   LogicalScan { table: supplier, columns: [s_suppkey, s_nationkey] }
-              LogicalProject { exprs: [$0], expr_alias: [ ] }
+              LogicalProject { exprs: [$0] }
                 LogicalFilter { predicate: ($1 = 'ARGENTINA':Varchar) }
                   LogicalScan { table: nation, columns: [n_nationkey, n_name] }
-        LogicalProject { exprs: [($0 * 0.0001000000:Decimal)], expr_alias: [ ] }
+        LogicalProject { exprs: [($0 * 0.0001000000:Decimal)] }
           LogicalAgg { group_keys: [], agg_calls: [sum($0)] }
-            LogicalProject { exprs: [($1 * $0)], expr_alias: [ ] }
+            LogicalProject { exprs: [($1 * $0)] }
               LogicalJoin { type: Inner, on: ($2 = $3) }
-                LogicalProject { exprs: [$1, $2, $4], expr_alias: [ ,  ,  ] }
+                LogicalProject { exprs: [$1, $2, $4] }
                   LogicalJoin { type: Inner, on: ($0 = $3) }
                     LogicalScan { table: partsupp, columns: [ps_suppkey, ps_availqty, ps_supplycost] }
                     LogicalScan { table: supplier, columns: [s_suppkey, s_nationkey] }
-                LogicalProject { exprs: [$0], expr_alias: [ ] }
+                LogicalProject { exprs: [$0] }
                   LogicalFilter { predicate: ($1 = 'ARGENTINA':Varchar) }
                     LogicalScan { table: nation, columns: [n_nationkey, n_name] }
   batch_plan: |
     BatchSort { order: [$1 DESC] }
-      BatchProject { exprs: [$0, $1], expr_alias: [ps_partkey, value] }
+      BatchProject { exprs: [$0, $1] }
         BatchNestedLoopJoin { type: Inner, predicate: ($2 > $3) }
           BatchExchange { order: [], dist: Single }
             BatchHashAgg { group_keys: [$0], aggs: [sum($1), sum($1)] }
-              BatchProject { exprs: [$0, ($2 * $1)], expr_alias: [ ,  ] }
+              BatchProject { exprs: [$0, ($2 * $1)] }
                 BatchExchange { order: [], dist: HashShard([0]) }
                   BatchHashJoin { type: Inner, predicate: $3 = $4 }
-                    BatchProject { exprs: [$0, $2, $3, $5], expr_alias: [ ,  ,  ,  ] }
+                    BatchProject { exprs: [$0, $2, $3, $5] }
                       BatchExchange { order: [], dist: HashShard([5]) }
                         BatchHashJoin { type: Inner, predicate: $1 = $4 }
                           BatchExchange { order: [], dist: HashShard([1]) }
                             BatchScan { table: partsupp, columns: [ps_partkey, ps_suppkey, ps_availqty, ps_supplycost] }
                           BatchExchange { order: [], dist: HashShard([0]) }
                             BatchScan { table: supplier, columns: [s_suppkey, s_nationkey] }
-                    BatchProject { exprs: [$0], expr_alias: [ ] }
+                    BatchProject { exprs: [$0] }
                       BatchExchange { order: [], dist: HashShard([0]) }
                         BatchFilter { predicate: ($1 = 'ARGENTINA':Varchar) }
                           BatchScan { table: nation, columns: [n_nationkey, n_name] }
-          BatchProject { exprs: [($0 * 0.0001000000:Decimal)], expr_alias: [ ] }
+          BatchProject { exprs: [($0 * 0.0001000000:Decimal)] }
             BatchSimpleAgg { aggs: [sum($0)] }
               BatchExchange { order: [], dist: Single }
-                BatchProject { exprs: [($1 * $0)], expr_alias: [ ] }
+                BatchProject { exprs: [($1 * $0)] }
                   BatchHashJoin { type: Inner, predicate: $2 = $3 }
-                    BatchProject { exprs: [$1, $2, $4], expr_alias: [ ,  ,  ] }
+                    BatchProject { exprs: [$1, $2, $4] }
                       BatchExchange { order: [], dist: HashShard([4]) }
                         BatchHashJoin { type: Inner, predicate: $0 = $3 }
                           BatchExchange { order: [], dist: HashShard([0]) }
                             BatchScan { table: partsupp, columns: [ps_suppkey, ps_availqty, ps_supplycost] }
                           BatchExchange { order: [], dist: HashShard([0]) }
                             BatchScan { table: supplier, columns: [s_suppkey, s_nationkey] }
-                    BatchProject { exprs: [$0], expr_alias: [ ] }
+                    BatchProject { exprs: [$0] }
                       BatchExchange { order: [], dist: HashShard([0]) }
                         BatchFilter { predicate: ($1 = 'ARGENTINA':Varchar) }
                           BatchScan { table: nation, columns: [n_nationkey, n_name] }
@@ -1108,30 +1100,28 @@
   batch_plan: |
     BatchExchange { order: [$0 ASC], dist: Single }
       BatchSort { order: [$0 ASC] }
-        BatchProject { exprs: [$0, $1, $2], expr_alias: [l_shipmode, high_line_count, low_line_count] }
-          BatchHashAgg { group_keys: [$0], aggs: [sum($1), sum($2)] }
-            BatchProject { exprs: [$3, Case((($1 = '1-URGENT':Varchar) OR ($1 = '2-HIGH':Varchar)), 1:Int32, 0:Int32), Case((($1 <> '1-URGENT':Varchar) AND ($1 <> '2-HIGH':Varchar)), 1:Int32, 0:Int32)], expr_alias: [ ,  ,  ] }
-              BatchExchange { order: [], dist: HashShard([3]) }
-                BatchHashJoin { type: Inner, predicate: $0 = $2 }
+        BatchHashAgg { group_keys: [$0], aggs: [sum($1), sum($2)] }
+          BatchProject { exprs: [$3, Case((($1 = '1-URGENT':Varchar) OR ($1 = '2-HIGH':Varchar)), 1:Int32, 0:Int32), Case((($1 <> '1-URGENT':Varchar) AND ($1 <> '2-HIGH':Varchar)), 1:Int32, 0:Int32)] }
+            BatchExchange { order: [], dist: HashShard([3]) }
+              BatchHashJoin { type: Inner, predicate: $0 = $2 }
+                BatchExchange { order: [], dist: HashShard([0]) }
+                  BatchScan { table: orders, columns: [o_orderkey, o_orderpriority] }
+                BatchProject { exprs: [$0, $4] }
                   BatchExchange { order: [], dist: HashShard([0]) }
-                    BatchScan { table: orders, columns: [o_orderkey, o_orderpriority] }
-                  BatchProject { exprs: [$0, $4], expr_alias: [ ,  ] }
-                    BatchExchange { order: [], dist: HashShard([0]) }
-                      BatchFilter { predicate: In($4, 'FOB':Varchar, 'SHIP':Varchar) AND ($2 < $3) AND ($1 < $2) AND ($3 >= '1994-01-01':Varchar::Date) AND ($3 < ('1994-01-01':Varchar::Date + '1 year 00:00:00':Interval)) }
-                        BatchScan { table: lineitem, columns: [l_orderkey, l_shipdate, l_commitdate, l_receiptdate, l_shipmode] }
+                    BatchFilter { predicate: In($4, 'FOB':Varchar, 'SHIP':Varchar) AND ($2 < $3) AND ($1 < $2) AND ($3 >= '1994-01-01':Varchar::Date) AND ($3 < ('1994-01-01':Varchar::Date + '1 year 00:00:00':Interval)) }
+                      BatchScan { table: lineitem, columns: [l_orderkey, l_shipdate, l_commitdate, l_receiptdate, l_shipmode] }
   stream_plan: |
-    StreamMaterialize { columns: [l_shipmode, high_line_count, low_line_count], pk_columns: [l_shipmode] }
-      StreamProject { exprs: [$0, $2, $3], expr_alias: [l_shipmode, high_line_count, low_line_count] }
-        StreamHashAgg { group_keys: [$0], aggs: [count, sum($1), sum($2)] }
-          StreamProject { exprs: [$4, Case((($1 = '1-URGENT':Varchar) OR ($1 = '2-HIGH':Varchar)), 1:Int32, 0:Int32), Case((($1 <> '1-URGENT':Varchar) AND ($1 <> '2-HIGH':Varchar)), 1:Int32, 0:Int32), $2, $5], expr_alias: [ ,  ,  ,  ,  ] }
-            StreamExchange { dist: HashShard([4]) }
-              StreamHashJoin { type: Inner, predicate: $0 = $3 }
+    StreamMaterialize { columns: [l_shipmode, agg#0(hidden), high_line_count, low_line_count], pk_columns: [l_shipmode] }
+      StreamHashAgg { group_keys: [$0], aggs: [count, sum($1), sum($2)] }
+        StreamProject { exprs: [$4, Case((($1 = '1-URGENT':Varchar) OR ($1 = '2-HIGH':Varchar)), 1:Int32, 0:Int32), Case((($1 <> '1-URGENT':Varchar) AND ($1 <> '2-HIGH':Varchar)), 1:Int32, 0:Int32), $2, $5] }
+          StreamExchange { dist: HashShard([4]) }
+            StreamHashJoin { type: Inner, predicate: $0 = $3 }
+              StreamExchange { dist: HashShard([0]) }
+                StreamTableScan { table: orders, columns: [o_orderkey, o_orderpriority, _row_id#0], pk_indices: [2] }
+              StreamProject { exprs: [$0, $4, $5] }
                 StreamExchange { dist: HashShard([0]) }
-                  StreamTableScan { table: orders, columns: [o_orderkey, o_orderpriority, _row_id#0], pk_indices: [2] }
-                StreamProject { exprs: [$0, $4, $5], expr_alias: [ ,  ,  ] }
-                  StreamExchange { dist: HashShard([0]) }
-                    StreamFilter { predicate: In($4, 'FOB':Varchar, 'SHIP':Varchar) AND ($2 < $3) AND ($1 < $2) AND ($3 >= '1994-01-01':Varchar::Date) AND ($3 < ('1994-01-01':Varchar::Date + '1 year 00:00:00':Interval)) }
-                      StreamTableScan { table: lineitem, columns: [l_orderkey, l_shipdate, l_commitdate, l_receiptdate, l_shipmode, _row_id#0], pk_indices: [5] }
+                  StreamFilter { predicate: In($4, 'FOB':Varchar, 'SHIP':Varchar) AND ($2 < $3) AND ($1 < $2) AND ($3 >= '1994-01-01':Varchar::Date) AND ($3 < ('1994-01-01':Varchar::Date + '1 year 00:00:00':Interval)) }
+                    StreamTableScan { table: lineitem, columns: [l_orderkey, l_shipdate, l_commitdate, l_receiptdate, l_shipmode, _row_id#0], pk_indices: [5] }
 - id: tpch_q13
   before:
     - create_tables
@@ -1159,30 +1149,28 @@
   batch_plan: |
     BatchExchange { order: [$1 DESC, $0 DESC], dist: Single }
       BatchSort { order: [$1 DESC, $0 DESC] }
-        BatchProject { exprs: [$0, $1], expr_alias: [c_count, custdist] }
-          BatchHashAgg { group_keys: [$0], aggs: [count] }
-            BatchProject { exprs: [$1], expr_alias: [ ] }
-              BatchExchange { order: [], dist: HashShard([1]) }
-                BatchHashAgg { group_keys: [$0], aggs: [count($1)] }
-                  BatchProject { exprs: [$0, $1], expr_alias: [ ,  ] }
-                    BatchHashJoin { type: LeftOuter, predicate: $0 = $2 AND Not(Like($3, '%:1%:2%':Varchar)) }
-                      BatchExchange { order: [], dist: HashShard([0]) }
-                        BatchScan { table: customer, columns: [c_custkey] }
-                      BatchExchange { order: [], dist: HashShard([1]) }
-                        BatchScan { table: orders, columns: [o_orderkey, o_custkey, o_comment] }
+        BatchHashAgg { group_keys: [$0], aggs: [count] }
+          BatchProject { exprs: [$1] }
+            BatchExchange { order: [], dist: HashShard([1]) }
+              BatchHashAgg { group_keys: [$0], aggs: [count($1)] }
+                BatchProject { exprs: [$0, $1] }
+                  BatchHashJoin { type: LeftOuter, predicate: $0 = $2 AND Not(Like($3, '%:1%:2%':Varchar)) }
+                    BatchExchange { order: [], dist: HashShard([0]) }
+                      BatchScan { table: customer, columns: [c_custkey] }
+                    BatchExchange { order: [], dist: HashShard([1]) }
+                      BatchScan { table: orders, columns: [o_orderkey, o_custkey, o_comment] }
   stream_plan: |
-    StreamMaterialize { columns: [c_count, custdist], pk_columns: [c_count], order_descs: [custdist, c_count] }
-      StreamProject { exprs: [$0, $2], expr_alias: [c_count, custdist] }
-        StreamHashAgg { group_keys: [$0], aggs: [count, count] }
-          StreamProject { exprs: [$2, $0], expr_alias: [ ,  ] }
-            StreamExchange { dist: HashShard([2]) }
-              StreamHashAgg { group_keys: [$0], aggs: [count, count($1)] }
-                StreamProject { exprs: [$0, $2, $1, $5], expr_alias: [ ,  ,  ,  ] }
-                  StreamHashJoin { type: LeftOuter, predicate: $0 = $3 AND Not(Like($4, '%:1%:2%':Varchar)) }
-                    StreamExchange { dist: HashShard([0]) }
-                      StreamTableScan { table: customer, columns: [c_custkey, _row_id#0], pk_indices: [1] }
-                    StreamExchange { dist: HashShard([1]) }
-                      StreamTableScan { table: orders, columns: [o_orderkey, o_custkey, o_comment, _row_id#0], pk_indices: [3] }
+    StreamMaterialize { columns: [c_count, agg#0(hidden), custdist], pk_columns: [c_count], order_descs: [custdist, c_count] }
+      StreamHashAgg { group_keys: [$0], aggs: [count, count] }
+        StreamProject { exprs: [$2, $0] }
+          StreamExchange { dist: HashShard([2]) }
+            StreamHashAgg { group_keys: [$0], aggs: [count, count($1)] }
+              StreamProject { exprs: [$0, $2, $1, $5] }
+                StreamHashJoin { type: LeftOuter, predicate: $0 = $3 AND Not(Like($4, '%:1%:2%':Varchar)) }
+                  StreamExchange { dist: HashShard([0]) }
+                    StreamTableScan { table: customer, columns: [c_custkey, _row_id#0], pk_indices: [1] }
+                  StreamExchange { dist: HashShard([1]) }
+                    StreamTableScan { table: orders, columns: [o_orderkey, o_custkey, o_comment, _row_id#0], pk_indices: [3] }
 - id: tpch_q14
   before:
     - create_tables
@@ -1201,12 +1189,12 @@
       and l_shipdate >= date '1995-09-01'
       and l_shipdate < date '1995-09-01' + interval '1' month;
   batch_plan: |
-    BatchProject { exprs: [((100.00:Decimal * $0) / $1)], expr_alias: [promo_revenue] }
+    BatchProject { exprs: [((100.00:Decimal * $0) / $1)] }
       BatchSimpleAgg { aggs: [sum($0), sum($1)] }
         BatchExchange { order: [], dist: Single }
-          BatchProject { exprs: [Case(Like($4, 'PROMO%':Varchar), ($1 * (1:Int32 - $2)), 0:Int32::Decimal), ($1 * (1:Int32 - $2))], expr_alias: [ ,  ] }
+          BatchProject { exprs: [Case(Like($4, 'PROMO%':Varchar), ($1 * (1:Int32 - $2)), 0:Int32::Decimal), ($1 * (1:Int32 - $2))] }
             BatchHashJoin { type: Inner, predicate: $0 = $3 }
-              BatchProject { exprs: [$0, $1, $2], expr_alias: [ ,  ,  ] }
+              BatchProject { exprs: [$0, $1, $2] }
                 BatchExchange { order: [], dist: HashShard([0]) }
                   BatchFilter { predicate: ($3 >= '1995-09-01':Varchar::Date) AND ($3 < ('1995-09-01':Varchar::Date + '1 mon 00:00:00':Interval)) }
                     BatchScan { table: lineitem, columns: [l_partkey, l_extendedprice, l_discount, l_shipdate] }
@@ -1214,12 +1202,12 @@
                 BatchScan { table: part, columns: [p_partkey, p_type] }
   stream_plan: |
     StreamMaterialize { columns: [promo_revenue, agg#0(hidden), agg#1(hidden), agg#2(hidden)], pk_columns: [agg#0, agg#1, agg#2] }
-      StreamProject { exprs: [((100.00:Decimal * $1) / $2), $0, $1, $2], expr_alias: [promo_revenue,  ,  ,  ] }
+      StreamProject { exprs: [((100.00:Decimal * $1) / $2), $0, $1, $2] }
         StreamSimpleAgg { aggs: [count, sum($0), sum($1)] }
           StreamExchange { dist: Single }
-            StreamProject { exprs: [Case(Like($5, 'PROMO%':Varchar), ($1 * (1:Int32 - $2)), 0:Int32::Decimal), ($1 * (1:Int32 - $2)), $3, $6], expr_alias: [ ,  ,  ,  ] }
+            StreamProject { exprs: [Case(Like($5, 'PROMO%':Varchar), ($1 * (1:Int32 - $2)), 0:Int32::Decimal), ($1 * (1:Int32 - $2)), $3, $6] }
               StreamHashJoin { type: Inner, predicate: $0 = $4 }
-                StreamProject { exprs: [$0, $1, $2, $4], expr_alias: [ ,  ,  ,  ] }
+                StreamProject { exprs: [$0, $1, $2, $4] }
                   StreamExchange { dist: HashShard([0]) }
                     StreamFilter { predicate: ($3 >= '1995-09-01':Varchar::Date) AND ($3 < ('1995-09-01':Varchar::Date + '1 mon 00:00:00':Interval)) }
                       StreamTableScan { table: lineitem, columns: [l_partkey, l_extendedprice, l_discount, l_shipdate, _row_id#0], pk_indices: [4] }
@@ -1273,55 +1261,51 @@
   batch_plan: |
     BatchExchange { order: [$0 ASC], dist: Single }
       BatchSort { order: [$0 ASC] }
-        BatchProject { exprs: [$0, $1, $2, $3, $4], expr_alias: [s_suppkey, s_name, s_address, s_phone, total_revenue] }
+        BatchProject { exprs: [$0, $1, $2, $3, $4] }
           BatchHashJoin { type: Inner, predicate: $4 = $5 }
-            BatchProject { exprs: [$0, $1, $2, $3, $5], expr_alias: [ ,  ,  ,  ,  ] }
+            BatchProject { exprs: [$0, $1, $2, $3, $5] }
               BatchExchange { order: [], dist: HashShard([5]) }
                 BatchHashJoin { type: Inner, predicate: $0 = $4 }
                   BatchExchange { order: [], dist: HashShard([0]) }
                     BatchScan { table: supplier, columns: [s_suppkey, s_name, s_address, s_phone] }
-                  BatchProject { exprs: [$0, $1], expr_alias: [l_suppkey, total_revenue] }
+                  BatchHashAgg { group_keys: [$0], aggs: [sum($1)] }
+                    BatchProject { exprs: [$0, ($1 * (1:Int32 - $2))] }
+                      BatchExchange { order: [], dist: HashShard([0]) }
+                        BatchFilter { predicate: ($3 >= '1993-01-01':Varchar::Date) AND ($3 < ('1993-01-01':Varchar::Date + '3 mons 00:00:00':Interval)) }
+                          BatchScan { table: lineitem, columns: [l_suppkey, l_extendedprice, l_discount, l_shipdate] }
+            BatchExchange { order: [], dist: HashShard([0]) }
+              BatchSimpleAgg { aggs: [max($0)] }
+                BatchExchange { order: [], dist: Single }
+                  BatchProject { exprs: [$1] }
                     BatchHashAgg { group_keys: [$0], aggs: [sum($1)] }
-                      BatchProject { exprs: [$0, ($1 * (1:Int32 - $2))], expr_alias: [ ,  ] }
+                      BatchProject { exprs: [$0, ($1 * (1:Int32 - $2))] }
                         BatchExchange { order: [], dist: HashShard([0]) }
                           BatchFilter { predicate: ($3 >= '1993-01-01':Varchar::Date) AND ($3 < ('1993-01-01':Varchar::Date + '3 mons 00:00:00':Interval)) }
                             BatchScan { table: lineitem, columns: [l_suppkey, l_extendedprice, l_discount, l_shipdate] }
-            BatchProject { exprs: [$0], expr_alias: [max_revenue] }
-              BatchExchange { order: [], dist: HashShard([0]) }
-                BatchSimpleAgg { aggs: [max($0)] }
-                  BatchExchange { order: [], dist: Single }
-                    BatchProject { exprs: [$1], expr_alias: [ ] }
-                      BatchHashAgg { group_keys: [$0], aggs: [sum($1)] }
-                        BatchProject { exprs: [$0, ($1 * (1:Int32 - $2))], expr_alias: [ ,  ] }
-                          BatchExchange { order: [], dist: HashShard([0]) }
-                            BatchFilter { predicate: ($3 >= '1993-01-01':Varchar::Date) AND ($3 < ('1993-01-01':Varchar::Date + '3 mons 00:00:00':Interval)) }
-                              BatchScan { table: lineitem, columns: [l_suppkey, l_extendedprice, l_discount, l_shipdate] }
   stream_plan: |
-    StreamMaterialize { columns: [s_suppkey, s_name, s_address, s_phone, total_revenue, _row_id#0(hidden), l_suppkey(hidden), agg#0(hidden), max_revenue(hidden)], pk_columns: [_row_id#0, l_suppkey, agg#0, max_revenue], order_descs: [s_suppkey, _row_id#0, l_suppkey, agg#0, max_revenue] }
+    StreamMaterialize { columns: [s_suppkey, s_name, s_address, s_phone, total_revenue, _row_id#0(hidden), l_suppkey(hidden), agg#0(hidden), agg#1(hidden)], pk_columns: [_row_id#0, l_suppkey, agg#0, agg#1], order_descs: [s_suppkey, _row_id#0, l_suppkey, agg#0, agg#1] }
       StreamExchange { dist: HashShard([5, 6, 7, 8]) }
-        StreamProject { exprs: [$0, $1, $2, $3, $4, $5, $6, $8, $7], expr_alias: [s_suppkey, s_name, s_address, s_phone, total_revenue,  ,  ,  ,  ] }
-          StreamHashJoin { type: Inner, predicate: $4 = $7 }
-            StreamProject { exprs: [$0, $1, $2, $3, $6, $4, $5], expr_alias: [ ,  ,  ,  ,  ,  ,  ] }
-              StreamExchange { dist: HashShard([6]) }
+        StreamProject { exprs: [$0, $1, $2, $3, $4, $5, $6, $7, $8] }
+          StreamHashJoin { type: Inner, predicate: $4 = $8 }
+            StreamProject { exprs: [$0, $1, $2, $3, $7, $4, $5] }
+              StreamExchange { dist: HashShard([7]) }
                 StreamHashJoin { type: Inner, predicate: $0 = $5 }
                   StreamExchange { dist: HashShard([0]) }
                     StreamTableScan { table: supplier, columns: [s_suppkey, s_name, s_address, s_phone, _row_id#0], pk_indices: [4] }
-                  StreamProject { exprs: [$0, $2], expr_alias: [l_suppkey, total_revenue] }
+                  StreamHashAgg { group_keys: [$0], aggs: [count, sum($1)] }
+                    StreamProject { exprs: [$0, ($1 * (1:Int32 - $2)), $4] }
+                      StreamExchange { dist: HashShard([0]) }
+                        StreamFilter { predicate: ($3 >= '1993-01-01':Varchar::Date) AND ($3 < ('1993-01-01':Varchar::Date + '3 mons 00:00:00':Interval)) }
+                          StreamTableScan { table: lineitem, columns: [l_suppkey, l_extendedprice, l_discount, l_shipdate, _row_id#0], pk_indices: [4] }
+            StreamExchange { dist: HashShard([1]) }
+              StreamSimpleAgg { aggs: [count, max($0)] }
+                StreamExchange { dist: Single }
+                  StreamProject { exprs: [$2, $0] }
                     StreamHashAgg { group_keys: [$0], aggs: [count, sum($1)] }
-                      StreamProject { exprs: [$0, ($1 * (1:Int32 - $2)), $4], expr_alias: [ ,  ,  ] }
+                      StreamProject { exprs: [$0, ($1 * (1:Int32 - $2)), $4] }
                         StreamExchange { dist: HashShard([0]) }
                           StreamFilter { predicate: ($3 >= '1993-01-01':Varchar::Date) AND ($3 < ('1993-01-01':Varchar::Date + '3 mons 00:00:00':Interval)) }
                             StreamTableScan { table: lineitem, columns: [l_suppkey, l_extendedprice, l_discount, l_shipdate, _row_id#0], pk_indices: [4] }
-            StreamProject { exprs: [$1, $0], expr_alias: [max_revenue,  ] }
-              StreamExchange { dist: HashShard([1]) }
-                StreamSimpleAgg { aggs: [count, max($0)] }
-                  StreamExchange { dist: Single }
-                    StreamProject { exprs: [$2, $0], expr_alias: [ ,  ] }
-                      StreamHashAgg { group_keys: [$0], aggs: [count, sum($1)] }
-                        StreamProject { exprs: [$0, ($1 * (1:Int32 - $2)), $4], expr_alias: [ ,  ,  ] }
-                          StreamExchange { dist: HashShard([0]) }
-                            StreamFilter { predicate: ($3 >= '1993-01-01':Varchar::Date) AND ($3 < ('1993-01-01':Varchar::Date + '3 mons 00:00:00':Interval)) }
-                              StreamTableScan { table: lineitem, columns: [l_suppkey, l_extendedprice, l_discount, l_shipdate, _row_id#0], pk_indices: [4] }
 - id: tpch_q16
   before:
     - create_tables
@@ -1357,15 +1341,15 @@
       p_type,
       p_size;
   logical_plan: |
-    LogicalProject { exprs: [$0, $1, $2, $3], expr_alias: [p_brand, p_type, p_size, supplier_cnt] }
+    LogicalProject { exprs: [$0, $1, $2, $3] }
       LogicalAgg { group_keys: [0, 1, 2], agg_calls: [count($3)] }
-        LogicalProject { exprs: [$10, $11, $12, $2], expr_alias: [ ,  ,  ,  ] }
+        LogicalProject { exprs: [$10, $11, $12, $2] }
           LogicalFilter { predicate: ($7 = $1) AND ($10 <> 'Brand#45':Varchar) AND Not(Like($11, 'SMALL PLATED%':Varchar)) AND In($12, 19:Int32, 17:Int32, 16:Int32, 23:Int32, 10:Int32, 4:Int32, 38:Int32, 11:Int32) }
             LogicalJoin { type: LeftAnti, on: ($2 = $16) }
               LogicalJoin { type: Inner, on: true }
                 LogicalScan { table: partsupp, columns: [_row_id#0, ps_partkey, ps_suppkey, ps_availqty, ps_supplycost, ps_comment] }
                 LogicalScan { table: part, columns: [_row_id#0, p_partkey, p_name, p_mfgr, p_brand, p_type, p_size, p_container, p_retailprice, p_comment] }
-              LogicalProject { exprs: [$1], expr_alias: [s_suppkey] }
+              LogicalProject { exprs: [$1] }
                 LogicalFilter { predicate: Like($7, '%Customer%Complaints%':Varchar) }
                   LogicalScan { table: supplier, columns: [_row_id#0, s_suppkey, s_name, s_address, s_nationkey, s_phone, s_acctbal, s_comment] }
 - id: tpch_q17
@@ -1390,14 +1374,14 @@
           l_partkey = p_partkey
       );
   batch_plan: |
-    BatchProject { exprs: [RoundDigit(($0 / 7.0:Decimal), 16:Int32)], expr_alias: [avg_yearly] }
+    BatchProject { exprs: [RoundDigit(($0 / 7.0:Decimal), 16:Int32)] }
       BatchSimpleAgg { aggs: [sum($0)] }
         BatchExchange { order: [], dist: Single }
-          BatchProject { exprs: [$1], expr_alias: [ ] }
+          BatchProject { exprs: [$1] }
             BatchFilter { predicate: ($0 < (0.2:Decimal * ($2 / $3))) }
-              BatchProject { exprs: [$5, $6, $27, $28], expr_alias: [ ,  ,  ,  ] }
+              BatchProject { exprs: [$5, $6, $27, $28] }
                 BatchHashAgg { group_keys: [$0, $1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16, $17, $18, $19, $20, $21, $22, $23, $24, $25, $26], aggs: [sum($27), count($27)] }
-                  BatchProject { exprs: [$0, $1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16, $17, $18, $19, $20, $21, $22, $23, $24, $25, $26, $27], expr_alias: [ ,  ,  ,  ,  ,  ,  ,  ,  ,  ,  ,  ,  ,  ,  ,  ,  ,  ,  ,  ,  ,  ,  ,  ,  ,  ,  ,  ] }
+                  BatchProject { exprs: [$0, $1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16, $17, $18, $19, $20, $21, $22, $23, $24, $25, $26, $27] }
                     BatchHashJoin { type: LeftOuter, predicate: $18 = $28 }
                       BatchExchange { order: [], dist: HashShard([18]) }
                         BatchHashJoin { type: Inner, predicate: $2 = $18 }
@@ -1406,19 +1390,19 @@
                           BatchExchange { order: [], dist: HashShard([1]) }
                             BatchFilter { predicate: ($4 = 'Brand#13':Varchar) AND ($7 = 'JUMBO PKG':Varchar) }
                               BatchScan { table: part, columns: [_row_id#0, p_partkey, p_name, p_mfgr, p_brand, p_type, p_size, p_container, p_retailprice, p_comment] }
-                      BatchProject { exprs: [$1, $0], expr_alias: [ ,  ] }
+                      BatchProject { exprs: [$1, $0] }
                         BatchExchange { order: [], dist: HashShard([0]) }
                           BatchScan { table: lineitem, columns: [l_partkey, l_quantity] }
   stream_plan: |
     StreamMaterialize { columns: [avg_yearly, agg#0(hidden), agg#1(hidden)], pk_columns: [agg#0, agg#1] }
-      StreamProject { exprs: [RoundDigit(($1 / 7.0:Decimal), 16:Int32), $0, $1], expr_alias: [avg_yearly,  ,  ] }
+      StreamProject { exprs: [RoundDigit(($1 / 7.0:Decimal), 16:Int32), $0, $1] }
         StreamSimpleAgg { aggs: [count, sum($0)] }
           StreamExchange { dist: Single }
-            StreamProject { exprs: [$1, $4, $5, $6, $7, $8, $0, $9, $10, $11, $12, $13, $14, $15, $16, $17, $18, $19, $20, $21, $22, $23, $24, $25, $26, $27, $28], expr_alias: [ ,  ,  ,  ,  ,  ,  ,  ,  ,  ,  ,  ,  ,  ,  ,  ,  ,  ,  ,  ,  ,  ,  ,  ,  ,  ,  ] }
+            StreamProject { exprs: [$1, $4, $5, $6, $7, $8, $0, $9, $10, $11, $12, $13, $14, $15, $16, $17, $18, $19, $20, $21, $22, $23, $24, $25, $26, $27, $28] }
               StreamFilter { predicate: ($0 < (0.2:Decimal * ($2 / $3))) }
-                StreamProject { exprs: [$5, $6, $28, $29, $0, $1, $2, $3, $4, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16, $17, $18, $19, $20, $21, $22, $23, $24, $25, $26], expr_alias: [ ,  ,  ,  ,  ,  ,  ,  ,  ,  ,  ,  ,  ,  ,  ,  ,  ,  ,  ,  ,  ,  ,  ,  ,  ,  ,  ,  ,  ] }
+                StreamProject { exprs: [$5, $6, $28, $29, $0, $1, $2, $3, $4, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16, $17, $18, $19, $20, $21, $22, $23, $24, $25, $26] }
                   StreamHashAgg { group_keys: [$0, $1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16, $17, $18, $19, $20, $21, $22, $23, $24, $25, $26], aggs: [count, sum($27), count($27)] }
-                    StreamProject { exprs: [$0, $1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16, $17, $18, $19, $20, $21, $22, $23, $24, $25, $26, $27, $29], expr_alias: [ ,  ,  ,  ,  ,  ,  ,  ,  ,  ,  ,  ,  ,  ,  ,  ,  ,  ,  ,  ,  ,  ,  ,  ,  ,  ,  ,  ,  ] }
+                    StreamProject { exprs: [$0, $1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16, $17, $18, $19, $20, $21, $22, $23, $24, $25, $26, $27, $29] }
                       StreamHashJoin { type: LeftOuter, predicate: $18 = $28 }
                         StreamExchange { dist: HashShard([18]) }
                           StreamHashJoin { type: Inner, predicate: $2 = $18 }
@@ -1427,7 +1411,7 @@
                             StreamExchange { dist: HashShard([1]) }
                               StreamFilter { predicate: ($4 = 'Brand#13':Varchar) AND ($7 = 'JUMBO PKG':Varchar) }
                                 StreamTableScan { table: part, columns: [_row_id#0, p_partkey, p_name, p_mfgr, p_brand, p_type, p_size, p_container, p_retailprice, p_comment], pk_indices: [0] }
-                        StreamProject { exprs: [$1, $0, $2], expr_alias: [ ,  ,  ] }
+                        StreamProject { exprs: [$1, $0, $2] }
                           StreamExchange { dist: HashShard([0]) }
                             StreamTableScan { table: lineitem, columns: [l_partkey, l_quantity, _row_id#0], pk_indices: [2] }
 - id: tpch_q18
@@ -1471,50 +1455,48 @@
   batch_plan: |
     BatchTopN { order: [$4 DESC, $3 ASC], limit: 100, offset: 0 }
       BatchExchange { order: [], dist: Single }
-        BatchProject { exprs: [$0, $1, $2, $3, $4, $5], expr_alias: [c_name, c_custkey, o_orderkey, o_orderdate, o_totalprice, quantity] }
-          BatchHashAgg { group_keys: [$0, $1, $2, $3, $4], aggs: [sum($5)] }
-            BatchProject { exprs: [$1, $0, $2, $4, $3, $5], expr_alias: [ ,  ,  ,  ,  ,  ] }
-              BatchHashJoin { type: LeftSemi, predicate: $2 = $6 }
-                BatchProject { exprs: [$0, $1, $2, $3, $4, $6], expr_alias: [ ,  ,  ,  ,  ,  ] }
-                  BatchHashJoin { type: Inner, predicate: $2 = $5 }
-                    BatchProject { exprs: [$0, $1, $2, $4, $5], expr_alias: [ ,  ,  ,  ,  ] }
-                      BatchExchange { order: [], dist: HashShard([2]) }
-                        BatchHashJoin { type: Inner, predicate: $0 = $3 }
-                          BatchExchange { order: [], dist: HashShard([0]) }
-                            BatchScan { table: customer, columns: [c_custkey, c_name] }
-                          BatchExchange { order: [], dist: HashShard([1]) }
-                            BatchScan { table: orders, columns: [o_orderkey, o_custkey, o_totalprice, o_orderdate] }
+        BatchHashAgg { group_keys: [$0, $1, $2, $3, $4], aggs: [sum($5)] }
+          BatchProject { exprs: [$1, $0, $2, $4, $3, $5] }
+            BatchHashJoin { type: LeftSemi, predicate: $2 = $6 }
+              BatchProject { exprs: [$0, $1, $2, $3, $4, $6] }
+                BatchHashJoin { type: Inner, predicate: $2 = $5 }
+                  BatchProject { exprs: [$0, $1, $2, $4, $5] }
+                    BatchExchange { order: [], dist: HashShard([2]) }
+                      BatchHashJoin { type: Inner, predicate: $0 = $3 }
+                        BatchExchange { order: [], dist: HashShard([0]) }
+                          BatchScan { table: customer, columns: [c_custkey, c_name] }
+                        BatchExchange { order: [], dist: HashShard([1]) }
+                          BatchScan { table: orders, columns: [o_orderkey, o_custkey, o_totalprice, o_orderdate] }
+                  BatchExchange { order: [], dist: HashShard([0]) }
+                    BatchScan { table: lineitem, columns: [l_orderkey, l_quantity] }
+              BatchProject { exprs: [$0] }
+                BatchFilter { predicate: ($1 > 1:Int32) }
+                  BatchHashAgg { group_keys: [$0], aggs: [sum($1)] }
                     BatchExchange { order: [], dist: HashShard([0]) }
                       BatchScan { table: lineitem, columns: [l_orderkey, l_quantity] }
-                BatchProject { exprs: [$0], expr_alias: [l_orderkey] }
-                  BatchFilter { predicate: ($1 > 1:Int32) }
-                    BatchHashAgg { group_keys: [$0], aggs: [sum($1)] }
-                      BatchExchange { order: [], dist: HashShard([0]) }
-                        BatchScan { table: lineitem, columns: [l_orderkey, l_quantity] }
   stream_plan: |
-    StreamMaterialize { columns: [c_name, c_custkey, o_orderkey, o_orderdate, o_totalprice, quantity], pk_columns: [c_name, c_custkey, o_orderkey, o_orderdate, o_totalprice], order_descs: [o_totalprice, o_orderdate, c_name, c_custkey, o_orderkey] }
+    StreamMaterialize { columns: [c_name, c_custkey, o_orderkey, o_orderdate, o_totalprice, agg#0(hidden), quantity], pk_columns: [c_name, c_custkey, o_orderkey, o_orderdate, o_totalprice], order_descs: [o_totalprice, o_orderdate, c_name, c_custkey, o_orderkey] }
       StreamTopN { order: [$4 DESC, $3 ASC], limit: 100, offset: 0 }
         StreamExchange { dist: Single }
-          StreamProject { exprs: [$0, $1, $2, $3, $4, $6], expr_alias: [c_name, c_custkey, o_orderkey, o_orderdate, o_totalprice, quantity] }
-            StreamHashAgg { group_keys: [$0, $1, $2, $3, $4], aggs: [count, sum($5)] }
-              StreamProject { exprs: [$1, $0, $2, $4, $3, $5, $6, $7, $8], expr_alias: [ ,  ,  ,  ,  ,  ,  ,  ,  ] }
-                StreamHashJoin { type: LeftSemi, predicate: $2 = $9 }
-                  StreamProject { exprs: [$0, $1, $2, $3, $4, $8, $5, $6, $9], expr_alias: [ ,  ,  ,  ,  ,  ,  ,  ,  ] }
-                    StreamHashJoin { type: Inner, predicate: $2 = $7 }
-                      StreamProject { exprs: [$0, $1, $3, $5, $6, $2, $7], expr_alias: [ ,  ,  ,  ,  ,  ,  ] }
-                        StreamExchange { dist: HashShard([3]) }
-                          StreamHashJoin { type: Inner, predicate: $0 = $4 }
-                            StreamExchange { dist: HashShard([0]) }
-                              StreamTableScan { table: customer, columns: [c_custkey, c_name, _row_id#0], pk_indices: [2] }
-                            StreamExchange { dist: HashShard([1]) }
-                              StreamTableScan { table: orders, columns: [o_orderkey, o_custkey, o_totalprice, o_orderdate, _row_id#0], pk_indices: [4] }
+          StreamHashAgg { group_keys: [$0, $1, $2, $3, $4], aggs: [count, sum($5)] }
+            StreamProject { exprs: [$1, $0, $2, $4, $3, $5, $6, $7, $8] }
+              StreamHashJoin { type: LeftSemi, predicate: $2 = $9 }
+                StreamProject { exprs: [$0, $1, $2, $3, $4, $8, $5, $6, $9] }
+                  StreamHashJoin { type: Inner, predicate: $2 = $7 }
+                    StreamProject { exprs: [$0, $1, $3, $5, $6, $2, $7] }
+                      StreamExchange { dist: HashShard([3]) }
+                        StreamHashJoin { type: Inner, predicate: $0 = $4 }
+                          StreamExchange { dist: HashShard([0]) }
+                            StreamTableScan { table: customer, columns: [c_custkey, c_name, _row_id#0], pk_indices: [2] }
+                          StreamExchange { dist: HashShard([1]) }
+                            StreamTableScan { table: orders, columns: [o_orderkey, o_custkey, o_totalprice, o_orderdate, _row_id#0], pk_indices: [4] }
+                    StreamExchange { dist: HashShard([0]) }
+                      StreamTableScan { table: lineitem, columns: [l_orderkey, l_quantity, _row_id#0], pk_indices: [2] }
+                StreamProject { exprs: [$0] }
+                  StreamFilter { predicate: ($2 > 1:Int32) }
+                    StreamHashAgg { group_keys: [$0], aggs: [count, sum($1)] }
                       StreamExchange { dist: HashShard([0]) }
                         StreamTableScan { table: lineitem, columns: [l_orderkey, l_quantity, _row_id#0], pk_indices: [2] }
-                  StreamProject { exprs: [$0], expr_alias: [l_orderkey] }
-                    StreamFilter { predicate: ($2 > 1:Int32) }
-                      StreamHashAgg { group_keys: [$0], aggs: [count, sum($1)] }
-                        StreamExchange { dist: HashShard([0]) }
-                          StreamTableScan { table: lineitem, columns: [l_orderkey, l_quantity, _row_id#0], pk_indices: [2] }
 - id: tpch_q19
   before:
     - create_tables
@@ -1555,34 +1537,32 @@
         and l_shipinstruct = 'DELIVER IN PERSON'
       );
   batch_plan: |
-    BatchProject { exprs: [$0], expr_alias: [revenue] }
-      BatchSimpleAgg { aggs: [sum($0)] }
-        BatchExchange { order: [], dist: Single }
-          BatchProject { exprs: [($2 * (1:Int32 - $3))], expr_alias: [ ] }
-            BatchFilter { predicate: ((((((($5 = 'Brand#52':Varchar) AND In($7, 'SM CASE':Varchar, 'SM BOX':Varchar, 'SM PACK':Varchar, 'SM PKG':Varchar)) AND ($1 >= 1:Int32)) AND ($1 <= 11:Int32)) AND ($6 <= 5:Int32)) OR ((((($5 = 'Brand#24':Varchar) AND In($7, 'MED BAG':Varchar, 'MED BOX':Varchar, 'MED PKG':Varchar, 'MED PACK':Varchar)) AND ($1 >= 30:Int32)) AND ($1 <= 40:Int32)) AND ($6 <= 10:Int32))) OR ((((($5 = 'Brand#32':Varchar) AND In($7, 'LG CASE':Varchar, 'LG BOX':Varchar, 'LG PACK':Varchar, 'LG PKG':Varchar)) AND ($1 >= 10:Int32)) AND ($1 <= 20:Int32)) AND ($6 <= 15:Int32))) }
-              BatchHashJoin { type: Inner, predicate: $0 = $4 }
-                BatchProject { exprs: [$0, $1, $2, $3], expr_alias: [ ,  ,  ,  ] }
-                  BatchExchange { order: [], dist: HashShard([0]) }
-                    BatchFilter { predicate: In($5, 'AIR':Varchar, 'AIR REG':Varchar) AND ($4 = 'DELIVER IN PERSON':Varchar) }
-                      BatchScan { table: lineitem, columns: [l_partkey, l_quantity, l_extendedprice, l_discount, l_shipinstruct, l_shipmode] }
+    BatchSimpleAgg { aggs: [sum($0)] }
+      BatchExchange { order: [], dist: Single }
+        BatchProject { exprs: [($2 * (1:Int32 - $3))] }
+          BatchFilter { predicate: ((((((($5 = 'Brand#52':Varchar) AND In($7, 'SM CASE':Varchar, 'SM BOX':Varchar, 'SM PACK':Varchar, 'SM PKG':Varchar)) AND ($1 >= 1:Int32)) AND ($1 <= 11:Int32)) AND ($6 <= 5:Int32)) OR ((((($5 = 'Brand#24':Varchar) AND In($7, 'MED BAG':Varchar, 'MED BOX':Varchar, 'MED PKG':Varchar, 'MED PACK':Varchar)) AND ($1 >= 30:Int32)) AND ($1 <= 40:Int32)) AND ($6 <= 10:Int32))) OR ((((($5 = 'Brand#32':Varchar) AND In($7, 'LG CASE':Varchar, 'LG BOX':Varchar, 'LG PACK':Varchar, 'LG PKG':Varchar)) AND ($1 >= 10:Int32)) AND ($1 <= 20:Int32)) AND ($6 <= 15:Int32))) }
+            BatchHashJoin { type: Inner, predicate: $0 = $4 }
+              BatchProject { exprs: [$0, $1, $2, $3] }
                 BatchExchange { order: [], dist: HashShard([0]) }
-                  BatchFilter { predicate: ($2 >= 1:Int32) }
-                    BatchScan { table: part, columns: [p_partkey, p_brand, p_size, p_container] }
+                  BatchFilter { predicate: In($5, 'AIR':Varchar, 'AIR REG':Varchar) AND ($4 = 'DELIVER IN PERSON':Varchar) }
+                    BatchScan { table: lineitem, columns: [l_partkey, l_quantity, l_extendedprice, l_discount, l_shipinstruct, l_shipmode] }
+              BatchExchange { order: [], dist: HashShard([0]) }
+                BatchFilter { predicate: ($2 >= 1:Int32) }
+                  BatchScan { table: part, columns: [p_partkey, p_brand, p_size, p_container] }
   stream_plan: |
-    StreamMaterialize { columns: [revenue, agg#0(hidden)], pk_columns: [agg#0, revenue] }
-      StreamProject { exprs: [$1, $0], expr_alias: [revenue,  ] }
-        StreamSimpleAgg { aggs: [count, sum($0)] }
-          StreamExchange { dist: Single }
-            StreamProject { exprs: [($2 * (1:Int32 - $3)), $4, $9], expr_alias: [ ,  ,  ] }
-              StreamFilter { predicate: ((((((($6 = 'Brand#52':Varchar) AND In($8, 'SM CASE':Varchar, 'SM BOX':Varchar, 'SM PACK':Varchar, 'SM PKG':Varchar)) AND ($1 >= 1:Int32)) AND ($1 <= 11:Int32)) AND ($7 <= 5:Int32)) OR ((((($6 = 'Brand#24':Varchar) AND In($8, 'MED BAG':Varchar, 'MED BOX':Varchar, 'MED PKG':Varchar, 'MED PACK':Varchar)) AND ($1 >= 30:Int32)) AND ($1 <= 40:Int32)) AND ($7 <= 10:Int32))) OR ((((($6 = 'Brand#32':Varchar) AND In($8, 'LG CASE':Varchar, 'LG BOX':Varchar, 'LG PACK':Varchar, 'LG PKG':Varchar)) AND ($1 >= 10:Int32)) AND ($1 <= 20:Int32)) AND ($7 <= 15:Int32))) }
-                StreamHashJoin { type: Inner, predicate: $0 = $5 }
-                  StreamProject { exprs: [$0, $1, $2, $3, $6], expr_alias: [ ,  ,  ,  ,  ] }
-                    StreamExchange { dist: HashShard([0]) }
-                      StreamFilter { predicate: In($5, 'AIR':Varchar, 'AIR REG':Varchar) AND ($4 = 'DELIVER IN PERSON':Varchar) }
-                        StreamTableScan { table: lineitem, columns: [l_partkey, l_quantity, l_extendedprice, l_discount, l_shipinstruct, l_shipmode, _row_id#0], pk_indices: [6] }
+    StreamMaterialize { columns: [agg#0(hidden), revenue], pk_columns: [agg#0, revenue] }
+      StreamSimpleAgg { aggs: [count, sum($0)] }
+        StreamExchange { dist: Single }
+          StreamProject { exprs: [($2 * (1:Int32 - $3)), $4, $9] }
+            StreamFilter { predicate: ((((((($6 = 'Brand#52':Varchar) AND In($8, 'SM CASE':Varchar, 'SM BOX':Varchar, 'SM PACK':Varchar, 'SM PKG':Varchar)) AND ($1 >= 1:Int32)) AND ($1 <= 11:Int32)) AND ($7 <= 5:Int32)) OR ((((($6 = 'Brand#24':Varchar) AND In($8, 'MED BAG':Varchar, 'MED BOX':Varchar, 'MED PKG':Varchar, 'MED PACK':Varchar)) AND ($1 >= 30:Int32)) AND ($1 <= 40:Int32)) AND ($7 <= 10:Int32))) OR ((((($6 = 'Brand#32':Varchar) AND In($8, 'LG CASE':Varchar, 'LG BOX':Varchar, 'LG PACK':Varchar, 'LG PKG':Varchar)) AND ($1 >= 10:Int32)) AND ($1 <= 20:Int32)) AND ($7 <= 15:Int32))) }
+              StreamHashJoin { type: Inner, predicate: $0 = $5 }
+                StreamProject { exprs: [$0, $1, $2, $3, $6] }
                   StreamExchange { dist: HashShard([0]) }
-                    StreamFilter { predicate: ($2 >= 1:Int32) }
-                      StreamTableScan { table: part, columns: [p_partkey, p_brand, p_size, p_container, _row_id#0], pk_indices: [4] }
+                    StreamFilter { predicate: In($5, 'AIR':Varchar, 'AIR REG':Varchar) AND ($4 = 'DELIVER IN PERSON':Varchar) }
+                      StreamTableScan { table: lineitem, columns: [l_partkey, l_quantity, l_extendedprice, l_discount, l_shipinstruct, l_shipmode, _row_id#0], pk_indices: [6] }
+                StreamExchange { dist: HashShard([0]) }
+                  StreamFilter { predicate: ($2 >= 1:Int32) }
+                    StreamTableScan { table: part, columns: [p_partkey, p_brand, p_size, p_container, _row_id#0], pk_indices: [4] }
 - id: tpch_q20
   before:
     - create_tables
@@ -1627,66 +1607,66 @@
   batch_plan: |
     BatchExchange { order: [$0 ASC], dist: Single }
       BatchSort { order: [$0 ASC] }
-        BatchProject { exprs: [$1, $2], expr_alias: [s_name, s_address] }
+        BatchProject { exprs: [$1, $2] }
           BatchHashJoin { type: LeftSemi, predicate: $0 = $3 }
-            BatchProject { exprs: [$0, $1, $2], expr_alias: [ ,  ,  ] }
+            BatchProject { exprs: [$0, $1, $2] }
               BatchExchange { order: [], dist: HashShard([0]) }
                 BatchHashJoin { type: Inner, predicate: $3 = $4 }
                   BatchExchange { order: [], dist: HashShard([3]) }
                     BatchScan { table: supplier, columns: [s_suppkey, s_name, s_address, s_nationkey] }
-                  BatchProject { exprs: [$0], expr_alias: [ ] }
+                  BatchProject { exprs: [$0] }
                     BatchExchange { order: [], dist: HashShard([0]) }
                       BatchFilter { predicate: ($1 = 'KENYA':Varchar) }
                         BatchScan { table: nation, columns: [n_nationkey, n_name] }
-            BatchProject { exprs: [$0], expr_alias: [ps_suppkey] }
+            BatchProject { exprs: [$0] }
               BatchExchange { order: [], dist: HashShard([0]) }
                 BatchFilter { predicate: ($1 > (0.5:Decimal * $2)) }
-                  BatchProject { exprs: [$2, $3, $6], expr_alias: [ ,  ,  ] }
+                  BatchProject { exprs: [$2, $3, $6] }
                     BatchHashAgg { group_keys: [$0, $1, $2, $3, $4, $5], aggs: [sum($6)] }
-                      BatchProject { exprs: [$0, $1, $2, $3, $4, $5, $6], expr_alias: [ ,  ,  ,  ,  ,  ,  ] }
+                      BatchProject { exprs: [$0, $1, $2, $3, $4, $5, $6] }
                         BatchHashJoin { type: LeftOuter, predicate: $1 = $7 AND $2 = $8 }
                           BatchExchange { order: [], dist: HashShard([1, 2]) }
                             BatchHashJoin { type: LeftSemi, predicate: $1 = $6 }
                               BatchExchange { order: [], dist: HashShard([1]) }
                                 BatchScan { table: partsupp, columns: [_row_id#0, ps_partkey, ps_suppkey, ps_availqty, ps_supplycost, ps_comment] }
-                              BatchProject { exprs: [$0], expr_alias: [p_partkey] }
+                              BatchProject { exprs: [$0] }
                                 BatchExchange { order: [], dist: HashShard([0]) }
                                   BatchFilter { predicate: Like($1, 'forest%':Varchar) }
                                     BatchScan { table: part, columns: [p_partkey, p_name] }
-                          BatchProject { exprs: [$2, $0, $1], expr_alias: [ ,  ,  ] }
+                          BatchProject { exprs: [$2, $0, $1] }
                             BatchExchange { order: [], dist: HashShard([0, 1]) }
                               BatchFilter { predicate: ($3 >= '1994-01-01':Varchar::Date) AND ($3 < ('1994-01-01':Varchar::Date + '1 year 00:00:00':Interval)) }
                                 BatchScan { table: lineitem, columns: [l_partkey, l_suppkey, l_quantity, l_shipdate] }
   stream_plan: |
     StreamMaterialize { columns: [s_name, s_address, _row_id#0(hidden), _row_id#1(hidden)], pk_columns: [_row_id#0, _row_id#1], order_descs: [s_name, _row_id#0, _row_id#1] }
       StreamExchange { dist: HashShard([2, 3]) }
-        StreamProject { exprs: [$1, $2, $3, $4], expr_alias: [s_name, s_address,  ,  ] }
+        StreamProject { exprs: [$1, $2, $3, $4] }
           StreamHashJoin { type: LeftSemi, predicate: $0 = $5 }
-            StreamProject { exprs: [$0, $1, $2, $4, $6], expr_alias: [ ,  ,  ,  ,  ] }
+            StreamProject { exprs: [$0, $1, $2, $4, $6] }
               StreamExchange { dist: HashShard([0]) }
                 StreamHashJoin { type: Inner, predicate: $3 = $5 }
                   StreamExchange { dist: HashShard([3]) }
                     StreamTableScan { table: supplier, columns: [s_suppkey, s_name, s_address, s_nationkey, _row_id#0], pk_indices: [4] }
-                  StreamProject { exprs: [$0, $2], expr_alias: [ ,  ] }
+                  StreamProject { exprs: [$0, $2] }
                     StreamExchange { dist: HashShard([0]) }
                       StreamFilter { predicate: ($1 = 'KENYA':Varchar) }
                         StreamTableScan { table: nation, columns: [n_nationkey, n_name, _row_id#0], pk_indices: [2] }
-            StreamProject { exprs: [$0, $3, $4, $1, $5, $6], expr_alias: [ps_suppkey,  ,  ,  ,  ,  ] }
+            StreamProject { exprs: [$0, $3, $4, $1, $5, $6] }
               StreamExchange { dist: HashShard([0]) }
                 StreamFilter { predicate: ($1 > (0.5:Decimal * $2)) }
-                  StreamProject { exprs: [$2, $3, $7, $0, $1, $4, $5], expr_alias: [ ,  ,  ,  ,  ,  ,  ] }
+                  StreamProject { exprs: [$2, $3, $7, $0, $1, $4, $5] }
                     StreamHashAgg { group_keys: [$0, $1, $2, $3, $4, $5], aggs: [count, sum($6)] }
-                      StreamProject { exprs: [$0, $1, $2, $3, $4, $5, $6, $9], expr_alias: [ ,  ,  ,  ,  ,  ,  ,  ] }
+                      StreamProject { exprs: [$0, $1, $2, $3, $4, $5, $6, $9] }
                         StreamHashJoin { type: LeftOuter, predicate: $1 = $7 AND $2 = $8 }
                           StreamExchange { dist: HashShard([1, 2]) }
                             StreamHashJoin { type: LeftSemi, predicate: $1 = $6 }
                               StreamExchange { dist: HashShard([1]) }
                                 StreamTableScan { table: partsupp, columns: [_row_id#0, ps_partkey, ps_suppkey, ps_availqty, ps_supplycost, ps_comment], pk_indices: [0] }
-                              StreamProject { exprs: [$0, $2], expr_alias: [p_partkey,  ] }
+                              StreamProject { exprs: [$0, $2] }
                                 StreamExchange { dist: HashShard([0]) }
                                   StreamFilter { predicate: Like($1, 'forest%':Varchar) }
                                     StreamTableScan { table: part, columns: [p_partkey, p_name, _row_id#0], pk_indices: [2] }
-                          StreamProject { exprs: [$2, $0, $1, $4], expr_alias: [ ,  ,  ,  ] }
+                          StreamProject { exprs: [$2, $0, $1, $4] }
                             StreamExchange { dist: HashShard([0, 1]) }
                               StreamFilter { predicate: ($3 >= '1994-01-01':Varchar::Date) AND ($3 < ('1994-01-01':Varchar::Date + '1 year 00:00:00':Interval)) }
                                 StreamTableScan { table: lineitem, columns: [l_partkey, l_suppkey, l_quantity, l_shipdate, _row_id#0], pk_indices: [4] }
@@ -1736,9 +1716,9 @@
     LIMIT 100;
   logical_plan: |
     LogicalTopN { order: [$1 DESC, $0 ASC], limit: 100, offset: 0 }
-      LogicalProject { exprs: [$0, $1], expr_alias: [s_name, numwait] }
+      LogicalProject { exprs: [$0, $1] }
         LogicalAgg { group_keys: [0], agg_calls: [count] }
-          LogicalProject { exprs: [$2], expr_alias: [ ] }
+          LogicalProject { exprs: [$2] }
             LogicalFilter { predicate: ($1 = $11) AND ($26 = $9) AND ($28 = 'F':Varchar) AND ($21 > $20) AND ($4 = $36) AND ($37 = 'GERMANY':Varchar) }
               LogicalApply { type: LeftAnti, on: true }
                 LogicalApply { type: LeftSemi, on: true }
@@ -1749,10 +1729,10 @@
                         LogicalScan { table: lineitem, columns: [_row_id#0, l_orderkey, l_partkey, l_suppkey, l_linenumber, l_quantity, l_extendedprice, l_discount, l_tax, l_returnflag, l_linestatus, l_shipdate, l_commitdate, l_receiptdate, l_shipinstruct, l_shipmode, l_comment] }
                       LogicalScan { table: orders, columns: [_row_id#0, o_orderkey, o_custkey, o_orderstatus, o_totalprice, o_orderdate, o_orderpriority, o_clerk, o_shippriority, o_comment] }
                     LogicalScan { table: nation, columns: [_row_id#0, n_nationkey, n_name, n_regionkey, n_comment] }
-                  LogicalProject { exprs: [$1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16], expr_alias: [l_orderkey, l_partkey, l_suppkey, l_linenumber, l_quantity, l_extendedprice, l_discount, l_tax, l_returnflag, l_linestatus, l_shipdate, l_commitdate, l_receiptdate, l_shipinstruct, l_shipmode, l_comment] }
+                  LogicalProject { exprs: [$1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16] }
                     LogicalFilter { predicate: ($1 = CorrelatedInputRef { index: 9, depth: 1 }) AND ($3 <> CorrelatedInputRef { index: 11, depth: 1 }) }
                       LogicalScan { table: lineitem, columns: [_row_id#0, l_orderkey, l_partkey, l_suppkey, l_linenumber, l_quantity, l_extendedprice, l_discount, l_tax, l_returnflag, l_linestatus, l_shipdate, l_commitdate, l_receiptdate, l_shipinstruct, l_shipmode, l_comment] }
-                LogicalProject { exprs: [$1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16], expr_alias: [l_orderkey, l_partkey, l_suppkey, l_linenumber, l_quantity, l_extendedprice, l_discount, l_tax, l_returnflag, l_linestatus, l_shipdate, l_commitdate, l_receiptdate, l_shipinstruct, l_shipmode, l_comment] }
+                LogicalProject { exprs: [$1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16] }
                   LogicalFilter { predicate: ($1 = CorrelatedInputRef { index: 9, depth: 1 }) AND ($3 <> CorrelatedInputRef { index: 11, depth: 1 }) AND ($13 > $12) }
                     LogicalScan { table: lineitem, columns: [_row_id#0, l_orderkey, l_partkey, l_suppkey, l_linenumber, l_quantity, l_extendedprice, l_discount, l_tax, l_returnflag, l_linestatus, l_shipdate, l_commitdate, l_receiptdate, l_shipinstruct, l_shipmode, l_comment] }
 - id: tpch_q22


### PR DESCRIPTION
## What's changed and what's your intention?

2nd part of #1433. Thanks to the refactor of #2465, we can simply remove all references to `aliases` of `LogicalProject` without breaking anything. As a result, projects that are purely for renaming are eliminated from the plans.

## Checklist

- [x] I have written necessary docs and comments
- [x] I have added necessary unit tests and integration tests

## Refer to a related PR or issue link (optional)
