### PR TITLE
feat(frontend): add `LogicalMultijoin`

### DIFF
--- a/src/frontend/src/optimizer/plan_node/logical_multi_join.rs
+++ b/src/frontend/src/optimizer/plan_node/logical_multi_join.rs
@@ -103,29 +103,47 @@ impl PlanTreeNode for LogicalMultiJoin {
         vec
     }
 
-    fn clone_with_inputs(&self, _inputs: &[crate::optimizer::PlanRef]) -> crate::optimizer::PlanRef {
-        todo!()
+    fn clone_with_inputs(
+        &self,
+        _inputs: &[crate::optimizer::PlanRef],
+    ) -> crate::optimizer::PlanRef {
+        panic!(
+            "Method not available for `LogicalMultiJoin` which is a placeholder node with \
+             a temporary lifetime. It only facilitates join reordering during logical planning."
+        )
     }
 }
 
 impl ToStream for LogicalMultiJoin {
     fn logical_rewrite_for_stream(&self) -> Result<(PlanRef, ColIndexMapping)> {
-        todo!()
+        panic!(
+            "Method not available for `LogicalMultiJoin` which is a placeholder node with \
+             a temporary lifetime. It only facilitates join reordering during logical planning."
+        )
     }
 
     fn to_stream(&self) -> Result<PlanRef> {
-        todo!()
+        panic!(
+            "Method not available for `LogicalMultiJoin` which is a placeholder node with \
+             a temporary lifetime. It only facilitates join reordering during logical planning."
+        )
     }
 }
 
 impl ToBatch for LogicalMultiJoin {
     fn to_batch(&self) -> Result<PlanRef> {
-        todo!()
+        panic!(
+            "Method not available for `LogicalMultiJoin` which is a placeholder node with \
+             a temporary lifetime. It only facilitates join reordering during logical planning."
+        )
     }
 }
 
 impl ColPrunable for LogicalMultiJoin {
     fn prune_col(&self, _required_cols: &[usize]) -> PlanRef {
-        todo!()
+        panic!(
+            "Method not available for `LogicalMultiJoin` which is a placeholder node with \
+             a temporary lifetime. It only facilitates join reordering during logical planning."
+        )
     }
 }

--- a/src/frontend/src/optimizer/plan_node/logical_multi_join.rs
+++ b/src/frontend/src/optimizer/plan_node/logical_multi_join.rs
@@ -12,24 +12,13 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-
 use std::fmt;
 
-
-
-
-use risingwave_common::error::{Result};
+use risingwave_common::error::Result;
 use risingwave_pb::plan_common::JoinType;
 
-use super::{
-    ColPrunable, PlanBase, PlanRef, PlanTreeNodeBinary, ToBatch, ToStream,
-};
-
-
-use crate::optimizer::plan_node::{
-    PlanTreeNode,
-};
-
+use super::{ColPrunable, PlanBase, PlanRef, PlanTreeNodeBinary, ToBatch, ToStream};
+use crate::optimizer::plan_node::PlanTreeNode;
 use crate::utils::{ColIndexMapping, Condition};
 
 /// `LogicalMultiJoin` combines two or more relations according to some condition.

