### PR TITLE
chore: switch avro to fork

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -64,7 +64,7 @@ dependencies = [
 [[package]]
 name = "apache-avro"
 version = "0.14.0"
-source = "git+https://github.com/apache/avro.git?branch=branch-1.11#36126feb661484f4c33e2091b9145b236a77e572"
+source = "git+https://github.com/singularity-data/avro?branch=master#024f422ebda0d33b153e2ceecd2c3d538f90af21"
 dependencies = [
  "byteorder 1.4.3",
  "bzip2",

--- a/src/source/Cargo.toml
+++ b/src/source/Cargo.toml
@@ -5,7 +5,7 @@ version = "0.1.7"
 
 [dependencies]
 anyhow = "1"
-apache-avro = { git = "https://github.com/apache/avro.git", branch = "branch-1.11", features = ["snappy", "zstandard", "bzip", "xz"] }
+apache-avro = { git = "https://github.com/singularity-data/avro", branch = "master", features = ["snappy", "zstandard", "bzip", "xz"] }
 async-stream = "0.3"
 async-trait = "0.1"
 aws-config = { version = "0.11.0", default-features = false, features = ["rt-tokio", "native-tls"] }


### PR DESCRIPTION
Signed-off-by: Alex Chi <iskyzh@gmail.com>

## What's changed and what's your intention?

Apache avro have docsy, bootstrap, etc. as submodule, which will make `cargo build` extremely slow. We switched to our own fork and remove the submodules.

## Checklist

- [x] I have written necessary docs and comments
- [x] I have added necessary unit tests and integration tests

## Refer to a related PR or issue link (optional)
