### PR TITLE
feat(frontend): Bind concat_ws expression

### DIFF
--- a/e2e_test/v2/batch/func.slt
+++ b/e2e_test/v2/batch/func.slt
@@ -96,15 +96,15 @@ select concat_ws(true, 1, 1.01, 'A', NULL);
 1true1.01trueA
 
 statement ok
-create table t (v1 bool, v2 smallint, v3 int, v4 decimal, v5 real, v6 double, v7 varchar, v8 varchar);
+create table t (v1 varchar, v2 smallint, v3 int, v4 decimal, v5 real, v6 double, v7 bool, v8 varchar);
 
 statement ok
-insert into t values (true, 1, 2, 3.01, 4, 5.01, 'abc', NULL);
+insert into t values (',', 1, 2, 3.01, 4, 5.01, true, NULL);
 
 query T
 select concat_ws(v1, v2, v3, v4, v5, v6, v7, v8) from t;
 ----
-1true2true3.01true4true5.01trueabc
+1,2,3.01,4,5.01,true
 
 statement ok
 drop table t;

--- a/e2e_test/v2/batch/func.slt
+++ b/e2e_test/v2/batch/func.slt
@@ -91,9 +91,9 @@ select concat_ws(NULL, NULL, 'b');
 NULL
 
 query T
-select concat_ws(true, 1, 1.01, 'A', NULL);
+select concat_ws(',', 1, 1.01, 'A', true, NULL);
 ----
-1true1.01trueA
+1,1.01,A,true
 
 statement ok
 create table t (v1 varchar, v2 smallint, v3 int, v4 decimal, v5 real, v6 double, v7 bool, v8 varchar);

--- a/e2e_test/v2/batch/func.slt
+++ b/e2e_test/v2/batch/func.slt
@@ -69,3 +69,42 @@ drop table t;
 
 statement ok
 drop table b;
+
+query T
+select concat_ws(',', 'a', 'b');
+----
+a,b
+
+query T
+select concat_ws(NULL, 'a', 'b');
+----
+NULL
+
+query T
+select concat_ws(',', NULL, 'b');
+----
+b
+
+query T
+select concat_ws(NULL, NULL, 'b');
+----
+NULL
+
+query T
+select concat_ws(true, 1, 1.01, 'A', NULL);
+----
+1true1.01trueA
+
+statement ok
+create table t (v1 bool, v2 smallint, v3 int, v4 decimal, v5 real, v6 double, v7 varchar, v8 varchar);
+
+statement ok
+insert into t values (true, 1, 2, 3.01, 4, 5.01, 'abc', NULL);
+
+query T
+select concat_ws(v1, v2, v3, v4, v5, v6, v7, v8) from t;
+----
+1true2true3.01true4true5.01trueabc
+
+statement ok
+drop table t;

--- a/e2e_test/v2/batch/func.slt
+++ b/e2e_test/v2/batch/func.slt
@@ -76,19 +76,9 @@ select concat_ws(',', 'a', 'b');
 a,b
 
 query T
-select concat_ws(NULL, 'a', 'b');
-----
-NULL
-
-query T
 select concat_ws(',', NULL, 'b');
 ----
 b
-
-query T
-select concat_ws(NULL, NULL, 'b');
-----
-NULL
 
 query T
 select concat_ws(',', 1, 1.01, 'A', true, NULL);
@@ -105,6 +95,7 @@ query T
 select concat_ws(v1, v2, v3, v4, v5, v6, v7, v8) from t;
 ----
 1,2,3.01,4,5.01,true
+
 
 statement ok
 drop table t;

--- a/e2e_test/v2/batch/func.slt
+++ b/e2e_test/v2/batch/func.slt
@@ -76,9 +76,19 @@ select concat_ws(',', 'a', 'b');
 a,b
 
 query T
+select concat_ws(NULL, 'a', 'b');
+----
+NULL
+
+query T
 select concat_ws(',', NULL, 'b');
 ----
 b
+
+query T
+select concat_ws(NULL, NULL, 'b');
+----
+NULL
 
 query T
 select concat_ws(',', 1, 1.01, 'A', true, NULL);

