### PR TITLE
feat(streaming): limit source ingestion rate based on barrier

### DIFF
--- a/src/compute/src/server.rs
+++ b/src/compute/src/server.rs
@@ -133,6 +133,7 @@ pub async fn compute_node_serve(
         client_addr.clone(),
         state_store.clone(),
         streaming_metrics.clone(),
+        config.clone(),
     ));
     let source_mgr = Arc::new(MemSourceManager::new(worker_id));
 

--- a/src/compute/tests/table_v2_materialize.rs
+++ b/src/compute/tests/table_v2_materialize.rs
@@ -146,6 +146,7 @@ async fn test_table_v2_materialize() -> Result<()> {
         "SourceExecutor".to_string(),
         Arc::new(StreamingMetrics::unused()),
         vec![],
+        u64::MAX,
     )?;
 
     // Create a `Materialize` to write the changes to storage

--- a/src/config/risingwave.toml
+++ b/src/config/risingwave.toml
@@ -10,7 +10,7 @@ chunk_size = 1024
 [storage]
 shared_buffer_capacity = 268435456
 sstable_size = 268435456
-block_size = 1048576
+block_size = 65536
 bloom_false_positive = 0.01
 data_directory = "hummock_001"
 async_checkpoint_enabled = true

--- a/src/config/risingwave.toml
+++ b/src/config/risingwave.toml
@@ -8,11 +8,11 @@ chunk_size = 1024
 chunk_size = 1024
 
 [storage]
-shared_buffer_threshold = 268435456
+shared_buffer_capacity = 268435456
 sstable_size = 268435456
-block_size = 4096
-bloom_false_positive = 0.1
+block_size = 1048576
+bloom_false_positive = 0.01
 data_directory = "hummock_001"
 async_checkpoint_enabled = true
-block_cache_capacity = 268435456
+block_cache_capacity = 4294967296
 meta_cache_capacity = 67108864

--- a/src/source/src/manager.rs
+++ b/src/source/src/manager.rs
@@ -83,6 +83,15 @@ impl SourceDesc {
     pub fn next_row_id(&self) -> RowId {
         self.row_id_generator.as_ref().lock().next()
     }
+
+    pub fn next_row_id_batch(&self, length: usize) -> Vec<RowId> {
+        let mut guard = self.row_id_generator.as_ref().lock();
+        let mut result = Vec::with_capacity(length);
+        for _ in 0..length {
+            result.push(guard.next());
+        }
+        result
+    }
 }
 
 pub type SourceManagerRef = Arc<dyn SourceManager>;

--- a/src/stream/src/executor/source.rs
+++ b/src/stream/src/executor/source.rs
@@ -19,6 +19,7 @@ use either::Either;
 use futures::stream::{select_with_strategy, PollNext};
 use futures::{Stream, StreamExt};
 use futures_async_stream::try_stream;
+use madsim::time::Instant;
 use risingwave_common::array::column::Column;
 use risingwave_common::array::{ArrayBuilder, ArrayImpl, I64ArrayBuilder, StreamChunk};
 use risingwave_common::catalog::{ColumnId, Schema, TableId};
@@ -30,6 +31,7 @@ use risingwave_connector::{ConnectorState, ConnectorStateV2, SplitImpl};
 use risingwave_source::*;
 use risingwave_storage::{Keyspace, StateStore};
 use tokio::sync::mpsc::UnboundedReceiver;
+use tokio::sync::Notify;
 
 use super::error::StreamExecutorError;
 use super::monitor::StreamingMetrics;
