### PR TITLE
fix(source): remove epoch in state user key and no flush on idle

### DIFF
--- a/risedev.yml
+++ b/risedev.yml
@@ -62,9 +62,7 @@ risedev:
   full:
     - use: minio
     - use: etcd
-    # - use: jaeger
     - use: meta-node
-      # enable-dashboard-v2: true
     - use: compute-node
     - use: frontend
     - use: compactor

--- a/risedev.yml
+++ b/risedev.yml
@@ -62,7 +62,9 @@ risedev:
   full:
     - use: minio
     - use: etcd
+    # - use: jaeger
     - use: meta-node
+      # enable-dashboard-v2: true
     - use: compute-node
     - use: frontend
     - use: compactor

--- a/src/connector/src/state.rs
+++ b/src/connector/src/state.rs
@@ -87,8 +87,8 @@ impl<S: StateStore> SourceStateHandler<S> {
         }
     }
 
-    /// Initializes the state of the specified ``state_identifier`` and returns an empty vec
-    /// if it does not exist (e.g., the first accessible source).
+    /// Retrieves the state of the specified ``state_identifier``
+    /// Returns None if it does not exist (e.g., the first accessible source).
     ///
     /// The function returns the serialized state.
     pub async fn restore_states(

--- a/src/connector/src/state.rs
+++ b/src/connector/src/state.rs
@@ -48,54 +48,7 @@ impl<S: StateStore> Debug for SourceStateHandler<S> {
     }
 }
 
-#[derive(Debug, Clone, PartialEq)]
-struct StateStoredKey {
-    state_identifier: String,
-    epoch: u64,
-}
 
