### PR TITLE
fix(batch): support incomplete timestamp literal

### DIFF
--- a/e2e_test/v2/batch/types/arithmetic.slt
+++ b/e2e_test/v2/batch/types/arithmetic.slt
@@ -42,3 +42,13 @@ query T
 select interval '1' day + timestamp '2022-02-22';
 ----
 2022-02-23 00:00:00
+
+query T
+select timestamp '2022-02-22 10:23';
+----
+2022-02-22 10:23:00
+
+query T
+select time '10:23';
+----
+10:23:00

--- a/e2e_test/v2/batch/types/arithmetic.slt
+++ b/e2e_test/v2/batch/types/arithmetic.slt
@@ -22,3 +22,23 @@ query T
 select 61 * interval '1' second;
 ----
 00:01:01
+
+query T
+select timestamp '1926-08-17 00:00:00'
+----
+1926-08-17 00:00:00
+
+query T
+select timestamp '1926-08-17'
+----
+1926-08-17 00:00:00
+
+query T
+select timestamp '1926-08-17' + interval '1' year + interval '14' month - interval '1' day + interval '1' hour + interval '1' minute - interval '1' second;
+----
+1928-10-16 01:00:59
+
+query T
+select interval '1' day + timestamp '2022-02-22';
+----
+2022-02-23 00:00:00

