### PR TITLE
fix(docs): use host network mode to start playground

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ Currently, only x86_64 is supported. We will provide arm64 builds in the future.
 # Pull nightly build of RisingWave
 docker pull ghcr.io/singularity-data/risingwave:latest
 # Start RisingWave in single-binary playground mode
-docker run -it ghcr.io/singularity-data/risingwave:latest playground
+docker run -it --network host rw-registry:5000/risingwave:latest playground
 ```
 
 **Compile from Source with [RiseDev](./CONTRIBUTING.md#setting-up-development-environment) (Linux and macOS)**


### PR DESCRIPTION
## What's changed and what's your intention?

Playground binds to 127.0.0.1 instead of 0.0.0.0, and currently we don't provide a config to set that. Therefore, we have to use host network mode for now.

## Checklist

- [x] I have written necessary docs and comments
- [x] I have added necessary unit tests and integration tests

## Refer to a related PR or issue link (optional)

fix https://github.com/singularity-data/risingwave/issues/2647