### PR TITLE
fix(batch & optimizer): 0-column chunk handling in filter & agg

### DIFF
--- a/e2e_test/v2/batch/const.slt
+++ b/e2e_test/v2/batch/const.slt
@@ -1,0 +1,36 @@
+query I
+select 42 where true;
+----
+42
+
+query I
+select 42 where false;
+----
+
+query I
+select 42 where 2 > 1;
+----
+42
+
+query I
+select 42 where 2 < 1;
+----
+
+query I
+select 42 having true;
+----
+42
+
+query I
+select 42 having false;
+----
+
+query I
+select 42 having 2 > 1;
+----
+42
+
+query I
+select 42 having 2 < 1;
+----
+

--- a/src/batch/src/executor2/sort_agg.rs
+++ b/src/batch/src/executor2/sort_agg.rs
@@ -204,7 +204,12 @@ impl SortAggExecutor2 {
             .map(|b| Ok(Column::new(Arc::new(b.finish()?))))
             .collect::<Result<Vec<_>>>()?;
 
-        let output = DataChunk::builder().columns(columns).build();
+        let output = match columns.is_empty() {
+            // Zero group column means SimpleAgg, which always returns 1 row.
+            true => DataChunk::new_dummy(1),
+            false => DataChunk::builder().columns(columns).build(),
+        };
+
         yield output;
     }
 

--- a/src/frontend/test_runner/tests/testdata/predicate_pushdown.yaml
+++ b/src/frontend/test_runner/tests/testdata/predicate_pushdown.yaml
@@ -65,3 +65,11 @@
       LogicalAgg { group_keys: [0], agg_calls: [min($1)] }
         LogicalFilter { predicate: ($0 > 1:Int32) AND (1:Int32 > 0:Int32) }
           LogicalScan { table: t, columns: [v1, v2] }
+- sql: |
+    /* Always false should not be pushed below SimpleAgg */
+    create table t(v1 int, v2 int, v3 int, v4 int);
+    select min(v1) from t having false;
+  optimized_logical_plan: |
+    LogicalFilter { predicate: false:Boolean }
+      LogicalAgg { group_keys: [], agg_calls: [min($0)] }
+        LogicalScan { table: t, columns: [v1] }


### PR DESCRIPTION
## What's changed and what's your intention?

Bug reported from #2611 for the following queries:
```
select 42 where true;
select 42 where false;
select 42 where 2 > 1;
select 42 where 2 < 1;
select 42 having true;
select 42 having false;
select 42 having 2 > 1;
select 42 having 2 < 1;
```

* Both batch filter & sort agg executor build chunks from columns. When there are no columns, they default to zero cardinality mistakenly.
* Pushing predicates thru SimpleAgg is wrong and should be skipped.

Limitations:
* There may be other API usages that default to 0-cardinality chunk. It should actually report an error when cardinality cannot be guessed from columns or visibility map.

## Checklist

- [x] I have written necessary docs and comments
- [x] I have added necessary unit tests and integration tests

## Refer to a related PR or issue link (optional)
FIxes #2611