### PR TITLE
fix(streaming): avoid sync states when forcing stop actors in recovery

### DIFF
--- a/src/compute/src/rpc/service/stream_service.rs
+++ b/src/compute/src/rpc/service/stream_service.rs
@@ -141,7 +141,12 @@ impl StreamService for StreamServiceImpl {
 
         let collect_result = self
             .mgr
-            .send_and_collect_barrier(&barrier, req.actor_ids_to_send, req.actor_ids_to_collect)
+            .send_and_collect_barrier(
+                &barrier,
+                req.actor_ids_to_send,
+                req.actor_ids_to_collect,
+                true,
+            )
             .await
             .map_err(|e| e.to_grpc_status())?;
 

--- a/src/meta/src/barrier/mod.rs
+++ b/src/meta/src/barrier/mod.rs
@@ -288,7 +288,7 @@ where
                     if self.enable_recovery {
                         // If failed, enter recovery mode.
                         let (new_epoch, actors_to_finish, finished_create_mviews) =
-                            self.recovery(state.prev_epoch).await;
+                            self.recovery(new_epoch).await;
                         unfinished = UnfinishedNotifiers::default();
                         unfinished.add(new_epoch.0, actors_to_finish, vec![]);
                         for finished in finished_create_mviews {


### PR DESCRIPTION
## What's changed and what's your intention?

As title, there's no need to sync states when forcing stop actors in recovery. As described in #2491 , when commit_epoch fails in barrier manager, the prev epoch is already used in this barrier lifecycle. To satisfy hummock epoch write check:
1. always use a new epoch as prev epoch in recovery.
2. avoid sync states when forcing stop actors.

Note that, In some scenarios such as network isolation appeared between some CNs and Meta, whether prev epoch is used or not is unknown. This might break some prev_epoch check in some executors. Need more test on this and further fix.

## Checklist

- [x] I have written necessary docs and comments
- [x] I have added necessary unit tests and integration tests

## Refer to a related PR or issue link (optional)
Resolve https://github.com/singularity-data/risingwave/issues/2492