### PR TITLE
feat(test): initial support for deterministic simulation testing

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4130,7 +4130,6 @@ dependencies = [
  "paste",
  "prometheus",
  "prost",
- "rand 0.8.5",
  "rdkafka",
  "risingwave_common",
  "risingwave_connector",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -667,6 +667,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "904dfeac50f3cdaba28fc6f57fdcddb75f49ed61346676a78c4ffe55877802fd"
 
 [[package]]
+name = "bincode"
+version = "1.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b1f45e9417d87227c7a56d22e471c6206462cba514c7590c09aff4cf6d1ddcad"
+dependencies = [
+ "serde",
+]
+
+[[package]]
 name = "bit-vec"
 version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1233,8 +1242,18 @@ version = "0.13.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a01d95850c592940db9b8194bc39f4bc0e89dee5c4265e4b1807c34a9aba453c"
 dependencies = [
- "darling_core",
- "darling_macro",
+ "darling_core 0.13.4",
+ "darling_macro 0.13.4",
+]
+
+[[package]]
+name = "darling"
+version = "0.14.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4529658bdda7fd6769b8614be250cdcfc3aeb0ee72fe66f9e41e5e5eb73eac02"
+dependencies = [
+ "darling_core 0.14.1",
+ "darling_macro 0.14.1",
 ]
 
 [[package]]
@@ -1252,12 +1271,37 @@ dependencies = [
 ]
 
 [[package]]
+name = "darling_core"
+version = "0.14.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "649c91bc01e8b1eac09fb91e8dbc7d517684ca6be8ebc75bb9cafc894f9fdb6f"
+dependencies = [
+ "fnv",
+ "ident_case",
+ "proc-macro2",
+ "quote",
+ "strsim",
+ "syn",
+]
+
+[[package]]
 name = "darling_macro"
 version = "0.13.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9c972679f83bdf9c42bd905396b6c3588a843a17f0f16dfcfa3e2c5d57441835"
 dependencies = [
- "darling_core",
+ "darling_core 0.13.4",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "darling_macro"
+version = "0.14.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ddfc69c5bfcbd2fc09a0f38451d2daf0e372e367986a83906d1b0dbc88134fb5"
+dependencies = [
+ "darling_core 0.14.1",
  "quote",
  "syn",
 ]
@@ -2201,6 +2245,63 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b823e83b2affd8f40a9ee8c29dbc56404c1e34cd2710921f2801e2cf29527afa"
 dependencies = [
  "libc",
+]
+
+[[package]]
+name = "madsim"
+version = "0.2.0-alpha.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0388d0406d38a382335ee9c55d8277c43cb0a6a02b879f5705795ab373712fc8"
+dependencies = [
+ "bincode",
+ "bytes",
+ "env_logger",
+ "futures",
+ "log 0.4.17",
+ "madsim-macros",
+ "rand 0.8.5",
+ "serde",
+ "tokio",
+ "tokio-util 0.7.1",
+]
+
+[[package]]
+name = "madsim-macros"
+version = "0.2.0-alpha.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e89839c0c226f4ef524e2760983b24f09c4a3358ae12ac7a4c6533fbaecf43c4"
+dependencies = [
+ "darling 0.14.1",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "madsim-tonic"
+version = "0.2.0-alpha.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e2dbc733c4b8d83f679c5386254912811962595b72ebd67349ddd14d7fcd89b2"
+dependencies = [
+ "async-stream",
+ "futures",
+ "log 0.4.17",
+ "madsim",
+ "tonic",
+]
+
+[[package]]
+name = "madsim-tonic-build"
+version = "0.2.0-alpha.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "320839c356bc1af23e730fbe460abe9bc338b5ccae220fe4c7924644b4535455"
+dependencies = [
+ "prettyplease",
+ "proc-macro2",
+ "prost-build",
+ "quote",
+ "syn",
+ "tonic-build",
 ]
 
 [[package]]
@@ -3342,6 +3443,7 @@ dependencies = [
  "itertools",
  "lazy_static",
  "log 0.4.17",
+ "madsim-tonic",
  "memcomparable",
  "num-traits",
  "parking_lot 0.12.0",
@@ -3366,7 +3468,6 @@ dependencies = [
  "thiserror",
  "tokio",
  "tokio-stream",
- "tonic",
  "tracing",
  "tracing-futures",
  "twox-hash",
@@ -3457,6 +3558,7 @@ dependencies = [
  "lazy_static",
  "log 0.4.17",
  "lru",
+ "madsim-tonic",
  "memcomparable",
  "more-asserts",
  "num-traits",
@@ -3472,7 +3574,6 @@ dependencies = [
  "tokio",
  "tokio-stream",
  "toml",
- "tonic",
  "tower",
  "tower-http",
  "tracing",
@@ -3486,6 +3587,7 @@ name = "risingwave_compactor"
 version = "0.1.0"
 dependencies = [
  "clap 3.1.17",
+ "madsim-tonic",
  "prometheus",
  "risingwave_common",
  "risingwave_pb",
@@ -3496,7 +3598,6 @@ dependencies = [
  "tokio-retry",
  "tokio-stream",
  "toml",
- "tonic",
  "tracing",
 ]
 
@@ -3520,6 +3621,7 @@ dependencies = [
  "itertools",
  "lazy_static",
  "log 0.4.17",
+ "madsim-tonic",
  "memcomparable",
  "num-traits",
  "paste",
@@ -3543,7 +3645,6 @@ dependencies = [
  "thiserror",
  "tokio",
  "tokio-stream",
- "tonic",
  "tower",
  "tower-http",
  "tracing",
@@ -3579,6 +3680,7 @@ dependencies = [
  "hyper",
  "itertools",
  "log 0.4.17",
+ "madsim-tonic",
  "maplit",
  "memcomparable",
  "num-traits",
@@ -3601,7 +3703,6 @@ dependencies = [
  "tokio",
  "tokio-stream",
  "tokio-util 0.7.1",
- "tonic",
  "twox-hash",
  "url",
  "urlencoding",
@@ -3640,6 +3741,7 @@ dependencies = [
  "lazy_static",
  "log 0.4.17",
  "lru",
+ "madsim-tonic",
  "memcomparable",
  "num-traits",
  "paste",
@@ -3653,7 +3755,6 @@ dependencies = [
  "tokio",
  "tokio-stream",
  "toml",
- "tonic",
  "value-encoding",
  "workspace-hack",
 ]
@@ -3678,6 +3779,7 @@ dependencies = [
  "itertools",
  "lazy_static",
  "log 0.4.17",
+ "madsim-tonic",
  "maplit",
  "num-integer",
  "num-traits",
@@ -3696,7 +3798,6 @@ dependencies = [
  "tempfile",
  "thiserror",
  "tokio",
- "tonic",
  "tracing",
  "uuid 1.0.0",
  "workspace-hack",
@@ -3776,6 +3877,7 @@ dependencies = [
  "itertools",
  "lazy_static",
  "log 0.4.17",
+ "madsim-tonic",
  "memcomparable",
  "moka",
  "num-integer",
@@ -3799,7 +3901,6 @@ dependencies = [
  "tokio",
  "tokio-retry",
  "tokio-stream",
- "tonic",
  "tower",
  "tower-http",
  "tracing",
@@ -3812,6 +3913,8 @@ name = "risingwave_pb"
 version = "0.1.0"
 dependencies = [
  "bytes",
+ "madsim-tonic",
+ "madsim-tonic-build",
  "pbjson",
  "pbjson-build",
  "prost",
@@ -3819,8 +3922,6 @@ dependencies = [
  "prost-types",
  "quote",
  "serde",
- "tonic",
- "tonic-build",
  "workspace-hack",
 ]
 
@@ -3845,12 +3946,12 @@ dependencies = [
  "async-trait",
  "futures",
  "log 0.4.17",
+ "madsim-tonic",
  "paste",
  "risingwave_common",
  "risingwave_hummock_sdk",
  "risingwave_pb",
  "tokio",
- "tonic",
  "tracing",
  "workspace-hack",
 ]
@@ -3876,6 +3977,7 @@ dependencies = [
  "itertools",
  "lazy_static",
  "log 0.4.17",
+ "madsim-tonic",
  "maplit",
  "memcomparable",
  "num-traits",
@@ -3902,7 +4004,6 @@ dependencies = [
  "thiserror",
  "tokio",
  "tokio-stream",
- "tonic",
  "tracing",
  "twox-hash",
  "url",
@@ -3966,6 +4067,7 @@ dependencies = [
  "libc",
  "log 0.4.17",
  "lz4",
+ "madsim-tonic",
  "memcomparable",
  "moka",
  "num-integer",
@@ -3989,7 +4091,6 @@ dependencies = [
  "tokio",
  "tokio-retry",
  "tokio-stream",
- "tonic",
  "tracing",
  "twox-hash",
  "uuid 1.0.0",
@@ -4020,6 +4121,8 @@ dependencies = [
  "itertools",
  "lazy_static",
  "log 0.4.17",
+ "madsim",
+ "madsim-tonic",
  "memcomparable",
  "moka",
  "num-traits",
@@ -4044,7 +4147,6 @@ dependencies = [
  "thiserror",
  "tokio",
  "tokio-stream",
- "tonic",
  "tower",
  "tracing",
  "tracing-futures",
@@ -4292,7 +4394,7 @@ version = "1.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e182d6ec6f05393cc0e5ed1bf81ad6db3a8feedf8ee515ecdd369809bcce8082"
 dependencies = [
- "darling",
+ "darling 0.13.4",
  "proc-macro2",
  "quote",
  "syn",
@@ -5380,11 +5482,9 @@ dependencies = [
  "fail",
  "fixedbitset",
  "futures",
- "futures-channel",
  "futures-executor",
  "futures-io",
  "futures-sink",
- "futures-task",
  "futures-util",
  "hashbrown 0.11.2",
  "hyper",

--- a/src/batch/Cargo.toml
+++ b/src/batch/Cargo.toml
@@ -49,7 +49,7 @@ tokio = { version = "1", features = [
     "fs",
 ] }
 tokio-stream = "0.1"
-tonic = "0.7"
+tonic = { version = "0.2.0-alpha.1", package = "madsim-tonic" }
 tracing = { version = "0.1" }
 tracing-futures = "0.2"
 twox-hash = "1"

--- a/src/common/Cargo.toml
+++ b/src/common/Cargo.toml
@@ -33,7 +33,7 @@ thiserror = "1"
 tokio = { version = "1", features = ["rt", "rt-multi-thread", "sync", "macros", "time", "signal"] }
 tokio-stream = "0.1"
 toml = "0.5"
-tonic = "0.7"
+tonic = { version = "0.2.0-alpha.1", package = "madsim-tonic" }
 tower = { version = "0.4", features = ["util", "load-shed"] }
 tower-http = { version = "0.3", features = ["add-extension", "cors"] }
 tracing = { version = "0.1" }

--- a/src/compute/Cargo.toml
+++ b/src/compute/Cargo.toml
@@ -49,7 +49,7 @@ tokio = { version = "1", features = [
     "fs",
 ] }
 tokio-stream = "0.1"
-tonic = "0.7"
+tonic = { version = "0.2.0-alpha.1", package = "madsim-tonic" }
 tower = { version = "0.4", features = ["util", "load-shed"] }
 tower-http = { version = "0.3", features = ["add-extension", "cors"] }
 tracing = { version = "0.1" }

--- a/src/connector/Cargo.toml
+++ b/src/connector/Cargo.toml
@@ -49,7 +49,7 @@ thiserror = "1"
 tokio = { version = "1", features = ["rt", "rt-multi-thread", "sync", "macros", "time", "signal", "fs"] }
 tokio-stream = "0.1"
 tokio-util = { version = "0.7", features = ["codec", "io"] }
-tonic = "0.7"
+tonic = { version = "0.2.0-alpha.1", package = "madsim-tonic" }
 twox-hash = "1"
 url = "2"
 urlencoding = "2"

--- a/src/expr/Cargo.toml
+++ b/src/expr/Cargo.toml
@@ -30,6 +30,6 @@ thiserror = "1"
 tokio = { version = "1", features = ["rt", "rt-multi-thread", "sync", "macros", "time", "signal"] }
 tokio-stream = "0.1"
 toml = "0.5"
-tonic = "0.7"
+tonic = { version = "0.2.0-alpha.1", package = "madsim-tonic" }
 value-encoding = { path = "../utils/value-encoding" }
 workspace-hack = { version = "0.1", path = "../workspace-hack" }

--- a/src/frontend/Cargo.toml
+++ b/src/frontend/Cargo.toml
@@ -47,7 +47,7 @@ tokio = { version = "1", features = [
     "signal",
     "fs",
 ] }
-tonic = "0.7"
+tonic = { version = "0.2.0-alpha.1", package = "madsim-tonic" }
 tracing = { version = "0.1" }
 uuid = "1"
 workspace-hack = { version = "0.1", path = "../workspace-hack" }

--- a/src/meta/Cargo.toml
+++ b/src/meta/Cargo.toml
@@ -53,7 +53,7 @@ tokio = { version = "1", features = [
 ] }
 tokio-retry = "0.3"
 tokio-stream = { version = "0.1", features = ["net"] }
-tonic = "0.7"
+tonic = { version = "0.2.0-alpha.1", package = "madsim-tonic" }
 tower = { version = "0.4", features = ["util", "load-shed"] }
 tower-http = { version = "0.3", features = ["add-extension", "cors", "fs"] }
 tracing = { version = "0.1" }

--- a/src/prost/Cargo.toml
+++ b/src/prost/Cargo.toml
@@ -10,7 +10,7 @@ prost = "0.10"
 prost-helpers = { path = "helpers" }
 prost-types = "0.10"
 serde = { version = "1", features = ["derive"] }
-tonic = "0.7"
+tonic = { version = "0.2.0-alpha.1", package = "madsim-tonic" }
 workspace-hack = { version = "0.1", path = "../workspace-hack" }
 
 [build-dependencies]
@@ -18,4 +18,4 @@ pbjson-build = "0.3"
 prost = "0.10"
 prost-types = "0.10"
 quote = "1"
-tonic-build = "0.7"
+tonic-build = { version = "0.2.0-alpha.1", package = "madsim-tonic-build" }

--- a/src/prost/build.rs
+++ b/src/prost/build.rs
@@ -39,13 +39,12 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         .collect();
 
     // Build protobuf structs.
-    let out_dir: PathBuf = PathBuf::from("./src");
+    let out_dir = PathBuf::from(std::env::var("OUT_DIR").unwrap());
     let file_descriptor_set_path: PathBuf = out_dir.join("file_descriptor_set.bin");
     tonic_build::configure()
         .file_descriptor_set_path(file_descriptor_set_path.as_path())
         .compile_well_known_types(true)
         .type_attribute(".", "#[derive(prost_helpers::AnyPB)]")
-        .out_dir(out_dir.as_path())
         .compile(&protos, &[proto_dir.to_string()])
         .expect("Failed to compile grpc!");
 
@@ -53,22 +52,8 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     let descriptor_set = std::fs::read(file_descriptor_set_path)?;
     pbjson_build::Builder::new()
         .register_descriptors(&descriptor_set)?
-        .out_dir(out_dir.as_path())
         .build(&["."])
         .expect("Failed to compile serde");
-
-    // Tweak the serde files so that they can be compiled in our project.
-    // By adding a `use crate::module::*`
-    let rewrite_files = proto_files;
-    for serde_proto_file in &rewrite_files {
-        let out_file = out_dir.join(format!("{}.serde.rs", serde_proto_file));
-        let file_content = String::from_utf8(std::fs::read(&out_file)?)?;
-        let module_path_id = serde_proto_file.replace('.', "::");
-        std::fs::write(
-            &out_file,
-            format!("use crate::{}::*;\n{}", module_path_id, file_content),
-        )?;
-    }
 
     Ok(())
 }

--- a/src/prost/src/lib.rs
+++ b/src/prost/src/lib.rs
@@ -1,66 +1,29 @@
 #![allow(clippy::all)]
 
+macro_rules! define_module {
+    ($name:ident) => {
+        define_module!($name, stringify!($name));
+    };
+    ($name:ident, $str:expr) => {
 #[rustfmt::skip]
-pub mod catalog;
-#[rustfmt::skip]
-pub mod common;
-#[rustfmt::skip]
-pub mod data;
-#[rustfmt::skip]
-pub mod ddl_service;
-#[rustfmt::skip]
-pub mod expr;
-#[rustfmt::skip]
-pub mod meta;
-#[rustfmt::skip]
-pub mod plan_common;
-#[rustfmt::skip]
-pub mod batch_plan;
-#[rustfmt::skip]
-pub mod task_service;
-#[rustfmt::skip]
-pub mod stream_plan;
-#[rustfmt::skip]
-pub mod stream_service;
-#[rustfmt::skip]
-pub mod hummock;
-
-#[rustfmt::skip]
-#[path = "catalog.serde.rs"]
-pub mod catalog_serde;
-#[rustfmt::skip]
-#[path = "common.serde.rs"]
-pub mod common_serde;
-#[rustfmt::skip]
-#[path = "data.serde.rs"]
-pub mod data_serde;
-#[rustfmt::skip]
-#[path = "ddl_service.serde.rs"]
-pub mod ddl_service_serde;
-#[rustfmt::skip]
-#[path = "expr.serde.rs"]
-pub mod expr_serde;
-#[rustfmt::skip]
-#[path = "meta.serde.rs"]
-pub mod meta_serde;
-#[rustfmt::skip]
-#[path = "plan_common.serde.rs"]
-pub mod plan_common_serde;
-#[rustfmt::skip]
-#[path = "batch_plan.serde.rs"]
-pub mod batch_plan_serde;
-#[rustfmt::skip]
-#[path = "task_service.serde.rs"]
-pub mod task_service_serde;
-#[rustfmt::skip]
-#[path = "stream_plan.serde.rs"]
-pub mod stream_plan_serde;
-#[rustfmt::skip]
-#[path = "stream_service.serde.rs"]
-pub mod stream_service_serde;
-#[rustfmt::skip]
-#[path = "hummock.serde.rs"]
-pub mod hummock_serde;
+        pub mod $name {
+            tonic::include_proto!($str);
+            include!(concat!(env!("OUT_DIR"), concat!("/", $str, ".serde.rs")));
+        }
+    };
+}
+define_module!(catalog);
+define_module!(common);
+define_module!(data);
+define_module!(ddl_service);
+define_module!(expr);
+define_module!(meta);
+define_module!(plan_common);
+define_module!(batch_plan);
+define_module!(task_service);
+define_module!(stream_plan);
+define_module!(stream_service);
+define_module!(hummock);
 
 #[derive(Clone, PartialEq, Eq, Debug)]
 pub struct ProstFieldNotFound(pub &'static str);

--- a/src/rpc_client/Cargo.toml
+++ b/src/rpc_client/Cargo.toml
@@ -19,6 +19,6 @@ tokio = { version = "1", features = [
     "time",
     "signal",
 ] }
-tonic = "0.7"
+tonic = { version = "0.2.0-alpha.1", package = "madsim-tonic" }
 tracing = { version = "0.1" }
 workspace-hack = { version = "0.1", path = "../workspace-hack" }

--- a/src/source/Cargo.toml
+++ b/src/source/Cargo.toml
@@ -46,7 +46,7 @@ tempfile = "3"
 thiserror = "1"
 tokio = { version = "1", features = ["rt", "rt-multi-thread", "sync", "macros", "time", "signal", "fs"] }
 tokio-stream = "0.1"
-tonic = "0.7"
+tonic = { version = "0.2.0-alpha.1", package = "madsim-tonic" }
 tracing = { version = "0.1", features = ["release_max_level_info"] }
 twox-hash = "1"
 url = "2"

--- a/src/storage/Cargo.toml
+++ b/src/storage/Cargo.toml
@@ -63,7 +63,7 @@ tokio = { version = "1", features = [
 ] }
 tokio-retry = "0.3"
 tokio-stream = "0.1"
-tonic = "0.7"
+tonic = { version = "0.2.0-alpha.1", package = "madsim-tonic" }
 tracing = { version = "0.1" }
 twox-hash = "1"
 value-encoding = { path = "../utils/value-encoding" }

--- a/src/storage/compactor/Cargo.toml
+++ b/src/storage/compactor/Cargo.toml
@@ -24,5 +24,5 @@ tokio = { version = "1", features = [
 tokio-retry = "0.3"
 tokio-stream = "0.1"
 toml = "0.5"
-tonic = "0.7"
+tonic = { version = "0.2.0-alpha.1", package = "madsim-tonic" }
 tracing = { version = "0.1" }

--- a/src/stream/Cargo.toml
+++ b/src/stream/Cargo.toml
@@ -23,6 +23,7 @@ iter-chunks = "0.1"
 itertools = "0.10"
 lazy_static = "1"
 log = "0.4"
+madsim = "0.2.0-alpha.1"
 memcomparable = { path = "../utils/memcomparable" }
 moka = { version = "0.8", features = ["future"] }
 num-traits = "0.2"
@@ -55,7 +56,7 @@ tokio = { version = "1", features = [
     "fs",
 ] }
 tokio-stream = "0.1"
-tonic = "0.7"
+tonic = { version = "0.2.0-alpha.1", package = "madsim-tonic" }
 tower = { version = "0.4", features = ["util", "load-shed"] }
 tracing = { version = "0.1" }
 tracing-futures = "0.2"

--- a/src/stream/Cargo.toml
+++ b/src/stream/Cargo.toml
@@ -31,7 +31,6 @@ parking_lot = "0.12"
 paste = "1"
 prometheus = { version = "0.13", features = ["process"] }
 prost = "0.10"
-rand = "0.8.5"
 rdkafka = { version = "0.28", features = ["cmake-build"] }
 risingwave_common = { path = "../common" }
 risingwave_connector = { path = "../connector" }
@@ -67,4 +66,3 @@ workspace-hack = { version = "0.1", path = "../workspace-hack" }
 
 [dev-dependencies]
 assert_matches = "1"
-rand = "0.8"

--- a/src/stream/src/executor/barrier_align.rs
+++ b/src/stream/src/executor/barrier_align.rs
@@ -91,12 +91,12 @@ mod tests {
 
     use async_stream::try_stream;
     use futures::TryStreamExt;
+    use madsim::time::sleep;
     use risingwave_common::array::stream_chunk::StreamChunkTestExt;
-    use tokio::time::sleep;
 
     use super::*;
 
-    #[tokio::test]
+    #[madsim::test]
     async fn test_barrier_align() {
         let left = try_stream! {
             yield Message::Chunk(StreamChunk::from_pretty("I\n + 1"));
@@ -127,7 +127,7 @@ mod tests {
         );
     }
 
-    #[tokio::test]
+    #[madsim::test]
     #[should_panic]
     async fn left_barrier_right_end_1() {
         let left = try_stream! {
@@ -143,7 +143,7 @@ mod tests {
         let _output: Vec<_> = barrier_align(left, right).try_collect().await.unwrap();
     }
 
-    #[tokio::test]
+    #[madsim::test]
     #[should_panic]
     async fn left_barrier_right_end_2() {
         let left = try_stream! {

--- a/src/stream/src/executor/batch_query.rs
+++ b/src/stream/src/executor/batch_query.rs
@@ -148,7 +148,7 @@ mod test {
     use super::*;
     use crate::executor::mview::test_utils::gen_basic_table;
 
-    #[tokio::test]
+    #[madsim::test]
     async fn test_basic() {
         let test_batch_size = 50;
         let test_batch_count = 5;

--- a/src/stream/src/executor/chain.rs
+++ b/src/stream/src/executor/chain.rs
@@ -150,7 +150,7 @@ mod test {
     use crate::executor::{Barrier, Executor, Message, PkIndices};
     use crate::task::{FinishCreateMviewNotifier, LocalBarrierManager};
 
-    #[tokio::test]
+    #[madsim::test]
     async fn test_basic() {
         let schema = Schema::new(vec![Field::unnamed(DataType::Int64)]);
         let first = Box::new(

--- a/src/stream/src/executor/debug/epoch_check.rs
+++ b/src/stream/src/executor/debug/epoch_check.rs
@@ -67,7 +67,7 @@ mod tests {
     use crate::executor::test_utils::MockSource;
     use crate::executor::Executor;
 
-    #[tokio::test]
+    #[madsim::test]
     async fn test_epoch_ok() {
         let (mut tx, source) = MockSource::channel(Default::default(), vec![]);
         tx.push_barrier(100, false);
@@ -87,7 +87,7 @@ mod tests {
     }
 
     #[should_panic]
-    #[tokio::test]
+    #[madsim::test]
     async fn test_epoch_bad() {
         let (mut tx, source) = MockSource::channel(Default::default(), vec![]);
         tx.push_barrier(100, false);
@@ -108,7 +108,7 @@ mod tests {
     }
 
     #[should_panic]
-    #[tokio::test]
+    #[madsim::test]
     async fn test_epoch_first_not_barrier() {
         let (mut tx, source) = MockSource::channel(Default::default(), vec![]);
         tx.push_chunk(StreamChunk::default());
@@ -120,7 +120,7 @@ mod tests {
         checked.next().await.unwrap().unwrap(); // should panic
     }
 
-    #[tokio::test]
+    #[madsim::test]
     async fn test_empty() {
         let (_, mut source) = MockSource::channel(Default::default(), vec![]);
         source = source.stop_on_finish(false);

--- a/src/stream/src/executor/debug/schema_check.rs
+++ b/src/stream/src/executor/debug/schema_check.rs
@@ -88,7 +88,7 @@ mod tests {
     use crate::executor::test_utils::MockSource;
     use crate::executor::Executor;
 
-    #[tokio::test]
+    #[madsim::test]
     async fn test_schema_ok() {
         let schema = Schema {
             fields: vec![
@@ -114,7 +114,7 @@ mod tests {
     }
 
     #[should_panic]
-    #[tokio::test]
+    #[madsim::test]
     async fn test_schema_bad() {
         let schema = Schema {
             fields: vec![

--- a/src/stream/src/executor/debug/update_check.rs
+++ b/src/stream/src/executor/debug/update_check.rs
@@ -65,7 +65,7 @@ mod tests {
     use crate::executor::Executor;
 
     #[should_panic]
-    #[tokio::test]
+    #[madsim::test]
     async fn test_not_next_to_each_other() {
         let (mut tx, source) = MockSource::channel(Default::default(), vec![]);
         tx.push_chunk(StreamChunk::from_pretty(
@@ -83,7 +83,7 @@ mod tests {
     }
 
     #[should_panic]
-    #[tokio::test]
+    #[madsim::test]
     async fn test_first_one_update_insert() {
         let (mut tx, source) = MockSource::channel(Default::default(), vec![]);
         tx.push_chunk(StreamChunk::from_pretty(
@@ -98,7 +98,7 @@ mod tests {
     }
 
     #[should_panic]
-    #[tokio::test]
+    #[madsim::test]
     async fn test_last_one_update_delete() {
         let (mut tx, source) = MockSource::channel(Default::default(), vec![]);
         tx.push_chunk(StreamChunk::from_pretty(
@@ -114,7 +114,7 @@ mod tests {
         checked.next().await.unwrap().unwrap(); // should panic
     }
 
-    #[tokio::test]
+    #[madsim::test]
     async fn test_empty_chunk() {
         let (mut tx, source) = MockSource::channel(Default::default(), vec![]);
         tx.push_chunk(StreamChunk::default());

--- a/src/stream/src/executor/dispatch.rs
+++ b/src/stream/src/executor/dispatch.rs
@@ -12,7 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use std::collections::{HashMap, HashSet};
 use std::fmt::Debug;
 use std::future::Future;
 use std::sync::Arc;
@@ -22,6 +21,7 @@ use futures::channel::mpsc::Sender;
 use futures::{SinkExt, Stream};
 use futures_async_stream::try_stream;
 use itertools::Itertools;
+use madsim::collections::{HashMap, HashSet};
 use risingwave_common::array::{Op, StreamChunk};
 use risingwave_common::error::{internal_error, Result};
 use risingwave_common::hash::VIRTUAL_NODE_COUNT;
@@ -767,13 +767,13 @@ impl Dispatcher for SimpleDispatcher {
 
 #[cfg(test)]
 mod tests {
-    use std::collections::HashMap;
     use std::hash::{BuildHasher, Hasher};
     use std::sync::{Arc, Mutex};
 
     use futures::channel::mpsc::channel;
     use futures::{pin_mut, StreamExt};
     use itertools::Itertools;
+    use madsim::collections::HashMap;
     use risingwave_common::array::column::Column;
     use risingwave_common::array::stream_chunk::StreamChunkTestExt;
     use risingwave_common::array::{Array, ArrayBuilder, I32ArrayBuilder, Op};

--- a/src/stream/src/executor/dispatch.rs
+++ b/src/stream/src/executor/dispatch.rs
@@ -809,7 +809,7 @@ mod tests {
         }
     }
 
-    #[tokio::test]
+    #[madsim::test]
     async fn test_hash_dispatcher_complex() {
         test_hash_dispatcher_complex_inner().await
     }
@@ -916,7 +916,7 @@ mod tests {
         }
     }
 
-    #[tokio::test]
+    #[madsim::test]
     async fn test_configuration_change() {
         let schema = Schema { fields: vec![] };
         let (mut tx, rx) = channel(16);
@@ -996,7 +996,7 @@ mod tests {
         }
     }
 
-    #[tokio::test]
+    #[madsim::test]
     async fn test_hash_dispatcher() {
         let num_outputs = 5; // actor id ranges from 1 to 5
         let cardinality = 10;

--- a/src/stream/src/executor/filter.rs
+++ b/src/stream/src/executor/filter.rs
@@ -188,7 +188,7 @@ mod tests {
     use super::super::*;
     use super::*;
 
-    #[tokio::test]
+    #[madsim::test]
     async fn test_filter() {
         let chunk1 = StreamChunk::from_pretty(
             " I I

--- a/src/stream/src/executor/global_simple_agg.rs
+++ b/src/stream/src/executor/global_simple_agg.rs
@@ -295,7 +295,7 @@ mod tests {
     use crate::executor::test_utils::*;
     use crate::executor::*;
 
-    #[tokio::test]
+    #[madsim::test]
     async fn test_local_simple_aggregation_in_memory() {
         test_local_simple_aggregation(create_in_memory_keyspace_agg(4)).await
     }

--- a/src/stream/src/executor/hash_agg.rs
+++ b/src/stream/src/executor/hash_agg.rs
@@ -498,22 +498,22 @@ mod tests {
 
     // --- Test HashAgg with in-memory KeyedState ---
 
-    #[tokio::test]
+    #[madsim::test]
     async fn test_local_hash_aggregation_count_in_memory() {
         test_local_hash_aggregation_count(create_in_memory_keyspace_agg(3)).await
     }
 
-    #[tokio::test]
+    #[madsim::test]
     async fn test_global_hash_aggregation_count_in_memory() {
         test_global_hash_aggregation_count(create_in_memory_keyspace_agg(3)).await
     }
 
-    #[tokio::test]
+    #[madsim::test]
     async fn test_local_hash_aggregation_min_in_memory() {
         test_local_hash_aggregation_min(create_in_memory_keyspace_agg(2)).await
     }
 
-    #[tokio::test]
+    #[madsim::test]
     async fn test_local_hash_aggregation_min_append_only_in_memory() {
         test_local_hash_aggregation_min_append_only(create_in_memory_keyspace_agg(2)).await
     }

--- a/src/stream/src/executor/hash_agg.rs
+++ b/src/stream/src/executor/hash_agg.rs
@@ -12,7 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use std::collections::HashMap;
 use std::marker::PhantomData;
 use std::sync::Arc;
 
@@ -20,6 +19,7 @@ use futures::{stream, StreamExt};
 use futures_async_stream::try_stream;
 use iter_chunks::IterChunks;
 use itertools::Itertools;
+use madsim::collections::HashMap;
 use risingwave_common::array::column::Column;
 use risingwave_common::array::StreamChunk;
 use risingwave_common::buffer::Bitmap;

--- a/src/stream/src/executor/hash_join.rs
+++ b/src/stream/src/executor/hash_join.rs
@@ -689,7 +689,7 @@ mod tests {
         (tx_l, tx_r, Box::new(executor).execute())
     }
 
-    #[tokio::test]
+    #[madsim::test]
     async fn test_streaming_hash_inner_join() {
         let chunk_l1 = StreamChunk::from_pretty(
             "  I I
@@ -764,7 +764,7 @@ mod tests {
         );
     }
 
-    #[tokio::test]
+    #[madsim::test]
     async fn test_streaming_hash_left_semi_join() {
         let chunk_l1 = StreamChunk::from_pretty(
             "  I I
@@ -874,7 +874,7 @@ mod tests {
         );
     }
 
-    #[tokio::test]
+    #[madsim::test]
     async fn test_streaming_hash_right_semi_join() {
         let chunk_r1 = StreamChunk::from_pretty(
             "  I I
@@ -984,7 +984,7 @@ mod tests {
         );
     }
 
-    #[tokio::test]
+    #[madsim::test]
     async fn test_streaming_hash_left_anti_join() {
         let chunk_l1 = StreamChunk::from_pretty(
             "  I I
@@ -1112,7 +1112,7 @@ mod tests {
         );
     }
 
-    #[tokio::test]
+    #[madsim::test]
     async fn test_streaming_hash_right_anti_join() {
         let chunk_r1 = StreamChunk::from_pretty(
             "  I I
@@ -1240,7 +1240,7 @@ mod tests {
         );
     }
 
-    #[tokio::test]
+    #[madsim::test]
     async fn test_streaming_hash_inner_join_with_barrier() {
         let chunk_l1 = StreamChunk::from_pretty(
             "  I I
@@ -1336,7 +1336,7 @@ mod tests {
         );
     }
 
-    #[tokio::test]
+    #[madsim::test]
     async fn test_streaming_hash_left_join() {
         let chunk_l1 = StreamChunk::from_pretty(
             "  I I
@@ -1417,7 +1417,7 @@ mod tests {
         );
     }
 
-    #[tokio::test]
+    #[madsim::test]
     async fn test_streaming_hash_right_join() {
         let chunk_l1 = StreamChunk::from_pretty(
             "  I I
@@ -1491,7 +1491,7 @@ mod tests {
         );
     }
 
-    #[tokio::test]
+    #[madsim::test]
     async fn test_streaming_hash_full_outer_join() {
         let chunk_l1 = StreamChunk::from_pretty(
             "  I I
@@ -1574,7 +1574,7 @@ mod tests {
         );
     }
 
-    #[tokio::test]
+    #[madsim::test]
     async fn test_streaming_hash_full_outer_join_with_nonequi_condition() {
         let chunk_l1 = StreamChunk::from_pretty(
             "  I I
@@ -1666,7 +1666,7 @@ mod tests {
         );
     }
 
-    #[tokio::test]
+    #[madsim::test]
     async fn test_streaming_hash_inner_join_with_nonequi_condition() {
         let chunk_l1 = StreamChunk::from_pretty(
             "  I I

--- a/src/stream/src/executor/hop_window.rs
+++ b/src/stream/src/executor/hop_window.rs
@@ -210,7 +210,7 @@ mod tests {
     use crate::executor::test_utils::MockSource;
     use crate::executor::{Executor, ExecutorInfo, StreamChunk};
 
-    #[tokio::test]
+    #[madsim::test]
     async fn test_execute() {
         let field1 = Field::unnamed(DataType::Int64);
         let field2 = Field::unnamed(DataType::Int64);

--- a/src/stream/src/executor/integration_tests.rs
+++ b/src/stream/src/executor/integration_tests.rs
@@ -36,7 +36,7 @@ use crate::task::SharedContext;
 /// This test creates a merger-dispatcher pair, and run a sum. Each chunk
 /// has 0~9 elements. We first insert the 10 chunks, then delete them,
 /// and do this again and again.
-#[tokio::test]
+#[madsim::test]
 async fn test_merger_sum_aggr() {
     // `make_actor` build an actor to do local aggregation
     let make_actor = |input_rx| {
@@ -90,7 +90,7 @@ async fn test_merger_sum_aggr() {
         let (tx, rx) = channel(16);
         let (actor, channel) = make_actor(rx);
         outputs.push(channel);
-        handles.push(tokio::spawn(actor.run()));
+        handles.push(madsim::task::spawn(actor.run()));
         inputs.push(Box::new(LocalOutput::new(233, tx)) as Box<dyn Output>);
     }
 
@@ -110,7 +110,7 @@ async fn test_merger_sum_aggr() {
     );
     let context = SharedContext::for_test().into();
     let actor = Actor::new(dispatcher, 0, context);
-    handles.push(tokio::spawn(actor.run()));
+    handles.push(madsim::task::spawn(actor.run()));
 
     // use a merge operator to collect data from dispatchers before sending them to aggregator
     let merger = MergeExecutor::new(schema, vec![], 0, outputs);
@@ -157,7 +157,7 @@ async fn test_merger_sum_aggr() {
     };
     let context = SharedContext::for_test().into();
     let actor = Actor::new(consumer, 0, context);
-    handles.push(tokio::spawn(actor.run()));
+    handles.push(madsim::task::spawn(actor.run()));
 
     let mut epoch = 1;
     input
@@ -187,14 +187,15 @@ async fn test_merger_sum_aggr() {
     }
     input
         .send(Message::Barrier(
-            Barrier::new_test_barrier(epoch).with_mutation(Mutation::Stop(HashSet::from([0]))),
+            Barrier::new_test_barrier(epoch)
+                .with_mutation(Mutation::Stop([0].into_iter().collect())),
         ))
         .await
         .unwrap();
 
     // wait for all actors
     for handle in handles {
-        handle.await.unwrap().unwrap();
+        handle.await.unwrap();
     }
 
     let data = items.lock().unwrap();

--- a/src/stream/src/executor/local_simple_agg.rs
+++ b/src/stream/src/executor/local_simple_agg.rs
@@ -181,7 +181,7 @@ mod tests {
     use crate::executor::test_utils::MockSource;
     use crate::executor::{Executor, LocalSimpleAggExecutor};
 
-    #[tokio::test]
+    #[madsim::test]
     async fn test_no_chunk() -> Result<()> {
         let schema = schema_test_utils::ii();
         let (mut tx, source) = MockSource::channel(schema, vec![2]);
@@ -220,7 +220,7 @@ mod tests {
         Ok(())
     }
 
-    #[tokio::test]
+    #[madsim::test]
     async fn test_local_simple_agg() -> Result<()> {
         let schema = schema_test_utils::iii();
         let (mut tx, source) = MockSource::channel(schema, vec![2]); // pk\

--- a/src/stream/src/executor/lookup/cache.rs
+++ b/src/stream/src/executor/lookup/cache.rs
@@ -12,8 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use std::collections::BTreeSet;
-
+use madsim::collections::BTreeSet;
 use risingwave_common::array::{Op, Row, StreamChunk};
 use risingwave_common::collection::evictable::EvictableHashMap;
 

--- a/src/stream/src/executor/lookup/tests.rs
+++ b/src/stream/src/executor/lookup/tests.rs
@@ -204,7 +204,7 @@ fn check_chunk_eq(chunk1: &StreamChunk, chunk2: &StreamChunk) {
     assert_eq!(format!("{:?}", chunk1), format!("{:?}", chunk2));
 }
 
-#[tokio::test]
+#[madsim::test]
 async fn test_lookup_this_epoch() {
     // TODO: memory state store doesn't support read epoch yet, so it is possible that this test
     // fails because read epoch doesn't take effect in memory state store.
@@ -274,7 +274,7 @@ async fn test_lookup_this_epoch() {
     check_chunk_eq(chunk2, &expected_chunk2);
 }
 
-#[tokio::test]
+#[madsim::test]
 async fn test_lookup_last_epoch() {
     let store = MemoryStateStore::new();
     let table_id = TableId::new(1);

--- a/src/stream/src/executor/lookup_union.rs
+++ b/src/stream/src/executor/lookup_union.rs
@@ -149,7 +149,7 @@ mod tests {
     use super::*;
     use crate::executor::test_utils::MockSource;
 
-    #[tokio::test]
+    #[madsim::test]
     async fn lookup_union() {
         let schema = Schema {
             fields: vec![Field::unnamed(DataType::Int64)],

--- a/src/stream/src/executor/managed_state/aggregation/extreme.rs
+++ b/src/stream/src/executor/managed_state/aggregation/extreme.rs
@@ -492,7 +492,7 @@ mod tests {
 
     use super::*;
 
-    #[tokio::test]
+    #[madsim::test]
     async fn test_managed_extreme_state() {
         let store = MemoryStateStore::new();
         let keyspace = Keyspace::executor_root(store.clone(), 0x2333);
@@ -657,22 +657,22 @@ mod tests {
         );
     }
 
-    #[tokio::test]
+    #[madsim::test]
     async fn test_replicated_value_min() {
         test_replicated_value_not_null::<{ variants::EXTREME_MIN }>().await
     }
 
-    #[tokio::test]
+    #[madsim::test]
     async fn test_replicated_value_max() {
         test_replicated_value_not_null::<{ variants::EXTREME_MAX }>().await
     }
 
-    #[tokio::test]
+    #[madsim::test]
     async fn test_replicated_value_min_with_null() {
         test_replicated_value_with_null::<{ variants::EXTREME_MIN }>().await
     }
 
-    #[tokio::test]
+    #[madsim::test]
     async fn test_replicated_value_max_with_null() {
         test_replicated_value_with_null::<{ variants::EXTREME_MAX }>().await
     }
@@ -865,7 +865,7 @@ mod tests {
         assert_eq!(managed_state.get_output(epoch).await.unwrap(), extreme);
     }
 
-    #[tokio::test]
+    #[madsim::test]
     async fn test_same_group_of_value() {
         let store = MemoryStateStore::new();
         let keyspace = Keyspace::executor_root(store.clone(), 0x2333);
@@ -931,12 +931,12 @@ mod tests {
         }
     }
 
-    #[tokio::test]
+    #[madsim::test]
     async fn chaos_test_min() {
         chaos_test::<{ variants::EXTREME_MIN }>().await;
     }
 
-    #[tokio::test]
+    #[madsim::test]
     async fn chaos_test_max() {
         chaos_test::<{ variants::EXTREME_MAX }>().await;
     }
@@ -1038,7 +1038,7 @@ mod tests {
         write_batch.ingest(epoch).await.unwrap();
     }
 
-    #[tokio::test]
+    #[madsim::test]
     async fn test_same_value_delete() {
         // In this test, we test this case:
         //

--- a/src/stream/src/executor/managed_state/aggregation/extreme.rs
+++ b/src/stream/src/executor/managed_state/aggregation/extreme.rs
@@ -12,10 +12,9 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use std::collections::BTreeMap;
-
 use async_trait::async_trait;
 use itertools::Itertools;
+use madsim::collections::BTreeMap;
 use risingwave_common::array::stream_chunk::{Op, Ops};
 use risingwave_common::array::{Array, ArrayImpl};
 use risingwave_common::buffer::Bitmap;
@@ -483,9 +482,8 @@ pub async fn create_streaming_extreme_state<S: StateStore>(
 
 #[cfg(test)]
 mod tests {
-    use std::collections::{BTreeSet, HashSet};
-
     use itertools::Itertools;
+    use madsim::collections::{BTreeSet, HashSet};
     use rand::prelude::*;
     use risingwave_common::array::{I64Array, Op};
     use risingwave_common::types::ScalarImpl;

--- a/src/stream/src/executor/managed_state/aggregation/extreme.rs
+++ b/src/stream/src/executor/managed_state/aggregation/extreme.rs
@@ -484,7 +484,7 @@ pub async fn create_streaming_extreme_state<S: StateStore>(
 mod tests {
     use itertools::Itertools;
     use madsim::collections::{BTreeSet, HashSet};
-    use rand::prelude::*;
+    use madsim::rand::prelude::*;
     use risingwave_common::array::{I64Array, Op};
     use risingwave_common::types::ScalarImpl;
     use risingwave_storage::memory::MemoryStateStore;

--- a/src/stream/src/executor/managed_state/aggregation/string_agg.rs
+++ b/src/stream/src/executor/managed_state/aggregation/string_agg.rs
@@ -12,11 +12,10 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use std::collections::BTreeMap;
-
 use async_trait::async_trait;
 use bytes::Bytes;
 use itertools::Itertools;
+use madsim::collections::BTreeMap;
 use risingwave_common::array::stream_chunk::{Op, Ops};
 use risingwave_common::array::ArrayImpl;
 use risingwave_common::buffer::Bitmap;

--- a/src/stream/src/executor/managed_state/aggregation/string_agg.rs
+++ b/src/stream/src/executor/managed_state/aggregation/string_agg.rs
@@ -304,7 +304,7 @@ mod tests {
         managed_state
     }
 
-    #[tokio::test]
+    #[madsim::test]
     async fn test_managed_string_agg_state() {
         let keyspace = create_in_memory_keyspace();
         let store = keyspace.state_store();

--- a/src/stream/src/executor/managed_state/aggregation/value.rs
+++ b/src/stream/src/executor/managed_state/aggregation/value.rs
@@ -134,7 +134,7 @@ mod tests {
         }
     }
 
-    #[tokio::test]
+    #[madsim::test]
     async fn test_managed_value_state() {
         let keyspace = create_in_memory_keyspace();
         let mut managed_state =

--- a/src/stream/src/executor/managed_state/flush_status.rs
+++ b/src/stream/src/executor/managed_state/flush_status.rs
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use std::collections::{btree_map, hash_map};
+use madsim::collections::{btree_map, hash_map};
 
 macro_rules! impl_flush_status {
     ([], $( { $entry_type:ty, $struct_name:ident } ),*) => {

--- a/src/stream/src/executor/managed_state/join/join_entry_state.rs
+++ b/src/stream/src/executor/managed_state/join/join_entry_state.rs
@@ -12,10 +12,10 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use std::collections::{btree_map, BTreeMap};
 use std::sync::Arc;
 
 use bytes::Bytes;
+use madsim::collections::{btree_map, BTreeMap};
 use risingwave_common::array::data_chunk_iter::RowDeserializer;
 use risingwave_common::error::Result;
 use risingwave_common::types::DataType;

--- a/src/stream/src/executor/managed_state/join/join_entry_state.rs
+++ b/src/stream/src/executor/managed_state/join/join_entry_state.rs
@@ -219,7 +219,7 @@ mod tests {
 
     use super::*;
 
-    #[tokio::test]
+    #[madsim::test]
     async fn test_managed_all_or_none_state() {
         let store = MemoryStateStore::new();
         let keyspace = Keyspace::executor_root(store.clone(), 0x2333);

--- a/src/stream/src/executor/managed_state/top_n/top_n_bottom_n_state.rs
+++ b/src/stream/src/executor/managed_state/top_n/top_n_bottom_n_state.rs
@@ -15,9 +15,9 @@
 #![allow(clippy::mutable_key_type)]
 #![allow(dead_code)]
 
-use std::collections::BTreeMap;
 use std::vec::Drain;
 
+use madsim::collections::BTreeMap;
 use risingwave_common::array::Row;
 use risingwave_common::catalog::ColumnId;
 use risingwave_common::error::Result;

--- a/src/stream/src/executor/managed_state/top_n/top_n_bottom_n_state.rs
+++ b/src/stream/src/executor/managed_state/top_n/top_n_bottom_n_state.rs
@@ -368,7 +368,7 @@ mod tests {
         )
     }
 
-    #[tokio::test]
+    #[madsim::test]
     async fn test_managed_top_n_bottom_n_state() {
         let data_types = vec![DataType::Varchar, DataType::Int64];
         let order_types = vec![OrderType::Descending, OrderType::Ascending];

--- a/src/stream/src/executor/managed_state/top_n/top_n_state.rs
+++ b/src/stream/src/executor/managed_state/top_n/top_n_state.rs
@@ -13,8 +13,8 @@
 // limitations under the License.
 
 use std::cmp::Ordering;
-use std::collections::BTreeMap;
 
+use madsim::collections::BTreeMap;
 use risingwave_common::array::Row;
 use risingwave_common::catalog::ColumnId;
 use risingwave_common::error::Result;

--- a/src/stream/src/executor/managed_state/top_n/top_n_state.rs
+++ b/src/stream/src/executor/managed_state/top_n/top_n_state.rs
@@ -416,7 +416,7 @@ mod tests {
         )
     }
 
-    #[tokio::test]
+    #[madsim::test]
     async fn test_managed_top_n_state() {
         let store = MemoryStateStore::new();
         let data_types = vec![DataType::Varchar, DataType::Int64];

--- a/src/stream/src/executor/merge.rs
+++ b/src/stream/src/executor/merge.rs
@@ -200,7 +200,6 @@ impl MergeExecutor {
 mod tests {
     use std::sync::atomic::{AtomicBool, Ordering};
     use std::sync::Arc;
-    use std::thread::sleep;
     use std::time::Duration;
 
     use assert_matches::assert_matches;
@@ -208,6 +207,7 @@ mod tests {
     use futures::SinkExt;
     use itertools::Itertools;
     use madsim::collections::HashSet;
+    use madsim::time::sleep;
     use risingwave_common::array::{Op, StreamChunk};
     use risingwave_pb::data::StreamMessage;
     use risingwave_pb::task_service::exchange_service_server::{
@@ -230,7 +230,7 @@ mod tests {
         StreamChunk::new(ops, vec![], None)
     }
 
-    #[tokio::test]
+    #[madsim::test]
     async fn test_merger() {
         const CHANNEL_NUMBER: usize = 10;
         let mut txs = Vec::with_capacity(CHANNEL_NUMBER);
@@ -247,7 +247,7 @@ mod tests {
 
         for mut tx in txs {
             let epochs = epochs.clone();
-            let handle = tokio::spawn(async move {
+            let handle = madsim::task::spawn(async move {
                 for epoch in epochs {
                     tx.send(Message::Chunk(build_test_chunk(epoch)))
                         .await
@@ -255,7 +255,7 @@ mod tests {
                     tx.send(Message::Barrier(Barrier::new_test_barrier(epoch)))
                         .await
                         .unwrap();
-                    tokio::time::sleep(Duration::from_millis(1)).await;
+                    sleep(Duration::from_millis(1)).await;
                 }
                 tx.send(Message::Barrier(
                     Barrier::new_test_barrier(1000)
@@ -289,7 +289,7 @@ mod tests {
         );
 
         for handle in handles {
-            handle.await.unwrap();
+            handle.await;
         }
     }
 
@@ -345,7 +345,7 @@ mod tests {
         }
     }
 
-    #[tokio::test(flavor = "multi_thread")]
+    #[madsim::test(flavor = "multi_thread")]
     async fn test_stream_exchange_client() {
         let rpc_called = Arc::new(AtomicBool::new(false));
         let server_run = Arc::new(AtomicBool::new(false));
@@ -357,7 +357,7 @@ mod tests {
             rpc_called: rpc_called.clone(),
         });
         let cp_server_run = server_run.clone();
-        let join_handle = tokio::spawn(async move {
+        let join_handle = madsim::task::spawn(async move {
             cp_server_run.store(true, Ordering::SeqCst);
             tonic::transport::Server::builder()
                 .add_service(exchange_svc)
@@ -368,10 +368,10 @@ mod tests {
                 .unwrap();
         });
 
-        sleep(Duration::from_secs(1));
+        sleep(Duration::from_secs(1)).await;
         assert!(server_run.load(Ordering::SeqCst));
         let (tx, mut rx) = channel(16);
-        let input_handle = tokio::spawn(async move {
+        let input_handle = madsim::task::spawn(async move {
             let remote_input =
                 RemoteInput::create(ComputeClient::new(addr.into()).await.unwrap(), (0, 0), tx)
                     .await
@@ -388,8 +388,8 @@ mod tests {
             assert_eq!(barrier_epoch.curr, 12345);
         });
         assert!(rpc_called.load(Ordering::SeqCst));
-        input_handle.await.unwrap();
+        input_handle.await;
         shutdown_send.send(()).unwrap();
-        join_handle.await.unwrap();
+        join_handle.await;
     }
 }

--- a/src/stream/src/executor/merge.rs
+++ b/src/stream/src/executor/merge.rs
@@ -198,7 +198,6 @@ impl MergeExecutor {
 
 #[cfg(test)]
 mod tests {
-    use std::collections::HashSet;
     use std::sync::atomic::{AtomicBool, Ordering};
     use std::sync::Arc;
     use std::thread::sleep;
@@ -208,6 +207,7 @@ mod tests {
     use futures::channel::mpsc::channel;
     use futures::SinkExt;
     use itertools::Itertools;
+    use madsim::collections::HashSet;
     use risingwave_common::array::{Op, StreamChunk};
     use risingwave_pb::data::StreamMessage;
     use risingwave_pb::task_service::exchange_service_server::{

--- a/src/stream/src/executor/mod.rs
+++ b/src/stream/src/executor/mod.rs
@@ -12,7 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use std::collections::{HashMap, HashSet};
 use std::fmt::Debug;
 use std::sync::Arc;
 
@@ -20,6 +19,7 @@ use enum_as_inner::EnumAsInner;
 use error::StreamExecutorResult;
 use futures::stream::BoxStream;
 use futures::Stream;
+use madsim::collections::{HashMap, HashSet};
 use risingwave_common::array::column::Column;
 use risingwave_common::array::{ArrayImpl, ArrayRef, DataChunk, StreamChunk};
 use risingwave_common::buffer::Bitmap;

--- a/src/stream/src/executor/mview/materialize.rs
+++ b/src/stream/src/executor/mview/materialize.rs
@@ -174,7 +174,7 @@ mod tests {
     use crate::executor::test_utils::*;
     use crate::executor::*;
 
-    #[tokio::test]
+    #[madsim::test]
     async fn test_materialize_executor() {
         // Prepare storage and memtable.
         let memory_state_store = MemoryStateStore::new();

--- a/src/stream/src/executor/mview/state.rs
+++ b/src/stream/src/executor/mview/state.rs
@@ -12,8 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use std::collections::HashMap;
-
+use madsim::collections::HashMap;
 use risingwave_common::array::Row;
 use risingwave_common::catalog::ColumnId;
 use risingwave_common::error::Result;

--- a/src/stream/src/executor/mview/state.rs
+++ b/src/stream/src/executor/mview/state.rs
@@ -112,7 +112,7 @@ mod tests {
 
     use super::*;
 
-    #[tokio::test]
+    #[madsim::test]
     async fn test_mview_state() {
         // Only assert pk and columns can be successfully put/delete/flush,
         // and the amount of rows is expected.

--- a/src/stream/src/executor/mview/table_state_tests.rs
+++ b/src/stream/src/executor/mview/table_state_tests.rs
@@ -24,7 +24,7 @@ use risingwave_storage::Keyspace;
 
 // use crate::executor::mview::ManagedMViewState;
 
-#[tokio::test]
+#[madsim::test]
 async fn test_cell_based_table_iter() {
     let state_store = MemoryStateStore::new();
     // let pk_columns = vec![0, 1]; leave a message to indicate pk columns
@@ -91,7 +91,7 @@ async fn test_cell_based_table_iter() {
     assert!(res.is_none());
 }
 
-#[tokio::test]
+#[madsim::test]
 async fn test_multi_cell_based_table_iter() {
     let state_store = MemoryStateStore::new();
     // let pk_columns = vec![0, 1]; leave a message to indicate pk columns
@@ -232,7 +232,7 @@ async fn test_multi_cell_based_table_iter() {
     assert!(res_2_2.is_none());
 }
 
-#[tokio::test]
+#[madsim::test]
 async fn test_cell_based_scan_empty_column_ids_cardinality() {
     let state_store = MemoryStateStore::new();
     let column_ids = vec![ColumnId::from(0), ColumnId::from(1), ColumnId::from(2)];
@@ -281,7 +281,7 @@ async fn test_cell_based_scan_empty_column_ids_cardinality() {
     assert_eq!(chunk.cardinality(), 2);
 }
 
-#[tokio::test]
+#[madsim::test]
 async fn test_get_row_by_scan() {
     let state_store = MemoryStateStore::new();
     let column_ids = vec![ColumnId::from(0), ColumnId::from(1), ColumnId::from(2)];
@@ -357,7 +357,7 @@ async fn test_get_row_by_scan() {
     assert_eq!(get_no_exist_res, None);
 }
 
-#[tokio::test]
+#[madsim::test]
 async fn test_get_row_by_muti_get() {
     let state_store = MemoryStateStore::new();
     let column_ids = vec![ColumnId::from(0), ColumnId::from(1), ColumnId::from(2)];
@@ -445,7 +445,7 @@ async fn test_get_row_by_muti_get() {
     assert_eq!(get_no_exist_res, None);
 }
 
-#[tokio::test]
+#[madsim::test]
 async fn test_get_row_for_string() {
     let state_store = MemoryStateStore::new();
     let order_types = vec![OrderType::Ascending, OrderType::Descending];
@@ -534,7 +534,7 @@ async fn test_get_row_for_string() {
     assert_eq!(get_row2_res, None);
 }
 
-#[tokio::test]
+#[madsim::test]
 async fn test_shuffled_column_id_for_get_row() {
     let state_store = MemoryStateStore::new();
     let column_ids = vec![ColumnId::from(3), ColumnId::from(2), ColumnId::from(1)];

--- a/src/stream/src/executor/project.rs
+++ b/src/stream/src/executor/project.rs
@@ -143,7 +143,7 @@ mod tests {
     use super::super::*;
     use super::*;
 
-    #[tokio::test]
+    #[madsim::test]
     async fn test_projection() {
         let chunk1 = StreamChunk::from_pretty(
             " I I

--- a/src/stream/src/executor/rearranged_chain.rs
+++ b/src/stream/src/executor/rearranged_chain.rs
@@ -152,7 +152,7 @@ impl RearrangedChainExecutor {
                 .unwrap();
 
             // 3. Spawn the background task.
-            let upstream_poll_handle = tokio::spawn(Self::rearrange(
+            let upstream_poll_handle = madsim::task::spawn(Self::rearrange(
                 upstream,
                 upstream_tx,
                 rearranged_barrier_tx,
@@ -215,7 +215,7 @@ impl RearrangedChainExecutor {
 
             // Now we take back the remaining upstream.
             // If there's any error in the rearrangement task, it will be thrown.
-            let remaining_upstream = upstream_poll_handle.await.unwrap()?;
+            let remaining_upstream = upstream_poll_handle.await?;
 
             // 8. Assemble the remaining messages.
             // Note that there may still be some messages in `rearranged`. However the rearranged

--- a/src/stream/src/executor/source.rs
+++ b/src/stream/src/executor/source.rs
@@ -346,7 +346,7 @@ mod tests {
 
     use super::*;
 
-    #[tokio::test]
+    #[madsim::test]
     async fn test_table_source() -> Result<()> {
         let table_id = TableId::default();
 
@@ -428,10 +428,11 @@ mod tests {
 
         let write_chunk = |chunk: StreamChunk| {
             let source = source.clone();
-            tokio::spawn(async move {
+            madsim::task::spawn(async move {
                 let table_source = source.as_table_v2().unwrap();
                 table_source.blocking_write_chunk(chunk).await.unwrap();
-            });
+            })
+            .detach();
         };
 
         barrier_sender.send(Barrier::new_test_barrier(1)).unwrap();
@@ -473,7 +474,7 @@ mod tests {
         Ok(())
     }
 
-    #[tokio::test]
+    #[madsim::test]
     async fn test_table_dropped() -> Result<()> {
         let table_id = TableId::default();
 
@@ -549,10 +550,11 @@ mod tests {
 
         let write_chunk = |chunk: StreamChunk| {
             let source = source.clone();
-            tokio::spawn(async move {
+            madsim::task::spawn(async move {
                 let table_source = source.as_table_v2().unwrap();
                 table_source.blocking_write_chunk(chunk).await.unwrap();
-            });
+            })
+            .detach();
         };
 
         write_chunk(chunk.clone());

--- a/src/stream/src/executor/top_n.rs
+++ b/src/stream/src/executor/top_n.rs
@@ -12,9 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use std::collections::HashSet;
-
 use async_trait::async_trait;
+use madsim::collections::HashSet;
 use risingwave_common::array::{Op, StreamChunk};
 use risingwave_common::catalog::{ColumnDesc, ColumnId, Schema};
 use risingwave_common::error::Result;

--- a/src/stream/src/executor/top_n.rs
+++ b/src/stream/src/executor/top_n.rs
@@ -556,7 +556,7 @@ mod tests {
         ))
     }
 
-    #[tokio::test]
+    #[madsim::test]
     async fn test_top_n_executor_with_offset() {
         let order_types = create_order_pairs();
         let source = create_source();
@@ -652,7 +652,7 @@ mod tests {
         );
     }
 
-    #[tokio::test]
+    #[madsim::test]
     async fn test_top_n_executor_with_limit() {
         let order_types = create_order_pairs();
         let source = create_source();
@@ -757,7 +757,7 @@ mod tests {
         );
     }
 
-    #[tokio::test]
+    #[madsim::test]
     async fn test_top_n_executor_with_offset_and_limit() {
         let order_types = create_order_pairs();
         let source = create_source();

--- a/src/stream/src/executor/top_n_appendonly.rs
+++ b/src/stream/src/executor/top_n_appendonly.rs
@@ -389,7 +389,7 @@ mod tests {
         ))
     }
 
-    #[tokio::test]
+    #[madsim::test]
     async fn test_append_only_top_n_executor_with_offset() {
         let order_pairs = create_order_pairs();
         let source = create_source();
@@ -463,7 +463,7 @@ mod tests {
         // Now (1, 1, 1) -> (1, 2, 2, 3, 3, 3, 7, 8, 9, 10)
     }
 
-    #[tokio::test]
+    #[madsim::test]
     async fn test_append_only_top_n_executor_with_limit() {
         let order_pairs = create_order_pairs();
         let source = create_source();
@@ -543,7 +543,7 @@ mod tests {
         // Now (1, 1, 1, 1, 2)
     }
 
-    #[tokio::test]
+    #[madsim::test]
     async fn test_append_only_top_n_executor_with_offset_and_limit() {
         let order_pairs = create_order_pairs();
         let source = create_source();

--- a/src/stream/src/executor/union.rs
+++ b/src/stream/src/executor/union.rs
@@ -104,7 +104,7 @@ mod tests {
 
     use super::*;
 
-    #[tokio::test]
+    #[madsim::test]
     async fn union() {
         let streams = vec![
             try_stream! {

--- a/src/stream/src/task/barrier_manager.rs
+++ b/src/stream/src/task/barrier_manager.rs
@@ -12,9 +12,9 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use std::collections::{HashMap, HashSet};
 use std::sync::Arc;
 
+use madsim::collections::{HashMap, HashSet};
 use risingwave_common::error::Result;
 use risingwave_pb::stream_service::inject_barrier_response::FinishedCreateMview as ProstFinishedCreateMview;
 use tokio::sync::mpsc::UnboundedSender;

--- a/src/stream/src/task/barrier_manager/managed_state.rs
+++ b/src/stream/src/task/barrier_manager/managed_state.rs
@@ -12,9 +12,9 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use std::collections::HashSet;
 use std::iter::once;
 
+use madsim::collections::HashSet;
 use tokio::sync::oneshot;
 
 use super::{CollectResult, FinishedCreateMview};

--- a/src/stream/src/task/mod.rs
+++ b/src/stream/src/task/mod.rs
@@ -12,10 +12,10 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use std::collections::HashMap;
 use std::sync::Arc;
 
 use futures::channel::mpsc::{Receiver, Sender};
+use madsim::collections::HashMap;
 use parking_lot::{Mutex, MutexGuard};
 use risingwave_common::error::{ErrorCode, Result, RwError};
 use risingwave_common::util::addr::HostAddr;

--- a/src/stream/src/task/stream_manager.rs
+++ b/src/stream/src/task/stream_manager.rs
@@ -12,12 +12,12 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use std::collections::{HashMap, HashSet};
 use std::fmt::Debug;
 use std::sync::Arc;
 
 use futures::channel::mpsc::{channel, Receiver};
 use itertools::Itertools;
+use madsim::collections::{HashMap, HashSet};
 use parking_lot::Mutex;
 use risingwave_common::error::{ErrorCode, Result, RwError};
 use risingwave_common::try_match_expand;

--- a/src/stream/src/task/stream_manager.rs
+++ b/src/stream/src/task/stream_manager.rs
@@ -18,6 +18,7 @@ use std::sync::Arc;
 use futures::channel::mpsc::{channel, Receiver};
 use itertools::Itertools;
 use madsim::collections::{HashMap, HashSet};
+use madsim::task::JoinHandle;
 use parking_lot::Mutex;
 use risingwave_common::error::{ErrorCode, Result, RwError};
 use risingwave_common::try_match_expand;
@@ -28,7 +29,6 @@ use risingwave_pb::stream_plan::stream_node::NodeBody;
 use risingwave_pb::{stream_plan, stream_service};
 use risingwave_storage::{dispatch_state_store, StateStore, StateStoreImpl};
 use tokio::sync::oneshot;
-use tokio::task::JoinHandle;
 
 use super::{unique_executor_id, unique_operator_id, CollectResult, ComputeClientPool};
 use crate::executor::dispatch::*;
@@ -253,7 +253,7 @@ impl LocalStreamManager {
     pub async fn wait_all(self) -> Result<()> {
         let handles = self.core.lock().take_all_handles()?;
         for (_id, handle) in handles {
-            handle.await?;
+            handle.await;
         }
         Ok(())
     }
@@ -262,7 +262,7 @@ impl LocalStreamManager {
     pub async fn wait_actors(&self, actor_ids: &[ActorId]) -> Result<()> {
         let handles = self.core.lock().remove_actor_handles(actor_ids)?;
         for handle in handles {
-            handle.await.unwrap();
+            handle.await;
         }
         Ok(())
     }
@@ -536,7 +536,7 @@ impl LocalStreamManagerCore {
 
                         let pool = self.compute_client_pool.clone();
 
-                        tokio::spawn(async move {
+                        madsim::task::spawn(async move {
                             let init_client = async move {
                                 let remote_input = RemoteInput::create(
                                     pool.get_client_for_addr(upstream_addr).await?,
@@ -552,7 +552,8 @@ impl LocalStreamManagerCore {
                                     error!("Spawn remote input fails:{}", e);
                                 }
                             }
-                        });
+                        })
+                        .detach();
                     }
                     Ok::<_, RwError>(self.context.take_receiver(&(*up_id, actor_id))?)
                 }
@@ -582,7 +583,7 @@ impl LocalStreamManagerCore {
             let actor = Actor::new(dispatcher, actor_id, self.context.clone());
             self.handles.insert(
                 actor_id,
-                tokio::spawn(async move {
+                madsim::task::spawn(async move {
                     // unwrap the actor result to panic on error
                     actor.run().await.expect("actor failed");
                 }),
@@ -630,7 +631,7 @@ impl LocalStreamManagerCore {
     /// `drop_actor` is invoked by meta node via RPC once the stop barrier arrives at the
     /// sink. All the actors in the actors should stop themselves before this method is invoked.
     fn drop_actor(&mut self, actor_id: ActorId) {
-        let handle = self.handles.remove(&actor_id).unwrap();
+        let mut handle = self.handles.remove(&actor_id).unwrap();
         self.context.retain(|&(up_id, _)| up_id != actor_id);
 
         self.actor_infos.remove(&actor_id);
@@ -642,7 +643,7 @@ impl LocalStreamManagerCore {
     /// `drop_all_actors` is invoked by meta node via RPC once the stop barrier arrives at all the
     /// sink. All the actors in the actors should stop themselves before this method is invoked.
     fn drop_all_actors(&mut self) {
-        for (actor_id, handle) in self.handles.drain() {
+        for (actor_id, mut handle) in self.handles.drain() {
             self.context.retain(|&(up_id, _)| up_id != actor_id);
             self.actors.remove(&actor_id);
             // Task should have already stopped when this method is invoked.

--- a/src/workspace-hack/Cargo.toml
+++ b/src/workspace-hack/Cargo.toml
@@ -23,11 +23,9 @@ either = { version = "1", features = ["use_std"] }
 fail = { version = "0.5", default-features = false, features = ["failpoints"] }
 fixedbitset = { version = "0.4", features = ["std"] }
 futures = { version = "0.3", features = ["alloc", "async-await", "executor", "futures-executor", "std"] }
-futures-channel = { version = "0.3", features = ["alloc", "futures-sink", "sink", "std"] }
 futures-executor = { version = "0.3", features = ["std"] }
 futures-io = { version = "0.3", features = ["std"] }
 futures-sink = { version = "0.3", features = ["alloc", "std"] }
-futures-task = { version = "0.3", default-features = false, features = ["alloc", "std"] }
 futures-util = { version = "0.3", features = ["alloc", "async-await", "async-await-macro", "channel", "futures-channel", "futures-io", "futures-macro", "futures-sink", "io", "memchr", "sink", "slab", "std"] }
 hashbrown = { version = "0.11", features = ["ahash", "inline-more", "raw"] }
 hyper = { version = "0.14", features = ["client", "full", "h2", "http1", "http2", "runtime", "server", "socket2", "stream", "tcp"] }
@@ -72,11 +70,9 @@ either = { version = "1", features = ["use_std"] }
 fail = { version = "0.5", default-features = false, features = ["failpoints"] }
 fixedbitset = { version = "0.4", features = ["std"] }
 futures = { version = "0.3", features = ["alloc", "async-await", "executor", "futures-executor", "std"] }
-futures-channel = { version = "0.3", features = ["alloc", "futures-sink", "sink", "std"] }
 futures-executor = { version = "0.3", features = ["std"] }
 futures-io = { version = "0.3", features = ["std"] }
 futures-sink = { version = "0.3", features = ["alloc", "std"] }
-futures-task = { version = "0.3", default-features = false, features = ["alloc", "std"] }
 futures-util = { version = "0.3", features = ["alloc", "async-await", "async-await-macro", "channel", "futures-channel", "futures-io", "futures-macro", "futures-sink", "io", "memchr", "sink", "slab", "std"] }
 hashbrown = { version = "0.11", features = ["ahash", "inline-more", "raw"] }
 hyper = { version = "0.14", features = ["client", "full", "h2", "http1", "http2", "runtime", "server", "socket2", "stream", "tcp"] }


### PR DESCRIPTION
This PR introduces [madsim](https://github.com/madsys-dev/madsim), a deterministic simulation testing framework to our project. 

With madsim, we can test our code deterministically on a simulator. The simulator will inject randomness and failures into the system, making bugs appear more frequent. Once a bug is found, we can always reproduce it with the given random seed. Hopefully, this technique will ease the pain of debugging and make our system more robust.

## How to run the demo

I chose the `stream` crate as a starting point and reformed all unit tests there.
You can run these tests in simulation with a special feature `sim`:

```sh
cd src/stream
cargo test --features=tonic/sim
```

Everything should work as usual except for one test: `executor::source::tests::test_table_dropped`.
It passed on tokio but failed on madsim. We are still looking for the reason.

Next, let's explore some interesting features of madsim!

### Logging

You can set the `RUST_LOG` env variable to see what's happening inside the simulator:

```sh
RUST_LOG=trace cargo test --features=tonic/sim test_stream_exchange_client
```

The output should be something like this:
<details>

```
[TRACE][madsim::sim::fs] fs: new at Node(0)
[DEBUG][madsim::sim::net::network] insert: Node(0)
[DEBUG][0.000003s][main][madsim::sim::net::network] bind: 127.0.0.1:12348 -> Node(0)
[DEBUG][1.000004s][main][madsim::sim::net::network] bind: 127.0.0.1:0 -> Node(0)
[TRACE][1.000004s][main][madsim::sim::net::network] send: Node(0) 127.0.0.1:1 -> 127.0.0.1:12348, tag=0
[TRACE][1.000004s][main][madsim::sim::net::network] delay: 2.735099ms
[TRACE][1.002742s][main][madsim::sim::net] recv: 127.0.0.1:12348 <- 127.0.0.1:1, tag=0
[TRACE][1.002742s][main][madsim_tonic::sim::transport::server] request: /task_service.ExchangeService/GetStream <- 127.0.0.1:1
[TRACE][1.002742s][main][madsim::sim::net::network] send: Node(0) 127.0.0.1:12348 -> 127.0.0.1:1, tag=3258726865127906000
[TRACE][1.002742s][main][madsim::sim::net::network] delay: 5.531016ms
[TRACE][1.002742s][main][madsim::sim::net::network] send: Node(0) 127.0.0.1:12348 -> 127.0.0.1:1, tag=3258726865127906001
[TRACE][1.002742s][main][madsim::sim::net::network] delay: 2.848245ms
[TRACE][1.002744s][main][madsim::sim::net::network] send: Node(0) 127.0.0.1:12348 -> 127.0.0.1:1, tag=3258726865127906002
[TRACE][1.002744s][main][madsim::sim::net::network] delay: 9.60552ms
[TRACE][1.008274s][main][madsim::sim::net] recv: 127.0.0.1:1 <- 127.0.0.1:12348, tag=3258726865127906000
[TRACE][1.008277s][main][madsim::sim::net] recv: 127.0.0.1:1 <- 127.0.0.1:12348, tag=3258726865127906001
[TRACE][1.012352s][main][madsim::sim::net] recv: 127.0.0.1:1 <- 127.0.0.1:12348, tag=3258726865127906002
[DEBUG][1.012352s][main][madsim::sim::net::network] close: Node(0) 127.0.0.1:1
[DEBUG][1.012352s][main][madsim::sim::net::network] close: Node(0) 127.0.0.1:12348
test executor::merge::tests::test_stream_exchange_client ... ok
```
</details>

### The Seed

If you run multiple times, you will find the timestamps are slightly different every time. This is because by default the simulator uses a random seed on each run.

You can specify the seed by setting the `MADSIM_TEST_SEED` env variable:

```sh
MADSIM_TEST_SEED=1 RUST_LOG=trace cargo test --features=tonic/sim test_stream_exchange_client
```

Now your output should be exactly the same as the following:

<details>

```
[TRACE][madsim::sim::fs] fs: new at Node(0)
[DEBUG][madsim::sim::net::network] insert: Node(0)
[DEBUG][0.000002s][main][madsim::sim::net::network] bind: 127.0.0.1:12348 -> Node(0)
[DEBUG][1.000003s][main][madsim::sim::net::network] bind: 127.0.0.1:0 -> Node(0)
[TRACE][1.000003s][main][madsim::sim::net::network] send: Node(0) 127.0.0.1:1 -> 127.0.0.1:12348, tag=0
[TRACE][1.000003s][main][madsim::sim::net::network] delay: 2.603073ms
[TRACE][1.002610s][main][madsim::sim::net] recv: 127.0.0.1:12348 <- 127.0.0.1:1, tag=0
[TRACE][1.002610s][main][madsim_tonic::sim::transport::server] request: /task_service.ExchangeService/GetStream <- 127.0.0.1:1
[TRACE][1.002610s][main][madsim::sim::net::network] send: Node(0) 127.0.0.1:12348 -> 127.0.0.1:1, tag=10804756285030244799
[TRACE][1.002610s][main][madsim::sim::net::network] delay: 9.413239ms
[TRACE][1.002610s][main][madsim::sim::net::network] send: Node(0) 127.0.0.1:12348 -> 127.0.0.1:1, tag=10804756285030244800
[TRACE][1.002610s][main][madsim::sim::net::network] delay: 9.977014ms
[TRACE][1.002612s][main][madsim::sim::net::network] send: Node(0) 127.0.0.1:12348 -> 127.0.0.1:1, tag=10804756285030244801
[TRACE][1.002612s][main][madsim::sim::net::network] delay: 1.44103ms
[TRACE][1.012026s][main][madsim::sim::net] recv: 127.0.0.1:1 <- 127.0.0.1:12348, tag=10804756285030244799
[TRACE][1.012589s][main][madsim::sim::net] recv: 127.0.0.1:1 <- 127.0.0.1:12348, tag=10804756285030244800
[TRACE][1.012590s][main][madsim::sim::net] recv: 127.0.0.1:1 <- 127.0.0.1:12348, tag=10804756285030244801
[DEBUG][1.012590s][main][madsim::sim::net::network] close: Node(0) 127.0.0.1:1
[DEBUG][1.012590s][main][madsim::sim::net::network] close: Node(0) 127.0.0.1:12348
```
</details>

### Configure

The simulator is also configurable. Currently, only a few parameters can be configured. For example, the latency of sending a message. You can create a configuration file `config.toml`:
```toml
[net]
send_latency = { start = { secs = 0, nanos = 1000000 }, end = { secs = 10, nanos = 0 } }
# the ugly syntax needs improvement...
```

Then run your test with the `MADSIM_TEST_CONFIG` env variable:
```sh
RUST_LOG=trace MADSIM_TEST_CONFIG=./config.toml cargo test --features=tonic/sim test_stream_exchange_client
```

You will see how the timestamp changes based on your settings.

### Mass Testing

To make sure your code can reliably pass the tests, set the `MADSIM_TEST_NUM` env variable:

```sh
MADSIM_TEST_NUM=100 cargo test --features=tonic/sim
```

This command will run all tests 100 times. It should be fast. Because the time is also simulated, we don't actually have to wait for the delay. Even so, a release build is recommended to reduce simulation time. The less time it consumes, the more situations we can cover.

### Non-Determinism Detection

A deterministic simulator is not enough for deterministic simulation! The application itself may introduce randomness. And just a little uncertainty will make the test unreproducible. To help developers find uncertainties in their code, madsim provides a `MADSIM_TEST_CHECK_DETERMINISM` env variable. If it is set, the simulator will run your code twice with the same seed, and compare the log sequence between them. It will panic as soon as a difference is found so that you can locate it via the backtrace.

Try to sleep a real random period of time in a test:

```rust
#[madsim::test]
async fn test_projection() {
    use rand::Rng;
    madsim::time::sleep(std::time::Duration::from_secs(
        rand::thread_rng().gen_range(1..10),
    )).await;
    // ...
}
```

Now let's catch it with this command:

```sh
MADSIM_TEST_CHECK_DETERMINISM=1 cargo test --features=tonic/sim test_projection
```

You will get a panic with some hints:

```
---- executor::project::tests::test_projection stdout ----
thread 'executor::project::tests::test_projection' panicked at 'non-determinism detected at 8.00000005s'
stack backtrace: ...
```

Note that this tool can not capture randomness at 100%, since not all of them are visible to the simulator.

## What's changed in this PR

To intergrate madsim into risingwave, this PR makes some simple changes:

1. Add `madsim` and replace all `tonic` and `tonic-build` in Cargo.toml.
2. Replace the following APIs and redirect them to madsim:
  ```rust
  use std::collections    -> use madsim::collections
  use rand                -> use madsim::rand
  use tokio::time         -> use madsim::time
  use tokio::task         -> use madsim::task
  use tokio::test         -> use madsim::test
  ```

Don't worry. These won't break anything. Because in normal build they are identical to the original APIs.
Only when the `sim` feature is enabled, these interfaces will be redirected to the simulator.

3. In the `prost` crate, move all generated files from `src` to `$OUT_DIR`.
  One reason is to follow Rust's requirement: build scripts should not modify any files outside the $OUT_DIR directory.
  The other is that madsim will generate another version of files for simulation. We need the `include_proto` macro to decide which version to use, based on whether the `sim` feature is enabled. Moving them to $OUT_DIR will make things easier.

## Limitations

Madsim is still under development. There are some known issues that will be resolved in the future:
- Now only a few randomness are injected by the simulator, including I/O delay and task scheduling. The chaos it creates may not be enough to reveal bugs in extreme situations.
- The tonic simulator will not work on an unreliable network, which means if you enable packet loss simulation, the client will block forever.
- How do we handle external services? Maybe we need to build an S3 simulator and an etcd simulator. 🤔

Nevertheless, I believe madsim will become more useful and make a big difference someday.
If you are excited about it, just try it yourself! Any feedback is welcome! 🥰

## Checklist

- [x] I have written necessary docs and comments
- [x] I have added necessary unit tests and integration tests
