### PR TITLE
feat(pgwire): report correct version on startup

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1426,11 +1426,31 @@ dependencies = [
 
 [[package]]
 name = "enum-iterator"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4eeac5c5edb79e4e39fe8439ef35207780a11f69c52cbe424ce3dfad4cb78de6"
+dependencies = [
+ "enum-iterator-derive 0.7.0",
+]
+
+[[package]]
+name = "enum-iterator"
 version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2953d1df47ac0eb70086ccabf0275aa8da8591a28bd358ee2b52bd9f9e3ff9e9"
 dependencies = [
- "enum-iterator-derive",
+ "enum-iterator-derive 0.8.1",
+]
+
+[[package]]
+name = "enum-iterator-derive"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c134c37760b27a871ba422106eedbb8247da973a09e82558bf26d619c882b159"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -1751,6 +1771,18 @@ dependencies = [
  "cfg-if 1.0.0",
  "libc",
  "wasi 0.10.2+wasi-snapshot-preview1",
+]
+
+[[package]]
+name = "getset"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e45727250e75cc04ff2846a66397da8ef2b3db8e40e0cef4df67950a07621eb9"
+dependencies = [
+ "proc-macro-error",
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -3421,7 +3453,7 @@ dependencies = [
  "clap 3.1.17",
  "console",
  "dialoguer",
- "enum-iterator",
+ "enum-iterator 0.8.1",
  "indicatif",
  "isahc",
  "itertools",
@@ -3590,6 +3622,7 @@ dependencies = [
  "tracing",
  "twox-hash",
  "value-encoding",
+ "vergen",
  "workspace-hack",
 ]
 
@@ -4778,6 +4811,7 @@ version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2702e08a7a860f005826c6815dcac101b19b5eb330c27fe4a5928fec1d20ddd"
 dependencies = [
+ "itoa 1.0.1",
  "libc",
  "num_threads",
 ]
@@ -5255,6 +5289,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
 
 [[package]]
+name = "vergen"
+version = "7.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "20e9626b9dd8e2b78d1f14adacd0787277e612094abceb023d550f9ba33d5d73"
+dependencies = [
+ "anyhow",
+ "cfg-if 1.0.0",
+ "enum-iterator 0.7.0",
+ "getset",
+ "rustc_version 0.4.0",
+ "rustversion",
+ "thiserror",
+ "time 0.3.9",
+]
+
+[[package]]
 name = "version_check"
 version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5524,6 +5574,7 @@ dependencies = [
  "smallvec",
  "socket2",
  "syn",
+ "time 0.3.9",
  "tokio",
  "tokio-stream",
  "tokio-util 0.7.1",

--- a/src/common/Cargo.toml
+++ b/src/common/Cargo.toml
@@ -43,3 +43,6 @@ workspace-hack = { version = "0.1", path = "../workspace-hack" }
 
 [dev-dependencies]
 rand = "0.8"
+
+[build-dependencies]
+vergen = { version = "7", default-features = false, features = ["build", "rustc"] }

--- a/src/common/build.rs
+++ b/src/common/build.rs
@@ -1,0 +1,5 @@
+use vergen::{vergen, Config};
+
+fn main() {
+    let _ = vergen(Config::default());
+}

--- a/src/common/build.rs
+++ b/src/common/build.rs
@@ -1,3 +1,17 @@
+// Copyright 2022 Singularity Data
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 use vergen::{vergen, Config};
 
 fn main() {

--- a/src/common/src/util/mod.rs
+++ b/src/common/src/util/mod.rs
@@ -33,6 +33,7 @@ pub mod sort_util;
 pub mod try_match;
 pub mod epoch;
 pub mod value_encoding;
+pub mod version;
 
 pub fn downcast_ref<S, T>(source: &S) -> Result<&T>
 where

--- a/src/common/src/util/version.rs
+++ b/src/common/src/util/version.rs
@@ -1,0 +1,21 @@
+// Copyright 2022 Singularity Data
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+lazy_static::lazy_static! {
+    pub static ref VERSION: String = {
+        let app = "risingwave";
+        let version = option_env!("VERGEN_BUILD_SEMVER").unwrap_or("?");
+        format!("{}-{}", app, version)
+    };
+}

--- a/src/frontend/src/session.rs
+++ b/src/frontend/src/session.rs
@@ -347,6 +347,10 @@ impl SessionManager for SessionManagerImpl {
             database.to_string(),
         )))
     }
+
+    fn version(&self) -> &'static str {
+        &risingwave_common::util::version::VERSION
+    }
 }
 
 impl SessionManagerImpl {

--- a/src/frontend/src/test_utils.rs
+++ b/src/frontend/src/test_utils.rs
@@ -55,6 +55,10 @@ impl SessionManager for LocalFrontend {
     ) -> std::result::Result<Arc<dyn Session>, Box<dyn Error + Send + Sync>> {
         Ok(self.session_ref())
     }
+
+    fn version(&self) -> &'static str {
+        ""
+    }
 }
 
 impl LocalFrontend {

--- a/src/utils/pgwire/src/pg_protocol.rs
+++ b/src/utils/pgwire/src/pg_protocol.rs
@@ -121,6 +121,9 @@ where
         self.write_message_no_flush(&BeMessage::ParameterStatus(
             BeParameterStatusMessage::StandardConformingString("on"),
         ))?;
+        self.write_message_no_flush(&BeMessage::ParameterStatus(
+            BeParameterStatusMessage::ServerVersion(self.session_mgr.version()),
+        ))?;
         self.write_message_no_flush(&BeMessage::ReadyForQuery)?;
         Ok(())
     }

