### PR TITLE
feat(frontend): plan `UPDATE`

### DIFF
--- a/src/frontend/src/optimizer/plan_node/batch_update.rs
+++ b/src/frontend/src/optimizer/plan_node/batch_update.rs
@@ -1,0 +1,82 @@
+// Copyright 2022 Singularity Data
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::fmt;
+
+use risingwave_common::error::Result;
+use risingwave_pb::batch_plan::plan_node::NodeBody;
+
+use super::{
+    LogicalUpdate, PlanBase, PlanRef, PlanTreeNodeUnary, ToBatchProst, ToDistributedBatch,
+};
+use crate::optimizer::plan_node::ToLocalBatch;
+use crate::optimizer::property::{Distribution, Order};
+
+/// `BatchUpdate` implements [`LogicalUpdate`]
+#[derive(Debug, Clone)]
+pub struct BatchUpdate {
+    pub base: PlanBase,
+    logical: LogicalUpdate,
+}
+
+impl BatchUpdate {
+    pub fn new(logical: LogicalUpdate) -> Self {
+        let ctx = logical.base.ctx.clone();
+        let base = PlanBase::new_batch(
+            ctx,
+            logical.schema().clone(),
+            Distribution::any().clone(),
+            Order::any().clone(),
+        );
+        Self { base, logical }
+    }
+}
+
+impl fmt::Display for BatchUpdate {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        self.logical.fmt_with_name(f, "BatchUpdate")
+    }
+}
+
+impl PlanTreeNodeUnary for BatchUpdate {
+    fn input(&self) -> PlanRef {
+        self.logical.input()
+    }
+
+    fn clone_with_input(&self, input: PlanRef) -> Self {
+        Self::new(self.logical.clone_with_input(input))
+    }
+}
+
+impl_plan_tree_node_for_unary! { BatchUpdate }
+
+impl ToDistributedBatch for BatchUpdate {
+    fn to_distributed(&self) -> Result<PlanRef> {
+        let new_input = self.input().to_distributed()?;
+        Ok(self.clone_with_input(new_input).into())
+    }
+}
+
+impl ToBatchProst for BatchUpdate {
+    fn to_batch_prost_body(&self) -> NodeBody {
+        todo!()
+    }
+}
+
+impl ToLocalBatch for BatchUpdate {
+    fn to_local(&self) -> Result<PlanRef> {
+        let new_input = self.input().to_local()?;
+        Ok(self.clone_with_input(new_input).into())
+    }
+}