--- a/src/frontend/src/optimizer/plan_node/logical_multi_join.rs
+++ b/src/frontend/src/optimizer/plan_node/logical_multi_join.rs
@@ -67,11 +67,8 @@ impl LogicalMultiJoin {
         if let Some(multi_join) = right.as_logical_multi_join() {
             inputs.extend(multi_join.inputs());
             let right_on = multi_join.on().clone();
-            let mut mapping = ColIndexMapping::with_shift_offset(
-                left_col_num + right_col_num,
-                -(left_col_num as isize),
-            )
-            .inverse();
+            let mut mapping =
+                ColIndexMapping::with_shift_offset(right_col_num, left_col_num as isize);
             let new_on = right_on.rewrite_expr(&mut mapping);
             conjunctions.extend(new_on.conjunctions);
         } else {

--- a/src/frontend/src/optimizer/plan_node/logical_multi_join.rs
+++ b/src/frontend/src/optimizer/plan_node/logical_multi_join.rs
@@ -103,7 +103,7 @@ impl PlanTreeNode for LogicalMultiJoin {
         vec
     }
 
-    fn clone_with_inputs(&self, inputs: &[crate::optimizer::PlanRef]) -> crate::optimizer::PlanRef {
+    fn clone_with_inputs(&self, _inputs: &[crate::optimizer::PlanRef]) -> crate::optimizer::PlanRef {
         todo!()
     }
 }

--- a/src/frontend/src/optimizer/plan_node/logical_multi_join.rs
+++ b/src/frontend/src/optimizer/plan_node/logical_multi_join.rs
@@ -125,3 +125,25 @@ impl PlanTreeNode for LogicalMultiJoin {
         .into()
     }
 }
+
+impl ToStream for LogicalMultiJoin {
+    fn logical_rewrite_for_stream(&self) -> Result<(PlanRef, ColIndexMapping)> {
+        todo!()
+    }
+
+    fn to_stream(&self) -> Result<PlanRef> {
+        todo!()
+    }
+}
+
+impl ToBatch for LogicalMultiJoin {
+    fn to_batch(&self) -> Result<PlanRef> {
+        todo!()
+    }
+}
+
+impl ColPrunable for LogicalMultiJoin {
+    fn prune_col(&self, required_cols: &[usize]) -> PlanRef {
+        todo!()
+    }
+}

--- a/src/frontend/src/optimizer/plan_node/logical_multi_join.rs
+++ b/src/frontend/src/optimizer/plan_node/logical_multi_join.rs
@@ -1,0 +1,127 @@
+// Copyright 2022 Singularity Data
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::collections::{HashMap, HashSet};
+use std::fmt;
+
+use fixedbitset::FixedBitSet;
+use itertools::Itertools;
+use risingwave_common::catalog::Schema;
+use risingwave_common::error::{ErrorCode, Result, RwError};
+use risingwave_pb::plan_common::JoinType;
+
+use super::{
+    ColPrunable, CollectInputRef, LogicalProject, PlanBase, PlanRef, PlanTreeNodeBinary,
+    StreamHashJoin, ToBatch, ToStream,
+};
+use crate::expr::ExprImpl;
+use crate::optimizer::plan_node::batch_nested_loop_join::BatchNestedLoopJoin;
+use crate::optimizer::plan_node::{
+    BatchFilter, BatchHashJoin, EqJoinPredicate, LogicalFilter, LogicalJoin, PlanTreeNode,
+    StreamFilter,
+};
+use crate::optimizer::property::{Distribution, Order};
+use crate::utils::{ColIndexMapping, Condition};
+
+/// `LogicalMultiJoin` combines two or more relations according to some condition.
+///
+/// Each output row has fields from one the inputs. The set of output rows is a subset
+/// of the cartesian product of all the inputs; The `LogicalMultiInnerJoin` is only supported
+/// for inner joins as it implicitly assumes commutativity. Non-inner joins should be
+/// expressed as 2-way `LogicalJoin`s.
+#[derive(Debug, Clone)]
+pub struct LogicalMultiJoin {
+    pub base: PlanBase,
+    inputs: Vec<PlanRef>,
+    on: Condition,
+}
+
+impl fmt::Display for LogicalMultiJoin {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f, "LogicalMultiJoin {{ on: {} }}", &self.on)
+    }
+}
+
+impl LogicalMultiJoin {
+    pub(crate) fn new(base: PlanBase, inputs: Vec<PlanRef>, on: Condition) -> Self {
+        Self { base, inputs, on }
+    }
+
+    pub(crate) fn from_join(join: &PlanRef) -> Option<Self> {
+        let logical_join = join.as_logical_join()?;
+        if logical_join.join_type() != JoinType::Inner {
+            return None;
+        }
+        let left = logical_join.left();
+        let right = logical_join.right();
+
+        let left_col_num = left.schema().len();
+        let right_col_num = right.schema().len();
+
+        let mut inputs = vec![];
+        let mut conjunctions = logical_join.on().conjunctions.clone();
+        if let Some(multi_join) = left.as_logical_multi_join() {
+            inputs.extend(multi_join.inputs());
+            conjunctions.extend(multi_join.on().clone());
+        } else {
+            inputs.push(left.clone());
+        }
+        if let Some(multi_join) = right.as_logical_multi_join() {
+            inputs.extend(multi_join.inputs());
+            let right_on = multi_join.on().clone();
+            let mut mapping = ColIndexMapping::with_shift_offset(
+                left_col_num + right_col_num,
+                -(left_col_num as isize),
+            )
+            .inverse();
+            let new_on = right_on.rewrite_expr(&mut mapping);
+            conjunctions.extend(new_on.conjunctions.clone());
+        } else {
+            inputs.push(right.clone());
+        }
+
+        Some(Self {
+            base: logical_join.base.clone(),
+            inputs,
+            on: Condition { conjunctions },
+        })
+    }
+
+    /// Get a reference to the logical join's on.
+    pub fn on(&self) -> &Condition {
+        &self.on
+    }
+
+    /// Clone with new `on` condition
+    pub fn clone_with_cond(&self, cond: Condition) -> Self {
+        Self::new(self.base.clone(), self.inputs.clone(), cond)
+    }
+}
+
+impl PlanTreeNode for LogicalMultiJoin {
+    fn inputs(&self) -> smallvec::SmallVec<[crate::optimizer::PlanRef; 2]> {
+        let mut vec = smallvec::SmallVec::new();
+        vec.extend(self.inputs.clone().into_iter());
+        vec
+    }
+
+    fn clone_with_inputs(&self, inputs: &[crate::optimizer::PlanRef]) -> crate::optimizer::PlanRef {
+        Self::new(
+            self.base.clone(),
+            inputs.iter().map(|i| i.clone()).collect(),
+            self.on.clone(),
+        )
+        .into()
+    }
+}

