### PR TITLE
fix(connector): make too big struct a Box

### DIFF
--- a/src/connector/src/base.rs
+++ b/src/connector/src/base.rs
@@ -156,10 +156,10 @@ pub trait SplitReader {
 }
 
 pub enum SplitReaderImpl {
-    Kafka(KafkaSplitReader),
+    Kafka(Box<KafkaSplitReader>),
     Kinesis(KinesisSplitReader),
     Dummy(DummySplitReader),
-    Nexmark(NexmarkSplitReader),
+    Nexmark(Box<NexmarkSplitReader>),
     Pulsar(PulsarSplitReader),
 }
 
@@ -187,13 +187,13 @@ impl SplitReaderImpl {
 
         let connector = match config {
             ConnectorProperties::Kafka(props) => {
-                Self::Kafka(KafkaSplitReader::new(props, state).await?)
+                Self::Kafka(Box::new(KafkaSplitReader::new(props, state).await?))
             }
             ConnectorProperties::Kinesis(props) => {
                 Self::Kinesis(KinesisSplitReader::new(props, state).await?)
             }
             ConnectorProperties::Nexmark(props) => {
-                Self::Nexmark(NexmarkSplitReader::new(*props, state).await?)
+                Self::Nexmark(Box::new(NexmarkSplitReader::new(*props, state).await?))
             }
             ConnectorProperties::Pulsar(props) => {
                 Self::Pulsar(PulsarSplitReader::new(props, state).await?)


### PR DESCRIPTION
Signed-off-by: tabVersion <tabvision@bupt.icu>

## What's changed and what's your intention?

***PLEASE DO NOT LEAVE THIS EMPTY !!!***

clippy warns `large size difference between variants`

more details [here](https://rust-lang.github.io/rust-clippy/master/index.html#large_enum_variant)

Please explain **IN DETAIL** what the changes are in this PR and why they are needed:

- Summarize your change (**mandatory**)
- How does this PR work? Need a brief introduction for the changed logic (optional)
- Describe clearly one logical change and avoid lazy messages (optional)
- Describe any limitations of the current code (optional)

## Checklist

- [x] I have written necessary docs and comments
- [x] I have added necessary unit tests and integration tests

## Refer to a related PR or issue link (optional)

merge this before #2432 