### PR TITLE
refactor(batch): Refactor batch task context for execution.

### DIFF
--- a/src/batch/src/execution/local_exchange.rs
+++ b/src/batch/src/execution/local_exchange.rs
@@ -18,19 +18,19 @@ use risingwave_common::array::DataChunk;
 use risingwave_common::error::Result;
 use risingwave_rpc_client::ExchangeSource;
 
-use crate::task::{BatchEnvironment, TaskId, TaskOutput, TaskOutputId};
+use crate::task::{BatchTaskContext, TaskId, TaskOutput, TaskOutputId};
 
 /// Exchange data from a local task execution.
-pub struct LocalExchangeSource {
-    task_output: TaskOutput,
+pub struct LocalExchangeSource<C> {
+    task_output: TaskOutput<C>,
 
     /// Id of task which contains the `ExchangeExecutor` of this source.
     task_id: TaskId,
 }
 
-impl LocalExchangeSource {
-    pub fn create(output_id: TaskOutputId, env: BatchEnvironment, task_id: TaskId) -> Result<Self> {
-        let task_output = env.task_manager().take_output(&output_id.to_prost())?;
+impl<C: BatchTaskContext> LocalExchangeSource<C> {
+    pub fn create(output_id: TaskOutputId, context: C, task_id: TaskId) -> Result<Self> {
+        let task_output = context.get_task_output(output_id)?;
         Ok(Self {
             task_output,
             task_id,
@@ -38,7 +38,7 @@ impl LocalExchangeSource {
     }
 }
 
-impl Debug for LocalExchangeSource {
+impl<C> Debug for LocalExchangeSource<C> {
     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
         f.debug_struct("LocalExchangeSource")
             .field("task_output_id", self.task_output.id())
@@ -47,7 +47,7 @@ impl Debug for LocalExchangeSource {
 }
 
 #[async_trait::async_trait]
-impl ExchangeSource for LocalExchangeSource {
+impl<C: BatchTaskContext> ExchangeSource for LocalExchangeSource<C> {
     async fn take_data(&mut self) -> Result<Option<DataChunk>> {
         let ret = self.task_output.direct_take_data().await?;
         if let Some(data) = ret {

--- a/src/batch/src/executor/mod.rs
+++ b/src/batch/src/executor/mod.rs
@@ -18,14 +18,14 @@ use risingwave_pb::batch_plan::plan_node::NodeBody;
 use risingwave_pb::batch_plan::PlanNode;
 
 use crate::executor2::{
-    BoxedExecutor2, BoxedExecutor2Builder, DeleteExecutor2, ExchangeExecutor2, FilterExecutor2,
-    GenerateSeriesExecutor2Builder, HashAggExecutor2Builder, HashJoinExecutor2Builder,
-    HopWindowExecutor2, InsertExecutor2, LimitExecutor2, MergeSortExchangeExecutor2,
-    NestedLoopJoinExecutor2, OrderByExecutor2, ProjectExecutor2, RowSeqScanExecutor2Builder,
-    SortAggExecutor2, SortMergeJoinExecutor2, TopNExecutor2, TraceExecutor2, UpdateExecutor,
-    ValuesExecutor2,
+    BoxedExecutor2, BoxedExecutor2Builder, DeleteExecutor2, FilterExecutor2,
+    GenerateSeriesExecutor2Builder, GenericExchangeExecutor2Builder, HashAggExecutor2Builder,
+    HashJoinExecutor2Builder, HopWindowExecutor2, InsertExecutor2, LimitExecutor2,
+    MergeSortExchangeExecutor2Builder, NestedLoopJoinExecutor2, OrderByExecutor2, ProjectExecutor2,
+    RowSeqScanExecutor2Builder, SortAggExecutor2, SortMergeJoinExecutor2, TopNExecutor2,
+    TraceExecutor2, ValuesExecutor2,
 };
-use crate::task::{BatchEnvironment, TaskId};
+use crate::task::{BatchTaskContext, TaskId};
 
 #[cfg(test)]
 pub mod test_utils;
@@ -33,22 +33,26 @@ pub mod test_utils;
 /// Every Executor should impl this trait to provide a static method to build a `BoxedExecutor` from
 /// proto and global environment
 pub trait BoxedExecutorBuilder {
-    fn new_boxed_executor2(source: &ExecutorBuilder) -> Result<BoxedExecutor2>;
+    fn new_boxed_executor2<C: BatchTaskContext>(
+        source: &ExecutorBuilder<C>,
+    ) -> Result<BoxedExecutor2>;
 }
 
 #[allow(dead_code)]
 struct NotImplementedBuilder;
 
 impl BoxedExecutorBuilder for NotImplementedBuilder {
-    fn new_boxed_executor2(_source: &ExecutorBuilder) -> Result<BoxedExecutor2> {
+    fn new_boxed_executor2<C: BatchTaskContext>(
+        _source: &ExecutorBuilder<C>,
+    ) -> Result<BoxedExecutor2> {
         Err(ErrorCode::NotImplemented("Executor not implemented".to_string(), None.into()).into())
     }
 }
 
-pub struct ExecutorBuilder<'a> {
+pub struct ExecutorBuilder<'a, C> {
     pub plan_node: &'a PlanNode,
     pub task_id: &'a TaskId,
-    env: BatchEnvironment,
+    context: C,
     epoch: u64,
 }
 
@@ -64,17 +68,12 @@ macro_rules! build_executor2 {
     }
 }
 
-impl<'a> ExecutorBuilder<'a> {
-    pub fn new(
-        plan_node: &'a PlanNode,
-        task_id: &'a TaskId,
-        env: BatchEnvironment,
-        epoch: u64,
-    ) -> Self {
+impl<'a, C: BatchTaskContext> ExecutorBuilder<'a, C> {
+    pub fn new(plan_node: &'a PlanNode, task_id: &'a TaskId, context: C, epoch: u64) -> Self {
         Self {
             plan_node,
             task_id,
-            env,
+            context,
             epoch,
         }
     }
@@ -92,7 +91,7 @@ impl<'a> ExecutorBuilder<'a> {
 
     #[must_use]
     pub fn clone_for_plan(&self, plan_node: &'a PlanNode) -> Self {
-        ExecutorBuilder::new(plan_node, self.task_id, self.env.clone(), self.epoch)
+        ExecutorBuilder::new(plan_node, self.task_id, self.context.clone(), self.epoch)
     }
 
     fn try_build2(&self) -> Result<BoxedExecutor2> {
@@ -100,6 +99,7 @@ impl<'a> ExecutorBuilder<'a> {
             NodeBody::RowSeqScan => RowSeqScanExecutor2Builder,
             NodeBody::Insert => InsertExecutor2,
             NodeBody::Delete => DeleteExecutor2,
+            NodeBody::Exchange => GenericExchangeExecutor2Builder,
             NodeBody::Update => UpdateExecutor,
             NodeBody::Exchange => ExchangeExecutor2,
             NodeBody::Filter => FilterExecutor2,
@@ -113,7 +113,7 @@ impl<'a> ExecutorBuilder<'a> {
             NodeBody::HashJoin => HashJoinExecutor2Builder,
             NodeBody::SortMergeJoin => SortMergeJoinExecutor2,
             NodeBody::HashAgg => HashAggExecutor2Builder,
-            NodeBody::MergeSortExchange => MergeSortExchangeExecutor2,
+            NodeBody::MergeSortExchange => MergeSortExchangeExecutor2Builder,
             NodeBody::GenerateSeries => GenerateSeriesExecutor2Builder,
             NodeBody::HopWindow => HopWindowExecutor2,
         }?;
@@ -125,8 +125,8 @@ impl<'a> ExecutorBuilder<'a> {
         self.plan_node
     }
 
-    pub fn global_batch_env(&self) -> &BatchEnvironment {
-        &self.env
+    pub fn batch_task_context(&self) -> &C {
+        &self.context
     }
 
     pub fn epoch(&self) -> u64 {
@@ -139,7 +139,7 @@ mod tests {
     use risingwave_pb::batch_plan::PlanNode;
 
     use crate::executor::ExecutorBuilder;
-    use crate::task::{BatchEnvironment, TaskId};
+    use crate::task::{ComputeNodeContext, TaskId};
 
     #[test]
     fn test_clone_for_plan() {
@@ -151,8 +151,12 @@ mod tests {
             stage_id: 1,
             query_id: "test_query_id".to_string(),
         };
-        let builder =
-            ExecutorBuilder::new(&plan_node, task_id, BatchEnvironment::for_test(), u64::MAX);
+        let builder = ExecutorBuilder::new(
+            &plan_node,
+            task_id,
+            ComputeNodeContext::new_for_test(),
+            u64::MAX,
+        );
         let child_plan = &PlanNode {
             ..Default::default()
         };

--- a/src/batch/src/executor/mod.rs
+++ b/src/batch/src/executor/mod.rs
@@ -23,7 +23,7 @@ use crate::executor2::{
     HashJoinExecutor2Builder, HopWindowExecutor2, InsertExecutor2, LimitExecutor2,
     MergeSortExchangeExecutor2Builder, NestedLoopJoinExecutor2, OrderByExecutor2, ProjectExecutor2,
     RowSeqScanExecutor2Builder, SortAggExecutor2, SortMergeJoinExecutor2, TopNExecutor2,
-    TraceExecutor2, ValuesExecutor2,
+    TraceExecutor2, UpdateExecutor, ValuesExecutor2,
 };
 use crate::task::{BatchTaskContext, TaskId};
 
@@ -101,7 +101,6 @@ impl<'a, C: BatchTaskContext> ExecutorBuilder<'a, C> {
             NodeBody::Delete => DeleteExecutor2,
             NodeBody::Exchange => GenericExchangeExecutor2Builder,
             NodeBody::Update => UpdateExecutor,
-            NodeBody::Exchange => ExchangeExecutor2,
             NodeBody::Filter => FilterExecutor2,
             NodeBody::Project => ProjectExecutor2,
             NodeBody::SortAgg => SortAggExecutor2,

--- a/src/batch/src/executor2/filter.rs
+++ b/src/batch/src/executor2/filter.rs
@@ -24,6 +24,7 @@ use risingwave_pb::batch_plan::plan_node::NodeBody;
 
 use crate::executor::ExecutorBuilder;
 use crate::executor2::{BoxedDataChunkStream, BoxedExecutor2, BoxedExecutor2Builder, Executor2};
+use crate::task::BatchTaskContext;
 
 pub struct FilterExecutor2 {
     expr: BoxedExpression,
@@ -93,7 +94,9 @@ impl FilterExecutor2 {
 }
 
 impl BoxedExecutor2Builder for FilterExecutor2 {
-    fn new_boxed_executor2(source: &ExecutorBuilder) -> Result<BoxedExecutor2> {
+    fn new_boxed_executor2<C: BatchTaskContext>(
+        source: &ExecutorBuilder<C>,
+    ) -> Result<BoxedExecutor2> {
         ensure!(source.plan_node().get_children().len() == 1);
 
         let filter_node = try_match_expand!(

--- a/src/batch/src/executor2/generate_series.rs
+++ b/src/batch/src/executor2/generate_series.rs
@@ -29,6 +29,7 @@ use risingwave_pb::batch_plan::plan_node::NodeBody;
 use super::{BoxedExecutor2, BoxedExecutor2Builder};
 use crate::executor::ExecutorBuilder;
 use crate::executor2::{BoxedDataChunkStream, Executor2};
+use crate::task::BatchTaskContext;
 
 pub struct GenerateSeriesExecutor2<T: Array, S: Array> {
     start: T::OwnedItem,
@@ -116,7 +117,9 @@ where
 pub struct GenerateSeriesExecutor2Builder {}
 
 impl BoxedExecutor2Builder for GenerateSeriesExecutor2Builder {
-    fn new_boxed_executor2(source: &ExecutorBuilder) -> Result<BoxedExecutor2> {
+    fn new_boxed_executor2<C: BatchTaskContext>(
+        source: &ExecutorBuilder<C>,
+    ) -> Result<BoxedExecutor2> {
         let node = try_match_expand!(
             source.plan_node().get_node_body().unwrap(),
             NodeBody::GenerateSeries

--- a/src/batch/src/executor2/hash_agg.rs
+++ b/src/batch/src/executor2/hash_agg.rs
@@ -34,7 +34,7 @@ use risingwave_pb::batch_plan::HashAggNode;
 
 use crate::executor::ExecutorBuilder;
 use crate::executor2::{BoxedDataChunkStream, BoxedExecutor2, BoxedExecutor2Builder, Executor2};
-use crate::task::TaskId;
+use crate::task::{BatchTaskContext, TaskId};
 
 type AggHashMap<K> = HashMap<K, Vec<BoxedAggState>, PrecomputedBuildHasher>;
 
@@ -113,7 +113,9 @@ impl HashAggExecutor2Builder {
 }
 
 impl BoxedExecutor2Builder for HashAggExecutor2Builder {
-    fn new_boxed_executor2(source: &ExecutorBuilder) -> Result<BoxedExecutor2> {
+    fn new_boxed_executor2<C: BatchTaskContext>(
+        source: &ExecutorBuilder<C>,
+    ) -> Result<BoxedExecutor2> {
         ensure!(source.plan_node().get_children().len() == 1);
 
         let proto_child = &source.plan_node().get_children()[0];

--- a/src/batch/src/executor2/hop_window.rs
+++ b/src/batch/src/executor2/hop_window.rs
@@ -28,6 +28,7 @@ use risingwave_pb::expr::expr_node;
 
 use crate::executor::ExecutorBuilder;
 use crate::executor2::{BoxedDataChunkStream, BoxedExecutor2, BoxedExecutor2Builder, Executor2};
+use crate::task::BatchTaskContext;
 
 pub struct HopWindowExecutor2 {
     child: BoxedExecutor2,
@@ -39,7 +40,9 @@ pub struct HopWindowExecutor2 {
 }
 
 impl BoxedExecutor2Builder for HopWindowExecutor2 {
-    fn new_boxed_executor2(source: &ExecutorBuilder) -> Result<BoxedExecutor2> {
+    fn new_boxed_executor2<C: BatchTaskContext>(
+        source: &ExecutorBuilder<C>,
+    ) -> Result<BoxedExecutor2> {
         ensure!(source.plan_node().get_children().len() == 1);
         let hop_window_node = try_match_expand!(
             source.plan_node().get_node_body().unwrap(),

--- a/src/batch/src/executor2/join/hash_join.rs
+++ b/src/batch/src/executor2/join/hash_join.rs
@@ -30,7 +30,7 @@ use crate::executor::ExecutorBuilder;
 use crate::executor2::join::hash_join_state::{BuildTable, ProbeTable};
 use crate::executor2::join::JoinType;
 use crate::executor2::{BoxedDataChunkStream, BoxedExecutor2, BoxedExecutor2Builder, Executor2};
-use crate::task::TaskId;
+use crate::task::{BatchTaskContext, TaskId};
 
 /// Parameters of equi-join.
 ///
@@ -281,7 +281,9 @@ impl HashKeyDispatcher for HashJoinExecutor2BuilderDispatcher {
 
 /// Hash join executor builder.
 impl BoxedExecutor2Builder for HashJoinExecutor2Builder {
-    fn new_boxed_executor2(context: &ExecutorBuilder) -> Result<BoxedExecutor2> {
+    fn new_boxed_executor2<C: BatchTaskContext>(
+        context: &ExecutorBuilder<C>,
+    ) -> Result<BoxedExecutor2> {
         ensure!(context.plan_node().get_children().len() == 2);
 
         let left_child = context

--- a/src/batch/src/executor2/join/nested_loop_join.rs
+++ b/src/batch/src/executor2/join/nested_loop_join.rs
@@ -34,6 +34,8 @@ use crate::executor2::join::JoinType;
 use crate::executor2::{
     BoxedDataChunkStream, BoxedExecutor2, BoxedExecutor2Builder, Executor2, ExecutorBuilder,
 };
+use crate::task::BatchTaskContext;
+
 /// Nested loop join executor.
 ///
 ///
@@ -187,7 +189,9 @@ impl NestedLoopJoinExecutor2 {
 }
 
 impl BoxedExecutor2Builder for NestedLoopJoinExecutor2 {
-    fn new_boxed_executor2(source: &ExecutorBuilder) -> Result<BoxedExecutor2> {
+    fn new_boxed_executor2<C: BatchTaskContext>(
+        source: &ExecutorBuilder<C>,
+    ) -> Result<BoxedExecutor2> {
         ensure!(source.plan_node().get_children().len() == 2);
 
         let nested_loop_join_node = try_match_expand!(

--- a/src/batch/src/executor2/join/sort_merge_join.rs
+++ b/src/batch/src/executor2/join/sort_merge_join.rs
@@ -30,6 +30,7 @@ use crate::executor2::join::JoinType;
 use crate::executor2::{
     BoxedDataChunkStream, BoxedExecutor2, BoxedExecutor2Builder, Executor2, ExecutorBuilder,
 };
+use crate::task::BatchTaskContext;
 
 /// [`SortMergeJoinExecutor2`] will not sort the data. If the join key is not sorted, optimizer
 /// should insert a sort executor above the data source.
@@ -233,8 +234,8 @@ impl SortMergeJoinExecutor2 {
 }
 
 impl BoxedExecutor2Builder for SortMergeJoinExecutor2 {
-    fn new_boxed_executor2(
-        source: &ExecutorBuilder,
+    fn new_boxed_executor2<C: BatchTaskContext>(
+        source: &ExecutorBuilder<C>,
     ) -> risingwave_common::error::Result<BoxedExecutor2> {
         ensure!(source.plan_node().get_children().len() == 2);
 

--- a/src/batch/src/executor2/limit.rs
+++ b/src/batch/src/executor2/limit.rs
@@ -24,6 +24,7 @@ use risingwave_pb::batch_plan::plan_node::NodeBody;
 
 use crate::executor::ExecutorBuilder;
 use crate::executor2::{BoxedDataChunkStream, BoxedExecutor2, BoxedExecutor2Builder, Executor2};
+use crate::task::BatchTaskContext;
 
 /// Limit executor.
 pub struct LimitExecutor2 {
@@ -37,7 +38,9 @@ pub struct LimitExecutor2 {
 }
 
 impl BoxedExecutor2Builder for LimitExecutor2 {
-    fn new_boxed_executor2(source: &ExecutorBuilder) -> Result<BoxedExecutor2> {
+    fn new_boxed_executor2<C: BatchTaskContext>(
+        source: &ExecutorBuilder<C>,
+    ) -> Result<BoxedExecutor2> {
         ensure!(source.plan_node().get_children().len() == 1);
 
         let limit_node =

--- a/src/batch/src/executor2/mod.rs
+++ b/src/batch/src/executor2/mod.rs
@@ -57,6 +57,7 @@ pub use update::*;
 pub use values::*;
 
 use crate::executor::ExecutorBuilder;
+use crate::task::BatchTaskContext;
 
 pub type BoxedExecutor2 = Box<dyn Executor2>;
 pub type BoxedDataChunkStream = BoxStream<'static, Result<DataChunk>>;
@@ -85,5 +86,7 @@ pub trait Executor2: Send + 'static {
 /// Every Executor should impl this trait to provide a static method to build a `BoxedExecutor2`
 /// from proto and global environment.
 pub trait BoxedExecutor2Builder {
-    fn new_boxed_executor2(source: &ExecutorBuilder) -> Result<BoxedExecutor2>;
+    fn new_boxed_executor2<C: BatchTaskContext>(
+        source: &ExecutorBuilder<C>,
+    ) -> Result<BoxedExecutor2>;
 }

--- a/src/batch/src/executor2/order_by.rs
+++ b/src/batch/src/executor2/order_by.rs
@@ -32,6 +32,7 @@ use risingwave_pb::batch_plan::plan_node::NodeBody;
 
 use crate::executor::ExecutorBuilder;
 use crate::executor2::{BoxedDataChunkStream, BoxedExecutor2, BoxedExecutor2Builder, Executor2};
+use crate::task::BatchTaskContext;
 
 pub struct OrderByExecutor2 {
     child: Option<BoxedExecutor2>,
@@ -81,7 +82,9 @@ impl OrderByExecutor2 {
     }
 }
 impl BoxedExecutor2Builder for OrderByExecutor2 {
-    fn new_boxed_executor2(source: &ExecutorBuilder) -> Result<BoxedExecutor2> {
+    fn new_boxed_executor2<C: BatchTaskContext>(
+        source: &ExecutorBuilder<C>,
+    ) -> Result<BoxedExecutor2> {
         ensure!(source.plan_node().get_children().len() == 1);
 
         let order_by_node = try_match_expand!(

--- a/src/batch/src/executor2/project.rs
+++ b/src/batch/src/executor2/project.rs
@@ -22,6 +22,7 @@ use risingwave_pb::batch_plan::plan_node::NodeBody;
 
 use crate::executor::ExecutorBuilder;
 use crate::executor2::{BoxedDataChunkStream, BoxedExecutor2, BoxedExecutor2Builder, Executor2};
+use crate::task::BatchTaskContext;
 
 pub struct ProjectExecutor2 {
     expr: Vec<BoxedExpression>,
@@ -67,7 +68,9 @@ impl ProjectExecutor2 {
 }
 
 impl BoxedExecutor2Builder for ProjectExecutor2 {
-    fn new_boxed_executor2(source: &ExecutorBuilder) -> Result<BoxedExecutor2> {
+    fn new_boxed_executor2<C: BatchTaskContext>(
+        source: &ExecutorBuilder<C>,
+    ) -> Result<BoxedExecutor2> {
         ensure!(source.plan_node().get_children().len() == 1);
 
         let project_node = try_match_expand!(

--- a/src/batch/src/executor2/sort_agg.rs
+++ b/src/batch/src/executor2/sort_agg.rs
@@ -29,6 +29,7 @@ use risingwave_pb::batch_plan::plan_node::NodeBody;
 
 use crate::executor::ExecutorBuilder;
 use crate::executor2::{BoxedDataChunkStream, BoxedExecutor2, BoxedExecutor2Builder, Executor2};
+use crate::task::BatchTaskContext;
 
 /// `SortAggExecutor` implements the sort aggregate algorithm, which assumes
 /// that the input chunks has already been sorted by group columns.
@@ -48,7 +49,9 @@ pub struct SortAggExecutor2 {
 }
 
 impl BoxedExecutor2Builder for SortAggExecutor2 {
-    fn new_boxed_executor2(source: &ExecutorBuilder) -> Result<BoxedExecutor2> {
+    fn new_boxed_executor2<C: BatchTaskContext>(
+        source: &ExecutorBuilder<C>,
+    ) -> Result<BoxedExecutor2> {
         ensure!(source.plan_node().get_children().len() == 1);
         let proto_child =
             source.plan_node().get_children().get(0).ok_or_else(|| {

--- a/src/batch/src/executor2/top_n.rs
+++ b/src/batch/src/executor2/top_n.rs
@@ -28,6 +28,7 @@ use risingwave_pb::batch_plan::plan_node::NodeBody;
 
 use crate::executor::ExecutorBuilder;
 use crate::executor2::{BoxedDataChunkStream, BoxedExecutor2, BoxedExecutor2Builder, Executor2};
+use crate::task::BatchTaskContext;
 
 struct TopNHeap {
     order_pairs: Arc<Vec<OrderPair>>,
@@ -91,7 +92,9 @@ pub struct TopNExecutor2 {
 }
 
 impl BoxedExecutor2Builder for TopNExecutor2 {
-    fn new_boxed_executor2(source: &ExecutorBuilder) -> Result<BoxedExecutor2> {
+    fn new_boxed_executor2<C: BatchTaskContext>(
+        source: &ExecutorBuilder<C>,
+    ) -> Result<BoxedExecutor2> {
         ensure!(source.plan_node().get_children().len() == 1);
 
         let top_n_node =

--- a/src/batch/src/executor2/values.rs
+++ b/src/batch/src/executor2/values.rs
@@ -27,6 +27,7 @@ use risingwave_pb::batch_plan::plan_node::NodeBody;
 
 use crate::executor::ExecutorBuilder;
 use crate::executor2::{BoxedDataChunkStream, BoxedExecutor2, BoxedExecutor2Builder, Executor2};
+use crate::task::BatchTaskContext;
 
 /// `ValuesExecutor` implements Values executor.
 pub struct ValuesExecutor2 {
@@ -110,7 +111,9 @@ impl ValuesExecutor2 {
     }
 }
 impl BoxedExecutor2Builder for ValuesExecutor2 {
-    fn new_boxed_executor2(source: &ExecutorBuilder) -> Result<BoxedExecutor2> {
+    fn new_boxed_executor2<C: BatchTaskContext>(
+        source: &ExecutorBuilder<C>,
+    ) -> Result<BoxedExecutor2> {
         let value_node = try_match_expand!(
             source.plan_node().get_node_body().unwrap(),
             NodeBody::Values

--- a/src/batch/src/rpc/service/task_service.rs
+++ b/src/batch/src/rpc/service/task_service.rs
@@ -21,7 +21,7 @@ use risingwave_pb::task_service::{
 };
 use tonic::{Request, Response, Status};
 
-use crate::task::{BatchEnvironment, BatchManager};
+use crate::task::{BatchEnvironment, BatchManager, ComputeNodeContext};
 
 #[derive(Clone)]
 pub struct BatchServiceImpl {
@@ -45,10 +45,10 @@ impl TaskService for BatchServiceImpl {
         let req = request.into_inner();
 
         let res = self.mgr.fire_task(
-            self.env.clone(),
             req.get_task_id().expect("no task id found"),
             req.get_plan().expect("no plan found").clone(),
             req.epoch,
+            ComputeNodeContext::new(self.env.clone()),
         );
         match res {
             Ok(_) => Ok(Response::new(CreateTaskResponse { status: None })),

--- a/src/batch/src/task/context.rs
+++ b/src/batch/src/task/context.rs
@@ -40,6 +40,12 @@ pub trait BatchTaskContext: Clone + Send + Sync + 'static {
 
     fn source_manager_ref(&self) -> Option<SourceManagerRef>;
 
+    fn try_get_source_manager_ref(&self) -> Result<SourceManagerRef> {
+        Ok(self
+            .source_manager_ref()
+            .ok_or_else(|| InternalError("Source manager not found".to_string()))?)
+    }
+
     fn state_store(&self) -> Option<StateStoreImpl>;
 
     fn try_get_state_store(&self) -> Result<StateStoreImpl> {

--- a/src/batch/src/task/context.rs
+++ b/src/batch/src/task/context.rs
@@ -1,0 +1,106 @@
+// Copyright 2022 Singularity Data
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::sync::Arc;
+
+use risingwave_common::error::ErrorCode::InternalError;
+use risingwave_common::error::{Result, RwError};
+use risingwave_common::util::addr::{is_local_address, HostAddr};
+use risingwave_source::SourceManagerRef;
+use risingwave_storage::StateStoreImpl;
+
+use crate::executor2::BatchMetrics;
+use crate::task::{BatchEnvironment, TaskId, TaskOutput, TaskOutputId};
+
+/// Context for batch task execution.
+///
+/// This context is specific to one task execution, and should *not* be shared by different tasks.
+pub trait BatchTaskContext: Clone + Send + Sync + 'static {
+    /// Get task output identified by `task_output_id`.
+    ///
+    /// Returns error if the task of `task_output_id` doesn't run in same worker as current task.
+    fn get_task_output(&self, task_output_id: TaskOutputId) -> Result<TaskOutput<Self>>;
+
+    /// Whether `peer_addr` is in same as current task.
+    fn is_local_addr(&self, peer_addr: &HostAddr) -> bool;
+
+    /// Get task error identified by `task_id`.
+    fn get_task_error(&self, task_id: TaskId) -> Result<Option<RwError>>;
+
+    fn source_manager_ref(&self) -> Option<SourceManagerRef>;
+
+    fn state_store(&self) -> Option<StateStoreImpl>;
+
+    fn try_get_state_store(&self) -> Result<StateStoreImpl> {
+        Ok(self
+            .state_store()
+            .ok_or_else(|| InternalError("State store not found".to_string()))?)
+    }
+
+    fn stats(&self) -> Arc<BatchMetrics>;
+
+    /// Returns error when `task_id` doesn't belong to current task runtime.
+    fn try_get_error(&self, task_id: &TaskId) -> Result<Option<RwError>>;
+}
+
+/// Batch task context on compute node.
+#[derive(Clone)]
+pub struct ComputeNodeContext {
+    env: BatchEnvironment,
+}
+
+impl BatchTaskContext for ComputeNodeContext {
+    fn get_task_output(&self, task_output_id: TaskOutputId) -> Result<TaskOutput<Self>> {
+        self.env
+            .task_manager()
+            .take_output(&task_output_id.to_prost())
+    }
+
+    fn is_local_addr(&self, peer_addr: &HostAddr) -> bool {
+        is_local_address(self.env.server_address(), peer_addr)
+    }
+
+    fn get_task_error(&self, task_id: TaskId) -> Result<Option<RwError>> {
+        self.env.task_manager().get_error(&task_id)
+    }
+
+    fn source_manager_ref(&self) -> Option<SourceManagerRef> {
+        Some(self.env.source_manager_ref())
+    }
+
+    fn state_store(&self) -> Option<StateStoreImpl> {
+        Some(self.env.state_store())
+    }
+
+    fn stats(&self) -> Arc<BatchMetrics> {
+        self.env.stats()
+    }
+
+    fn try_get_error(&self, task_id: &TaskId) -> Result<Option<RwError>> {
+        self.env.task_manager().get_error(task_id)
+    }
+}
+
+impl ComputeNodeContext {
+    #[cfg(test)]
+    pub fn new_for_test() -> Self {
+        Self {
+            env: BatchEnvironment::for_test(),
+        }
+    }
+
+    pub fn new(env: BatchEnvironment) -> Self {
+        Self { env }
+    }
+}

--- a/src/batch/src/task/mod.rs
+++ b/src/batch/src/task/mod.rs
@@ -12,12 +12,14 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+pub use context::*;
 pub use env::*;
 pub use task_::*;
 pub use task_manager::*;
 
 mod broadcast_channel;
 mod channel;
+mod context;
 mod env;
 mod fifo_channel;
 mod hash_shuffle_channel;


### PR DESCRIPTION
## What's changed and what's your intention?

In this PR we add a trait `BatchTaskContext` so that we can provide different executor execution/task context. Since we need to add support for local executor mode, which will construct executors in frontend (currently we only construct it in compute node), so we need to abstract out the execution context for different execution environments.

## Checklist

- [x] I have written necessary docs and comments
- [x] I have added necessary unit tests and integration tests

## Refer to a related PR or issue link (optional)
