### PR TITLE
fix(binder): handle ambiguous names in order by

### DIFF
--- a/src/frontend/src/binder/query.rs
+++ b/src/frontend/src/binder/query.rs
@@ -70,14 +70,19 @@ impl Binder {
         let offset = query.get_offset_value();
         let body = self.bind_set_expr(query.body)?;
         let mut name_to_index = HashMap::new();
-        match &body {
-            BoundSetExpr::Select(s) => s.aliases.iter().enumerate().for_each(|(index, alias)| {
-                if let Some(name) = alias {
-                    name_to_index.insert(name.clone(), index);
-                }
-            }),
-            BoundSetExpr::Values(_) => {}
-        };
+        body.schema()
+            .fields()
+            .iter()
+            .enumerate()
+            .for_each(|(index, field)| {
+                name_to_index
+                    .entry(field.name.clone())
+                    // Ambiguous (duplicate) output names are marked with usize::MAX.
+                    // This is not necessarily an error as long as not actually referenced by order
+                    // by.
+                    .and_modify(|v| *v = usize::MAX)
+                    .or_insert(index);
+            });
         let mut extra_order_exprs = vec![];
         let visible_output_num = body.schema().len();
         let order = query
@@ -113,7 +118,10 @@ impl Binder {
             Some(false) => Direction::Desc,
         };
         let index = match order_by_expr.expr {
-            Expr::Identifier(name) if let Some(index) = name_to_index.get(&name.value) => *index,
+            Expr::Identifier(name) if let Some(index) = name_to_index.get(&name.value) => match *index != usize::MAX {
+                true => *index,
+                false => return Err(ErrorCode::BindError(format!("ORDER BY \"{}\" is ambiguous", name.value)).into()),
+            }
             Expr::Value(Value::Number(number, _)) => match number.parse::<usize>() {
                 Ok(index) if 1 <= index && index <= visible_output_num => index - 1,
                 _ => {

--- a/src/frontend/test_runner/tests/testdata/order_by.yaml
+++ b/src/frontend/test_runner/tests/testdata/order_by.yaml
@@ -1,4 +1,5 @@
 - sql: |
+    /* desc */
     create table t (v1 bigint, v2 double precision);
     select * from t order by v1 desc;
   batch_plan: |
@@ -9,6 +10,7 @@
     StreamMaterialize { columns: [v1, v2, _row_id#0(hidden)], pk_columns: [_row_id#0], order_descs: [v1, _row_id#0] }
       StreamTableScan { table: t, columns: [v1, v2, _row_id#0], pk_indices: [2] }
 - sql: |
+    /* output names are not quailified after table names */
     create table t (v1 bigint, v2 double precision);
     select t.* from t order by v1;
   batch_plan: |
@@ -31,12 +33,21 @@
       BatchSort { order: [$0 ASC] }
         BatchScan { table: t, columns: [v1] }
 - sql: |
+    /* order by output alias */
     create table t (v1 bigint, v2 double precision);
     select v1 as a1 from t order by a1;
   batch_plan: |
     BatchExchange { order: [$0 ASC], dist: Single }
       BatchSort { order: [$0 ASC] }
         BatchScan { table: t, columns: [v1] }
+- sql: |
+    /* order by ambiguous */
+    create table t (v1 bigint, v2 double precision);
+    select v1 as a, v2 as a from t order by a;
+  batch_plan: |
+    BatchExchange { order: [$1 ASC], dist: Single }
+      BatchSort { order: [$1 ASC] }
+        BatchScan { table: t, columns: [v1, v2] }
 - sql: |
     create table t (v1 bigint, v2 double precision);
     select * from t order by 1+1;

--- a/src/frontend/test_runner/tests/testdata/order_by.yaml
+++ b/src/frontend/test_runner/tests/testdata/order_by.yaml
@@ -44,6 +44,11 @@
     /* order by ambiguous */
     create table t (v1 bigint, v2 double precision);
     select v1 as a, v2 as a from t order by a;
+  binder_error: 'Bind error: ORDER BY "a" is ambiguous'
+- sql: |
+    /* ambiguous output name is okay as long as not used in order by */
+    create table t (v1 bigint, v2 double precision);
+    select v1 as a, v2 as a from t order by 2;
   batch_plan: |
     BatchExchange { order: [$1 ASC], dist: Single }
       BatchSort { order: [$1 ASC] }


### PR DESCRIPTION
## What's changed and what's your intention?

```
select v1 as a, v2 as a from t order by a;  -- error
select v1 as a, v2 as a from t;  -- okay
select v1 as a, v2 as a from t order by 2;  -- okay
create materialized view mv1 as select v1 as a, v2 as a from t;  -- error
```

## Checklist

- [x] I have written necessary docs and comments
- [x] I have added necessary unit tests and integration tests

## Refer to a related PR or issue link (optional)
