### PR TITLE
feat(meta): build vnode mapping according to table in fragmenter

### DIFF
--- a/src/meta/src/cluster/mod.rs
+++ b/src/meta/src/cluster/mod.rs
@@ -332,11 +332,6 @@ where
         core.get_parallel_unit_count(parallel_unit_type)
     }
 
-    // /// Get default vnode hash mapping, which uses all hash parallel units in the cluster.
-    // pub async fn get_hash_mapping(&self) -> Vec<ParallelUnitId> {
-    //     self.hash_mapping_manager.get_default_mapping().await
-    // }
-
     /// Get vnode hash mapping for a specific relational state table.
     pub async fn get_table_hash_mapping(&self, table_id: &TableId) -> Option<Vec<ParallelUnitId>> {
         self.hash_mapping_manager.get_table_mapping(table_id).await

--- a/src/meta/src/cluster/mod.rs
+++ b/src/meta/src/cluster/mod.rs
@@ -332,27 +332,25 @@ where
         core.get_parallel_unit_count(parallel_unit_type)
     }
 
-    /// Get default hash mapping, which uses all hash parallel units in the cluster.
-    pub async fn get_hash_mapping(&self) -> Vec<ParallelUnitId> {
-        self.hash_mapping_manager.get_default_mapping().await
+    // /// Get default vnode hash mapping, which uses all hash parallel units in the cluster.
+    // pub async fn get_hash_mapping(&self) -> Vec<ParallelUnitId> {
+    //     self.hash_mapping_manager.get_default_mapping().await
+    // }
+
+    /// Get vnode hash mapping for a specific relational state table.
+    pub async fn get_table_hash_mapping(&self, table_id: &TableId) -> Option<Vec<ParallelUnitId>> {
+        self.hash_mapping_manager.get_table_mapping(table_id).await
     }
 
-    /// Get hash mapping for a specific relational state table. If the mapping does not exist yet,
-    /// then build one and return the mapping.
-    pub async fn get_table_hash_mapping(&self, table_id: &TableId) -> Result<Vec<ParallelUnitId>> {
-        match self.hash_mapping_manager.get_table_mapping(table_id).await {
-            Some(mapping) => Ok(mapping),
-            None => {
-                self.hash_mapping_manager
-                    .build_table_mapping(*table_id)
-                    .await?;
-                Ok(self
-                    .hash_mapping_manager
-                    .get_table_mapping(table_id)
-                    .await
-                    .unwrap())
-            }
-        }
+    /// Build vnode hash mapping for a specific relational state table.
+    pub async fn build_table_hash_mapping(&self, table_id: TableId) -> Result<()> {
+        self.hash_mapping_manager
+            .build_table_mapping(table_id)
+            .await
+    }
+
+    pub async fn get_all_table_mappings(&self) -> HashMap<TableId, Vec<ParallelUnitId>> {
+        self.hash_mapping_manager.get_all_table_mappings().await
     }
 
     async fn generate_cn_parallel_units(

--- a/src/meta/src/hummock/hummock_manager_tests.rs
+++ b/src/meta/src/hummock/hummock_manager_tests.rs
@@ -111,9 +111,16 @@ async fn test_hummock_pin_unpin() {
 
 #[tokio::test]
 async fn test_hummock_compaction_task() {
-    let (env, hummock_manager, _cluster_manager, worker_node) = setup_compute_env(80).await;
+    let (env, hummock_manager, cluster_manager, worker_node) = setup_compute_env(80).await;
     let context_id = worker_node.id;
     let sst_num = 2;
+
+    for table_id in 1..sst_num + 2 {
+        cluster_manager
+            .build_table_hash_mapping(table_id as u32)
+            .await
+            .unwrap();
+    }
 
     // No compaction task available.
     let task = hummock_manager.get_compact_task().await.unwrap();

--- a/src/meta/src/manager/hash_mapping.rs
+++ b/src/meta/src/manager/hash_mapping.rs
@@ -103,6 +103,10 @@ where
         let mut core = self.core.lock().await;
         core.build_table_mapping(table_id)
     }
+
+    pub async fn get_all_table_mappings(&self) -> HashMap<TableId, Vec<ParallelUnitId>> {
+        self.core.lock().await.table_mappings.clone()
+    }
 }
 
 /// [`HashMappingManagerCore`] contains the core logic for mapping change when one or more nodes

--- a/src/meta/src/rpc/service/ddl_service.rs
+++ b/src/meta/src/rpc/service/ddl_service.rs
@@ -18,7 +18,6 @@ use risingwave_common::catalog::CatalogVersion;
 use risingwave_common::error::{tonic_err, Result as RwResult};
 use risingwave_pb::catalog::table::OptionalAssociatedSourceId;
 use risingwave_pb::catalog::*;
-use risingwave_pb::common::ParallelUnitType;
 use risingwave_pb::ddl_service::ddl_service_server::DdlService;
 use risingwave_pb::ddl_service::*;
 use risingwave_pb::plan_common::TableRefId;
@@ -409,20 +408,14 @@ where
         );
 
         // Resolve fragments.
-        let hash_mapping = self.cluster_manager.get_hash_mapping().await;
-        let parallel_degree = self
-            .cluster_manager
-            .get_parallel_unit_count(Some(ParallelUnitType::Hash))
-            .await;
         let mut ctx = CreateMaterializedViewContext {
             affiliated_source,
-            hash_mapping,
             ..Default::default()
         };
         let graph = StreamFragmenter::generate_graph(
             self.env.id_gen_manager_ref(),
             self.fragment_manager.clone(),
-            parallel_degree as u32,
+            self.cluster_manager.clone(),
             false,
             &stream_node,
             &mut ctx,

--- a/src/meta/src/rpc/service/stream_service.rs
+++ b/src/meta/src/rpc/service/stream_service.rs
@@ -14,7 +14,6 @@
 
 use risingwave_common::catalog::TableId;
 use risingwave_common::error::tonic_err;
-use risingwave_pb::common::ParallelUnitType;
 use risingwave_pb::meta::stream_manager_service_server::StreamManagerService;
 use risingwave_pb::meta::*;
 use tonic::{Request, Response, Status};
@@ -78,21 +77,15 @@ where
             "create materialized view"
         );
 
-        let hash_mapping = self.cluster_manager.get_hash_mapping().await;
-        let parallel_degree = self
-            .cluster_manager
-            .get_parallel_unit_count(Some(ParallelUnitType::Hash))
-            .await;
         let mut ctx = CreateMaterializedViewContext {
             is_legacy_frontend: true,
-            hash_mapping,
             ..Default::default()
         };
 
         let graph = StreamFragmenter::generate_graph(
             self.env.id_gen_manager_ref(),
             self.fragment_manager.clone(),
-            parallel_degree as u32,
+            self.cluster_manager.clone(),
             true,
             req.get_stream_node().map_err(tonic_err)?,
             &mut ctx,


### PR DESCRIPTION
## What's changed and what's your intention?

### Summarize your change

- Build vnode mapping in fragmenter after relational state tables have been created. 
- Set downstream vnode mappings to dispatchers accordingly.
- Find out the vnode mapping of input MV and set it into `BatchQuery` in `Chain`.

## Checklist

- [x] I have written necessary docs and comments
- [x] I have added necessary unit tests and integration tests
