### PR TITLE
feat(streaming): use new channel as barrier receiver

### DIFF
--- a/src/stream/src/executor/source.rs
+++ b/src/stream/src/executor/source.rs
@@ -196,7 +196,9 @@ async fn bridge_channel(
         if stop_rx.try_recv().is_ok() {
             break;
         };
-        tx.send(rx.recv().await.unwrap()).unwrap();
+        if let Some(msg) = rx.recv().await {
+            tx.send(msg).unwrap();
+        }
     }
     rx
 }

--- a/src/stream/src/executor/source.rs
+++ b/src/stream/src/executor/source.rs
@@ -207,6 +207,7 @@ impl<S: StateStore> SourceExecutor<S> {
         let mut barrier_receiver = self.barrier_receiver.take().unwrap();
         let barrier = barrier_receiver.recv().await.unwrap();
         let epoch = barrier.epoch.prev;
+        self.barrier_receiver = Some(barrier_receiver);
 
         yield Message::Barrier(barrier);
 

--- a/src/stream/src/lib.rs
+++ b/src/stream/src/lib.rs
@@ -31,6 +31,7 @@
 #![feature(more_qualified_paths)]
 #![feature(binary_heap_drain_sorted)]
 #![feature(map_first_last)]
+#![feature(async_closure)]
 #![feature(let_chains)]
 #![feature(let_else)]
 #![feature(hash_drain_filter)]


### PR DESCRIPTION
Signed-off-by: tabVersion <tabvision@bupt.icu>

## What's changed and what's your intention?

In prev design, the source executor's unbounded channel was used as a barrier receiver and combined into an async stream, making it impossible to rebuild the underlying source. 

now we use a new unbounded channel instead of the one registered on meta, allowing us to build the executor inner component possible. 

***PLEASE DO NOT LEAVE THIS EMPTY !!!***

Please explain **IN DETAIL** what the changes are in this PR and why they are needed:

- Summarize your change (**mandatory**)
- How does this PR work? Need a brief introduction for the changed logic (optional)
- Describe clearly one logical change and avoid lazy messages (optional)
- Describe any limitations of the current code (optional)

## Checklist

- [x] I have written necessary docs and comments
- [x] I have added necessary unit tests and integration tests

## Refer to a related PR or issue link (optional)

part of #1285 