### PR TITLE
feat(config): human-readable config

### DIFF
--- a/risedev.yml
+++ b/risedev.yml
@@ -19,7 +19,6 @@ risedev:
     - use: meta-node
       enable-dashboard-v2: false
       unsafe-disable-recovery: true
-      checkpoint-interval: 100
     - use: compute-node
     - use: frontend
 

--- a/src/bench/ss_bench/main.rs
+++ b/src/bench/ss_bench/main.rs
@@ -145,17 +145,16 @@ async fn main() {
     println!("Configurations after preprocess:\n {:?}", &opts);
 
     let config = Arc::new(StorageConfig {
-        shared_buffer_threshold: opts.shared_buffer_threshold_mb * (1 << 20),
-        shared_buffer_capacity: opts.shared_buffer_capacity_mb * (1 << 20),
+        shared_buffer_capacity_mb: opts.shared_buffer_capacity_mb,
         bloom_false_positive: opts.bloom_false_positive,
-        sstable_size: opts.table_size_mb * (1 << 20),
-        block_size: opts.block_size_kb * (1 << 10),
+        sstable_size_mb: opts.table_size_mb,
+        block_size_kb: opts.block_size_kb,
         share_buffers_sync_parallelism: opts.share_buffers_sync_parallelism,
         data_directory: "hummock_001".to_string(),
         async_checkpoint_enabled: !opts.async_checkpoint_disabled,
         write_conflict_detection_enabled: opts.write_conflict_detection_enabled,
-        block_cache_capacity: opts.block_cache_capacity_mb as usize * (1 << 20),
-        meta_cache_capacity: opts.meta_cache_capacity_mb as usize * (1 << 20),
+        block_cache_capacity_mb: opts.block_cache_capacity_mb as usize,
+        meta_cache_capacity_mb: opts.meta_cache_capacity_mb as usize,
         disable_remote_compactor: true,
         enable_local_spill: false,
         local_object_store: "memory".to_string(),

--- a/src/common/src/config.rs
+++ b/src/common/src/config.rs
@@ -42,6 +42,15 @@ pub struct ComputeNodeConfig {
     pub storage: StorageConfig,
 }
 
+pub fn load_config(path: &str) -> ComputeNodeConfig {
+    if path.is_empty() {
+        tracing::warn!("risingwave.toml not found, using default config.");
+        return ComputeNodeConfig::default();
+    }
+
+    ComputeNodeConfig::init(path.to_owned().into()).unwrap()
+}
+
 #[derive(Clone, Debug, Serialize, Deserialize, Default)]
 #[serde(deny_unknown_fields)]
 pub struct FrontendConfig {
@@ -52,8 +61,8 @@ pub struct FrontendConfig {
 
 #[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct ServerConfig {
-    #[serde(default = "default::heartbeat_interval")]
-    pub heartbeat_interval: u32,
+    #[serde(default = "default::heartbeat_interval_ms")]
+    pub heartbeat_interval_ms: u32,
 }
 
 impl Default for ServerConfig {
@@ -65,8 +74,8 @@ impl Default for ServerConfig {
 #[derive(Clone, Debug, Serialize, Deserialize)]
 #[serde(deny_unknown_fields)]
 pub struct BatchConfig {
-    #[serde(default = "default::chunk_size")]
-    pub chunk_size: u32,
+    // #[serde(default = "default::chunk_size")]
+    // pub chunk_size: u32,
 }
 
 impl Default for BatchConfig {
@@ -78,8 +87,10 @@ impl Default for BatchConfig {
 #[derive(Clone, Debug, Serialize, Deserialize)]
 #[serde(deny_unknown_fields)]
 pub struct StreamingConfig {
-    #[serde(default = "default::chunk_size")]
-    pub chunk_size: u32,
+    // #[serde(default = "default::chunk_size")]
+    // pub chunk_size: u32,
+    #[serde(default = "default::checkpoint_interval_ms")]
+    pub checkpoint_interval_ms: u32,
 }
 
 impl Default for StreamingConfig {
@@ -93,12 +104,12 @@ impl Default for StreamingConfig {
 #[serde(deny_unknown_fields)]
 pub struct StorageConfig {
     /// Target size of the SSTable.
-    #[serde(default = "default::sst_size")]
-    pub sstable_size: u32,
+    #[serde(default = "default::sst_size_mb")]
+    pub sstable_size_mb: u32,
 
     /// Size of each block in bytes in SST.
-    #[serde(default = "default::block_size")]
-    pub block_size: u32,
+    #[serde(default = "default::block_size_kb")]
+    pub block_size_kb: u32,
 
     /// False positive probability of bloom filter.
     #[serde(default = "default::bloom_false_positive")]
@@ -108,14 +119,13 @@ pub struct StorageConfig {
     #[serde(default = "default::share_buffers_sync_parallelism")]
     pub share_buffers_sync_parallelism: u32,
 
-    /// Size threshold to trigger shared buffer flush.
-    #[serde(default = "default::shared_buffer_threshold")]
-    pub shared_buffer_threshold: u32,
-
+    // /// Size threshold to trigger shared buffer flush.
+    // #[serde(default = "default::shared_buffer_threshold")]
+    // pub shared_buffer_threshold: u32,
     /// Maximum shared buffer size, writes attempting to exceed the capacity will stall until there
     /// is enough space.
-    #[serde(default = "default::shared_buffer_capacity")]
-    pub shared_buffer_capacity: u32,
+    #[serde(default = "default::shared_buffer_capacity_mb")]
+    pub shared_buffer_capacity_mb: u32,
 
     /// Remote directory for storing data and metadata objects.
     #[serde(default = "default::data_directory")]
@@ -130,12 +140,12 @@ pub struct StorageConfig {
     pub write_conflict_detection_enabled: bool,
 
     /// Capacity of sstable block cache.
-    #[serde(default = "default::block_cache_capacity")]
-    pub block_cache_capacity: usize,
+    #[serde(default = "default::block_cache_capacity_mb")]
+    pub block_cache_capacity_mb: usize,
 
     /// Capacity of sstable meta cache.
-    #[serde(default = "default::meta_cache_capacity")]
-    pub meta_cache_capacity: usize,
+    #[serde(default = "default::meta_cache_capacity_mb")]
+    pub meta_cache_capacity_mb: usize,
 
     #[serde(default = "default::disable_remote_compactor")]
     pub disable_remote_compactor: bool,
@@ -186,7 +196,7 @@ impl FrontendConfig {
 
 mod default {
 
-    pub fn heartbeat_interval() -> u32 {
+    pub fn heartbeat_interval_ms() -> u32 {
         1000
     }
 
@@ -194,17 +204,16 @@ mod default {
         1024
     }
 
-    pub fn sst_size() -> u32 {
-        // 256MB
-        268435456
+    pub fn sst_size_mb() -> u32 {
+        256
     }
 
-    pub fn block_size() -> u32 {
-        65536
+    pub fn block_size_kb() -> u32 {
+        16
     }
 
     pub fn bloom_false_positive() -> f64 {
-        0.1
+        0.01
     }
 
     pub fn share_buffers_sync_parallelism() -> u32 {
@@ -216,9 +225,8 @@ mod default {
         201326592
     }
 
-    pub fn shared_buffer_capacity() -> u32 {
-        // 256MB
-        268435456
+    pub fn shared_buffer_capacity_mb() -> u32 {
+        256
     }
 
     pub fn data_directory() -> String {
@@ -233,14 +241,12 @@ mod default {
         cfg!(debug_assertions)
     }
 
-    pub fn block_cache_capacity() -> usize {
-        // 256 MB
-        268435456
+    pub fn block_cache_capacity_mb() -> usize {
+        256
     }
 
-    pub fn meta_cache_capacity() -> usize {
-        // 64 MB
-        67108864
+    pub fn meta_cache_capacity_mb() -> usize {
+        64
     }
 
     pub fn disable_remote_compactor() -> bool {
@@ -254,45 +260,8 @@ mod default {
     pub fn local_object_store() -> String {
         "tempdisk".to_string()
     }
-}
 
-#[cfg(test)]
-mod tests {
-
-    #[test]
-    fn test_default() {
-        use super::*;
-
-        let cfg = ComputeNodeConfig::default();
-        assert_eq!(cfg.server.heartbeat_interval, default::heartbeat_interval());
-
-        let cfg: ComputeNodeConfig = toml::from_str("").unwrap();
-        assert_eq!(cfg.storage.block_size, default::block_size());
-
-        let partial_toml_str = r#"
-        [server]
-        heartbeat_interval = 10
-        
-        [batch]
-        chunk_size = 256
-        
-        [streaming]
-        
-        [storage]
-        sstable_size = 1024
-        data_directory = "test"
-        async_checkpoint_enabled = false
-    "#;
-        let cfg: ComputeNodeConfig = toml::from_str(partial_toml_str).unwrap();
-        assert_eq!(cfg.server.heartbeat_interval, 10);
-        assert_eq!(cfg.batch.chunk_size, 256);
-        assert_eq!(cfg.storage.sstable_size, 1024);
-        assert_eq!(cfg.storage.block_size, default::block_size());
-        assert_eq!(
-            cfg.storage.bloom_false_positive,
-            default::bloom_false_positive()
-        );
-        assert_eq!(cfg.storage.data_directory, "test");
-        assert!(!cfg.storage.async_checkpoint_enabled);
+    pub fn checkpoint_interval_ms() -> u32 {
+        100
     }
 }

--- a/src/config/risingwave.toml
+++ b/src/config/risingwave.toml
@@ -1,18 +1,17 @@
 [server]
-heartbeat_interval = 1000
+heartbeat_interval_ms = 1000
 
 [batch]
-chunk_size = 1024
 
 [streaming]
-chunk_size = 1024
+checkpoint_interval_ms = 100
 
 [storage]
-shared_buffer_capacity = 268435456
-sstable_size = 268435456
-block_size = 65536
+shared_buffer_capacity_mb = 4096
+sstable_size_mb = 256
+block_size_kb = 64
 bloom_false_positive = 0.01
 data_directory = "hummock_001"
 async_checkpoint_enabled = true
-block_cache_capacity = 4294967296
-meta_cache_capacity = 67108864
+block_cache_capacity_mb = 4096
+meta_cache_capacity_mb = 256

--- a/src/frontend/src/session.rs
+++ b/src/frontend/src/session.rs
@@ -177,7 +177,7 @@ impl FrontendEnv {
 
         let (heartbeat_join_handle, heartbeat_shutdown_sender) = MetaClient::start_heartbeat_loop(
             meta_client.clone(),
-            Duration::from_millis(config.server.heartbeat_interval as u64),
+            Duration::from_millis(config.server.heartbeat_interval_ms as u64),
         );
 
         let (catalog_updated_tx, catalog_updated_rx) = watch::channel(0);

--- a/src/risedevtool/src/service_config.rs
+++ b/src/risedevtool/src/service_config.rs
@@ -59,7 +59,6 @@ pub struct MetaNodeConfig {
 
     pub enable_dashboard_v2: bool,
     pub unsafe_disable_recovery: bool,
-    pub checkpoint_interval: Option<u32>,
 }
 
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]

--- a/src/risedevtool/src/task/meta_node_service.rs
+++ b/src/risedevtool/src/task/meta_node_service.rs
@@ -82,10 +82,6 @@ impl MetaNodeService {
             cmd.arg("--disable-recovery");
         }
 
-        if let Some(interval) = config.checkpoint_interval {
-            cmd.arg("--checkpoint-interval").arg(interval.to_string());
-        }
-
         Ok(())
     }
 }
@@ -99,6 +95,10 @@ impl Task for MetaNodeService {
 
         cmd.env("RUST_BACKTRACE", "1");
         Self::apply_command_args(&mut cmd, &self.config)?;
+
+        let prefix_config = env::var("PREFIX_CONFIG")?;
+        cmd.arg("--config-path")
+            .arg(Path::new(&prefix_config).join("risingwave.toml"));
 
         if !self.config.user_managed {
             ctx.run_command(ctx.tmux_run(cmd)?)?;

--- a/src/storage/compactor/src/server.rs
+++ b/src/storage/compactor/src/server.rs
@@ -81,14 +81,14 @@ pub async fn compactor_serve(
         object_store,
         storage_config.data_directory.to_string(),
         state_store_stats.clone(),
-        storage_config.block_cache_capacity,
-        storage_config.meta_cache_capacity,
+        storage_config.block_cache_capacity_mb * (1 << 20),
+        storage_config.meta_cache_capacity_mb * (1 << 20),
     ));
 
     let sub_tasks = vec![
         MetaClient::start_heartbeat_loop(
             meta_client.clone(),
-            Duration::from_millis(config.server.heartbeat_interval as u64),
+            Duration::from_millis(config.server.heartbeat_interval_ms as u64),
         ),
         risingwave_storage::hummock::compactor::Compactor::start_compactor(
             storage_config,

--- a/src/storage/src/hummock/block_cache.rs
+++ b/src/storage/src/hummock/block_cache.rs
@@ -73,6 +73,9 @@ pub struct BlockCache {
 
 impl BlockCache {
     pub fn new(capacity: usize) -> Self {
+        if capacity == 0 {
+            panic!("block cache capacity == 0");
+        }
         let cache = LruCache::new(CACHE_SHARD_BITS, capacity, DEFAULT_OBJECT_POOL_SIZE);
         Self {
             inner: Arc::new(cache),

--- a/src/storage/src/hummock/compactor_tests.rs
+++ b/src/storage/src/hummock/compactor_tests.rs
@@ -35,8 +35,8 @@ mod tests {
     ) -> HummockStorage {
         let remote_dir = "hummock_001_test".to_string();
         let options = Arc::new(StorageConfig {
-            sstable_size: 32,
-            block_size: 1 << 10,
+            sstable_size_mb: 1,
+            block_size_kb: 1,
             bloom_false_positive: 0.1,
             data_directory: remote_dir.clone(),
             async_checkpoint_enabled: true,
@@ -81,7 +81,7 @@ mod tests {
 
         // 1. add sstables
         let key = Bytes::from(&b"same_key"[..]);
-        let val = Bytes::from(&b"value"[..]);
+        let val = Bytes::from(b"0"[..].repeat(4 << 20)); // 4MB value
         let kv_count = 128;
         let mut epoch: u64 = 1;
         for _ in 0..kv_count {
@@ -132,7 +132,7 @@ mod tests {
             .sstable(output_table_id)
             .await
             .unwrap();
-        let target_table_size = storage.options().sstable_size;
+        let target_table_size = storage.options().sstable_size_mb * (1 << 20);
         assert!(
             table.value().meta.estimated_size > target_table_size,
             "table.meta.estimated_size {} <= target_table_size {}",

--- a/src/storage/src/hummock/local_version_manager.rs
+++ b/src/storage/src/hummock/local_version_manager.rs
@@ -121,7 +121,7 @@ impl LocalVersionManager {
                 shared_buffer_uploader_tx,
             },
             buffer_tracker: BufferTracker {
-                capacity: options.shared_buffer_capacity as usize,
+                capacity: (options.shared_buffer_capacity_mb as usize) * (1 << 20),
                 upload_size: global_upload_batches_size,
                 replicate_size: global_replicate_batches_size,
             },

--- a/src/storage/src/hummock/sstable/builder.rs
+++ b/src/storage/src/hummock/sstable/builder.rs
@@ -47,8 +47,8 @@ pub struct SSTableBuilderOptions {
 impl From<&StorageConfig> for SSTableBuilderOptions {
     fn from(options: &StorageConfig) -> SSTableBuilderOptions {
         SSTableBuilderOptions {
-            capacity: options.sstable_size as usize,
-            block_capacity: options.block_size as usize,
+            capacity: (options.sstable_size_mb as usize) * (1 << 20),
+            block_capacity: (options.block_size_kb as usize) * (1 << 10),
             restart_interval: DEFAULT_RESTART_INTERVAL,
             bloom_false_positive: options.bloom_false_positive,
             // TODO: Make this configurable.

--- a/src/storage/src/hummock/state_store_tests.rs
+++ b/src/storage/src/hummock/state_store_tests.rs
@@ -250,8 +250,7 @@ async fn test_state_store_sync() {
     let sstable_store = mock_sstable_store();
 
     let mut config = default_config_for_test();
-    config.shared_buffer_capacity = 64;
-    config.shared_buffer_threshold = 64;
+    config.shared_buffer_capacity_mb = 64;
     config.write_conflict_detection_enabled = false;
 
     let hummock_options = Arc::new(config);

--- a/src/storage/src/hummock/test_utils.rs
+++ b/src/storage/src/hummock/test_utils.rs
@@ -37,17 +37,16 @@ use crate::store::StateStoreIter;
 
 pub fn default_config_for_test() -> StorageConfig {
     StorageConfig {
-        sstable_size: 256 * (1 << 20),
-        block_size: 64 * (1 << 10),
+        sstable_size_mb: 256,
+        block_size_kb: 64,
         bloom_false_positive: 0.1,
         share_buffers_sync_parallelism: 2,
-        shared_buffer_capacity: 64 << 20,
-        shared_buffer_threshold: 48 << 20,
+        shared_buffer_capacity_mb: 64,
         data_directory: "hummock_001".to_string(),
         async_checkpoint_enabled: true,
         write_conflict_detection_enabled: true,
-        block_cache_capacity: 64 << 20,
-        meta_cache_capacity: 64 << 20,
+        block_cache_capacity_mb: 64,
+        meta_cache_capacity_mb: 64,
         disable_remote_compactor: false,
         enable_local_spill: false,
         local_object_store: "memory".to_string(),

--- a/src/storage/src/store_impl.rs
+++ b/src/storage/src/store_impl.rs
@@ -113,8 +113,8 @@ impl StateStoreImpl {
                     )),
                     config.data_directory.to_string(),
                     state_store_stats.clone(),
-                    config.block_cache_capacity,
-                    config.meta_cache_capacity,
+                    config.block_cache_capacity_mb * (1 << 20),
+                    config.meta_cache_capacity_mb * (1 << 20),
                 ));
                 let inner = HummockStorage::new(
                     config.clone(),

--- a/src/stream/src/from_proto/source.rs
+++ b/src/stream/src/from_proto/source.rs
@@ -79,8 +79,7 @@ impl ExecutorBuilder for SourceExecutorBuilder {
             params.op_info,
             params.executor_stats,
             stream_source_splits,
-            // TODO: move checkpoint interval to stream config
-            100,
+            stream.config.checkpoint_interval_ms as u64,
         )?))
     }
 }

--- a/src/stream/src/task/stream_manager.rs
+++ b/src/stream/src/task/stream_manager.rs
@@ -20,7 +20,7 @@ use itertools::Itertools;
 use madsim::collections::{HashMap, HashSet};
 use madsim::task::JoinHandle;
 use parking_lot::Mutex;
-use risingwave_common::config::ComputeNodeConfig;
+use risingwave_common::config::StreamingConfig;
 use risingwave_common::error::{ErrorCode, Result, RwError};
 use risingwave_common::try_match_expand;
 use risingwave_common::util::addr::{is_local_address, HostAddr};
@@ -79,9 +79,8 @@ pub struct LocalStreamManagerCore {
     /// disconnected.
     compute_client_pool: ComputeClientPool,
 
-    /// Config of compute node
-    #[allow(dead_code)]
-    pub(crate) config: ComputeNodeConfig,
+    /// Config of streaming engine
+    pub(crate) config: StreamingConfig,
 }
 
 /// `LocalStreamManager` manages all stream executors in this project.
@@ -137,7 +136,7 @@ impl LocalStreamManager {
         addr: HostAddr,
         state_store: StateStoreImpl,
         streaming_metrics: Arc<StreamingMetrics>,
-        config: ComputeNodeConfig,
+        config: StreamingConfig,
     ) -> Self {
         Self::with_core(LocalStreamManagerCore::new(
             addr,
@@ -325,7 +324,7 @@ impl LocalStreamManagerCore {
         addr: HostAddr,
         state_store: StateStoreImpl,
         streaming_metrics: Arc<StreamingMetrics>,
-        config: ComputeNodeConfig,
+        config: StreamingConfig,
     ) -> Self {
         let context = SharedContext::new(addr);
         Self::with_store_and_context(state_store, context, streaming_metrics, config)
@@ -335,7 +334,7 @@ impl LocalStreamManagerCore {
         state_store: StateStoreImpl,
         context: SharedContext,
         streaming_metrics: Arc<StreamingMetrics>,
-        config: ComputeNodeConfig,
+        config: StreamingConfig,
     ) -> Self {
         let (tx, rx) = channel(LOCAL_OUTPUT_CHANNEL_SIZE);
 
@@ -362,7 +361,7 @@ impl LocalStreamManagerCore {
             StateStoreImpl::shared_in_memory_store(Arc::new(StateStoreMetrics::unused())),
             SharedContext::for_test(),
             streaming_metrics,
-            ComputeNodeConfig::default(),
+            StreamingConfig::default(),
         )
     }
 


### PR DESCRIPTION
Signed-off-by: Alex Chi <iskyzh@gmail.com>

## What's changed and what's your intention?

Use `item_<mb|kb>` for config items, so that they are easier to read and config.

double checked with @Little-Wallace , the block cache capacity is indeed memory consumption instead of entry number 🤣 @zwang28 

## Checklist

- [x] I have written necessary docs and comments
- [x] I have added necessary unit tests and integration tests

## Refer to a related PR or issue link (optional)

close https://github.com/singularity-data/risingwave/issues/2657