--- a/src/frontend/src/optimizer/plan_node/logical_multi_join.rs
+++ b/src/frontend/src/optimizer/plan_node/logical_multi_join.rs
@@ -12,26 +12,24 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use std::collections::{HashMap, HashSet};
+
 use std::fmt;
 
-use fixedbitset::FixedBitSet;
-use itertools::Itertools;
-use risingwave_common::catalog::Schema;
-use risingwave_common::error::{ErrorCode, Result, RwError};
+
+
+
+use risingwave_common::error::{Result};
 use risingwave_pb::plan_common::JoinType;
 
 use super::{
-    ColPrunable, CollectInputRef, LogicalProject, PlanBase, PlanRef, PlanTreeNodeBinary,
-    StreamHashJoin, ToBatch, ToStream,
+    ColPrunable, PlanBase, PlanRef, PlanTreeNodeBinary, ToBatch, ToStream,
 };
-use crate::expr::ExprImpl;
-use crate::optimizer::plan_node::batch_nested_loop_join::BatchNestedLoopJoin;
+
+
 use crate::optimizer::plan_node::{
-    BatchFilter, BatchHashJoin, EqJoinPredicate, LogicalFilter, LogicalJoin, PlanTreeNode,
-    StreamFilter,
+    PlanTreeNode,
 };
-use crate::optimizer::property::{Distribution, Order};
+
 use crate::utils::{ColIndexMapping, Condition};
 
 /// `LogicalMultiJoin` combines two or more relations according to some condition.
@@ -86,7 +84,7 @@ impl LogicalMultiJoin {
             )
             .inverse();
             let new_on = right_on.rewrite_expr(&mut mapping);
