### PR TITLE
feat(connector): Integrate avro format parser to SourceParserImpl

### DIFF
--- a/src/source/src/manager.rs
+++ b/src/source/src/manager.rs
@@ -16,6 +16,7 @@ use std::collections::HashMap;
 use std::fmt::Debug;
 use std::sync::Arc;
 
+use async_trait::async_trait;
 use parking_lot::{Mutex, MutexGuard};
 use risingwave_common::catalog::{ColumnDesc, ColumnId, TableId};
 use risingwave_common::ensure;
@@ -34,8 +35,9 @@ use crate::{ConnectorSource, SourceFormat, SourceImpl, SourceParserImpl};
 pub type SourceRef = Arc<SourceImpl>;
 
 /// The local source manager on the compute node.
+#[async_trait]
 pub trait SourceManager: Debug + Sync + Send {
-    fn create_source(&self, table_id: &TableId, info: StreamSourceInfo) -> Result<()>;
+    async fn create_source(&self, table_id: &TableId, info: StreamSourceInfo) -> Result<()>;
     fn create_table_source(&self, table_id: &TableId, columns: Vec<ColumnDesc>) -> Result<()>;
 
     fn get_source(&self, source_id: &TableId) -> Result<SourceDesc>;
@@ -94,8 +96,9 @@ pub struct MemSourceManager {
     worker_id: u32,
 }
 
+#[async_trait]
 impl SourceManager for MemSourceManager {
-    fn create_source(&self, source_id: &TableId, info: StreamSourceInfo) -> Result<()> {
+    async fn create_source(&self, source_id: &TableId, info: StreamSourceInfo) -> Result<()> {
         let format = match info.get_row_format()? {
             RowFormatType::Json => SourceFormat::Json,
             RowFormatType::Protobuf => SourceFormat::Protobuf,
@@ -108,9 +111,14 @@ impl SourceManager for MemSourceManager {
                 "protobuf file location not provided".to_string(),
             )));
         }
-
-        let parser =
-            SourceParserImpl::create(&format, &info.properties, info.row_schema_location.as_str())?;
+        let source_parser_rs =
+            SourceParserImpl::create(&format, &info.properties, info.row_schema_location.as_str())
+                .await;
+        let parser = if let Ok(source_parser) = source_parser_rs {
+            source_parser
+        } else {
+            return Err(source_parser_rs.err().unwrap());
+        };
 
         let columns = info
             .columns
@@ -230,7 +238,6 @@ impl MemSourceManager {
 
 #[cfg(test)]
 mod tests {
-
     use risingwave_common::catalog::{ColumnDesc, ColumnId, Field, Schema, TableId};
     use risingwave_common::error::Result;
     use risingwave_common::types::DataType;
@@ -267,7 +274,7 @@ mod tests {
         let source_id = TableId::default();
 
         let mem_source_manager = MemSourceManager::default();
-        let source = mem_source_manager.create_source(&source_id, info);
+        let source = mem_source_manager.create_source(&source_id, info).await;
 
         assert!(source.is_ok());
 

--- a/src/source/src/parser/mod.rs
+++ b/src/source/src/parser/mod.rs
@@ -24,6 +24,7 @@ use risingwave_common::error::ErrorCode::ProtocolError;
 use risingwave_common::error::{Result, RwError};
 use risingwave_common::types::Datum;
 
+use crate::parser::avro_parser::AvroParser;
 use crate::{SourceColumnDesc, SourceFormat};
 
 #[allow(dead_code)]
@@ -53,6 +54,7 @@ pub enum SourceParserImpl {
     Json(JSONParser),
     Protobuf(ProtobufParser),
     DebeziumJson(DebeziumJsonParser),
+    Avro(AvroParser),
 }
 
 impl SourceParserImpl {
@@ -61,16 +63,16 @@ impl SourceParserImpl {
             Self::Json(parser) => parser.parse(payload, columns),
             Self::Protobuf(parser) => parser.parse(payload, columns),
             Self::DebeziumJson(parser) => parser.parse(payload, columns),
+            Self::Avro(avro_parser) => avro_parser.parse(payload, columns),
         }
     }
 
-    pub fn create(
+    pub async fn create(
         format: &SourceFormat,
         properties: &HashMap<String, String>,
         schema_location: &str,
     ) -> Result<Arc<Self>> {
         const PROTOBUF_MESSAGE_KEY: &str = "proto.message";
-
         let parser = match format {
             SourceFormat::Json => SourceParserImpl::Json(JSONParser {}),
             SourceFormat::Protobuf => {
@@ -83,6 +85,9 @@ impl SourceParserImpl {
                 SourceParserImpl::Protobuf(ProtobufParser::new(schema_location, message_name)?)
             }
             SourceFormat::DebeziumJson => SourceParserImpl::DebeziumJson(DebeziumJsonParser {}),
+            SourceFormat::Avro => {
+                SourceParserImpl::Avro(AvroParser::new(schema_location, properties.clone()).await?)
+            }
             _ => {
                 return Err(RwError::from(ProtocolError(
                     "format not support".to_string(),


### PR DESCRIPTION
## What's changed and what's your intention?

Integrate Avro Parser to SourceParserImpl. As Avro Schema file needs to be read from S3 and S3 SDK is async, so change the following function to async.

` StreamServiceImpl.create_source_inner`
` SourceManager.create_source`
` SourceParserImpl.create`

## Checklist

- [x] I have written necessary docs and comments
- [x] I have added necessary unit tests and integration tests

## Refer to a related PR or issue link (optional)
