### PR TITLE
feat(expr): IN-list support non-literals

### DIFF
--- a/e2e_test/v2/batch/func.slt
+++ b/e2e_test/v2/batch/func.slt
@@ -35,3 +35,37 @@ select coalesce(v1,v2,v3) from t1;
 
 statement ok
 drop table t1;
+
+statement ok
+create table t (v1 int);
+
+statement ok
+create table b (b1 int, b2 int);
+
+
+statement ok
+insert into t values (2);
+
+statement ok
+insert into b values (2, 1);
+
+query T
+SELECT 1 in (3, 0.5*2, min(v1)) from t;
+----
+t
+
+query I
+SELECT b2 from b where 1 in (3, 1.0, (select min(v1) from t));
+----
+1
+
+query I
+SELECT b2 from b where exists (select 2 from t where v1 in (3, 1.0, b1));
+----
+1
+
+statement ok
+drop table t;
+
+statement ok
+drop table b;

--- a/src/expr/src/expr/build_expr_from_prost.rs
+++ b/src/expr/src/expr/build_expr_from_prost.rs
@@ -17,7 +17,7 @@ use risingwave_common::ensure;
 use risingwave_common::error::{ErrorCode, Result, RwError};
 use risingwave_common::types::{DataType, ToOwnedDatum};
 use risingwave_pb::expr::expr_node::RexNode;
-use risingwave_pb::expr::{expr_node, ExprNode};
+use risingwave_pb::expr::ExprNode;
 
 use crate::expr::expr_binary_bytes::new_substr_start;
 use crate::expr::expr_binary_nonnull::{new_binary_expr, new_like_default};