--- a/src/frontend/src/optimizer/plan_node/logical_update.rs
+++ b/src/frontend/src/optimizer/plan_node/logical_update.rs
@@ -1,0 +1,131 @@
+// Copyright 2022 Singularity Data
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::{fmt, vec};
+
+use risingwave_common::catalog::{Field, Schema};
+use risingwave_common::error::Result;
+use risingwave_common::types::DataType;
+
+use super::{BatchUpdate, ColPrunable, PlanBase, PlanRef, PlanTreeNodeUnary, ToBatch, ToStream};
+use crate::catalog::TableId;
+use crate::expr::ExprImpl;
+
+/// [`LogicalUpdate`] iterates on input relation, set some columns, and inject update records into
+/// specified table.
+///
+/// It corresponds to the `UPDATE` statements in SQL.
+#[derive(Debug, Clone)]
+pub struct LogicalUpdate {
+    pub base: PlanBase,
+    table_source_name: String, // explain-only
+    source_id: TableId,        // TODO: use SourceId
+    input: PlanRef,
+    exprs: Vec<ExprImpl>,
+}
+
+impl LogicalUpdate {
+    /// Create a [`LogicalUpdate`] node. Used internally by optimizer.
+    pub fn new(
+        input: PlanRef,
+        table_source_name: String,
+        source_id: TableId,
+        exprs: Vec<ExprImpl>,
+    ) -> Self {
+        let ctx = input.ctx();
+        // TODO: support `RETURNING`.
+        let schema = Schema::new(vec![Field::unnamed(DataType::Int64)]);
+        let base = PlanBase::new_logical(ctx, schema, vec![]);
+        Self {
+            base,
+            table_source_name,
+            source_id,
+            input,
+            exprs,
+        }
+    }
+
+    /// Create a [`LogicalUpdate`] node. Used by planner.
+    pub fn create(
+        input: PlanRef,
+        table_source_name: String,
+        source_id: TableId,
+        exprs: Vec<ExprImpl>,
+    ) -> Result<Self> {
+        Ok(Self::new(input, table_source_name, source_id, exprs))
+    }
+
+    pub(super) fn fmt_with_name(&self, f: &mut fmt::Formatter, name: &str) -> fmt::Result {
+        write!(
+            f,
+            "{} {{ table: {}, exprs: {:?} }}",
+            name, self.table_source_name, self.exprs
+        )
+    }
+
+    /// Get the logical delete's source id.
+    #[must_use]
+    pub fn source_id(&self) -> TableId {
+        self.source_id
+    }
+}
+
+impl PlanTreeNodeUnary for LogicalUpdate {
+    fn input(&self) -> PlanRef {
+        self.input.clone()
+    }
+
+    fn clone_with_input(&self, input: PlanRef) -> Self {
+        Self::new(
+            input,
+            self.table_source_name.clone(),
+            self.source_id,
+            self.exprs.clone(),
+        )
+    }
+}
+
+impl_plan_tree_node_for_unary! { LogicalUpdate }
+
+impl fmt::Display for LogicalUpdate {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        self.fmt_with_name(f, "LogicalUpdate")
+    }
+}
+
+impl ColPrunable for LogicalUpdate {
+    fn prune_col(&self, _required_cols: &[usize]) -> PlanRef {
+        let required_cols: Vec<_> = (0..self.input.schema().len()).collect();
+        self.clone_with_input(self.input.prune_col(&required_cols))
+            .into()
+    }
+}
+
+impl ToBatch for LogicalUpdate {
+    fn to_batch(&self) -> Result<PlanRef> {
+        let new_input = self.input().to_batch()?;
+        let new_logical = self.clone_with_input(new_input);
+        Ok(BatchUpdate::new(new_logical).into())
+    }
+}
+
+impl ToStream for LogicalUpdate {
+    fn to_stream(&self) -> Result<PlanRef> {
+        unreachable!("delete should always be converted to batch plan");
+    }
+
+    fn logical_rewrite_for_stream(&self) -> Result<(PlanRef, crate::utils::ColIndexMapping)> {
+        unreachable!("delete should always be converted to batch plan");
+    }
+}

--- a/src/frontend/src/optimizer/plan_node/mod.rs
+++ b/src/frontend/src/optimizer/plan_node/mod.rs
@@ -217,6 +217,7 @@ mod batch_seq_scan;
 mod batch_simple_agg;
 mod batch_sort;
 mod batch_topn;
+mod batch_update;
 mod batch_values;
 mod logical_agg;
 mod logical_apply;
@@ -232,6 +233,7 @@ mod logical_project;
 mod logical_scan;
 mod logical_source;
 mod logical_topn;
+mod logical_update;
 mod logical_values;
 mod stream_delta_join;
 mod stream_exchange;
@@ -262,6 +264,7 @@ pub use batch_seq_scan::BatchSeqScan;
 pub use batch_simple_agg::BatchSimpleAgg;
 pub use batch_sort::BatchSort;
 pub use batch_topn::BatchTopN;
+pub use batch_update::BatchUpdate;
 pub use batch_values::BatchValues;
 pub use logical_agg::{LogicalAgg, PlanAggCall};
 pub use logical_apply::LogicalApply;
@@ -277,6 +280,7 @@ pub use logical_project::LogicalProject;
 pub use logical_scan::LogicalScan;
 pub use logical_source::LogicalSource;
 pub use logical_topn::LogicalTopN;
+pub use logical_update::LogicalUpdate;
 pub use logical_values::LogicalValues;
 pub use stream_delta_join::StreamDeltaJoin;
 pub use stream_exchange::StreamExchange;