--- a/src/expr/src/vector_op/cast.rs
+++ b/src/expr/src/vector_op/cast.rs
@@ -34,7 +34,7 @@ const FALSE_BOOL_LITERALS: [&str; 10] = [
 const PARSE_ERROR_STR_TO_TIMESTAMP: &str = "Can't cast string to timestamp (expected format is YYYY-MM-DD HH:MM:SS[.MS] or YYYY-MM-DD HH:MM or YYYY-MM-DD)";
 const PARSE_ERROR_STR_TO_TIME: &str =
     "Can't cast string to time (expected format is HH:MM:SS[.MS] or HH:MM)";
-const PARSE_ERROR_STR_TO_DATA: &str = "Can't cast string to date (expected format is YYYY-MM-DD)";
+const PARSE_ERROR_STR_TO_DATE: &str = "Can't cast string to date (expected format is YYYY-MM-DD)";
 
 #[inline(always)]
 pub fn num_up<T, R>(n: T) -> Result<R>
@@ -61,7 +61,7 @@ pub fn str_to_str(n: &str) -> Result<String> {
 pub fn str_to_date(elem: &str) -> Result<NaiveDateWrapper> {
     Ok(NaiveDateWrapper::new(
         NaiveDate::parse_from_str(elem, "%Y-%m-%d")
-            .map_err(|_| parse_error(PARSE_ERROR_STR_TO_DATA))?,
+            .map_err(|_| parse_error(PARSE_ERROR_STR_TO_DATE))?,
     ))
 }
 

--- a/src/expr/src/vector_op/cast.rs
+++ b/src/expr/src/vector_op/cast.rs
@@ -31,6 +31,10 @@ const TRUE_BOOL_LITERALS: [&str; 9] = ["true", "tru", "tr", "t", "on", "1", "yes
 const FALSE_BOOL_LITERALS: [&str; 10] = [
     "false", "fals", "fal", "fa", "f", "off", "of", "0", "no", "n",
 ];
+const PARSE_ERROR_STR_TO_TIMESTAMP: &str = "Can't cast string to timestamp (expected format is YYYY-MM-DD HH:MM:SS[.MS] or YYYY-MM-DD HH:MM or YYYY-MM-DD)";
+const PARSE_ERROR_STR_TO_TIME: &str =
+    "Can't cast string to time (expected format is HH:MM:SS[.MS] or HH:MM)";
+const PARSE_ERROR_STR_TO_DATA: &str = "Can't cast string to date (expected format is YYYY-MM-DD)";
 
 #[inline(always)]
 pub fn num_up<T, R>(n: T) -> Result<R>
@@ -56,19 +60,20 @@ pub fn str_to_str(n: &str) -> Result<String> {
 #[inline(always)]
 pub fn str_to_date(elem: &str) -> Result<NaiveDateWrapper> {
     Ok(NaiveDateWrapper::new(
-        NaiveDate::parse_from_str(elem, "%Y-%m-%d").map_err(|_| {
-            parse_error("Can't cast string to date (expected format is YYYY-MM-DD)")
-        })?,
+        NaiveDate::parse_from_str(elem, "%Y-%m-%d")
+            .map_err(|_| parse_error(PARSE_ERROR_STR_TO_DATA))?,
     ))
 }
 
 #[inline(always)]
 pub fn str_to_time(elem: &str) -> Result<NaiveTimeWrapper> {
-    Ok(NaiveTimeWrapper::new(
-        NaiveTime::parse_from_str(elem, "%H:%M:%S%.f").map_err(|_| {
-            parse_error("Can't cast string to time (expected format is HH:MM:SS[.MS])")
-        })?,
-    ))
+    if let Ok(time) = NaiveTime::parse_from_str(elem, "%H:%M:%S%.f") {
+        return Ok(NaiveTimeWrapper::new(time));
+    }
+    if let Ok(time) = NaiveTime::parse_from_str(elem, "%H:%M") {
+        return Ok(NaiveTimeWrapper::new(time));
+    }
+    Err(parse_error(PARSE_ERROR_STR_TO_TIME))
 }
 
 #[inline(always)]
@@ -76,13 +81,13 @@ pub fn str_to_timestamp(elem: &str) -> Result<NaiveDateTimeWrapper> {
     if let Ok(timestamp) = NaiveDateTime::parse_from_str(elem, "%Y-%m-%d %H:%M:%S%.f") {
         return Ok(NaiveDateTimeWrapper::new(timestamp));
     }
+    if let Ok(timestamp) = NaiveDateTime::parse_from_str(elem, "%Y-%m-%d %H:%M") {
+        return Ok(NaiveDateTimeWrapper::new(timestamp));
+    }
     if let Ok(date) = NaiveDate::parse_from_str(elem, "%Y-%m-%d") {
         return Ok(NaiveDateTimeWrapper::new(date.and_hms(0, 0, 0)));
     }
-    Err(parse_error(
-        "Can't cast string to timestamp \
-    (expected format is YYYY-MM-DD HH:MM:SS[.MS] OR YYYY-MM-DD)",
-    ))
+    Err(parse_error(PARSE_ERROR_STR_TO_TIMESTAMP))
 }
 
 #[inline(always)]
@@ -225,16 +230,17 @@ mod tests {
     #[test]
     fn parse_str() {
         use super::*;
-        str_to_timestamp("1999-01-08").unwrap();
+        str_to_timestamp("1999-01-08 04:02").unwrap();
         str_to_timestamp("1999-01-08 04:05:06").unwrap();
         str_to_date("1999-01-08").unwrap();
+        str_to_time("04:05").unwrap();
         str_to_time("04:05:06").unwrap();
 
         assert_eq!(
             str_to_timestamp("1999-01-08 04:05:06AA")
                 .unwrap_err()
                 .to_string(),
-            "Parse error: Can't cast string to timestamp (expected format is YYYY-MM-DD HH:MM:SS[.MS] OR YYYY-MM-DD)".to_string()
+            parse_error(PARSE_ERROR_STR_TO_TIMESTAMP).to_string()
         );
         assert_eq!(
             str_to_date("1999-01-08AA").unwrap_err().to_string(),
@@ -242,7 +248,7 @@ mod tests {
         );
         assert_eq!(
             str_to_time("AA04:05:06").unwrap_err().to_string(),
-            "Parse error: Can't cast string to time (expected format is HH:MM:SS[.MS])".to_string()
+            parse_error(PARSE_ERROR_STR_TO_TIME).to_string()
         );
     }
 


### PR DESCRIPTION
## What's changed and what's your intention?

As title, support incomplete timestamp literal to compatible with PG

```
select timestamp '1996-08-26';
```

## Checklist

- [x] I have written necessary docs and comments
- [x] I have added necessary unit tests and integration tests

## Refer to a related PR or issue link (optional)
#2460 