### PR TITLE
feat(relational_table_iter): implement relational iter

### DIFF
--- a/src/storage/src/keyspace.rs
+++ b/src/storage/src/keyspace.rs
@@ -156,10 +156,7 @@ impl<S: StateStore> Keyspace<S> {
         self.store.iter(range, epoch).await
     }
 
-    pub async fn iter(
-        &'_ self,
-        epoch: u64,
-    ) -> StorageResult<impl StateStoreIter<Item = (Bytes, Bytes)> + '_> {
+    pub async fn iter(&self, epoch: u64) -> StorageResult<StripPrefixIterator<S::Iter>> {
         let iter = self.iter_inner(epoch).await?;
         let strip_prefix_iterator = StripPrefixIterator {
             iter,
@@ -174,7 +171,7 @@ impl<S: StateStore> Keyspace<S> {
     }
 }
 
-struct StripPrefixIterator<I: StateStoreIter<Item = (Bytes, Bytes)>> {
+pub struct StripPrefixIterator<I: StateStoreIter<Item = (Bytes, Bytes)>> {
     iter: I,
     prefix_len: usize,
 }

--- a/src/storage/src/table/cell_based_table.rs
+++ b/src/storage/src/table/cell_based_table.rs
@@ -31,9 +31,10 @@ use super::TableIter;
 use crate::cell_based_row_deserializer::CellBasedRowDeserializer;
 use crate::cell_based_row_serializer::CellBasedRowSerializer;
 use crate::error::{StorageError, StorageResult};
+use crate::keyspace::StripPrefixIterator;
 use crate::monitor::StateStoreMetrics;
 use crate::storage_value::{StorageValue, ValueMeta};
-use crate::{Keyspace, StateStore};
+use crate::{Keyspace, StateStore, StateStoreIter};
 
 /// `CellBasedTable` is the interface accessing relational data in KV(`StateStore`) with encoding
 /// format: [keyspace | pk | `column_id` (4B)] -> value.
@@ -281,11 +282,20 @@ impl<S: StateStore> CellBasedTable<S> {
     pub async fn iter(&self, epoch: u64) -> StorageResult<CellBasedTableRowIter<S>> {
         CellBasedTableRowIter::new(
             self.keyspace.clone(),
-            self.column_descs.clone(),
+            &self.column_descs,
             epoch,
             self.stats.clone(),
         )
         .await
+    }
+
+    // streaming_iter is uesed for streaming executors, which is regarded as a short-term iterator
+    // and will not wait for epoch.
+    pub async fn streaming_iter(
+        &self,
+        epoch: u64,
+    ) -> StorageResult<CellBasedTableStreamingIter<S>> {
+        CellBasedTableStreamingIter::new(&self.keyspace, &self.column_descs, epoch).await
     }
 
     pub fn schema(&self) -> &Schema {
@@ -318,15 +328,15 @@ pub struct CellBasedTableRowIter<S: StateStore> {
 impl<S: StateStore> CellBasedTableRowIter<S> {
     const SCAN_LIMIT: usize = 1024;
 
-    async fn new(
+    pub async fn new(
         keyspace: Keyspace<S>,
-        table_descs: Vec<ColumnDesc>,
+        table_descs: &[ColumnDesc],
         epoch: u64,
         _stats: Arc<StateStoreMetrics>,
     ) -> StorageResult<Self> {
         keyspace.state_store().wait_epoch(epoch).await?;
 
-        let cell_based_row_deserializer = CellBasedRowDeserializer::new(table_descs);
+        let cell_based_row_deserializer = CellBasedRowDeserializer::new(table_descs.to_vec());
 
         let iter = Self {
             keyspace,
@@ -452,6 +462,58 @@ impl<S: StateStore> TableIter for CellBasedTableRowIter<S> {
             match pk_and_row {
                 Some(_) => return Ok(pk_and_row.map(|(_pk, row)| row)),
                 None => {}
+            }
+        }
+    }
+}
+
+/// [`CellBasedTableStreamingIter`] is used for streaming executor, and will not wait for epoch.
+pub struct CellBasedTableStreamingIter<S: StateStore> {
+    /// An iterator that returns raw bytes from storage.
+    iter: StripPrefixIterator<S::Iter>,
+    /// Cell-based row deserializer
+    cell_based_row_deserializer: CellBasedRowDeserializer,
+}
+
+impl<S: StateStore> CellBasedTableStreamingIter<S> {
+    pub async fn new(
+        keyspace: &Keyspace<S>,
+        table_descs: &[ColumnDesc],
+        epoch: u64,
+    ) -> StorageResult<Self> {
+        let cell_based_row_deserializer = CellBasedRowDeserializer::new(table_descs.to_vec());
+        let iter = keyspace.iter(epoch).await?;
+        let iter = Self {
+            iter,
+            cell_based_row_deserializer,
+        };
+        Ok(iter)
+    }
+
+    /// return a row with its pk.
+    pub async fn next(&mut self) -> StorageResult<Option<(Vec<u8>, Row)>> {
+        loop {
+            match self.iter.next().await? {
+                None => {
+                    let pk_and_row = self.cell_based_row_deserializer.take();
+                    return Ok(pk_and_row);
+                }
+                Some((key, value)) => {
+                    tracing::trace!(
+                        target: "events::storage::CellBasedTable::scan",
+                        "CellBasedTable scanned key = {:?}, value = {:?}",
+                        key,
+                        value
+                    );
+                    let pk_and_row = self
+                        .cell_based_row_deserializer
+                        .deserialize(&key, &value)
+                        .map_err(err)?;
+                    match pk_and_row {
+                        Some(pk_row) => return Ok(Some(pk_row)),
+                        None => {}
+                    }
+                }
             }
         }
     }

--- a/src/storage/src/table/state_table.rs
+++ b/src/storage/src/table/state_table.rs
@@ -163,7 +163,7 @@ impl<'a, S: StateStore> StateTableRowIter<'a, S> {
         let mut mem_table_iter_next_flag = false;
         let mut cell_based_iter_next_flag = false;
         let mut res = None;
-        let cell_based_item = std::mem::take(&mut self.cell_based_item);
+        let cell_based_item = self.cell_based_item.take();
         match (cell_based_item, self.mem_table_iter.peek()) {
             (None, None) => {
                 res = None;

--- a/src/storage/src/table/state_table.rs
+++ b/src/storage/src/table/state_table.rs
@@ -11,16 +11,18 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
-#![allow(dead_code)]
+use std::cmp::Ordering;
+use std::collections::btree_map;
+use std::iter::Peekable;
 use std::sync::Arc;
 
 use risingwave_common::array::Row;
 use risingwave_common::catalog::ColumnDesc;
 use risingwave_common::error::RwError;
-use risingwave_common::util::ordered::OrderedRowSerializer;
+use risingwave_common::util::ordered::{serialize_pk, OrderedRowSerializer};
 use risingwave_common::util::sort_util::OrderType;
 
-use super::cell_based_table::{CellBasedTable, CellBasedTableRowIter};
+use super::cell_based_table::{CellBasedTable, CellBasedTableStreamingIter};
 use super::mem_table::{MemTable, RowOp};
 use crate::error::{StorageError, StorageResult};
 use crate::monitor::StateStoreMetrics;
@@ -29,6 +31,9 @@ use crate::{Keyspace, StateStore};
 /// `StateTable` is the interface accessing relational data in KV(`StateStore`) with encoding
 #[derive(Clone)]
 pub struct StateTable<S: StateStore> {
+    keyspace: Keyspace<S>,
+
+    column_descs: Vec<ColumnDesc>,
     // /// Ordering of primary key (for assertion)
     order_types: Vec<OrderType>,
 
@@ -44,12 +49,16 @@ impl<S: StateStore> StateTable<S> {
         column_descs: Vec<ColumnDesc>,
         order_types: Vec<OrderType>,
     ) -> Self {
+        let cell_based_keyspace = keyspace.clone();
+        let cell_based_column_descs = column_descs.clone();
         Self {
+            keyspace,
+            column_descs,
             order_types: order_types.clone(),
             mem_table: MemTable::new(),
             cell_based_table: CellBasedTable::new(
-                keyspace,
-                column_descs,
+                cell_based_keyspace,
+                cell_based_column_descs,
                 Some(OrderedRowSerializer::new(order_types)),
                 Arc::new(StateStoreMetrics::unused()),
             ),
@@ -102,28 +111,118 @@ impl<S: StateStore> StateTable<S> {
         Ok(())
     }
 
-    pub async fn iter(&self, _pk: Row) -> StorageResult<StateTableRowIter<S>> {
-        todo!()
+    pub async fn iter(&self, epoch: u64) -> StorageResult<StateTableRowIter<'_, S>> {
+        let mem_table_iter = self.mem_table.buffer.iter().peekable();
+        StateTableRowIter::new(
+            &self.keyspace,
+            &self.column_descs,
+            mem_table_iter,
+            &self.order_types,
+            epoch,
+        )
+        .await
     }
 }
 
-pub struct StateTableRowIter<S: StateStore> {
-    cell_based_iter: CellBasedTableRowIter<S>,
-    mem_table: MemTable,
-}
+/// `StateTableRowIter` is able to read the just written data (uncommited data).
+/// It will merge the result of `mem_table_iter` and `cell_based_streaming_iter`
+pub struct StateTableRowIter<'a, S: StateStore> {
+    mem_table_iter: Peekable<MemTableIter<'a>>,
+    cell_based_streaming_iter: CellBasedTableStreamingIter<S>,
 
-impl<S: StateStore> StateTableRowIter<S> {
+    /// The result of the last cell_based_streaming_iter next is saved, which can avoid being
+    /// discarded.
+    cell_based_item: Option<(Vec<u8>, Row)>,
+    pk_serializer: OrderedRowSerializer,
+}
+type MemTableIter<'a> = btree_map::Iter<'a, Row, RowOp>;
+
+impl<'a, S: StateStore> StateTableRowIter<'a, S> {
     async fn new(
-        _keyspace: Keyspace<S>,
-        _table_descs: Vec<ColumnDesc>,
-        _epoch: u64,
-        _stats: Arc<StateStoreMetrics>,
-    ) -> StorageResult<Self> {
-        todo!()
+        keyspace: &Keyspace<S>,
+        table_descs: &[ColumnDesc],
+        mem_table_iter: Peekable<MemTableIter<'a>>,
+        order_types_vec: &[OrderType],
+        epoch: u64,
+    ) -> StorageResult<StateTableRowIter<'a, S>> {
+        let cell_based_streaming_iter =
+            CellBasedTableStreamingIter::new(keyspace, table_descs, epoch).await?;
+        let pk_serializer = OrderedRowSerializer::new(order_types_vec.to_vec());
+        let state_table_iter = Self {
+            mem_table_iter,
+            cell_based_streaming_iter,
+            cell_based_item: None,
+            pk_serializer,
+        };
+
+        Ok(state_table_iter)
     }
 
-    async fn next(&mut self) -> StorageResult<Option<Row>> {
-        todo!()
+    pub async fn next(&mut self) -> StorageResult<Option<Row>> {
+        let mut mem_table_iter_next_flag = false;
+        let mut res = None;
+        if self.cell_based_item.is_none() {
+            self.cell_based_item = self.cell_based_streaming_iter.next().await.map_err(err)?;
+        }
+        match (self.cell_based_item.as_ref(), self.mem_table_iter.peek()) {
+            (None, None) => {
+                res = None;
+            }
+            (Some((_, row)), None) => {
+                res = Some(row.clone());
+                self.cell_based_item = self.cell_based_streaming_iter.next().await.map_err(err)?
+            }
+            (None, Some((_, row_op))) => {
+                mem_table_iter_next_flag = true;
+                match row_op {
+                    RowOp::Insert(row) => res = Some(row.clone()),
+                    RowOp::Delete(_) => {}
+                    RowOp::Update((_, new_row)) => res = Some(new_row.clone()),
+                }
+            }
+            (Some((cell_based_pk, cell_based_row)), Some((mem_table_pk, mem_table_row_op))) => {
+                let mem_table_pk_bytes =
+                    serialize_pk(mem_table_pk, &self.pk_serializer).map_err(err)?;
+                match cell_based_pk.cmp(&mem_table_pk_bytes) {
+                    Ordering::Less => {
+                        // cell_based_table_item will be return
+                        res = Some(cell_based_row.clone());
+                        self.cell_based_item =
+                            self.cell_based_streaming_iter.next().await.map_err(err)?
+                    }
+                    Ordering::Equal => {
+                        // mem_table_item will be return, while both cell_based_streaming_iter and
+                        // mem_table_iter need to execute next() once.
+                        mem_table_iter_next_flag = true;
+                        self.cell_based_item =
+                            self.cell_based_streaming_iter.next().await.map_err(err)?;
+                        match mem_table_row_op {
+                            RowOp::Insert(row) => {
+                                res = Some(row.clone());
+                            }
+                            RowOp::Delete(_) => {}
+                            RowOp::Update((_, new_row)) => res = Some(new_row.clone()),
+                        }
+                    }
+                    Ordering::Greater => {
+                        // mem_table_item will be return
+                        mem_table_iter_next_flag = true;
+                        match mem_table_row_op {
+                            RowOp::Insert(row) => res = Some(row.clone()),
+                            RowOp::Delete(_) => {}
+                            RowOp::Update((old_row, new_row)) => {
+                                debug_assert!(old_row == cell_based_row);
+                                res = Some(new_row.clone());
+                            }
+                        }
+                    }
+                }
+            }
+        }
+        if mem_table_iter_next_flag {
+            self.mem_table_iter.next();
+        }
+        Ok(res)
     }
 }
 

--- a/src/storage/src/table/state_table.rs
+++ b/src/storage/src/table/state_table.rs
@@ -115,7 +115,7 @@ impl<S: StateStore> StateTable<S> {
         let mem_table_iter = self.mem_table.buffer.iter().peekable();
         StateTableRowIter::new(
             &self.keyspace,
-            &self.column_descs,
+            self.column_descs.clone(),
             mem_table_iter,
             &self.order_types,
             epoch,
@@ -140,7 +140,7 @@ type MemTableIter<'a> = btree_map::Iter<'a, Row, RowOp>;
 impl<'a, S: StateStore> StateTableRowIter<'a, S> {
     async fn new(
         keyspace: &Keyspace<S>,
-        table_descs: &[ColumnDesc],
+        table_descs: Vec<ColumnDesc>,
         mem_table_iter: Peekable<MemTableIter<'a>>,
         order_types_vec: &[OrderType],
         epoch: u64,

--- a/src/storage/src/table/state_table.rs
+++ b/src/storage/src/table/state_table.rs
@@ -218,8 +218,10 @@ impl<'a, S: StateStore> StateTableRowIter<'a, S> {
                         match mem_table_row_op {
                             RowOp::Insert(row) => res = Some(row.clone()),
                             RowOp::Delete(_) => {}
-                            RowOp::Update((_, new_row)) => {
-                                res = Some(new_row.clone());
+                            RowOp::Update(_) => {
+                                panic!(
+                                    "There must be a record in shared storage, so this case is unreachable.",
+                                );
                             }
                         }
                         self.cell_based_item = Some((cell_based_pk, cell_based_row));

--- a/src/stream/src/executor/mview/table_state_tests.rs
+++ b/src/stream/src/executor/mview/table_state_tests.rs
@@ -233,6 +233,400 @@ async fn test_multi_cell_based_table_iter() {
 }
 
 #[madsim::test]
+async fn test_state_table_iter() {
+    let state_store = MemoryStateStore::new();
+    let order_types = vec![OrderType::Ascending, OrderType::Descending];
+    let keyspace = Keyspace::executor_root(state_store, 0x42);
+    let column_ids = vec![ColumnId::from(0), ColumnId::from(1), ColumnId::from(2)];
+    let column_descs = vec![
+        ColumnDesc::unnamed(column_ids[0], DataType::Int32),
+        ColumnDesc::unnamed(column_ids[1], DataType::Int32),
+        ColumnDesc::unnamed(column_ids[2], DataType::Int32),
+    ];
+
+    let mut state = StateTable::new(keyspace.clone(), column_descs.clone(), order_types.clone());
+    let epoch: u64 = 0;
+
+    state
+        .insert(
+            Row(vec![Some(1_i32.into()), Some(11_i32.into())]),
+            Row(vec![
+                Some(1_i32.into()),
+                Some(11_i32.into()),
+                Some(111_i32.into()),
+            ]),
+        )
+        .unwrap();
+    state
+        .insert(
+            Row(vec![Some(2_i32.into()), Some(22_i32.into())]),
+            Row(vec![
+                Some(2_i32.into()),
+                Some(22_i32.into()),
+                Some(222_i32.into()),
+            ]),
+        )
+        .unwrap();
+    state
+        .delete(
+            Row(vec![Some(2_i32.into()), Some(22_i32.into())]),
+            Row(vec![
+                Some(2_i32.into()),
+                Some(22_i32.into()),
+                Some(222_i32.into()),
+            ]),
+        )
+        .unwrap();
+
+    let mut iter = state.iter(epoch).await.unwrap();
+
+    let res = iter.next().await.unwrap();
+    assert!(res.is_some());
+    assert_eq!(
+        Row(vec![
+            Some(1_i32.into()),
+            Some(11_i32.into()),
+            Some(111_i32.into())
+        ]),
+        res.unwrap()
+    );
+
+    let res = iter.next().await.unwrap();
+
+    assert!(res.is_none());
+
+    state
+        .insert(
+            Row(vec![Some(3_i32.into()), Some(33_i32.into())]),
+            Row(vec![
+                Some(3333_i32.into()),
+                Some(3333_i32.into()),
+                Some(3333_i32.into()),
+            ]),
+        )
+        .unwrap();
+
+    state
+        .insert(
+            Row(vec![Some(6_i32.into()), Some(66_i32.into())]),
+            Row(vec![
+                Some(6_i32.into()),
+                Some(66_i32.into()),
+                Some(666_i32.into()),
+            ]),
+        )
+        .unwrap();
+
+    state
+        .insert(
+            Row(vec![Some(9_i32.into()), Some(99_i32.into())]),
+            Row(vec![
+                Some(9_i32.into()),
+                Some(99_i32.into()),
+                Some(999_i32.into()),
+            ]),
+        )
+        .unwrap();
+
+    state.commit(epoch).await.unwrap();
+
+    let epoch = u64::MAX;
+
+    // write [3, 33, 333], [4, 44, 444], [5, 55, 555], [7, 77, 777], [8, 88, 888]into mem_table,
+    // [1, 11, 111], [3333, 3333, 3333], [6, 66, 666], [9, 99, 999] exists in cell_based_table
+
+    state
+        .insert(
+            Row(vec![Some(3_i32.into()), Some(33_i32.into())]),
+            Row(vec![
+                Some(3_i32.into()),
+                Some(33_i32.into()),
+                Some(333_i32.into()),
+            ]),
+        )
+        .unwrap();
+
+    state
+        .insert(
+            Row(vec![Some(4_i32.into()), Some(44_i32.into())]),
+            Row(vec![
+                Some(4_i32.into()),
+                Some(44_i32.into()),
+                Some(444_i32.into()),
+            ]),
+        )
+        .unwrap();
+
+    state
+        .insert(
+            Row(vec![Some(5_i32.into()), Some(55_i32.into())]),
+            Row(vec![
+                Some(5_i32.into()),
+                Some(55_i32.into()),
+                Some(555_i32.into()),
+            ]),
+        )
+        .unwrap();
+    state
+        .insert(
+            Row(vec![Some(7_i32.into()), Some(77_i32.into())]),
+            Row(vec![
+                Some(7_i32.into()),
+                Some(77_i32.into()),
+                Some(777_i32.into()),
+            ]),
+        )
+        .unwrap();
+
+    state
+        .insert(
+            Row(vec![Some(8_i32.into()), Some(88_i32.into())]),
+            Row(vec![
+                Some(8_i32.into()),
+                Some(88_i32.into()),
+                Some(888_i32.into()),
+            ]),
+        )
+        .unwrap();
+
+    let mut iter = state.iter(epoch).await.unwrap();
+
+    let res = iter.next().await.unwrap();
+    assert!(res.is_some());
+    // this row exists in cell_based_table
+    assert_eq!(
+        Row(vec![
+            Some(1_i32.into()),
+            Some(11_i32.into()),
+            Some(111_i32.into())
+        ]),
+        res.unwrap()
+    );
+
+    let res = iter.next().await.unwrap();
+
+    // this pk exist in both cell_based_table(shared_storage) and mem_table(buffer)
+    assert_eq!(
+        Row(vec![
+            Some(3_i32.into()),
+            Some(33_i32.into()),
+            Some(333_i32.into())
+        ]),
+        res.unwrap()
+    );
+
+    // this row exists in mem_table
+    let res = iter.next().await.unwrap();
+    assert_eq!(
+        Row(vec![
+            Some(4_i32.into()),
+            Some(44_i32.into()),
+            Some(444_i32.into())
+        ]),
+        res.unwrap()
+    );
+
+    let res = iter.next().await.unwrap();
+
+    // this row exists in mem_table
+    assert_eq!(
+        Row(vec![
+            Some(5_i32.into()),
+            Some(55_i32.into()),
+            Some(555_i32.into())
+        ]),
+        res.unwrap()
+    );
+    let res = iter.next().await.unwrap();
+
+    // this row exists in cell_based_table
+    assert_eq!(
+        Row(vec![
+            Some(6_i32.into()),
+            Some(66_i32.into()),
+            Some(666_i32.into())
+        ]),
+        res.unwrap()
+    );
+
+    let res = iter.next().await.unwrap();
+    // this row exists in mem_table
+    assert_eq!(
+        Row(vec![
+            Some(7_i32.into()),
+            Some(77_i32.into()),
+            Some(777.into())
+        ]),
+        res.unwrap()
+    );
+
+    let res = iter.next().await.unwrap();
+
+    // this row exists in mem_table
+    assert_eq!(
+        Row(vec![
+            Some(8_i32.into()),
+            Some(88_i32.into()),
+            Some(888_i32.into())
+        ]),
+        res.unwrap()
+    );
+
+    let res = iter.next().await.unwrap();
+
+    // this row exists in cell_based_table
+    assert_eq!(
+        Row(vec![
+            Some(9_i32.into()),
+            Some(99_i32.into()),
+            Some(999_i32.into())
+        ]),
+        res.unwrap()
+    );
+
+    // there is no row in both cell_based_table and mem_table
+    let res = iter.next().await.unwrap();
+    assert!(res.is_none());
+}
+
+#[madsim::test]
+async fn test_multi_state_table_iter() {
+    let state_store = MemoryStateStore::new();
+    // let pk_columns = vec![0, 1]; leave a message to indicate pk columns
+    let order_types = vec![OrderType::Ascending, OrderType::Descending];
+
+    let keyspace_1 = Keyspace::executor_root(state_store.clone(), 0x1111);
+    let keyspace_2 = Keyspace::executor_root(state_store.clone(), 0x2222);
+    let epoch: u64 = 0;
+
+    let column_ids = vec![ColumnId::from(0), ColumnId::from(1), ColumnId::from(2)];
+    let column_descs_1 = vec![
+        ColumnDesc::unnamed(column_ids[0], DataType::Int32),
+        ColumnDesc::unnamed(column_ids[1], DataType::Int32),
+        ColumnDesc::unnamed(column_ids[2], DataType::Int32),
+    ];
+    let column_descs_2 = vec![
+        ColumnDesc::unnamed(column_ids[0], DataType::Varchar),
+        ColumnDesc::unnamed(column_ids[1], DataType::Varchar),
+        ColumnDesc::unnamed(column_ids[2], DataType::Varchar),
+    ];
+
+    let mut state_1 = StateTable::new(
+        keyspace_1.clone(),
+        column_descs_1.clone(),
+        order_types.clone(),
+    );
+    let mut state_2 = StateTable::new(
+        keyspace_2.clone(),
+        column_descs_2.clone(),
+        order_types.clone(),
+    );
+
+    state_1
+        .insert(
+            Row(vec![Some(1_i32.into()), Some(11_i32.into())]),
+            Row(vec![
+                Some(1_i32.into()),
+                Some(11_i32.into()),
+                Some(111_i32.into()),
+            ]),
+        )
+        .unwrap();
+    state_1
+        .insert(
+            Row(vec![Some(2_i32.into()), Some(22_i32.into())]),
+            Row(vec![
+                Some(2_i32.into()),
+                Some(22_i32.into()),
+                Some(222_i32.into()),
+            ]),
+        )
+        .unwrap();
+    state_1
+        .delete(
+            Row(vec![Some(2_i32.into()), Some(22_i32.into())]),
+            Row(vec![
+                Some(2_i32.into()),
+                Some(22_i32.into()),
+                Some(222_i32.into()),
+            ]),
+        )
+        .unwrap();
+
+    state_2
+        .insert(
+            Row(vec![
+                Some("1".to_string().into()),
+                Some("11".to_string().into()),
+            ]),
+            Row(vec![
+                Some("1".to_string().into()),
+                Some("11".to_string().into()),
+                Some("111".to_string().into()),
+            ]),
+        )
+        .unwrap();
+    state_2
+        .insert(
+            Row(vec![
+                Some("2".to_string().into()),
+                Some("22".to_string().into()),
+            ]),
+            Row(vec![
+                Some("2".to_string().into()),
+                Some("22".to_string().into()),
+                Some("222".to_string().into()),
+            ]),
+        )
+        .unwrap();
+    state_2
+        .delete(
+            Row(vec![
+                Some("2".to_string().into()),
+                Some("22".to_string().into()),
+            ]),
+            Row(vec![
+                Some("2".to_string().into()),
+                Some("22".to_string().into()),
+                Some("222".to_string().into()),
+            ]),
+        )
+        .unwrap();
+
+    let mut iter_1 = state_1.iter(epoch).await.unwrap();
+    let mut iter_2 = state_2.iter(epoch).await.unwrap();
+
+    let res_1_1 = iter_1.next().await.unwrap();
+    assert!(res_1_1.is_some());
+    assert_eq!(
+        Row(vec![
+            Some(1_i32.into()),
+            Some(11_i32.into()),
+            Some(111_i32.into()),
+        ]),
+        res_1_1.unwrap()
+    );
+    let res_1_2 = iter_1.next().await.unwrap();
+    assert!(res_1_2.is_none());
+
+    let res_2_1 = iter_2.next().await.unwrap();
+    assert!(res_2_1.is_some());
+    assert_eq!(
+        Row(vec![
+            Some("1".to_string().into()),
+            Some("11".to_string().into()),
+            Some("111".to_string().into())
+        ]),
+        res_2_1.unwrap()
+    );
+    let res_2_2 = iter_2.next().await.unwrap();
+    assert!(res_2_2.is_none());
+
+    state_1.commit(epoch).await.unwrap();
+    state_2.commit(epoch).await.unwrap();
+}
+
+#[madsim::test]
 async fn test_cell_based_scan_empty_column_ids_cardinality() {
     let state_store = MemoryStateStore::new();
     let column_ids = vec![ColumnId::from(0), ColumnId::from(1), ColumnId::from(2)];


### PR DESCRIPTION
## What's changed and what's your intention?

This PR implements the StateTableIter, which is a merge iterator for CellBasedRowIter and MemTableIter.

## Checklist

- [x] I have written necessary docs and comments
- [x] I have added necessary unit tests and integration tests

## Refer to a related PR or issue link (optional)