-            conjunctions.extend(new_on.conjunctions.clone());
+            conjunctions.extend(new_on.conjunctions);
         } else {
             inputs.push(right.clone());
         }
@@ -117,12 +115,7 @@ impl PlanTreeNode for LogicalMultiJoin {
     }
 
     fn clone_with_inputs(&self, inputs: &[crate::optimizer::PlanRef]) -> crate::optimizer::PlanRef {
-        Self::new(
-            self.base.clone(),
-            inputs.iter().map(|i| i.clone()).collect(),
-            self.on.clone(),
-        )
-        .into()
+        todo!()
     }
 }
 
@@ -143,7 +136,7 @@ impl ToBatch for LogicalMultiJoin {
 }
 
 impl ColPrunable for LogicalMultiJoin {
-    fn prune_col(&self, required_cols: &[usize]) -> PlanRef {
+    fn prune_col(&self, _required_cols: &[usize]) -> PlanRef {
         todo!()
     }
 }

--- a/src/frontend/src/optimizer/plan_node/mod.rs
+++ b/src/frontend/src/optimizer/plan_node/mod.rs
@@ -227,6 +227,7 @@ mod logical_hop_window;
 mod logical_insert;
 mod logical_join;
 mod logical_limit;
+mod logical_multi_join;
 mod logical_project;
 mod logical_scan;
 mod logical_source;
@@ -271,6 +272,7 @@ pub use logical_hop_window::LogicalHopWindow;
 pub use logical_insert::LogicalInsert;
 pub use logical_join::LogicalJoin;
 pub use logical_limit::LogicalLimit;
+pub use logical_multi_join::LogicalMultiJoin;
 pub use logical_project::LogicalProject;
 pub use logical_scan::LogicalScan;
 pub use logical_source::LogicalSource;
@@ -323,6 +325,7 @@ macro_rules! for_all_plan_nodes {
             , { Logical, TopN }
             , { Logical, HopWindow }
             , { Logical, GenerateSeries }
+            , { Logical, MultiJoin }
             // , { Logical, Sort } we don't need a LogicalSort, just require the Order
             , { Batch, SimpleAgg }
             , { Batch, HashAgg }
@@ -377,6 +380,7 @@ macro_rules! for_logical_plan_nodes {
             , { Logical, TopN }
             , { Logical, HopWindow }
             , { Logical, GenerateSeries }
+            , { Logical, MultiJoin }
             // , { Logical, Sort} not sure if we will support Order by clause in subquery/view/MV
             // if we dont support thatk, we don't need LogicalSort, just require the Order at the top of query
         }

--- a/src/frontend/src/optimizer/rule/mod.rs
+++ b/src/frontend/src/optimizer/rule/mod.rs
@@ -45,3 +45,5 @@ mod pull_up_correlated_predicate;
 pub use pull_up_correlated_predicate::*;
 mod index_delta_join;
 pub use index_delta_join::*;
+mod multijoin_join;
+pub use multijoin_join::*;

--- a/src/frontend/src/optimizer/rule/multijoin_join.rs
+++ b/src/frontend/src/optimizer/rule/multijoin_join.rs
@@ -29,21 +29,23 @@ impl Rule for MultiJoinJoinRule {
 }
 
 impl MultiJoinJoinRule {
+    // TODO: remove #[allow(unused)] once used
+    #[allow(unused)]
     pub fn create() -> BoxedRule {
         Box::new(MultiJoinJoinRule {})
     }
 }
 #[cfg(test)]
 mod tests {
-    use rand::Rng;
     use risingwave_common::catalog::{Field, Schema};
-    use risingwave_common::types::{DataType, Datum};
+    use risingwave_common::types::DataType;
     use risingwave_pb::expr::expr_node::Type;
+    use risingwave_pb::plan_common::JoinType;
 
     use super::*;
-    use crate::expr::{Expr, ExprImpl, ExprType, FunctionCall, InputRef};
-    use crate::optimizer::heuristic::{ApplyOrder, HeuristicOptimizer};
+    use crate::expr::{ExprImpl, FunctionCall, InputRef};
     use crate::session::OptimizerContext;
+    use crate::utils::Condition;
 
     #[tokio::test]
     async fn test_joins_get_merged_into_multijoin() {

--- a/src/frontend/src/optimizer/rule/multijoin_join.rs
+++ b/src/frontend/src/optimizer/rule/multijoin_join.rs
@@ -12,13 +12,9 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-
-
 use super::super::plan_node::*;
 use super::Rule;
-
 use crate::optimizer::rule::BoxedRule;
-
 
 /// Merges adjacent inner joins into a single `LogicalMultiJoin`.
 /// The `LogicalMultiJoin` is short-lived and will be immediately

--- a/src/frontend/src/optimizer/rule/multijoin_join.rs
+++ b/src/frontend/src/optimizer/rule/multijoin_join.rs
@@ -20,29 +20,9 @@ use crate::expr::{ExprImpl, ExprType};
 use crate::optimizer::rule::BoxedRule;
 use crate::utils::{ColIndexMapping, Condition};
 
-/// Pushes predicates above and within a join node into the join node and/or its children nodes.
-///
-/// # Which predicates can be pushed
-///
-/// For inner join, we can do all kinds of pushdown.
-///
-/// For left/right semi join, we can push filter to left/right and on-clause,
-/// and push on-clause to left/right.
-///
-/// For left/right anti join, we can push filter to left/right, but on-clause can not be pushed
-///
-/// ## Outer Join
-///
-/// Preserved Row table
-/// : The table in an Outer Join that must return all rows.
-///
-/// Null Supplying table
-/// : This is the table that has nulls filled in for its columns in unmatched rows.
-///
-/// |                          | Preserved Row table | Null Supplying table |
-/// |--------------------------|---------------------|----------------------|
-/// | Join predicate (on)      | Not Pushed          | Pushed               |
-/// | Where predicate (filter) | Pushed              | Not Pushed           |
+/// Merges adjacent inner joins into a single LogicalMultiJoin.
+/// The LogicalMultiJoin is short-lived and will be immediately
+/// rewritten into a join tree of binary joins.
 pub struct MultiJoinJoinRule {}
 
 impl Rule for MultiJoinJoinRule {

--- a/src/frontend/src/optimizer/rule/multijoin_join.rs
+++ b/src/frontend/src/optimizer/rule/multijoin_join.rs
@@ -12,16 +12,16 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use risingwave_pb::plan_common::JoinType;
+
 
 use super::super::plan_node::*;
 use super::Rule;
-use crate::expr::{ExprImpl, ExprType};
-use crate::optimizer::rule::BoxedRule;
-use crate::utils::{ColIndexMapping, Condition};
 
-/// Merges adjacent inner joins into a single LogicalMultiJoin.
-/// The LogicalMultiJoin is short-lived and will be immediately
+use crate::optimizer::rule::BoxedRule;
+
+
+/// Merges adjacent inner joins into a single `LogicalMultiJoin`.
+/// The `LogicalMultiJoin` is short-lived and will be immediately
 /// rewritten into a join tree of binary joins.
 pub struct MultiJoinJoinRule {}
 

--- a/src/frontend/src/optimizer/rule/multijoin_join.rs
+++ b/src/frontend/src/optimizer/rule/multijoin_join.rs
@@ -100,7 +100,7 @@ mod tests {
                 Type::Equal,
                 vec![
                     ExprImpl::InputRef(Box::new(InputRef::new(2, ty.clone()))),
-                    ExprImpl::InputRef(Box::new(InputRef::new(8, ty))),
+                    ExprImpl::InputRef(Box::new(InputRef::new(8, ty.clone()))),
                 ],
             )
             .unwrap(),
@@ -109,7 +109,7 @@ mod tests {
             mid.clone().into(),
             LogicalMultiJoin::from_join(&join_0.into()).unwrap().into(),
             join_type,
-            Condition::with_expr(on_1),
+            Condition::with_expr(on_1.clone()),
         );
         let multi_join = LogicalMultiJoin::from_join(&join_1.into()).unwrap();
         for (input, schema) in
@@ -120,5 +120,21 @@ mod tests {
         {
             assert_eq!(input.schema(), schema);
         }
+
+        assert_eq!(multi_join.on().conjunctions.len(), 2);
+        assert!(multi_join.on().conjunctions.contains(&on_1));
+
+        let on_0_shifted: ExprImpl = ExprImpl::FunctionCall(Box::new(
+            FunctionCall::new(
+                Type::Equal,
+                vec![
+                    ExprImpl::InputRef(Box::new(InputRef::new(4, ty.clone()))),
+                    ExprImpl::InputRef(Box::new(InputRef::new(6, ty))),
+                ],
+            )
+            .unwrap(),
+        ));
+
+        assert!(multi_join.on().conjunctions.contains(&on_0_shifted));
     }
 }

--- a/src/frontend/src/optimizer/rule/multijoin_join.rs
+++ b/src/frontend/src/optimizer/rule/multijoin_join.rs
@@ -1,0 +1,146 @@
+// Copyright 2022 Singularity Data
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use risingwave_pb::plan_common::JoinType;
+
+use super::super::plan_node::*;
+use super::Rule;
+use crate::expr::{ExprImpl, ExprType};
+use crate::optimizer::rule::BoxedRule;
+use crate::utils::{ColIndexMapping, Condition};
+
+/// Pushes predicates above and within a join node into the join node and/or its children nodes.
+///
+/// # Which predicates can be pushed
+///
+/// For inner join, we can do all kinds of pushdown.
+///
+/// For left/right semi join, we can push filter to left/right and on-clause,
+/// and push on-clause to left/right.
+///
+/// For left/right anti join, we can push filter to left/right, but on-clause can not be pushed
+///
+/// ## Outer Join
+///
+/// Preserved Row table
+/// : The table in an Outer Join that must return all rows.
+///
+/// Null Supplying table
+/// : This is the table that has nulls filled in for its columns in unmatched rows.
+///
+/// |                          | Preserved Row table | Null Supplying table |
+/// |--------------------------|---------------------|----------------------|
+/// | Join predicate (on)      | Not Pushed          | Pushed               |
+/// | Where predicate (filter) | Pushed              | Not Pushed           |
+pub struct MultiJoinJoinRule {}
+
+impl Rule for MultiJoinJoinRule {
+    fn apply(&self, plan: PlanRef) -> Option<PlanRef> {
+        let join = LogicalMultiJoin::from_join(&plan)?;
+        Some(join.into())
+    }
+}
+
+impl MultiJoinJoinRule {
+    pub fn create() -> BoxedRule {
+        Box::new(MultiJoinJoinRule {})
+    }
+}
+#[cfg(test)]
+mod tests {
+    use rand::Rng;
+    use risingwave_common::catalog::{Field, Schema};
+    use risingwave_common::types::{DataType, Datum};
+    use risingwave_pb::expr::expr_node::Type;
+
+    use super::*;
+    use crate::expr::{Expr, ExprImpl, ExprType, FunctionCall, InputRef};
+    use crate::optimizer::heuristic::{ApplyOrder, HeuristicOptimizer};
+    use crate::session::OptimizerContext;
+
+    #[tokio::test]
+    async fn test_joins_get_merged_into_multijoin() {
+        let ty = DataType::Int32;
+        let ctx = OptimizerContext::mock().await;
+        let fields: Vec<Field> = (1..10)
+            .map(|i| Field::with_name(ty.clone(), format!("v{}", i)))
+            .collect();
+        let left = LogicalValues::new(
+            vec![],
+            Schema {
+                fields: fields[0..3].to_vec(),
+            },
+            ctx.clone(),
+        );
+        let right = LogicalValues::new(
+            vec![],
+            Schema {
+                fields: fields[3..6].to_vec(),
+            },
+            ctx.clone(),
+        );
+        let mid = LogicalValues::new(
+            vec![],
+            Schema {
+                fields: fields[6..9].to_vec(),
+            },
+            ctx,
+        );
+
+        let join_type = JoinType::Inner;
+        let on_0: ExprImpl = ExprImpl::FunctionCall(Box::new(
+            FunctionCall::new(
+                Type::Equal,
+                vec![
+                    ExprImpl::InputRef(Box::new(InputRef::new(1, ty.clone()))),
+                    ExprImpl::InputRef(Box::new(InputRef::new(3, ty.clone()))),
+                ],
+            )
+            .unwrap(),
+        ));
+        let join_0 = LogicalJoin::new(
+            left.clone().into(),
+            right.clone().into(),
+            join_type,
+            Condition::with_expr(on_0),
+        );
+
+        let on_1: ExprImpl = ExprImpl::FunctionCall(Box::new(
+            FunctionCall::new(
+                Type::Equal,
+                vec![
+                    ExprImpl::InputRef(Box::new(InputRef::new(2, ty.clone()))),
+                    ExprImpl::InputRef(Box::new(InputRef::new(8, ty))),
+                ],
+            )
+            .unwrap(),
+        ));
+        let join_1 = LogicalJoin::new(
+            mid.clone().into(),
+            LogicalMultiJoin::from_join(&join_0.into()).unwrap().into(),
+            join_type,
+            Condition::with_expr(on_1),
+        );
+        let multi_join = LogicalMultiJoin::from_join(&join_1.into()).unwrap();
+        for (input, schema) in
+            multi_join
+                .inputs()
+                .iter()
+                .zip(vec![mid.schema(), left.schema(), right.schema()])
+        {
+            assert_eq!(input.schema(), schema);
+        }
+        println!("{:?}", multi_join);
+    }
+}

--- a/src/frontend/src/optimizer/rule/multijoin_join.rs
+++ b/src/frontend/src/optimizer/rule/multijoin_join.rs
@@ -37,6 +37,7 @@ impl MultiJoinJoinRule {
 }
 #[cfg(test)]
 mod tests {
+    use itertools::Itertools;
     use risingwave_common::catalog::{Field, Schema};
     use risingwave_common::types::DataType;
     use risingwave_pb::expr::expr_node::Type;
@@ -115,7 +116,7 @@ mod tests {
             multi_join
                 .inputs()
                 .iter()
-                .zip(vec![mid.schema(), left.schema(), right.schema()])
+                .zip_eq(vec![mid.schema(), left.schema(), right.schema()])
         {
             assert_eq!(input.schema(), schema);
         }

--- a/src/frontend/src/optimizer/rule/multijoin_join.rs
+++ b/src/frontend/src/optimizer/rule/multijoin_join.rs
@@ -121,6 +121,5 @@ mod tests {
         {
             assert_eq!(input.schema(), schema);
         }
-        println!("{:?}", multi_join);
     }
 }


### PR DESCRIPTION
## What's changed and what's your intention?
Adds `LogicalMultiJoin` PlanTreeNode. 

In a follow up PR (in progress; passes e2e tests reliably but missing unit tests) we will add optimizer rules for converting a `LogicalMultiJoin` into a left-deep join tree with heuristic reordering to avoid cross joins (and prioritize e.g. joins with primary keys in join columns).


## Refer to a related PR or issue link (optional)
https://github.com/singularity-data/risingwave/issues/2425
https://github.com/singularity-data/risingwave/issues/1866