### PR TITLE
feat(ci): pr title checker

### DIFF
--- a/.github/pr-title-checker-config.json
+++ b/.github/pr-title-checker-config.json
@@ -1,0 +1,10 @@
+{
+  "LABEL": {
+    "name": "Invalid PR Title",
+    "color": "B60205"
+  },
+  "CHECKS": {
+    "regexp": "^(feat|fix|test|refactor|chore|style|doc)(\\(.*\\))?:.*",
+    "ignoreLabels" : ["ignore-title"]
+  }
+}

--- a/.github/workflows/pr-title-checker.yml
+++ b/.github/workflows/pr-title-checker.yml
@@ -1,0 +1,15 @@
+name: PR Title Checker
+
+on:
+  pull_request:
+    types: [opened, edited, labeled]
+
+jobs:
+  check:
+    runs-on: ubuntu-latest
+    name: pr-title-checker
+    steps:
+      - uses: thehanimo/pr-title-checker@v1.3.4
+        with:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          configuration_path: ".github/pr-title-checker-config.json"


### PR DESCRIPTION
## What's changed and what's your intention?
~Try to add a pr title checker.
Testing its effect.~

If it blocks the merging somehow like the already removed `semantic check`, we may tag an `ignore-title` to bypass the check.
