### PR TITLE
Revert "test(streaming): enable tpch q4, q18, q20"

### DIFF
--- a/e2e_test/v2/streaming/tpch_snapshot.slt
+++ b/e2e_test/v2/streaming/tpch_snapshot.slt
@@ -12,7 +12,7 @@ include ../../tpch/insert_supplier.slt.part
 include ../../streaming/tpch/views/q1.slt.part
 include ../../streaming/tpch/views/q2.join_reorder.workaround.slt.part
 include ../../streaming/tpch/views/q3.slt.part
-include ../../streaming/tpch/views/q4.slt.part
+# include ../../streaming/tpch/views/q4.slt.part
 include ../../streaming/tpch/views/q5.slt.part
 include ../../streaming/tpch/views/q6.slt.part
 include ../../streaming/tpch/views/q7.slt.part
@@ -24,14 +24,14 @@ include ../../streaming/tpch/views/q12.slt.part
 include ../../streaming/tpch/views/q13.slt.part
 include ../../streaming/tpch/views/q14.slt.part
 include ../../streaming/tpch/views/q17.slt.part
-include ../../streaming/tpch/views/q18.slt.part
+# include ../../streaming/tpch/views/q18.slt.part
 include ../../streaming/tpch/views/q19.slt.part
-include ../../streaming/tpch/views/q20.slt.part
+# include ../../streaming/tpch/views/q20.slt.part
 
 include ../../streaming/tpch/q1.slt.part
 include ../../streaming/tpch/q2.slt.part
 include ../../streaming/tpch/q3.slt.part
-include ../../streaming/tpch/q4.slt.part
+# include ../../streaming/tpch/q4.slt.part
 include ../../streaming/tpch/q5.slt.part
 include ../../streaming/tpch/q6.slt.part
 include ../../streaming/tpch/q7.slt.part
@@ -43,9 +43,9 @@ include ../../streaming/tpch/q12.slt.part
 include ../../streaming/tpch/q13.slt.part
 include ../../streaming/tpch/q14.slt.part
 include ../../streaming/tpch/q17.slt.part
-include ../../streaming/tpch/q18.slt.part
+# include ../../streaming/tpch/q18.slt.part
 include ../../streaming/tpch/q19.slt.part
-include ../../streaming/tpch/q20.slt.part
+# include ../../streaming/tpch/q20.slt.part
 
 statement ok
 drop materialized view tpch_q1;
@@ -55,9 +55,6 @@ drop materialized view tpch_q2;
 
 statement ok
 drop materialized view tpch_q3;
-
-statement ok
-drop materialized view tpch_q4;
 
 statement ok
 drop materialized view tpch_q5;
@@ -90,12 +87,6 @@ statement ok
 drop materialized view tpch_q17;
 
 statement ok
-drop materialized view tpch_q18;
-
-statement ok
 drop materialized view tpch_q19;
-
-statement ok
-drop materialized view tpch_q20;
 
 include ../../tpch/drop_tables.slt.part

--- a/e2e_test/v2/streaming/tpch_upstream.slt
+++ b/e2e_test/v2/streaming/tpch_upstream.slt
@@ -3,7 +3,7 @@ include ../../tpch/create_tables.slt.part
 include ../../streaming/tpch/views/q1.slt.part
 include ../../streaming/tpch/views/q2.join_reorder.workaround.slt.part
 include ../../streaming/tpch/views/q3.slt.part
-include ../../streaming/tpch/views/q4.slt.part
+# include ../../streaming/tpch/views/q4.slt.part
 include ../../streaming/tpch/views/q5.slt.part
 include ../../streaming/tpch/views/q6.slt.part
 include ../../streaming/tpch/views/q7.slt.part
@@ -15,9 +15,9 @@ include ../../streaming/tpch/views/q12.slt.part
 include ../../streaming/tpch/views/q13.slt.part
 include ../../streaming/tpch/views/q14.slt.part
 include ../../streaming/tpch/views/q17.slt.part
-include ../../streaming/tpch/views/q18.slt.part
+# include ../../streaming/tpch/views/q18.slt.part
 include ../../streaming/tpch/views/q19.slt.part
-include ../../streaming/tpch/views/q20.slt.part
+# include ../../streaming/tpch/views/q20.slt.part
 
 include ../../tpch/insert_customer.slt.part
 include ../../tpch/insert_lineitem.slt.part
@@ -34,7 +34,7 @@ flush;
 include ../../streaming/tpch/q1.slt.part
 include ../../streaming/tpch/q2.slt.part
 include ../../streaming/tpch/q3.slt.part
-include ../../streaming/tpch/q4.slt.part
+# include ../../streaming/tpch/q4.slt.part
 include ../../streaming/tpch/q5.slt.part
 include ../../streaming/tpch/q6.slt.part
 include ../../streaming/tpch/q7.slt.part
@@ -46,9 +46,9 @@ include ../../streaming/tpch/q12.slt.part
 include ../../streaming/tpch/q13.slt.part
 include ../../streaming/tpch/q14.slt.part
 include ../../streaming/tpch/q17.slt.part
-include ../../streaming/tpch/q18.slt.part
+# include ../../streaming/tpch/q18.slt.part
 include ../../streaming/tpch/q19.slt.part
-include ../../streaming/tpch/q20.slt.part
+# include ../../streaming/tpch/q20.slt.part
 
 statement ok
 drop materialized view tpch_q1;
@@ -58,9 +58,6 @@ drop materialized view tpch_q2;
 
 statement ok
 drop materialized view tpch_q3;
-
-statement ok
-drop materialized view tpch_q4;
 
 statement ok
 drop materialized view tpch_q5;
@@ -93,12 +90,6 @@ statement ok
 drop materialized view tpch_q17;
 
 statement ok
-drop materialized view tpch_q18;
-
-statement ok
 drop materialized view tpch_q19;
-
-statement ok
-drop materialized view tpch_q20;
 
 include ../../tpch/drop_tables.slt.part


### PR DESCRIPTION
Reverts singularity-data/risingwave#2518

The test works in local and PR CI, but fails in main CI. The stuck problem still exists...

failing main CI:
https://github.com/singularity-data/risingwave/runs/6433891863?check_suite_focus=true

passing PR CI:
https://github.com/singularity-data/risingwave/runs/6433748795?check_suite_focus=true

related PRs:
#2430 #2518 