### PR TITLE
fix(cargo-doc): fix wrong usage in rust doc string.

### DIFF
--- a/src/frontend/src/utils/column_index_mapping.rs
+++ b/src/frontend/src/utils/column_index_mapping.rs
@@ -135,7 +135,7 @@ impl ColIndexMapping {
     /// # use fixedbitset::FixedBitSet;
     /// # use risingwave_frontend::utils::ColIndexMapping;
     /// let mut remaining_cols = vec![1, 3];
-    /// let mapping = ColIndexMapping::with_remaining_columns(&remaining_cols, 5);
+    /// let mapping = ColIndexMapping::with_remaining_columns(&remaining_cols, 4);
     /// assert_eq!(mapping.map(1), 0);
     /// assert_eq!(mapping.map(3), 1);
     /// assert_eq!(mapping.try_map(0), None);

--- a/src/frontend/src/utils/column_index_mapping.rs
+++ b/src/frontend/src/utils/column_index_mapping.rs
@@ -135,7 +135,7 @@ impl ColIndexMapping {
     /// # use fixedbitset::FixedBitSet;
     /// # use risingwave_frontend::utils::ColIndexMapping;
     /// let mut remaining_cols = vec![1, 3];
-    /// let mapping = ColIndexMapping::with_remaining_columns(&remaining_cols);
+    /// let mapping = ColIndexMapping::with_remaining_columns(&remaining_cols, 5);
     /// assert_eq!(mapping.map(1), 0);
     /// assert_eq!(mapping.map(3), 1);
     /// assert_eq!(mapping.try_map(0), None);
@@ -159,7 +159,7 @@ impl ColIndexMapping {
     /// # use fixedbitset::FixedBitSet;
     /// # use risingwave_frontend::utils::ColIndexMapping;
     /// let mut removed_cols = vec![0, 2, 4];
-    /// let mapping = ColIndexMapping::with_removed_columns(&removed_cols);
+    /// let mapping = ColIndexMapping::with_removed_columns(&removed_cols, 5);
     /// assert_eq!(mapping.map(1), 0);
     /// assert_eq!(mapping.map(3), 1);
     /// assert_eq!(mapping.try_map(0), None);


### PR DESCRIPTION
## What's changed and what's your intention?

Otherwise cargo test will fail

## Checklist

- [x] I have written necessary docs and comments
- [x] I have added necessary unit tests and integration tests

## Refer to a related PR or issue link (optional)