@@ -64,6 +66,9 @@ pub struct SourceExecutor<S: StateStore> {
     // store latest split to offset mapping.
     // None if there is no update on source state since the previsouly seen barrier.
     state_cache: Option<Vec<ConnectorState>>,
+
+    /// Expected barrier latency
+    expected_barrier_latency_ms: u64,
 }
 
 impl<S: StateStore> SourceExecutor<S> {
@@ -81,6 +86,7 @@ impl<S: StateStore> SourceExecutor<S> {
         _op_info: String,
         streaming_metrics: Arc<StreamingMetrics>,
         stream_source_splits: Vec<SplitImpl>,
+        expected_barrier_latency_ms: u64,
     ) -> Result<Self> {
         Ok(Self {
             source_id,
@@ -95,17 +101,17 @@ impl<S: StateStore> SourceExecutor<S> {
             source_identify: "Table_".to_string() + &source_id.table_id().to_string(),
             split_state_store: SourceStateHandler::new(keyspace),
             state_cache: None,
+            expected_barrier_latency_ms,
         })
     }
 
     /// Generate a row ID column.
     fn gen_row_id_column(&mut self, len: usize) -> Column {
         let mut builder = I64ArrayBuilder::new(len).unwrap();
+        let row_ids = self.source_desc.next_row_id_batch(len);
 
-        for _ in 0..len {
-            builder
-                .append(Some(self.source_desc.next_row_id()))
-                .unwrap();
+        for row_id in row_ids {
+            builder.append(Some(row_id)).unwrap();
         }
 
         Column::new(Arc::new(ArrayImpl::from(builder.finish().unwrap())))
@@ -129,37 +135,58 @@ impl<S: StateStore> SourceExecutor<S> {
 }
 
 struct SourceReader {
-    /// The reader for stream source
+    /// The reader for stream source.
     stream_reader: Box<dyn StreamSourceReader>,
-    /// The reader for barrier
+    /// The reader for barrier.
     barrier_receiver: UnboundedReceiver<Barrier>,
+    /// Expected barrier latency in ms. If there are no barrier within the expected barrier
+    /// latency, source will stall.
+    expected_barrier_latency_ms: u64,
 }
 
 impl SourceReader {
     #[try_stream(ok = StreamChunkWithState, error = RwError)]
-    async fn stream_reader(mut stream_reader: Box<dyn StreamSourceReader>) {
-        loop {
-            match stream_reader.next().await {
-                Ok(chunk) => yield chunk,
-                Err(e) => {
-                    // TODO: report this error to meta service to mark the actors failed.
-                    error!("hang up stream reader due to polling error: {}", e);
+    async fn stream_reader(
+        mut stream_reader: Box<dyn StreamSourceReader>,
+        notifier: Arc<Notify>,
+        expected_barrier_latency_ms: u64,
+    ) {
+        'outer: loop {
+            let now = Instant::now();
 
-                    // Drop the reader, then the error might be caught by the writer side.
-                    drop(stream_reader);
-                    // Then hang up this stream by breaking the loop.
-                    break;
+            // We allow data to flow for `expected_barrier_latency_ms` milliseconds.
+            while now.elapsed().as_millis() < expected_barrier_latency_ms as u128 {
+                match stream_reader.next().await {
+                    Ok(chunk) => yield chunk,
+                    Err(e) => {
+                        // TODO: report this error to meta service to mark the actors failed.
+                        error!("hang up stream reader due to polling error: {}", e);
+
+                        // Drop the reader, then the error might be caught by the writer side.
+                        drop(stream_reader);
+                        // Then hang up this stream by breaking the loop.
+                        break 'outer;
+                    }
                 }
             }
+
+            // Here we consider two cases:
+            //
+            // 1. Barrier arrived before waiting for notified. In this case, this await will
+            // complete instantly, and we will continue to produce new data.
+            // 2. Barrier arrived after waiting for notified. Then source will be stalled.
+
+            notifier.notified().await;
         }
 
         futures::future::pending().await
     }
 
     #[try_stream(ok = Message, error = RwError)]
-    async fn barrier_receiver(mut rx: UnboundedReceiver<Barrier>) {
+    async fn barrier_receiver(mut rx: UnboundedReceiver<Barrier>, notifier: Arc<Notify>) {
         while let Some(barrier) = rx.recv().await {
             yield Message::Barrier(barrier);
+            notifier.notify_one();
         }
         return Err(RwError::from(InternalError(
             "barrier reader closed unexpectedly".to_string(),
@@ -169,8 +196,14 @@ impl SourceReader {
     fn into_stream(
         self,
     ) -> impl Stream<Item = Either<Result<Message>, Result<StreamChunkWithState>>> {
-        let barrier_receiver = Self::barrier_receiver(self.barrier_receiver);
-        let stream_reader = Self::stream_reader(self.stream_reader);
+        let notifier = Arc::new(Notify::new());
+
+        let barrier_receiver = Self::barrier_receiver(self.barrier_receiver, notifier.clone());
+        let stream_reader = Self::stream_reader(
+            self.stream_reader,
+            notifier,
+            self.expected_barrier_latency_ms,
+        );
         select_with_strategy(
             barrier_receiver.map(Either::Left),
             stream_reader.map(Either::Right),
@@ -217,6 +250,7 @@ impl<S: StateStore> SourceExecutor<S> {
         let reader = SourceReader {
             stream_reader: Box::new(stream_reader),
             barrier_receiver,
+            expected_barrier_latency_ms: self.expected_barrier_latency_ms,
         };
         yield Message::Barrier(barrier);
 
@@ -389,6 +423,7 @@ mod tests {
             "SourceExecutor".to_string(),
             Arc::new(StreamingMetrics::new(prometheus::Registry::new())),
             vec![],
+            u64::MAX,
         )
         .unwrap();
         let mut executor = Box::new(executor).execute();
@@ -511,6 +546,7 @@ mod tests {
             "SourceExecutor".to_string(),
             Arc::new(StreamingMetrics::unused()),
             vec![],
+            u64::MAX,
         )
         .unwrap();
         let mut executor = Box::new(executor).execute();

--- a/src/stream/src/from_proto/source.rs
+++ b/src/stream/src/from_proto/source.rs
@@ -79,6 +79,8 @@ impl ExecutorBuilder for SourceExecutorBuilder {
             params.op_info,
             params.executor_stats,
             stream_source_splits,
+            // TODO: move checkpoint interval to stream config
+            100,
         )?))
     }
 }

--- a/src/stream/src/task/mod.rs
+++ b/src/stream/src/task/mod.rs
@@ -33,7 +33,7 @@ pub use env::*;
 pub use stream_manager::*;
 
 /// Default capacity of channel if two actors are on the same node
-pub const LOCAL_OUTPUT_CHANNEL_SIZE: usize = 16;
+pub const LOCAL_OUTPUT_CHANNEL_SIZE: usize = 4;
 
 pub type ConsumableChannelPair = (Option<Sender<Message>>, Option<Receiver<Message>>);
 pub type ConsumableChannelVecPair = (Vec<Sender<Message>>, Vec<Receiver<Message>>);

--- a/src/stream/src/task/stream_manager.rs
+++ b/src/stream/src/task/stream_manager.rs
@@ -20,6 +20,7 @@ use itertools::Itertools;
 use madsim::collections::{HashMap, HashSet};
 use madsim::task::JoinHandle;
 use parking_lot::Mutex;
+use risingwave_common::config::ComputeNodeConfig;
 use risingwave_common::error::{ErrorCode, Result, RwError};
 use risingwave_common::try_match_expand;
 use risingwave_common::util::addr::{is_local_address, HostAddr};
@@ -77,6 +78,10 @@ pub struct LocalStreamManagerCore {
     /// TODO: currently the client pool won't be cleared. Should remove compute clients when
     /// disconnected.
     compute_client_pool: ComputeClientPool,
+
+    /// Config of compute node
+    #[allow(dead_code)]
+    pub(crate) config: ComputeNodeConfig,
 }
 
 /// `LocalStreamManager` manages all stream executors in this project.
@@ -132,11 +137,13 @@ impl LocalStreamManager {
         addr: HostAddr,
         state_store: StateStoreImpl,
         streaming_metrics: Arc<StreamingMetrics>,
+        config: ComputeNodeConfig,
     ) -> Self {
         Self::with_core(LocalStreamManagerCore::new(
             addr,
             state_store,
             streaming_metrics,
+            config,
         ))
     }
 
@@ -318,15 +325,17 @@ impl LocalStreamManagerCore {
         addr: HostAddr,
         state_store: StateStoreImpl,
         streaming_metrics: Arc<StreamingMetrics>,
+        config: ComputeNodeConfig,
     ) -> Self {
         let context = SharedContext::new(addr);
-        Self::with_store_and_context(state_store, context, streaming_metrics)
+        Self::with_store_and_context(state_store, context, streaming_metrics, config)
     }
 
     fn with_store_and_context(
         state_store: StateStoreImpl,
         context: SharedContext,
         streaming_metrics: Arc<StreamingMetrics>,
+        config: ComputeNodeConfig,
     ) -> Self {
         let (tx, rx) = channel(LOCAL_OUTPUT_CHANNEL_SIZE);
 
@@ -339,6 +348,7 @@ impl LocalStreamManagerCore {
             state_store,
             streaming_metrics,
             compute_client_pool: ComputeClientPool::new(1024),
+            config,
         }
     }
 
@@ -352,6 +362,7 @@ impl LocalStreamManagerCore {
             StateStoreImpl::shared_in_memory_store(Arc::new(StateStoreMetrics::unused())),
             SharedContext::for_test(),
             streaming_metrics,
+            ComputeNodeConfig::default(),
         )
     }
 
@@ -508,11 +519,7 @@ impl LocalStreamManagerCore {
         input_pos: usize,
         streaming_metrics: Arc<StreamingMetrics>,
     ) -> BoxedExecutor {
-        if cfg!(debug_assertions) {
-            DebugExecutor::new(executor, input_pos, actor_id, streaming_metrics).boxed()
-        } else {
-            executor
-        }
+        DebugExecutor::new(executor, input_pos, actor_id, streaming_metrics).boxed()
     }
 
     pub(crate) fn get_receive_message(


### PR DESCRIPTION
Signed-off-by: Alex Chi <iskyzh@gmail.com>

## What's changed and what's your intention?

As title. We hard-code 100ms for now, until we can specify checkpoint interval in risingwave.toml. I'll test and bench later to see if this really works.

## Checklist

- [x] I have written necessary docs and comments
- [x] I have added necessary unit tests and integration tests

## Refer to a related PR or issue link (optional)

close https://github.com/singularity-data/risingwave/issues/2625
fix partially https://github.com/singularity-data/risingwave/issues/2626
fix https://github.com/singularity-data/risingwave/issues/2578