### PR TITLE
refactor(stream): remove STREAM_NULL_BY_ROW_COUNT

### DIFF
--- a/proto/expr.proto
+++ b/proto/expr.proto
@@ -68,7 +68,6 @@ message ExprNode {
     // Search operator and Search ARGument
     SEARCH = 998;
     SARG = 999;
-    STREAM_NULL_BY_ROW_COUNT = 1000;
   }
   Type expr_type = 1;
   data.DataType return_type = 3;

--- a/src/expr/src/expr/expr_binary_nullable.rs
+++ b/src/expr/src/expr/expr_binary_nullable.rs
@@ -14,10 +14,7 @@
 
 //! For expression that only accept two nullable arguments as input.
 
-use risingwave_common::array::{
-    BoolArray, DecimalArray, F32Array, F64Array, I16Array, I32Array, I64Array,
-};
-use risingwave_common::error::Result;
+use risingwave_common::array::BoolArray;
 use risingwave_common::types::DataType;
 use risingwave_pb::expr::expr_node::Type;
 

--- a/src/expr/src/expr/expr_binary_nullable.rs
+++ b/src/expr/src/expr/expr_binary_nullable.rs
@@ -25,36 +25,6 @@ use super::BoxedExpression;
 use crate::expr::template::BinaryNullableExpression;
 use crate::vector_op::conjunction::{and, or};
 
-// TODO: consider implement it using generic function.
-macro_rules! gen_stream_null_by_row_count_expr {
-    ($l:expr, $r:expr, $ret:expr, $OA:ty) => {
-        Box::new(BinaryNullableExpression::<I64Array, $OA, $OA, _>::new(
-            $l,
-            $r,
-            $ret,
-            stream_null_by_row_count,
-        ))
-    };
-}
-
-/// `stream_null_by_row_count` is mainly used for a special case of the conditional aggregation. For
-/// example:
-///
-/// ```sql
-/// SELECT stream_null_by_row_count(row_count, x) FROM
-/// (SELECT count(*) AS row_count, avg(x) AS x FROM t1);
-/// ```
-///
-/// is equivalent to:
-///
-/// ```sql
-/// SELECT avg(case when row_count > 0 then x else NULL)
-/// FROM t1;
-/// ```
-fn stream_null_by_row_count<T1>(l: Option<i64>, r: Option<T1>) -> Result<Option<T1>> {
-    Ok(l.filter(|l| *l > 0).and(r))
-}
-
 pub fn new_nullable_binary_expr(
     expr_type: Type,
     ret: DataType,
@@ -62,31 +32,6 @@ pub fn new_nullable_binary_expr(
     r: BoxedExpression,
 ) -> BoxedExpression {
     match expr_type {
-        Type::StreamNullByRowCount => match l.return_type() {
-            DataType::Int64 => match r.return_type() {
-                DataType::Boolean => gen_stream_null_by_row_count_expr!(l, r, ret, BoolArray),
-                DataType::Int16 => gen_stream_null_by_row_count_expr!(l, r, ret, I16Array),
-                DataType::Int32 => gen_stream_null_by_row_count_expr!(l, r, ret, I32Array),
-                DataType::Int64 => gen_stream_null_by_row_count_expr!(l, r, ret, I64Array),
-                DataType::Float32 => gen_stream_null_by_row_count_expr!(l, r, ret, F32Array),
-                DataType::Float64 => gen_stream_null_by_row_count_expr!(l, r, ret, F64Array),
-                DataType::Decimal => {
-                    gen_stream_null_by_row_count_expr!(l, r, ret, DecimalArray)
-                }
-                DataType::Date => gen_stream_null_by_row_count_expr!(l, r, ret, DecimalArray),
-                _ => {
-                    unimplemented!(
-                        "The output type isn't supported by stream_null_by_row_count function."
-                    )
-                }
-            },
-            tp => {
-                unimplemented!(
-                    "The first argument of StreamNullByRowCount must be Int64 but not {:?}",
-                    tp
-                )
-            }
-        },
         Type::And => Box::new(
             BinaryNullableExpression::<BoolArray, BoolArray, BoolArray, _>::new(l, r, ret, and),
         ),
@@ -98,26 +43,6 @@ pub fn new_nullable_binary_expr(
                 "The expression {:?} using vectorized expression framework is not supported yet!",
                 tp
             )
-        }
-    }
-}
-
-#[cfg(test)]
-mod tests {
-    use super::stream_null_by_row_count;
-
-    #[test]
-    fn test_stream_if_not_null() {
-        let cases = [
-            (Some(1), Some(2), Some(2)),
-            (Some(0), Some(2), None),
-            (Some(3), None, None),
-            (None, Some(3), None),
-        ];
-        for (arg1, arg2, expected) in cases {
-            let output =
-                stream_null_by_row_count(arg1, arg2).expect("No error in stream_null_by_row_count");
-            assert_eq!(output, expected);
         }
     }
 }

--- a/src/expr/src/expr/mod.rs
+++ b/src/expr/src/expr/mod.rs
@@ -79,7 +79,7 @@ pub fn build_from_prost(prost: &ExprNode) -> Result<BoxedExpression> {
         Equal | NotEqual | LessThan | LessThanOrEqual | GreaterThan | GreaterThanOrEqual | Add
         | Subtract | Multiply | Divide | Modulus | Extract | RoundDigit | TumbleStart
         | Position => build_binary_expr_prost(prost),
-        StreamNullByRowCount | And | Or => build_nullable_binary_expr_prost(prost),
+        And | Or => build_nullable_binary_expr_prost(prost),
         Coalesce => CoalesceExpression::try_from(prost).map(|d| Box::new(d) as BoxedExpression),
         Substr => build_substr_expr(prost),
         Length => build_length_expr(prost),

--- a/src/meta/src/stream/test_fragmenter.rs
+++ b/src/meta/src/stream/test_fragmenter.rs
@@ -103,19 +103,6 @@ fn make_column_order(idx: i32) -> ColumnOrder {
 /// create table t (v1 int, v2 int);
 /// create materialized view T_distributed as select sum(v1)+1 as V from t where v1>v2;
 /// ```
-///
-/// plan:
-///
-/// ```ignore
-///     RwStreamMaterializedView(name=[t_distributed])
-///           RwStreamProject(v=[+($STREAM_NULL_BY_ROW_COUNT($0, $1), 1)], $f0=[$0], $f1=[$1])
-///             RwStreamAgg(group=[{}], agg#0=[$SUM0($0)], agg#1=[SUM($1)])
-///               RwStreamExchange(distribution=[RwDistributionTrait{type=SINGLETON, keys=[]}], collation=[[]])
-///                 RwStreamAgg(group=[{}], agg#0=[COUNT()], agg#1=[SUM($0)])
-///                   RwStreamFilter(condition=[>($0, $1)])
-///                     RwStreamExchange(distribution=[RwDistributionTrait{type=HASH_DISTRIBUTED,keys=[0]}], collation=[[]])
-///                       RwStreamTableSource(table=[[test_schema,t]], columns=[`v1,v2,_row_id`])
-/// ```
 fn make_stream_node() -> StreamNode {
     let table_ref_id = make_table_ref_id(1);
     // table source node


### PR DESCRIPTION
Signed-off-by: TennyZhuang <zty0826@gmail.com>

## What's changed and what's your intention?

Remove unused internal function `STREAM_NULL_BY_ROW_COUNT`.

## Checklist

- [x] I have written necessary docs and comments
- [x] I have added necessary unit tests and integration tests

## Refer to a related PR or issue link (optional)

Fix #794 