@@ -319,6 +323,7 @@ macro_rules! for_all_plan_nodes {
             , { Logical, Source }
             , { Logical, Insert }
             , { Logical, Delete }
+            , { Logical, Update }
             , { Logical, Join }
             , { Logical, Values }
             , { Logical, Limit }
@@ -333,6 +338,7 @@ macro_rules! for_all_plan_nodes {
             , { Batch, Filter }
             , { Batch, Insert }
             , { Batch, Delete }
+            , { Batch, Update }
             , { Batch, SeqScan }
             , { Batch, HashJoin }
             , { Batch, NestedLoopJoin }
@@ -374,6 +380,7 @@ macro_rules! for_logical_plan_nodes {
             , { Logical, Source }
             , { Logical, Insert }
             , { Logical, Delete }
+            , { Logical, Update }
             , { Logical, Join }
             , { Logical, Values }
             , { Logical, Limit }
@@ -407,6 +414,7 @@ macro_rules! for_batch_plan_nodes {
             , { Batch, Exchange }
             , { Batch, Insert }
             , { Batch, Delete }
+            , { Batch, Update }
             , { Batch, HopWindow }
             , { Batch, GenerateSeries }
         }

--- a/src/frontend/test_runner/src/lib.rs
+++ b/src/frontend/test_runner/src/lib.rs
@@ -242,7 +242,10 @@ impl TestCase {
         for stmt in statements {
             let context = OptimizerContext::new(session.clone());
             match stmt.clone() {
-                Statement::Query(_) | Statement::Insert { .. } | Statement::Delete { .. } => {
+                Statement::Query(_)
+                | Statement::Insert { .. }
+                | Statement::Delete { .. }
+                | Statement::Update { .. } => {
                     if result.is_some() {
                         panic!("two queries in one test case");
                     }

--- a/src/frontend/test_runner/tests/testdata/update.yaml
+++ b/src/frontend/test_runner/tests/testdata/update.yaml
@@ -1,0 +1,36 @@
+- sql: |
+    create table t (v1 int, v2 int);
+    update t set v1 = 0;
+  batch_plan: |
+    BatchUpdate { table: t, exprs: [$0, 0:Int32, $2] }
+      BatchScan { table: t, columns: [_row_id#0, v1, v2] }
+- sql: |
+    create table t (v1 int, v2 int);
+    update t set v1 = true;
+  binder_error: 'Bind error: cannot cast type Boolean to Int32 in Assign context'
+- sql: |
+    create table t (v1 int, v2 int);
+    update t set v1 = v2 + 1;
+  batch_plan: |
+    BatchUpdate { table: t, exprs: [$0, ($2 + 1:Int32), $2] }
+      BatchScan { table: t, columns: [_row_id#0, v1, v2] }
+- sql: |
+    create table t (v1 int, v2 real);
+    update t set v1 = v2;
+  batch_plan: |
+    BatchUpdate { table: t, exprs: [$0, $2::Int32, $2] }
+      BatchScan { table: t, columns: [_row_id#0, v1, v2] }
+- sql: |
+    create table t (v1 int, v2 int);
+    update t set v1 = v2 + 1 where v2 > 0;
+  batch_plan: |
+    BatchUpdate { table: t, exprs: [$0, ($2 + 1:Int32), $2] }
+      BatchFilter { predicate: ($2 > 0:Int32) }
+        BatchScan { table: t, columns: [_row_id#0, v1, v2] }
+- sql: |
+    create table t (v1 int, v2 int);
+    update t set (v1, v2) = (v2 + 1, v1 - 1) where v1 != v2;
+  batch_plan: |
+    BatchUpdate { table: t, exprs: [$0, ($2 + 1:Int32), ($1 - 1:Int32)] }
+      BatchFilter { predicate: ($1 <> $2) }
+        BatchScan { table: t, columns: [_row_id#0, v1, v2] }


### PR DESCRIPTION
Signed-off-by: Bugen Zhao <i@bugenzhao.com>

## What's changed and what's your intention?

The plan for `UPDATE` is similar to Project. It projects the original filtered input to an updated row, then the executor will combine the two rows into a pair of `U-` and `U+`.

## Checklist

- [x] I have written necessary docs and comments
- [x] I have added necessary unit tests and integration tests

## Refer to a related PR or issue link (optional)
- Close #2619