@@ -142,22 +142,19 @@ pub fn build_like_expr(prost: &ExprNode) -> Result<BoxedExpression> {
 pub fn build_in_expr(prost: &ExprNode) -> Result<BoxedExpression> {
     let (children, ret_type) = get_return_type_and_children(prost)?;
     ensure!(ret_type == DataType::Boolean);
-    ensure!(children[0].get_expr_type()? == expr_node::Type::InputRef);
-    let input_ref_expr = expr_build_from_prost(&children[0])?;
-    for child in &children[1..] {
-        ensure!(child.get_expr_type()? == expr_node::Type::ConstantValue);
-    }
+    let left_expr = expr_build_from_prost(&children[0])?;
     let mut data = Vec::new();
-    // Used for literal expression below to generate datum
+    // Used for const expression below to generate datum.
+    // Frontend has made sure these can all be folded to constants.
     let data_chunk = DataChunk::new_dummy(1);
     for child in &children[1..] {
-        let literal_expr = expr_build_from_prost(child)?;
-        let array = literal_expr.eval(&data_chunk)?;
+        let const_expr = expr_build_from_prost(child)?;
+        let array = const_expr.eval(&data_chunk)?;
         let datum = array.value_at(0).to_owned_datum();
         data.push(datum);
     }
     Ok(Box::new(InExpression::new(
-        input_ref_expr,
+        left_expr,
         data.into_iter(),
         ret_type,
     )))

--- a/src/expr/src/expr/expr_in.rs
+++ b/src/expr/src/expr/expr_in.rs
@@ -24,14 +24,14 @@ use crate::expr::{BoxedExpression, Expression};
 
 #[derive(Debug)]
 pub(crate) struct InExpression {
-    input_ref: BoxedExpression,
+    left: BoxedExpression,
     set: HashSet<Datum>,
     return_type: DataType,
 }
 
 impl InExpression {
     pub fn new(
-        input_ref: BoxedExpression,
+        left: BoxedExpression,
         data: impl Iterator<Item = Datum>,
         return_type: DataType,
     ) -> Self {
@@ -40,7 +40,7 @@ impl InExpression {
             sarg.insert(datum);
         }
         Self {
-            input_ref,
+            left,
             set: sarg,
             return_type,
         }
@@ -57,7 +57,7 @@ impl Expression for InExpression {
     }
 
     fn eval(&self, input: &DataChunk) -> risingwave_common::error::Result<ArrayRef> {
-        let input_array = self.input_ref.eval(input)?;
+        let input_array = self.left.eval(input)?;
         let visibility = input.visibility();
         let mut output_array = BoolArrayBuilder::new(input.cardinality())?;
         match visibility {

--- a/src/frontend/src/expr/mod.rs
+++ b/src/frontend/src/expr/mod.rs
@@ -189,6 +189,35 @@ impl ExprImpl {
         visitor.visit_expr(self);
         visitor.has
     }
+
+    /// Checks whether this is a constant expr that can be evaluated over a dummy chunk.
+    /// Equivalent to `!has_input_ref && !has_agg_call && !has_subquery &&
+    /// !has_correlated_input_ref` but checks them in one pass.
+    pub fn is_const(&self) -> bool {
+        struct Has {
+            has: bool,
+        }
+        impl ExprVisitor for Has {
+            fn visit_input_ref(&mut self, _: &InputRef) {
+                self.has = true;
+            }
+
+            fn visit_agg_call(&mut self, _: &AggCall) {
+                self.has = true;
+            }
+
+            fn visit_subquery(&mut self, _: &Subquery) {
+                self.has = true;
+            }
+
+            fn visit_correlated_input_ref(&mut self, _: &CorrelatedInputRef) {
+                self.has = true;
+            }
+        }
+        let mut visitor = Has { has: false };
+        visitor.visit_expr(self);
+        !visitor.has
+    }
 }
 
 impl Expr for ExprImpl {

--- a/src/frontend/test_runner/tests/testdata/expr.yaml
+++ b/src/frontend/test_runner/tests/testdata/expr.yaml
@@ -51,6 +51,42 @@
     SELECT true in (3, 1.0, 2);
   binder_error: 'Bind error: types Boolean and Int32 cannot be matched'
 - sql: |
+    /* in-list with non-const: agg */
+    create table t (v1 int);
+    SELECT 1 in (3, 0.5*2, min(v1)) from t;
+  batch_plan: |
+    BatchProject { exprs: [(In(1:Int32::Decimal, 3:Int32::Decimal, (0.5:Decimal * 2:Int32)) OR (1:Int32 = $0))] }
+      BatchSimpleAgg { aggs: [min($0)] }
+        BatchExchange { order: [], dist: Single }
+          BatchScan { table: t, columns: [v1] }
+- sql: |
+    /* in-list with non-const: scalar subquery */
+    create table t (v1 int);
+    create table b (b1 int, b2 int);
+    SELECT b2 from b where 1 in (3, 1.0, (select min(v1) from t));
+  batch_plan: |
+    BatchProject { exprs: [$0] }
+      BatchFilter { predicate: (In(1:Int32::Decimal, 3:Int32::Decimal, 1.0:Decimal) OR (1:Int32 = $1)) }
+        BatchNestedLoopJoin { type: LeftOuter, predicate: true }
+          BatchExchange { order: [], dist: Single }
+            BatchScan { table: b, columns: [b2] }
+          BatchSimpleAgg { aggs: [min($0)] }
+            BatchExchange { order: [], dist: Single }
+              BatchScan { table: t, columns: [v1] }
+- sql: |
+    /* in-list with non-const: correlated ref */
+    create table t (v1 int);
+    create table b (b1 int, b2 int);
+    SELECT b2 from b where exists (select 2 from t where v1 in (3, 1.0, b1));
+  batch_plan: |
+    BatchProject { exprs: [$1] }
+      BatchNestedLoopJoin { type: LeftSemi, predicate: (In($2::Decimal, 3:Int32::Decimal, 1.0:Decimal) OR ($3 = $0)) }
+        BatchExchange { order: [], dist: Single }
+          BatchScan { table: b, columns: [b1, b2] }
+        BatchExchange { order: [], dist: Single }
+          BatchProject { exprs: [$0, $0] }
+            BatchScan { table: t, columns: [v1] }
+- sql: |
     select +1.0, -2.0;
   batch_plan: |
     BatchProject { exprs: [1.0:Decimal, Neg(2.0:Decimal)] }


### PR DESCRIPTION
## What's changed and what's your intention?

The backend impl used to restrict the left side to be `InputRef` and right side to be `[Literal]`.
It can actually be extended naturally without any change:
* left: `InputRef` -> any expr
* right: `Literal` -> any const expr that evaluates without `InputRef` into input data chunk

On the frontend, we split the list in const ones and non-const ones, and rewrite the non-const ones as or-equal.

Limitations:
* A long list of `or-equal` is not performant. But most use cases should be constants.
* Constant folding is done at backend expr building time, and frontend only checks it is foldable.

## Checklist

- [x] I have written necessary docs and comments
- [x] I have added necessary unit tests and integration tests

## Refer to a related PR or issue link (optional)

Fixes #2456