--- a/src/utils/pgwire/src/pg_server.rs
+++ b/src/utils/pgwire/src/pg_server.rs
@@ -27,6 +27,8 @@ use crate::pg_response::PgResponse;
 /// We can mock it for testing purpose.
 pub trait SessionManager: Send + Sync {
     fn connect(&self, database: &str) -> Result<Arc<dyn Session>, Box<dyn Error + Send + Sync>>;
+
+    fn version(&self) -> &'static str;
 }
 
 /// A psql connection. Each connection binds with a database. Switching database will need to

--- a/src/workspace-hack/Cargo.toml
+++ b/src/workspace-hack/Cargo.toml
@@ -47,6 +47,7 @@ serde = { version = "1", features = ["alloc", "derive", "serde_derive", "std"] }
 serde_json = { version = "1", features = ["raw_value", "std"] }
 smallvec = { version = "1", default-features = false, features = ["serde"] }
 socket2 = { version = "0.4", default-features = false, features = ["all"] }
+time = { version = "0.3", features = ["alloc", "formatting", "itoa", "parsing", "std"] }
 tokio = { version = "1", features = ["bytes", "fs", "io-std", "io-util", "libc", "macros", "memchr", "mio", "net", "num_cpus", "once_cell", "process", "rt", "rt-multi-thread", "signal", "signal-hook-registry", "socket2", "sync", "time", "tokio-macros"] }
 tokio-stream = { version = "0.1", features = ["net", "time"] }
 tokio-util = { version = "0.7", features = ["codec", "io", "tracing"] }
@@ -95,6 +96,7 @@ serde_json = { version = "1", features = ["raw_value", "std"] }
 smallvec = { version = "1", default-features = false, features = ["serde"] }
 socket2 = { version = "0.4", default-features = false, features = ["all"] }
 syn = { version = "1", features = ["clone-impls", "derive", "extra-traits", "full", "parsing", "printing", "proc-macro", "quote", "visit", "visit-mut"] }
+time = { version = "0.3", features = ["alloc", "formatting", "itoa", "parsing", "std"] }
 tokio = { version = "1", features = ["bytes", "fs", "io-std", "io-util", "libc", "macros", "memchr", "mio", "net", "num_cpus", "once_cell", "process", "rt", "rt-multi-thread", "signal", "signal-hook-registry", "socket2", "sync", "time", "tokio-macros"] }
 tokio-stream = { version = "0.1", features = ["net", "time"] }
 tokio-util = { version = "0.7", features = ["codec", "io", "tracing"] }


### PR DESCRIPTION
Signed-off-by: Bugen Zhao <i@bugenzhao.com>

## What's changed and what's your intention?

As title. We will get the current package version at compile time using `vergen` crate, which provides much more flexibility if we want to extend it in the future. When pgwire accepts a new connection, it will return with the correct version field.

<img width="463" alt="image" src="https://user-images.githubusercontent.com/25862682/169002648-6fddcebd-53e0-4c72-a933-34aa7255586a.png">

To avoid rebuild after committing, we do not put the git hash into the version for now.

## Checklist

- [x] I have written necessary docs and comments
- [x] I have added necessary unit tests and integration tests

## Refer to a related PR or issue link (optional)
- #793