--- a/src/frontend/src/binder/expr/function.rs
+++ b/src/frontend/src/binder/expr/function.rs
@@ -110,6 +110,9 @@ impl Binder {
         if inputs.len() < 2 {
             Err(ErrorCode::BindError("ConcatWs function must contain at least 2 arguments".to_string()).into())
         } else {
+            // concat_ws is a special case which casts arguments from
+            // any type (int, timestamps, etc...) to varchar.
+            // cast_explicit is used because it permits all of these casts, cast_implicit does not.
             let inputs = inputs
                 .into_iter()
                 .map(|input| input.cast_explicit(DataType::Varchar))

--- a/src/frontend/src/binder/expr/function.rs
+++ b/src/frontend/src/binder/expr/function.rs
@@ -108,7 +108,10 @@ impl Binder {
     /// ConcatWs(expr1,expr2) -> ConcatWs(expr1 AS varchar, expr2 as varchar)
     fn rewrite_concat_ws_args_when(inputs: Vec<ExprImpl>) -> Result<Vec<ExprImpl>> {
         if inputs.len() < 2 {
-            Err(ErrorCode::BindError("ConcatWs function must contain at least 2 arguments".to_string()).into())
+            Err(ErrorCode::BindError(
+                "ConcatWs function must contain at least 2 arguments".to_string(),
+            )
+            .into())
         } else {
             // concat_ws is a special case which casts arguments from
             // any type (int, timestamps, etc...) to varchar.

--- a/src/frontend/src/binder/expr/function.rs
+++ b/src/frontend/src/binder/expr/function.rs
@@ -62,10 +62,7 @@ impl Binder {
                     inputs = Self::rewrite_nullif_to_case_when(inputs)?;
                     ExprType::Case
                 }
-                "concat_ws" => {
-                    inputs = Self::rewrite_concat_ws_args_when(inputs)?;
-                    ExprType::ConcatWs
-                }
+                "concat_ws" => ExprType::ConcatWs,
                 "coalesce" => ExprType::Coalesce,
                 "round" => {
                     inputs = Self::rewrite_round_args(inputs);
@@ -100,26 +97,6 @@ impl Binder {
                 Literal::new(None, inputs[0].return_type()).into(),
                 inputs[0].clone(),
             ];
-            Ok(inputs)
-        }
-    }
-
-    /// Make sure inputs have at least 2 values and add explicit casts to Varchar
-    /// ConcatWs(expr1,expr2) -> ConcatWs(expr1 AS varchar, expr2 as varchar)
-    fn rewrite_concat_ws_args_when(inputs: Vec<ExprImpl>) -> Result<Vec<ExprImpl>> {
-        if inputs.len() < 2 {
-            Err(ErrorCode::BindError(
-                "ConcatWs function must contain at least 2 arguments".to_string(),
-            )
-            .into())
-        } else {
-            // concat_ws is a special case which casts arguments from
-            // any type (int, timestamps, etc...) to varchar.
-            // cast_explicit is used because it permits all of these casts, cast_implicit does not.
-            let inputs = inputs
-                .into_iter()
-                .map(|input| input.cast_explicit(DataType::Varchar))
-                .collect::<Result<Vec<_>>>()?;
             Ok(inputs)
         }
     }

--- a/src/frontend/src/expr/function_call.rs
+++ b/src/frontend/src/expr/function_call.rs
@@ -118,12 +118,25 @@ impl FunctionCall {
             ExprType::ConcatWs => {
                 if inputs.len() < 2 {
                     return Err(ErrorCode::BindError(
-                        "ConcatWs function must contain more than 2 arguments".into(),
+                        "ConcatWs function must contain at least 2 arguments".into(),
                     )
                     .into());
                 }
-                // NOTE: inputs can be any type, they will be casted into varchars with
+
+                if inputs[0].return_type() != DataType::Varchar {
+                     return Err(ErrorCode::BindError(
+                        "ConcatWs function must have text as first argument".into(),
+                    )
+                    .into());
+                }
+
+                // subsequent inputs can be any type, they are cast into varchars with
                 // explicit_cast.
+                inputs = inputs
+                    .into_iter()
+                    .map(|input| input.cast_explicit(DataType::Varchar))
+                    .collect::<Result<Vec<_>>>()?;
+
                 Ok(DataType::Varchar)
             }
             _ => infer_type(

--- a/src/frontend/src/expr/function_call.rs
+++ b/src/frontend/src/expr/function_call.rs
@@ -118,11 +118,12 @@ impl FunctionCall {
             ExprType::ConcatWs => {
                  if inputs.len() < 2 {
                     return Err(ErrorCode::BindError(
-                        "Coalesce function must contain more than 2 arguments".into(),
+                        "ConcatWs function must contain more than 2 arguments".into(),
                     )
                     .into());
                 }
-                align_types(inputs.iter_mut())
+                // NOTE: inputs can be any type, they will be casted into varchars with explicit_cast.
+                Ok(DataType::Varchar)
             }
             _ => infer_type(
                 func_type,

--- a/src/frontend/src/expr/function_call.rs
+++ b/src/frontend/src/expr/function_call.rs
@@ -115,6 +115,15 @@ impl FunctionCall {
                 }
                 align_types(inputs.iter_mut())
             }
+            ExprType::ConcatWs => {
+                 if inputs.len() < 2 {
+                    return Err(ErrorCode::BindError(
+                        "Coalesce function must contain more than 2 arguments".into(),
+                    )
+                    .into());
+                }
+                align_types(inputs.iter_mut())
+            }
             _ => infer_type(
                 func_type,
                 inputs.iter().map(|expr| expr.return_type()).collect(),

--- a/src/frontend/src/expr/function_call.rs
+++ b/src/frontend/src/expr/function_call.rs
@@ -116,13 +116,14 @@ impl FunctionCall {
                 align_types(inputs.iter_mut())
             }
             ExprType::ConcatWs => {
-                 if inputs.len() < 2 {
+                if inputs.len() < 2 {
                     return Err(ErrorCode::BindError(
                         "ConcatWs function must contain more than 2 arguments".into(),
                     )
                     .into());
                 }
-                // NOTE: inputs can be any type, they will be casted into varchars with explicit_cast.
+                // NOTE: inputs can be any type, they will be casted into varchars with
+                // explicit_cast.
                 Ok(DataType::Varchar)
             }
             _ => infer_type(

--- a/src/frontend/src/expr/function_call.rs
+++ b/src/frontend/src/expr/function_call.rs
@@ -123,15 +123,6 @@ impl FunctionCall {
                     .into());
                 }
 
-                if inputs[0].return_type() != DataType::Varchar {
-                    return Err(ErrorCode::BindError(
-                        "ConcatWs function must have text as first argument".into(),
-                    )
-                    .into());
-                }
-
-                // subsequent inputs can be any type, they are cast into varchars with
-                // explicit_cast.
                 inputs = inputs
                     .into_iter()
                     .enumerate()

--- a/src/frontend/src/expr/function_call.rs
+++ b/src/frontend/src/expr/function_call.rs
@@ -134,9 +134,14 @@ impl FunctionCall {
                 // explicit_cast.
                 inputs = inputs
                     .into_iter()
-                    .map(|input| input.cast_explicit(DataType::Varchar))
+                    .enumerate()
+                    .map(|(i, input)| match i {
+                        // 0-th arg must be string
+                        0 => input.cast_implicit(DataType::Varchar),
+                        // subsequent can be any type
+                        _ => input.cast_explicit(DataType::Varchar),
+                    })
                     .collect::<Result<Vec<_>>>()?;
-
                 Ok(DataType::Varchar)
             }
             _ => infer_type(

--- a/src/frontend/src/expr/function_call.rs
+++ b/src/frontend/src/expr/function_call.rs
@@ -124,7 +124,7 @@ impl FunctionCall {
                 }
 
                 if inputs[0].return_type() != DataType::Varchar {
-                     return Err(ErrorCode::BindError(
+                    return Err(ErrorCode::BindError(
                         "ConcatWs function must have text as first argument".into(),
                     )
                     .into());

--- a/src/frontend/test_runner/tests/testdata/expr.yaml
+++ b/src/frontend/test_runner/tests/testdata/expr.yaml
@@ -215,3 +215,29 @@
     create table t (v1 int);
     select coalesce(1,'a') from t;
   binder_error: 'Bind error: types Int32 and Varchar cannot be matched'
+- sql: |
+    create table t (v1 varchar);
+    select concat_ws(v1, 1) as expr from t;
+  batch_plan: |
+    BatchExchange { order: [], dist: Single }
+      BatchProject { exprs: [ConcatWs($0, 1:Int32::Varchar)] }
+        BatchScan { table: t, columns: [v1] }
+  stream_plan: |
+    StreamMaterialize { columns: [expr, _row_id#0(hidden)], pk_columns: [_row_id#0] }
+      StreamProject { exprs: [ConcatWs($0, 1:Int32::Varchar), $1] }
+        StreamTableScan { table: t, columns: [v1, _row_id#0], pk_indices: [1] }
+- sql: |
+    create table t (v1 varchar);
+    select concat_ws(v1, 1.2) from t;
+  batch_plan: |
+    BatchExchange { order: [], dist: Single }
+      BatchProject { exprs: [ConcatWs($0, 1.2:Decimal::Varchar)] }
+        BatchScan { table: t, columns: [v1] }
+- sql: |
+    create table t (v1 int);
+    select concat_ws(v1, 1.2) from t;
+  binder_error: 'Bind error: ConcatWs function must have text as first argument'
+- sql: |
+    create table t (v1 int);
+    select concat_ws() from t;
+  binder_error: 'Bind error: ConcatWs function must contain at least 2 arguments'

--- a/src/frontend/test_runner/tests/testdata/expr.yaml
+++ b/src/frontend/test_runner/tests/testdata/expr.yaml
@@ -236,7 +236,7 @@
 - sql: |
     create table t (v1 int);
     select concat_ws(v1, 1.2) from t;
-  binder_error: 'Bind error: ConcatWs function must have text as first argument'
+  binder_error: 'Bind error: cannot cast type Int32 to Varchar in Implicit context'
 - sql: |
     create table t (v1 int);
     select concat_ws() from t;


### PR DESCRIPTION
## What's changed and what's your intention?

Implement support for `concat_ws` on frontend.

- Summarize your change (**mandatory**)

  Bind `concat_ws` on frontend. Call cast over function arguments to ensure they are `varchar`.

- How does this PR work? Need a brief introduction for the changed logic (optional)
- Describe clearly one logical change and avoid lazy messages (optional)
- Describe any limitations of the current code (optional)

## Checklist

- [x] I have written necessary docs and comments
- [x] I have added necessary unit tests and integration tests

## Refer to a related PR or issue link (optional)

Part of #2405 