-impl Default for StateStoredKey {
-    fn default() -> Self {
-        Self {
-            state_identifier: "".to_string(),
-            epoch: u64::MIN,
-        }
-    }
-}
-
-impl StateStoredKey {
-    fn new(state_identifier: String, epoch: u64) -> Self {
-        Self {
-            state_identifier,
-            epoch,
-        }
-    }
-
-    // default key format [state_identifier | epoch]
-    fn build_stored_key(&self) -> String {
-        [
-            self.state_identifier.clone(),
-            "|".to_string(),
-            self.epoch.clone().to_string(),
-        ]
-        .concat()
-    }
-
-    fn build_from_bytes(&self, key_bytes: Bytes) -> Option<Self> {
-        if key_bytes.is_empty() {
-            None
-        } else {
-            let key_string = String::from_utf8(key_bytes.to_vec()).unwrap();
-            let key_string_len = key_string.len();
-            let delimiter_idx = key_string.find('|').unwrap();
-
-            let identifier = &(*key_string.as_str())[0..delimiter_idx];
-            let epoch_string = &(*key_string.as_str())[delimiter_idx + 1..key_string_len];
-            let epoch = epoch_string.parse::<u64>().unwrap();
-            Some(StateStoredKey::new(String::from(identifier), epoch))
-        }
-    }
-}
 
 impl<S: StateStore> SourceStateHandler<S> {
     pub fn new(keyspace: Keyspace<S>) -> Self {
@@ -117,11 +70,9 @@ impl<S: StateStore> SourceStateHandler<S> {
             let mut write_batch = self.keyspace.state_store().start_write_batch();
             let mut local_batch = write_batch.prefixify(&self.keyspace);
             states.iter().for_each(|state| {
-                // state inner key format (state_identifier | epoch)
-                let inner_key = StateStoredKey::new(state.id(), epoch).build_stored_key();
                 let value = state.to_json_bytes();
                 // TODO(Yuanxin): Implement value meta
-                local_batch.put(inner_key, StorageValue::new_default_put(value));
+                local_batch.put(state.id(), StorageValue::new_default_put(value));
             });
             // If an error is returned, the underlying state should be rollback
             let ingest_rs = write_batch.ingest(epoch).await;
@@ -141,28 +92,14 @@ impl<S: StateStore> SourceStateHandler<S> {
     /// Initializes the state of the specified ``state_identifier`` and returns an empty vec
     /// if it does not exist (e.g., the first accessible source).
     ///
-    /// The function returns a collection of tuple (epoch, state).
-    pub async fn restore_states(&self, state_identifier: String) -> Result<Vec<(u64, Bytes)>> {
-        // TODO: do we need snapshot read here?
-        let epoch = u64::MAX;
-        let scan_rs = self.keyspace.scan(Option::None, epoch).await;
-        let mut restore_values = Vec::new();
-        match scan_rs {
-            Ok(scan_list) => {
-                for pair in scan_list {
-                    let stored_key = StateStoredKey::default().build_from_bytes(pair.0).unwrap();
-                    if stored_key
-                        .clone()
-                        .state_identifier
-                        .eq(&state_identifier.clone())
-                    {
-                        restore_values.push((stored_key.epoch, pair.1))
-                    }
-                }
-                Ok(restore_values)
-            }
-            Err(e) => Err(anyhow!(e)),
-        }
+    /// The function returns the serialized state.
+    pub async fn restore_states(
+        &self,
+        state_identifier: String,
+        epoch: u64,
+    ) -> Result<Option<Bytes>> {
+        self.keyspace.get(state_identifier, epoch).await.map_err(|e| anyhow!(e))
+
     }
 
     pub async fn try_recover_from_state_store(
@@ -170,34 +107,14 @@ impl<S: StateStore> SourceStateHandler<S> {
         stream_source_splits: &SplitImpl,
         epoch: u64,
     ) -> RwResult<ConnectorState> {
-        let mut state = self
-            .restore_states(stream_source_splits.id())
-            .await
-            .map_err(|e| RwError::from(InternalError(e.to_string())))?
-            .iter()
-            .filter(|(e, _)| e == &epoch)
-            .map(|(_, s)| {
-                ConnectorState::restore_from_bytes(s)
-                    .map_err(|e| RwError::from(InternalError(e.to_string())))
-            })
-            .collect::<RwResult<Vec<ConnectorState>>>()?;
-
-        assert!(state.len() <= 1);
-
-        if state.len() == 1 {
-            Ok(state.pop().unwrap())
-        } else if state.is_empty() {
-            Err(RwError::from(InternalError(format!(
+        match self.restore_states(stream_source_splits.id(), epoch).await {
+            Ok(Some(s)) => ConnectorState::restore_from_bytes(&s)
+                .map_err(|e| RwError::from(InternalError(e.to_string()))),
+            Ok(None) => Err(RwError::from(InternalError(format!(
                 "cannot found state for {:?}, epoch: {:?}",
                 stream_source_splits, epoch
-            ))))
-        } else {
-            Err(RwError::from(InternalError(format!(
-                "expected load one state from epoch {:?}, got {:?}: {:?}",
-                epoch,
-                state.len(),
-                state
-            ))))
+            )))),
+            Err(e) => Err(RwError::from(InternalError(e.to_string()))),
         }
     }
 }
@@ -240,46 +157,6 @@ mod tests {
     }
 
     #[test]
-    fn test_new_state_stored_key() {
-        let state_inner_key = StateStoredKey::new(TEST_STATE_IDENTIFIER.to_string(), TEST_EPOCH);
-        assert_eq!(
-            TEST_STATE_IDENTIFIER.to_string(),
-            state_inner_key.state_identifier
-        );
-        assert_eq!(TEST_EPOCH, state_inner_key.epoch);
-    }
-
-    #[test]
-    fn test_build_stored_key() {
-        assert_eq!(
-            [
-                TEST_STATE_IDENTIFIER.to_string(),
-                "|".to_string(),
-                TEST_EPOCH.to_string()
-            ]
-            .concat(),
-            StateStoredKey::new(TEST_STATE_IDENTIFIER.to_string(), TEST_EPOCH).build_stored_key()
-        );
-    }
-
-    #[test]
-    fn test_stored_key_from_bytes() {
-        let ss_key = StateStoredKey::new(TEST_STATE_IDENTIFIER.to_string(), TEST_EPOCH);
-        let key_bytes = Bytes::from(
-            [
-                TEST_STATE_IDENTIFIER.to_string(),
-                "|".to_string(),
-                TEST_EPOCH.to_string(),
-            ]
-            .concat(),
-        );
-        let ss_key_from_bytes = ss_key.build_from_bytes(key_bytes);
-        if let Some(ss_val) = ss_key_from_bytes {
-            assert_eq!(ss_key, ss_val)
-        };
-    }
-
-    #[test]
     fn test_state_encode() -> Result<()> {
         let offset = 100_i64;
         let partition = String::from("p0");
@@ -310,8 +187,8 @@ mod tests {
 
     async fn take_snapshot_and_get_states(
         state_handler: SourceStateHandler<MemoryStateStore>,
+        current_epoch: u64,
     ) -> (Vec<TestSourceState>, Result<()>) {
-        let current_epoch = 1000;
         let states = test_state_store_vec();
         println!("Vec<TestSourceStat>={:?}", states.clone());
         let rs = state_handler
@@ -324,7 +201,7 @@ mod tests {
     async fn test_take_snapshot() {
         let current_epoch = 1000;
         let state_store_handler = SourceStateHandler::new(new_test_keyspace());
-        let _rs = take_snapshot_and_get_states(state_store_handler.clone()).await;
+        let _rs = take_snapshot_and_get_states(state_store_handler.clone(), current_epoch).await;
         let stored_states = state_store_handler
             .keyspace
             .scan(None, current_epoch)
@@ -337,34 +214,37 @@ mod tests {
     async fn test_empty_state_restore() {
         let partition = "p01".to_string();
         let state_store_handler = SourceStateHandler::new(new_test_keyspace());
-
-        let list_states = state_store_handler.restore_states(partition).await.unwrap();
+        let list_states = state_store_handler
+            .restore_states(partition, u64::MAX)
+            .await
+            .unwrap();
         println!("current list_states={:?}", list_states);
-        assert_eq!(0, list_states.len())
+        assert!(list_states.is_none())
     }
 
     #[tokio::test]
     async fn test_state_restore() {
         let state_store_handler = SourceStateHandler::new(new_test_keyspace());
-        let saved_states = take_snapshot_and_get_states(state_store_handler.clone())
+        let current_epoch = 1000;
+        let saved_states = take_snapshot_and_get_states(state_store_handler.clone(), current_epoch)
             .await
             .0;
 
         for state in saved_states {
             let identifier = state.id();
             let state_pair = state_store_handler
-                .restore_states(identifier)
+                .restore_states(identifier, current_epoch)
                 .await
                 .unwrap();
             println!("source_state_handler restore state_pair={:?}", state_pair);
             state_pair.into_iter().for_each(|s| {
                 assert_eq!(
                     state.offset,
-                    TestSourceState::restore_from_bytes(&s.1).unwrap().offset
+                    TestSourceState::restore_from_bytes(&s).unwrap().offset
                 );
                 assert_eq!(
                     state.partition,
-                    TestSourceState::restore_from_bytes(&s.1).unwrap().partition
+                    TestSourceState::restore_from_bytes(&s).unwrap().partition
                 );
             });
         }

--- a/src/connector/src/state.rs
+++ b/src/connector/src/state.rs
@@ -48,8 +48,6 @@ impl<S: StateStore> Debug for SourceStateHandler<S> {
     }
 }
 
-
-
 impl<S: StateStore> SourceStateHandler<S> {
     pub fn new(keyspace: Keyspace<S>) -> Self {
         Self { keyspace }
@@ -98,8 +96,10 @@ impl<S: StateStore> SourceStateHandler<S> {
         state_identifier: String,
         epoch: u64,
     ) -> Result<Option<Bytes>> {
-        self.keyspace.get(state_identifier, epoch).await.map_err(|e| anyhow!(e))
-
+        self.keyspace
+            .get(state_identifier, epoch)
+            .await
+            .map_err(|e| anyhow!(e))
     }
 
     pub async fn try_recover_from_state_store(

--- a/src/stream/src/executor/source.rs
+++ b/src/stream/src/executor/source.rs
@@ -59,7 +59,7 @@ pub struct SourceExecutor<S: StateStore> {
     source_identify: String,
 
     split_state_store: SourceStateHandler<S>,
-    
+
     // store latest split to offset mapping.
     // None if there is no update on source state since the previsouly seen barrier.
     state_cache: Option<Vec<ConnectorState>>,


### PR DESCRIPTION
## What's changed and what's your intention?
Fix #2546 

- Use state_identifier directly for source state key without encoding epoch in it.
- Add `idle_between_barriers` in source executor to track whether there is any data ingesting from source between barriers. Do not update source state to storage if the source state does not change.

With this PR, I confirmed (via grafana and manual checking on minio) that the number of newly added SSTs and number of kvs written to storage drop to zero after I stop producing data into the kafka source.

## Checklist

- [x] I have written necessary docs and comments
- [x] I have added necessary unit tests and integration tests

## Refer to a related PR or issue link (optional)
