### PR TITLE
refactor(prost): use src as default build path for prost

### DIFF
--- a/src/prost/build.rs
+++ b/src/prost/build.rs
@@ -39,12 +39,13 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         .collect();
 
     // Build protobuf structs.
-    let out_dir = PathBuf::from(std::env::var("OUT_DIR").unwrap());
+    let out_dir = PathBuf::from(std::env::var("OUT_DIR").unwrap_or("./src".to_string()));
     let file_descriptor_set_path: PathBuf = out_dir.join("file_descriptor_set.bin");
     tonic_build::configure()
         .file_descriptor_set_path(file_descriptor_set_path.as_path())
         .compile_well_known_types(true)
         .type_attribute(".", "#[derive(prost_helpers::AnyPB)]")
+        .out_dir(out_dir.as_path())
         .compile(&protos, &[proto_dir.to_string()])
         .expect("Failed to compile grpc!");
 
@@ -52,8 +53,21 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     let descriptor_set = std::fs::read(file_descriptor_set_path)?;
     pbjson_build::Builder::new()
         .register_descriptors(&descriptor_set)?
+        .out_dir(out_dir.as_path())
         .build(&["."])
         .expect("Failed to compile serde");
 
+    // Tweak the serde files so that they can be compiled in our project.
+    // By adding a `use crate::module::*`
+    let rewrite_files = proto_files;
+    for serde_proto_file in &rewrite_files {
+        let out_file = out_dir.join(format!("{}.serde.rs", serde_proto_file));
+        let file_content = String::from_utf8(std::fs::read(&out_file)?)?;
+        let module_path_id = serde_proto_file.replace('.', "::");
+        std::fs::write(
+            &out_file,
+            format!("use crate::{}::*;\n{}", module_path_id, file_content),
+        )?;
+    }
     Ok(())
 }

--- a/src/prost/build.rs
+++ b/src/prost/build.rs
@@ -39,7 +39,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         .collect();
 
     // Build protobuf structs.
-    let out_dir = PathBuf::from(std::env::var("OUT_DIR").unwrap_or("./src".to_string()));
+    let out_dir = PathBuf::from("./src");
     let file_descriptor_set_path: PathBuf = out_dir.join("file_descriptor_set.bin");
     tonic_build::configure()
         .file_descriptor_set_path(file_descriptor_set_path.as_path())

--- a/src/prost/src/lib.rs
+++ b/src/prost/src/lib.rs
@@ -1,29 +1,67 @@
 #![allow(clippy::all)]
 
-macro_rules! define_module {
-    ($name:ident) => {
-        define_module!($name, stringify!($name));
-    };
-    ($name:ident, $str:expr) => {
 #[rustfmt::skip]
-        pub mod $name {
-            tonic::include_proto!($str);
-            include!(concat!(env!("OUT_DIR"), concat!("/", $str, ".serde.rs")));
-        }
-    };
-}
-define_module!(catalog);
-define_module!(common);
-define_module!(data);
-define_module!(ddl_service);
-define_module!(expr);
-define_module!(meta);
-define_module!(plan_common);
-define_module!(batch_plan);
-define_module!(task_service);
-define_module!(stream_plan);
-define_module!(stream_service);
-define_module!(hummock);
+pub mod catalog;
+#[rustfmt::skip]
+pub mod common;
+#[rustfmt::skip]
+pub mod data;
+#[rustfmt::skip]
+pub mod ddl_service;
+#[rustfmt::skip]
+pub mod expr;
+#[rustfmt::skip]
+pub mod meta;
+#[rustfmt::skip]
+pub mod plan_common;
+#[rustfmt::skip]
+pub mod batch_plan;
+#[rustfmt::skip]
+pub mod task_service;
+#[rustfmt::skip]
+pub mod stream_plan;
+#[rustfmt::skip]
+pub mod stream_service;
+#[rustfmt::skip]
+pub mod hummock;
+
+#[rustfmt::skip]
+#[path = "catalog.serde.rs"]
+pub mod catalog_serde;
+#[rustfmt::skip]
+#[path = "common.serde.rs"]
+pub mod common_serde;
+#[rustfmt::skip]
+#[path = "data.serde.rs"]
+pub mod data_serde;
+#[rustfmt::skip]
+#[path = "ddl_service.serde.rs"]
+pub mod ddl_service_serde;
+#[rustfmt::skip]
+#[path = "expr.serde.rs"]
+pub mod expr_serde;
+#[rustfmt::skip]
+#[path = "meta.serde.rs"]
+pub mod meta_serde;
+#[rustfmt::skip]
+#[path = "plan_common.serde.rs"]
+pub mod plan_common_serde;
+#[rustfmt::skip]
+#[path = "batch_plan.serde.rs"]
+pub mod batch_plan_serde;
+#[rustfmt::skip]
+#[path = "task_service.serde.rs"]
+pub mod task_service_serde;
+#[rustfmt::skip]
+#[path = "stream_plan.serde.rs"]
+pub mod stream_plan_serde;
+#[rustfmt::skip]
+#[path = "stream_service.serde.rs"]
+pub mod stream_service_serde;
+#[rustfmt::skip]
+#[path = "hummock.serde.rs"]
+pub mod hummock_serde;
+
 
 #[derive(Clone, PartialEq, Eq, Debug)]
 pub struct ProstFieldNotFound(pub &'static str);


### PR DESCRIPTION
Signed-off-by: Little-Wallace <bupt2013211450@gmail.com>

## What's changed and what's your intention?

revert some of https://github.com/singularity-data/risingwave/pull/2477
Because CLion can not parse code generated in `OUT_DIR`.

## Checklist


## Refer to a related PR or issue link (optional)
