### PR TITLE
refactor(common): use next_visible_row_idx for data chunk iter

### DIFF
--- a/src/common/src/array/data_chunk_iter.rs
+++ b/src/common/src/array/data_chunk_iter.rs
@@ -31,48 +31,34 @@ impl DataChunk {
     pub fn rows(&self) -> impl Iterator<Item = RowRef> {
         DataChunkRefIter {
             chunk: self,
-            idx: 0,
+            idx: Some(0),
         }
     }
 }
 
 struct DataChunkRefIter<'a> {
     chunk: &'a DataChunk,
-    idx: usize,
+    idx: Option<usize>,
 }
 
 impl<'a> Iterator for DataChunkRefIter<'a> {
     type Item = RowRef<'a>;
 
     fn next(&mut self) -> Option<Self::Item> {
-        match self.chunk.visibility() {
-            Some(bitmap) => {
-                loop {
-                    let idx = self.idx;
-                    if idx >= self.chunk.capacity() {
-                        return None;
-                    }
-                    // SAFETY: idx is checked.
-                    let vis = unsafe { bitmap.is_set_unchecked(idx) };
-                    self.idx += 1;
-                    if vis {
-                        return Some(RowRef {
+        match self.idx {
+            None => None,
+            Some(idx) => {
+                self.idx = self.chunk.next_visible_row_idx(idx);
+                match self.idx {
+                    None => None,
+                    Some(idx) => {
+                        self.idx = Some(self.idx.unwrap() + 1);
+                        Some(RowRef {
                             chunk: self.chunk,
                             idx,
-                        });
+                        })
                     }
                 }
-            }
-            None => {
-                let idx = self.idx;
-                if idx >= self.chunk.capacity() {
-                    return None;
-                }
-                self.idx += 1;
-                Some(RowRef {
-                    chunk: self.chunk,
-                    idx,
-                })
             }
         }
     }

--- a/src/common/src/array/data_chunk_iter.rs
+++ b/src/common/src/array/data_chunk_iter.rs
@@ -38,6 +38,7 @@ impl DataChunk {
 
 struct DataChunkRefIter<'a> {
     chunk: &'a DataChunk,
+    /// `None` means finished
     idx: Option<usize>,
 }
 
@@ -52,7 +53,7 @@ impl<'a> Iterator for DataChunkRefIter<'a> {
                 match self.idx {
                     None => None,
                     Some(idx) => {
-                        self.idx = Some(self.idx.unwrap() + 1);
+                        self.idx = Some(idx + 1);
                         Some(RowRef {
                             chunk: self.chunk,
                             idx,


### PR DESCRIPTION
## What's changed and what's your intention?

Refactor the `next` method of `DataChunkIter`. 
`next_visible_row_idx` can be reused to implement it.