### PR TITLE
fix: enable etcd auto compaction by revision

### DIFF
--- a/src/risedevtool/src/task/etcd_service.rs
+++ b/src/risedevtool/src/task/etcd_service.rs
@@ -71,7 +71,11 @@ impl Task for EtcdService {
             .arg("--name")
             .arg("risedev-meta")
             .arg("--max-txn-ops")
-            .arg("999999");
+            .arg("999999")
+            .arg("--auto-compaction-mode")
+            .arg("revision")
+            .arg("--auto-compaction-retention")
+            .arg("100");
 
         if self.config.unsafe_no_fsync {
             cmd.arg("--unsafe-no-fsync");


### PR DESCRIPTION
Fix #2491 by enabling auto compaction by revision in etcd. The compaction will be triggered every 5mins acoording to https://etcd.io/docs/v3.3/op-guide/maintenance/#auto-compaction.
