### PR TITLE
chore(risedev): disable env info

### DIFF
--- a/Makefile.toml
+++ b/Makefile.toml
@@ -40,7 +40,7 @@ end
 default_to_workspace = false
 skip_core_tasks = true
 skip_git_env_info = true
-skip_rust_env_info = true
+skip_rust_env_info = false
 skip_crate_env_info = true
 
 [tasks.clean-full]

--- a/Makefile.toml
+++ b/Makefile.toml
@@ -11,7 +11,6 @@ extend = [
 
 env_files = ["./risedev-components.user.env"]
 
-
 env_scripts = [
   '''
 #!@duckscript
@@ -38,8 +37,11 @@ end
 ]
 
 [config]
-skip_core_tasks = true
 default_to_workspace = false
+skip_core_tasks = true
+skip_git_env_info = true
+skip_rust_env_info = true
+skip_crate_env_info = true
 
 [tasks.clean-full]
 category = "Misc"


### PR DESCRIPTION
Signed-off-by: Alex Chi <iskyzh@gmail.com>

## What's changed and what's your intention?

Getting env info is slow. What's more, getting crate info requires downloading the whole crates.io index. So we disable it.

## Checklist

- [x] I have written necessary docs and comments
- [x] I have added necessary unit tests and integration tests

## Refer to a related PR or issue link (optional)

close https://github.com/singularity-data/risingwave/issues/2615