### PR TITLE
feat(array): use compact encoding for bitmap and bool array

### DIFF
--- a/src/common/src/array/bool_array.rs
+++ b/src/common/src/array/bool_array.rs
@@ -162,8 +162,6 @@ impl ArrayBuilder for BoolArrayBuilder {
 
 #[cfg(test)]
 mod tests {
-    use std::convert::identity;
-
     use itertools::Itertools;
 
     use super::*;
@@ -212,7 +210,7 @@ mod tests {
                 .collect_vec();
 
             let array = helper_test_builder(v.clone());
-            let cardinality = array.iter().filter_map(identity).count();
+            let cardinality = array.iter().flatten().count();
 
             let encoded = array.to_protobuf();
             let decoded = read_bool_array(&encoded, cardinality).unwrap().into_bool();

--- a/src/common/src/array/bool_array.rs
+++ b/src/common/src/array/bool_array.rs
@@ -195,8 +195,7 @@ mod tests {
 
     #[test]
     fn test_bool_array_serde() {
-        for rem in 0..8 {
-            let num_bits = 128 + rem;
+        for num_bits in [0..8, 128..136].into_iter().flatten() {
             let v = (0..num_bits)
                 .map(|x| {
                     if x % 2 == 0 {
@@ -210,10 +209,9 @@ mod tests {
                 .collect_vec();
 
             let array = helper_test_builder(v.clone());
-            let cardinality = array.iter().flatten().count();
 
             let encoded = array.to_protobuf();
-            let decoded = read_bool_array(&encoded, cardinality).unwrap().into_bool();
+            let decoded = read_bool_array(&encoded, num_bits).unwrap().into_bool();
 
             let equal = array.iter().zip_eq(decoded.iter()).all(|(a, b)| a == b);
             assert!(equal);

--- a/src/common/src/array/column_proto_readers.rs
+++ b/src/common/src/array/column_proto_readers.rs
@@ -20,8 +20,8 @@ use risingwave_pb::data::Array as ProstArray;
 
 use crate::array::value_reader::{PrimitiveValueReader, VarSizedValueReader};
 use crate::array::{
-    ArrayBuilder, ArrayImpl, ArrayMeta, BoolArrayBuilder, IntervalArrayBuilder,
-    NaiveDateArrayBuilder, NaiveDateTimeArrayBuilder, NaiveTimeArrayBuilder, PrimitiveArrayBuilder,
+    ArrayBuilder, ArrayImpl, ArrayMeta, BoolArray, IntervalArrayBuilder, NaiveDateArrayBuilder,
+    NaiveDateTimeArrayBuilder, NaiveTimeArrayBuilder, PrimitiveArrayBuilder,
     PrimitiveArrayItemType,
 };
 use crate::buffer::Bitmap;
@@ -64,11 +64,18 @@ pub fn read_numeric_array<T: PrimitiveArrayItemType, R: PrimitiveValueReader<T>>
     Ok(arr.into())
 }
 
-fn read_bool(cursor: &mut Cursor<&[u8]>) -> Result<bool> {
-    let v = cursor
-        .read_u8()
-        .map_err(|e| InternalError(format!("Failed to read u8 from bool buffer: {}", e)))?;
-    Ok(v != 0)
+pub fn read_bool_array(array: &ProstArray, cardinality: usize) -> Result<ArrayImpl> {
+    ensure!(
+        array.get_values().len() == 1,
+        "Must have only 1 buffer in a bool array"
+    );
+
+    let data = (&array.get_values()[0]).try_into()?;
+    let bitmap: Bitmap = array.get_null_bitmap()?.try_into()?;
+    assert_eq!(bitmap.num_high_bits(), cardinality);
+
+    let arr = BoolArray::new(bitmap, data);
+    Ok(arr.into())
 }
 
 fn read_naive_date(cursor: &mut Cursor<&[u8]>) -> Result<NaiveDateWrapper> {
@@ -149,7 +156,6 @@ macro_rules! read_one_value_array {
 
 read_one_value_array! {
     { IntervalUnit, IntervalArrayBuilder },
-    { bool, BoolArrayBuilder },
     { NaiveDate, NaiveDateArrayBuilder },
     { NaiveTime, NaiveTimeArrayBuilder },
     { NaiveDateTime, NaiveDateTimeArrayBuilder }

--- a/src/common/src/array/column_proto_readers.rs
+++ b/src/common/src/array/column_proto_readers.rs
@@ -20,8 +20,8 @@ use risingwave_pb::data::Array as ProstArray;
 
 use crate::array::value_reader::{PrimitiveValueReader, VarSizedValueReader};
 use crate::array::{
-    ArrayBuilder, ArrayImpl, ArrayMeta, BoolArray, IntervalArrayBuilder, NaiveDateArrayBuilder,
-    NaiveDateTimeArrayBuilder, NaiveTimeArrayBuilder, PrimitiveArrayBuilder,
+    Array, ArrayBuilder, ArrayImpl, ArrayMeta, BoolArray, IntervalArrayBuilder,
+    NaiveDateArrayBuilder, NaiveDateTimeArrayBuilder, NaiveTimeArrayBuilder, PrimitiveArrayBuilder,
     PrimitiveArrayItemType,
 };
 use crate::buffer::Bitmap;
@@ -72,9 +72,10 @@ pub fn read_bool_array(array: &ProstArray, cardinality: usize) -> Result<ArrayIm
 
     let data = (&array.get_values()[0]).try_into()?;
     let bitmap: Bitmap = array.get_null_bitmap()?.try_into()?;
-    assert_eq!(bitmap.num_high_bits(), cardinality);
 
     let arr = BoolArray::new(bitmap, data);
+    assert_eq!(arr.len(), cardinality);
+
     Ok(arr.into())
 }
 

--- a/src/common/src/buffer/bitmap.rs
+++ b/src/common/src/buffer/bitmap.rs
@@ -484,15 +484,16 @@ mod tests {
 
     #[test]
     fn test_bitmap_from_protobuf() {
-        let bitmap_bytes = vec![0u8, 1, 0, 1, 0, 0, 1, 0];
+        let bitmap_bytes = vec![3u8 /* len % 8 */, 0b0101_0010, 0b110];
         let buf = ProstBuffer {
-            body: bitmap_bytes.clone(),
-            ..Default::default()
+            body: bitmap_bytes,
+            compression: CompressionType::None as _,
         };
         let bitmap: Bitmap = (&buf).try_into().unwrap();
         let actual_bytes: Vec<u8> = bitmap.iter().map(|b| b as u8).collect();
-        assert_eq!(actual_bytes, bitmap_bytes);
-        assert_eq!(bitmap.num_high_bits(), 3);
+
+        assert_eq!(actual_bytes, vec![0, 1, 0, 0, 1, 0, 1, 0, /*  */ 0, 1, 1]); // in reverse order
+        assert_eq!(bitmap.num_high_bits(), 5);
     }
 
     #[test]

--- a/src/common/src/buffer/bitmap.rs
+++ b/src/common/src/buffer/bitmap.rs
@@ -215,11 +215,10 @@ impl Bitmap {
     }
 
     pub fn to_protobuf(&self) -> ProstBuffer {
-        let mut buf = ProstBuffer::default();
-        for b in self.iter() {
-            buf.body.push(b as u8);
+        ProstBuffer {
+            body: self.bits.as_slice().to_vec(),
+            ..Default::default()
         }
-        buf
     }
 
     pub fn iter(&self) -> BitmapIter<'_> {
@@ -307,13 +306,7 @@ impl TryFrom<&ProstBuffer> for Bitmap {
     type Error = RwError;
 
     fn try_from(buf: &ProstBuffer) -> Result<Bitmap> {
-        let mut builder = BitmapBuilder::default();
-        let body = buf.get_body().as_slice();
-        body.iter().for_each(|e| {
-            builder.append(*e == 1_u8);
-        });
-
-        Ok(builder.finish())
+        Buffer::from_slice(&buf.body).map(Into::into)
     }
 }
 


### PR DESCRIPTION
## What's changed and what's your intention?

Previously, we encoded the bitmap and bool array to protobuf with 1 byte per item, which is inefficient. This PR makes it directly use the memory representation to encode bits, prepending a byte telling the number of trailing bits in the last byte.

## Checklist

- [x] I have written necessary docs and comments
- [x] I have added necessary unit tests and integration tests

## Refer to a related PR or issue link (optional)
- Close #2569 