### PR TITLE
feat(ctl) add args ( epoch , table ) in list-kv

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3732,6 +3732,7 @@ dependencies = [
  "bytes",
  "clap 3.1.17",
  "risingwave_common",
+ "risingwave_hummock_sdk",
  "risingwave_pb",
  "risingwave_rpc_client",
  "risingwave_storage",

--- a/src/ctl/Cargo.toml
+++ b/src/ctl/Cargo.toml
@@ -8,6 +8,7 @@ anyhow = "1"
 bytes = "1"
 clap = { version = "3", features = ["derive"] }
 risingwave_common = { path = "../common" }
+risingwave_hummock_sdk = { path = "../storage/hummock_sdk" }
 risingwave_pb = { path = "../prost" }
 risingwave_rpc_client = { path = "../rpc_client" }
 risingwave_storage = { path = "../storage" }

--- a/src/ctl/src/cmd_impl/hummock/list_kv.rs
+++ b/src/ctl/src/cmd_impl/hummock/list_kv.rs
@@ -12,18 +12,48 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use bytes::{Buf, BufMut, BytesMut};
+use risingwave_hummock_sdk::key::next_key;
 use risingwave_storage::StateStore;
 
 use crate::common::HummockServiceOpts;
 
-pub async fn list_kv() -> anyhow::Result<()> {
+pub async fn list_kv(epoch: u64, table_id: u32) -> anyhow::Result<()> {
     let hummock_opts = HummockServiceOpts::from_env()?;
     let hummock = hummock_opts.create_hummock_store().await?;
-    // TODO: support specify epoch
-    tracing::info!("using u64::MAX as epoch");
-
-    for (k, v) in hummock.scan::<_, Vec<u8>>(.., None, u64::MAX).await? {
-        println!("{:?} => {:?}", k, v);
+    if epoch == u64::MAX {
+        tracing::info!("using u64::MAX as epoch");
+    }
+    let scan_result = match table_id {
+        u32::MAX => {
+            tracing::info!("using .. as range");
+            hummock.scan::<_, Vec<u8>>(.., None, u64::MAX).await?
+        }
+        _ => {
+            let mut buf = BytesMut::with_capacity(5);
+            buf.put_u8(b't');
+            buf.put_u32(table_id);
+            let range = buf.to_vec()..next_key(buf.to_vec().as_slice());
+            hummock.scan::<_, Vec<u8>>(range, None, u64::MAX).await?
+        }
+    };
+    for (k, v) in scan_result {
+        let print_string = match k[0] {
+            b't' => {
+                let mut buf = &k[1..];
+                format!("table_id:{:?}", buf.get_u32())
+            }
+            b's' => {
+                let mut buf = &k[1..];
+                format!("shared_executor_id:{:?}", buf.get_u64())
+            }
+            b'e' => {
+                let mut buf = &k[1..];
+                format!("executor_id:{:?}", buf.get_u64())
+            }
+            _ => "no title".to_string(),
+        };
+        println!("{}\n key : {:?} ====> value : {:?}", print_string, k, v)
     }
 
     Ok(())

--- a/src/ctl/src/common/hummock_service.rs
+++ b/src/ctl/src/common/hummock_service.rs
@@ -40,7 +40,8 @@ impl HummockServiceOpts {
     pub fn from_env() -> Result<Self> {
         let meta_opts = MetaServiceOpts::from_env()?;
         let hummock_url = env::var("RW_HUMMOCK_URL").unwrap_or_else(|_| {
-            const DEFAULT_ADDR: &str = "hummock+minio://hummock:12345678@127.0.0.1:9301/hummock001";
+            const DEFAULT_ADDR: &str =
+                "hummock+minio://hummockadmin:hummockadmin@127.0.0.1:9301/hummock001";
             tracing::warn!(
                 "`RW_HUMMOCK_URL` not found, using default hummock URL {}",
                 DEFAULT_ADDR

--- a/src/ctl/src/lib.rs
+++ b/src/ctl/src/lib.rs
@@ -38,7 +38,13 @@ enum HummockCommands {
     /// list latest Hummock version on meta node
     ListVersion,
     /// list all Hummock key-value pairs
-    ListKv,
+    ListKv {
+        #[clap(short, long = "epoch", default_value_t = u64::MAX)]
+        epoch: u64,
+
+        #[clap(short, long = "table-id", default_value_t = u32::MAX)]
+        tableid: u32,
+    },
 }
 
 pub async fn start(opts: CliOpts) {
@@ -46,6 +52,8 @@ pub async fn start(opts: CliOpts) {
         Commands::Hummock(HummockCommands::ListVersion) => {
             cmd_impl::hummock::list_version().await.unwrap()
         }
-        Commands::Hummock(HummockCommands::ListKv) => cmd_impl::hummock::list_kv().await.unwrap(),
+        Commands::Hummock(HummockCommands::ListKv { epoch, tableid }) => {
+            cmd_impl::hummock::list_kv(*epoch, *tableid).await.unwrap()
+        }
     }
 }


### PR DESCRIPTION
## What's changed and what's your intention?

***PLEASE DO NOT LEAVE THIS EMPTY !!!***
1. Add args ( epoch , table ) in `ctl/list-kv`, we can use it to query the "kv" in hummock store.  
 
   `cargo run --bin risectl -- hummock list-kv --epoch<epoch> --table-id<tableid>`

    We will query the "kv" in all tables , if `--table-id` is null or `u32::MAX.` And we will query the "kv" with `u64::MAX`( epoch ) , if `--epoch` is null
2. We will see table_id, executor_id in results. 
### example
usage:
` cargo run --bin risectl -- hummock list-kv --epoch=1 --table-id=180`
              result with epoch = 1 and table_id = 180;
` cargo run --bin risectl -- hummock list-kv `
              result with epoch = `u64::MAX` and all_table;
output:
`table_id:180
 key : b"........." ====> value : b"..........."`

## Checklist

- [x] I have written necessary docs and comments
- [x] I have added necessary unit tests and integration tests

## Refer to a related PR or issue link (optional)
