### PR TITLE
refactor(optimizer): cleanup unnecessary check on mview aliases

### DIFF
--- a/src/frontend/src/optimizer/plan_node/stream_materialize.rs
+++ b/src/frontend/src/optimizer/plan_node/stream_materialize.rs
@@ -116,9 +116,6 @@ impl StreamMaterialize {
 
         let mut col_names = HashSet::new();
         for name in &out_names {
-            if name == crate::binder::UNNAMED_COLUMN {
-                continue;
-            }
             if !col_names.insert(name) {
                 return Err(
                     InternalError(format!("column {} specified more than once", name)).into(),
@@ -137,9 +134,7 @@ impl StreamMaterialize {
                 };
                 if !c.is_hidden {
                     let name = out_name_iter.next().unwrap();
-                    if name != crate::binder::UNNAMED_COLUMN {
-                        c.column_desc.name = name;
-                    }
+                    c.column_desc.name = name;
                 }
                 c
             })


### PR DESCRIPTION
## What's changed and what's your intention?

> Checks against `UNNAMED_COLUMN` would be unnecessary after #2436

_Originally posted by @xiangjinwu in https://github.com/singularity-data/risingwave/pull/2465#discussion_r871164005_

## Checklist

~~- [ ] I have written necessary docs and comments~~
~~- [ ] I have added necessary unit tests and integration tests~~

## Refer to a related PR or issue link (optional)
