### PR TITLE
minor: use 0 as the higher bit to represent remote sst id for better logging

### DIFF
--- a/src/storage/hummock_sdk/src/lib.rs
+++ b/src/storage/hummock_sdk/src/lib.rs
@@ -27,17 +27,17 @@ pub type HummockEpoch = u64;
 pub const INVALID_VERSION_ID: HummockVersionId = 0;
 pub const FIRST_VERSION_ID: HummockVersionId = 1;
 
-pub const REMOTE_SST_ID_MASK: HummockSSTableId = 1 << (HummockSSTableId::BITS - 1);
-pub const LOCAL_SST_ID_MASK: HummockSSTableId = !REMOTE_SST_ID_MASK;
+pub const LOCAL_SST_ID_MASK: HummockSSTableId = 1 << (HummockSSTableId::BITS - 1);
+pub const REMOTE_SST_ID_MASK: HummockSSTableId = !LOCAL_SST_ID_MASK;
 
 pub fn get_remote_sst_id(id: HummockSSTableId) -> HummockSSTableId {
-    id | REMOTE_SST_ID_MASK
+    id & REMOTE_SST_ID_MASK
 }
 
 pub fn get_local_sst_id(id: HummockSSTableId) -> HummockSSTableId {
-    id & LOCAL_SST_ID_MASK
+    id | LOCAL_SST_ID_MASK
 }
 
 pub fn is_remote_sst_id(id: HummockSSTableId) -> bool {
-    id & REMOTE_SST_ID_MASK != 0
+    id & LOCAL_SST_ID_MASK == 0
 }


### PR DESCRIPTION
As titled
