### PR TITLE
feat(frontend): add new IndexDeltaJoin rule

### DIFF
--- a/src/frontend/src/optimizer/delta_join_solver.rs
+++ b/src/frontend/src/optimizer/delta_join_solver.rs
@@ -234,7 +234,7 @@ pub struct DeltaJoinSolver {
 /// c -> a  -> b  ->
 /// ```
 #[derive(Clone, Debug, Eq, PartialEq)]
-pub struct LookupPath(JoinTable, pub Vec<JoinTable>);
+pub struct LookupPath(pub JoinTable, pub Vec<JoinTable>);
 
 struct SolverEnv {
     /// Stores all join edges in map. [`JoinEdge`]'s left side is always the key in map.

--- a/src/frontend/src/optimizer/mod.rs
+++ b/src/frontend/src/optimizer/mod.rs
@@ -137,6 +137,13 @@ impl PlanRoot {
             heuristic_optimizer.optimize(plan)
         };
 
+        // // Generate delta join plans if indicies are available
+        // plan = {
+        //     let rules = vec![IndexDeltaJoinRule::create()];
+        //     let heuristic_optimizer = HeuristicOptimizer::new(ApplyOrder::TopDown, rules);
+        //     heuristic_optimizer.optimize(plan)
+        // };
+
         // Reorder multijoin into left-deep join tree.
         plan = {
             let rules = vec![ReorderMultiJoinRule::create()];
@@ -242,8 +249,9 @@ impl PlanRoot {
         }?;
 
         // Rewrite joins with index to delta join
+        // TODO: remove this after the full migration
         let plan = {
-            let rules = vec![IndexDeltaJoinRule::create()];
+            let rules = vec![IndexDeltaJoinRuleLegacy::create()];
             let heuristic_optimizer = HeuristicOptimizer::new(ApplyOrder::BottomUp, rules);
             heuristic_optimizer.optimize(plan)
         };

--- a/src/frontend/src/optimizer/plan_node/logical_lookup_union.rs
+++ b/src/frontend/src/optimizer/plan_node/logical_lookup_union.rs
@@ -1,0 +1,116 @@
+// Copyright 2022 Singularity Data
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::fmt;
+
+use itertools::Itertools;
+use risingwave_common::error::Result;
+
+use super::{ColPrunable, PlanBase, PlanRef, ToBatch, ToStream};
+use crate::optimizer::plan_node::PlanTreeNode;
+use crate::utils::ColIndexMapping;
+
+#[derive(Debug, Clone)]
+pub struct LogicalLookupUnion {
+    pub base: PlanBase,
+    inputs: Vec<PlanRef>,
+}
+
+impl fmt::Display for LogicalLookupUnion {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f, "LogicalLookupUnion")
+    }
+}
+
+impl LogicalLookupUnion {
+    pub(crate) fn new(inputs: Vec<PlanRef>) -> Self {
+        assert!(!inputs.is_empty());
+        let mut expected_pk_indices = inputs[0].plan_base().pk_indices.clone();
+        expected_pk_indices.sort();
+
+        for input in &inputs {
+            // We don't care about the order of pk indices
+            let mut pk_indices = input.plan_base().pk_indices.clone();
+            pk_indices.sort();
+            assert_eq!(pk_indices, expected_pk_indices);
+
+            assert_eq!(
+                input.plan_base().append_only,
+                inputs[0].plan_base().append_only
+            );
+
+            assert_eq!(input.plan_base().dist, inputs[0].plan_base().dist);
+            assert_eq!(input.plan_base().schema, inputs[0].plan_base().schema);
+            // TODO: check other properties
+        }
+        let ctx = inputs[0].ctx();
+        let base = PlanBase::new_logical(
+            ctx,
+            inputs[0].schema().clone(),
+            inputs[0].pk_indices().to_vec(),
+        );
+        Self { base, inputs }
+    }
+}
+
+impl PlanTreeNode for LogicalLookupUnion {
+    fn inputs(&self) -> smallvec::SmallVec<[PlanRef; 2]> {
+        let mut vec = smallvec::SmallVec::new();
+        vec.extend(self.inputs.clone().into_iter());
+        vec
+    }
+
+    fn clone_with_inputs(&self, inputs: &[PlanRef]) -> PlanRef {
+        Self::new(inputs.to_vec()).into()
+    }
+}
+
+impl ColPrunable for LogicalLookupUnion {
+    fn prune_col(&self, required_cols: &[usize]) -> PlanRef {
+        self.clone_with_inputs(
+            &self
+                .inputs
+                .iter()
+                .map(|input| input.prune_col(required_cols))
+                .collect_vec(),
+        )
+    }
+}
+
+impl ToBatch for LogicalLookupUnion {
+    fn to_batch(&self) -> Result<PlanRef> {
+        todo!()
+    }
+}
+
+impl ToStream for LogicalLookupUnion {
+    fn to_stream(&self) -> Result<PlanRef> {
+        todo!()
+    }
+
+    fn logical_rewrite_for_stream(&self) -> Result<(PlanRef, ColIndexMapping)> {
+        let mut new_inputs = vec![];
+        let mut out_col_change = None;
+        for input in &self.inputs {
+            let (input, input_col_change) = input.logical_rewrite_for_stream()?;
+            new_inputs.push(input);
+            if let Some(ref out_col_change) = out_col_change {
+                assert_eq!(out_col_change, &input_col_change);
+            } else {
+                out_col_change = Some(input_col_change);
+            }
+        }
+        Ok((Self::new(new_inputs).into(), out_col_change.unwrap()))
+    }
+}

--- a/src/frontend/src/optimizer/plan_node/logical_multi_join.rs
+++ b/src/frontend/src/optimizer/plan_node/logical_multi_join.rs
@@ -95,6 +95,7 @@ impl LogicalMultiJoin {
             inputs.push(right.clone());
         }
 
+        // TODO: derive schema and pk
         Some(Self {
             base: logical_join.base.clone(),
             inputs,
@@ -107,6 +108,7 @@ impl LogicalMultiJoin {
         let input = logical_filter.input();
         let multijoin = input.as_logical_multi_join()?;
 
+        // TODO: derive schema and pk
         Some(Self {
             base: logical_filter.base.clone(),
             inputs: multijoin.inputs().to_vec(),

--- a/src/frontend/src/optimizer/plan_node/logical_scan.rs
+++ b/src/frontend/src/optimizer/plan_node/logical_scan.rs
@@ -121,7 +121,8 @@ impl LogicalScan {
         self.table_desc.as_ref()
     }
 
-    /// Get a reference to the logical scan's table desc.
+    /// Get a reference to the logical scan's table desc. The columns are not exactly the same as
+    /// the original table as being pruned, but will have the same order as the required input.
     #[must_use]
     pub fn column_descs(&self) -> Vec<ColumnDesc> {
         self.required_col_idx

--- a/src/frontend/src/optimizer/plan_node/mod.rs
+++ b/src/frontend/src/optimizer/plan_node/mod.rs
@@ -231,12 +231,12 @@ mod logical_hop_window;
 mod logical_insert;
 mod logical_join;
 mod logical_limit;
-mod logical_lookup_union;
 mod logical_multi_join;
 mod logical_project;
 mod logical_scan;
 mod logical_source;
 mod logical_topn;
+mod logical_union;
 mod logical_update;
 mod logical_values;
 mod stream_delta_join;
@@ -279,12 +279,12 @@ pub use logical_hop_window::LogicalHopWindow;
 pub use logical_insert::LogicalInsert;
 pub use logical_join::LogicalJoin;
 pub use logical_limit::LogicalLimit;
-pub use logical_lookup_union::LogicalLookupUnion;
 pub use logical_multi_join::LogicalMultiJoin;
 pub use logical_project::LogicalProject;
 pub use logical_scan::LogicalScan;
 pub use logical_source::LogicalSource;
 pub use logical_topn::LogicalTopN;
+pub use logical_union::{LogicalUnion, UnionMode};
 pub use logical_update::LogicalUpdate;
 pub use logical_values::LogicalValues;
 pub use stream_delta_join::StreamDeltaJoin;
@@ -336,8 +336,7 @@ macro_rules! for_all_plan_nodes {
             , { Logical, HopWindow }
             , { Logical, GenerateSeries }
             , { Logical, MultiJoin }
-            , { Logical, LookupUnion }
-            // , { Logical, Sort } we don't need a LogicalSort, just require the Order
+            , { Logical, Union }
             , { Batch, SimpleAgg }
             , { Batch, HashAgg }
             , { Batch, Project }
@@ -394,9 +393,7 @@ macro_rules! for_logical_plan_nodes {
             , { Logical, HopWindow }
             , { Logical, GenerateSeries }
             , { Logical, MultiJoin }
-            , { Logical, LookupUnion }
-            // , { Logical, Sort} not sure if we will support Order by clause in subquery/view/MV
-            // if we dont support thatk, we don't need LogicalSort, just require the Order at the top of query
+            , { Logical, Union }
         }
     };
 }

--- a/src/frontend/src/optimizer/plan_node/mod.rs
+++ b/src/frontend/src/optimizer/plan_node/mod.rs
@@ -231,6 +231,7 @@ mod logical_hop_window;
 mod logical_insert;
 mod logical_join;
 mod logical_limit;
+mod logical_lookup_union;
 mod logical_multi_join;
 mod logical_project;
 mod logical_scan;
@@ -278,6 +279,7 @@ pub use logical_hop_window::LogicalHopWindow;
 pub use logical_insert::LogicalInsert;
 pub use logical_join::LogicalJoin;
 pub use logical_limit::LogicalLimit;
+pub use logical_lookup_union::LogicalLookupUnion;
 pub use logical_multi_join::LogicalMultiJoin;
 pub use logical_project::LogicalProject;
 pub use logical_scan::LogicalScan;
@@ -334,6 +336,7 @@ macro_rules! for_all_plan_nodes {
             , { Logical, HopWindow }
             , { Logical, GenerateSeries }
             , { Logical, MultiJoin }
+            , { Logical, LookupUnion }
             // , { Logical, Sort } we don't need a LogicalSort, just require the Order
             , { Batch, SimpleAgg }
             , { Batch, HashAgg }
@@ -391,6 +394,7 @@ macro_rules! for_logical_plan_nodes {
             , { Logical, HopWindow }
             , { Logical, GenerateSeries }
             , { Logical, MultiJoin }
+            , { Logical, LookupUnion }
             // , { Logical, Sort} not sure if we will support Order by clause in subquery/view/MV
             // if we dont support thatk, we don't need LogicalSort, just require the Order at the top of query
         }

--- a/src/frontend/src/optimizer/rule/index_delta_join.rs
+++ b/src/frontend/src/optimizer/rule/index_delta_join.rs
@@ -22,9 +22,9 @@ use super::super::plan_node::*;
 use super::{BoxedRule, Rule};
 
 /// Use index scan and delta joins for supported queries.
-pub struct IndexDeltaJoinRule {}
+pub struct IndexDeltaJoinRuleLegacy {}
 
-impl Rule for IndexDeltaJoinRule {
+impl Rule for IndexDeltaJoinRuleLegacy {
     fn apply(&self, plan: PlanRef) -> Option<PlanRef> {
         let join = plan.as_stream_hash_join()?;
         if join.eq_join_predicate().has_non_eq() || join.join_type() != JoinType::Inner {
@@ -124,7 +124,7 @@ impl Rule for IndexDeltaJoinRule {
     }
 }
 
-impl IndexDeltaJoinRule {
+impl IndexDeltaJoinRuleLegacy {
     pub fn create() -> BoxedRule {
         Box::new(Self {})
     }

--- a/src/frontend/src/optimizer/rule/index_delta_join_new.rs
+++ b/src/frontend/src/optimizer/rule/index_delta_join_new.rs
@@ -203,7 +203,7 @@ impl Rule for IndexDeltaJoinRule {
             inputs.push(plan);
         }
 
-        let lookup_union = LogicalLookupUnion::new(inputs);
+        let lookup_union = LogicalUnion::new(inputs, UnionMode::StreamLastToFirst);
 
         Some(lookup_union.into())
     }

--- a/src/frontend/src/optimizer/rule/index_delta_join_new.rs
+++ b/src/frontend/src/optimizer/rule/index_delta_join_new.rs
@@ -1,0 +1,217 @@
+// Copyright 2022 Singularity Data
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::collections::{BTreeMap, HashSet};
+
+use itertools::Itertools;
+
+use super::super::plan_node::*;
+use super::{BoxedRule, Rule};
+use crate::optimizer::delta_join_solver::{
+    DeltaJoinSolver, JoinEdge, JoinTable, LookupPath, StreamStrategy,
+};
+use crate::utils::Condition;
+
+/// Use index scan and delta joins for supported queries.
+pub struct IndexDeltaJoinRule {}
+
+impl Rule for IndexDeltaJoinRule {
+    fn apply(&self, plan: PlanRef) -> Option<PlanRef> {
+        // Find a multi-join node
+        let multi_join = plan.as_logical_multi_join()?;
+
+        tracing::trace!("processing multi-way join in index delta join rule");
+
+        // Require all children to be table scans
+        let inputs = multi_join.inputs();
+        let children = inputs
+            .iter()
+            .map(|x| x.as_logical_scan())
+            .collect::<Option<Vec<_>>>()?;
+
+        tracing::trace!("all children are table scans");
+
+        fn match_index(join_indices: &[usize], table_scan: &LogicalScan) -> Option<PlanRef> {
+            if table_scan.indexes().is_empty() {
+                return None;
+            }
+            let column_descs = table_scan.column_descs();
+            // We assume column id of create index's MV is exactly the same as corresponding columns
+            // in the original table. We generate a list of column ids, and match them against
+            // prefixes of indexes.
+            let columns_to_match = join_indices
+                .iter()
+                .map(|idx| column_descs[*idx].column_id)
+                .collect_vec();
+
+            for (name, index) in table_scan.indexes() {
+                // 1. Check if distribution keys are the same.
+                // We don't assume the hash function we are using satisfies commutativity
+                // `Hash(A, B) == Hash(B, A)`, so we consider order of each item in distribution
+                // keys here.
+                if index
+                    .distribution_keys
+                    .iter()
+                    .map(|x| index.columns[*x].column_id)
+                    .collect_vec()
+                    != columns_to_match
+                {
+                    continue;
+                }
+
+                // 2. Check if the join keys are prefix of order keys
+
+                // A HashSet containing remaining columns to match
+                let mut remaining_to_match =
+                    columns_to_match.iter().copied().collect::<HashSet<_>>();
+
+                // Begin match join columns with index prefix. e.g., if the join columns are `a, b,
+                // c`, and the index has `a, b, c` or `a, c, b` or any combination as prefix, then
+                // we can use this index.
+                for ordered_column in &index.order_desc {
+                    let column_id = ordered_column.column_desc.column_id;
+
+                    match remaining_to_match.remove(&column_id) {
+                        true => continue, // matched
+                        false => break,   // not matched
+                    }
+                }
+
+                if remaining_to_match.is_empty() {
+                    return Some(table_scan.to_index_scan(name, index).into());
+                }
+            }
+
+            None
+        }
+
+        // Number of columns in each table.
+        let input_cols = multi_join.input_col_nums();
+        tracing::trace!("cols: {:?}", input_cols);
+
+        let begin_offsets = {
+            let mut offsets = vec![];
+            let mut sum = 0;
+
+            for &n in &input_cols {
+                offsets.push(sum);
+                sum += n;
+            }
+            offsets
+        };
+
+        // Firstly, we get all eq join conditions from the multi-join plan node.
+        let (eq_join_conditions, _) = multi_join.on().clone().split_by_input_col_nums(
+            &input_cols,
+            // only eq conditions
+            true,
+        );
+
+        // Stores `(table_1, table_2) -> (vec![col1, col2], vec![col3, col4])`,
+        // where col1, col2, col3, col4 are the real column id in each table.
+        let mut tables = BTreeMap::new();
+
+        for (&(left_table_id, right_table_id), cond) in &eq_join_conditions {
+            tracing::trace!("processing eq condition: {}", cond);
+
+            if cond.conjunctions.is_empty() {
+                return None;
+            }
+            let mut left_keys = vec![];
+            let mut right_keys = vec![];
+            for conj in &cond.conjunctions {
+                let (left_key, right_key) = Condition::as_eq_cond(conj)?;
+                // The keys are position in the schema instead of in table, so we need to map it to
+                // the table column id.
+                let l = left_key.index();
+                let r = right_key.index();
+
+                let left_table = begin_offsets.partition_point(|&offset| offset <= l) - 1;
+                let right_table = begin_offsets.partition_point(|&offset| offset <= r) - 1;
+                left_keys.push(l - begin_offsets[left_table]);
+                right_keys.push(r - begin_offsets[right_table]);
+            }
+            tables.insert((left_table_id, right_table_id), (left_keys, right_keys));
+        }
+
+        tracing::trace!("resolved eq relation between tables: {:?}", tables);
+
+        // All matched indices
+        let mut matched_index = BTreeMap::new();
+
+        // Check if all join keys have indices.
+        for (&(left_table, right_table), (left_join_keys, right_join_keys)) in &tables {
+            for (table, join_keys) in [
+                (left_table, left_join_keys.clone()),
+                (right_table, right_join_keys.clone()),
+            ] {
+                if !matched_index.contains_key(&(table, join_keys.clone())) {
+                    tracing::trace!("matching index: {} with {:?}", left_table, join_keys);
+                    let index = match_index(&join_keys, children[table])?;
+                    matched_index.insert((table, join_keys), index);
+                }
+            }
+        }
+
+        tracing::trace!(
+            "all matched index: {:?}",
+            matched_index.keys().collect_vec()
+        );
+
+        let heuristic_ordering = multi_join.heuristic_ordering().ok()?;
+        tracing::trace!("heuristic ordering: {:?}", heuristic_ordering);
+
+        let solver = DeltaJoinSolver::new(
+            StreamStrategy::LeftThisEpoch,
+            tables
+                .iter()
+                .map(
+                    |(&(left_table, right_table), (left_join_keys, right_join_keys))| JoinEdge {
+                        left: JoinTable(left_table),
+                        right: JoinTable(right_table),
+                        left_join_keys: left_join_keys.clone(),
+                        right_join_keys: right_join_keys.clone(),
+                    },
+                )
+                .collect(),
+            heuristic_ordering
+                .iter()
+                .map(|&table| JoinTable(table))
+                .collect(),
+        );
+
+        let solution = solver.solve().ok()?;
+        tracing::trace!("delta join solution: {:#?}", solution);
+
+        let mut inputs = Vec::with_capacity(children.len());
+        for LookupPath(stream, tables) in solution {
+            let mut join_ordering = Vec::with_capacity(children.len());
+            join_ordering.push(stream.0);
+            join_ordering.extend(tables.iter().map(|x| x.0));
+            let plan = multi_join.as_reordered_left_deep_join(&join_ordering);
+            inputs.push(plan);
+        }
+
+        let lookup_union = LogicalLookupUnion::new(inputs);
+
+        Some(lookup_union.into())
+    }
+}
+
+impl IndexDeltaJoinRule {
+    #[allow(dead_code)]
+    pub fn create() -> BoxedRule {
+        Box::new(Self {})
+    }
+}

--- a/src/frontend/src/optimizer/rule/mod.rs
+++ b/src/frontend/src/optimizer/rule/mod.rs
@@ -35,6 +35,8 @@ mod unnest_agg_for_loj;
 pub use unnest_agg_for_loj::*;
 mod pull_up_correlated_predicate;
 pub use pull_up_correlated_predicate::*;
+mod index_delta_join_new;
+pub use index_delta_join_new::*;
 mod index_delta_join;
 pub use index_delta_join::*;
 mod multijoin_filter;

--- a/src/frontend/src/utils/column_index_mapping.rs
+++ b/src/frontend/src/utils/column_index_mapping.rs
@@ -24,7 +24,7 @@ use crate::optimizer::property::{Distribution, FieldOrder, Order, RequiredDist};
 /// `ColIndexMapping` is a partial mapping from usize to usize.
 ///
 /// It is used in optimizer for transformation of column index.
-#[derive(Clone)]
+#[derive(Clone, Eq, PartialEq)]
 pub struct ColIndexMapping {
     /// The size of the target space, i.e. target index is in the range `(0..target_size)`.
     target_size: usize,

--- a/src/frontend/test_runner/tests/testdata/array.yaml
+++ b/src/frontend/test_runner/tests/testdata/array.yaml
@@ -2,26 +2,28 @@
 
 - sql: |
     values (ARRAY['foo', 'bar']);
-  logical_plan: |
-    LogicalValues { rows: [[Array('foo':Varchar, 'bar':Varchar)]], schema: Schema { fields: [:List { datatype: Varchar }] } }
   batch_plan: |
     BatchValues { rows: [[Array('foo':Varchar, 'bar':Varchar)]] }
+  logical_plan: |
+    LogicalValues { rows: [[Array('foo':Varchar, 'bar':Varchar)]], schema: Schema { fields: [:List { datatype: Varchar }] } }
 - sql: |
     values (ARRAY[1, 2+3, 4*5+1]);
-  logical_plan: |
-    LogicalValues { rows: [[Array(1:Int32, (2:Int32 + 3:Int32), ((4:Int32 * 5:Int32) + 1:Int32))]], schema: Schema { fields: [:List { datatype: Int32 }] } }
   batch_plan: |
     BatchValues { rows: [[Array(1:Int32, (2:Int32 + 3:Int32), ((4:Int32 * 5:Int32) + 1:Int32))]] }
+  logical_plan: |
+    LogicalValues { rows: [[Array(1:Int32, (2:Int32 + 3:Int32), ((4:Int32 * 5:Int32) + 1:Int32))]], schema: Schema { fields: [:List { datatype: Int32 }] } }
+
 - sql: |
     create table t (v1 int);
     select (ARRAY[1, v1]) from t;
-  logical_plan: |
-    LogicalProject { exprs: [Array(1:Int32, $1)] }
-      LogicalScan { table: t, columns: [_row_id, v1] }
   batch_plan: |
     BatchExchange { order: [], dist: Single }
       BatchProject { exprs: [Array(1:Int32, $0)] }
         BatchScan { table: t, columns: [v1] }
+  logical_plan: |
+    LogicalProject { exprs: [Array(1:Int32, $1)] }
+      LogicalScan { table: t, columns: [_row_id, v1] }
+
 - sql: |
     select ARRAY[null];
   logical_plan: |


### PR DESCRIPTION
Signed-off-by: Alex Chi <iskyzh@gmail.com>

## What's changed and what's your intention?

This PR is a step towards migrating delta join rewriter into the frontend. Currently, the rule is not enabled by default. We will do this migration step by step.

If the rule gets enabled, the plan will be like:

```yaml
- sql: |
    create table t1 (v1 int, v2 float);
    create table t2 (v3 int, v4 numeric, v5 bigint);
    create index t1_v1 on t1(v1);
    create index t2_v3 on t2(v3);
    /* should generate delta join plan, and stream index scan */
    select * from t1, t2 where t1.v1 = t2.v3;
  optimized_logical_plan: |
    LogicalLookupUnion
      LogicalJoin { type: Inner, on: ($0 = $2) }
        LogicalScan { table: t1, columns: [v1, v2] }
        LogicalScan { table: t2, columns: [v3, v4, v5] }
      LogicalProject { exprs: [$3, $4, $0, $1, $2] }
        LogicalJoin { type: Inner, on: ($3 = $0) }
          LogicalScan { table: t2, columns: [v3, v4, v5] }
          LogicalScan { table: t1, columns: [v1, v2] }
- id: 3-way-join-one-key
  sql: |
    create table a (v1 int, v2 int);
    create table b (vb int);
    create table c (vc int);
    create index a_v1 on a(v1);
    create index a_v2 on a(v2);
    create index b_vb on b(vb);
    create index c_vc on c(vc);
    /* filter is not added, tracked at https://github.com/singularity-data/risingwave/issues/2711 */
    select * from a, b, c where a.v1 = b.vb and a.v1 = c.vc /* and a.v1 > 10 and b.vb > c.vc */;
  optimized_logical_plan: |
    LogicalLookupUnion
      LogicalJoin { type: Inner, on: ($0 = $3) }
        LogicalJoin { type: Inner, on: ($0 = $2) }
          LogicalScan { table: a, columns: [v1, v2] }
          LogicalScan { table: b, columns: [vb] }
        LogicalScan { table: c, columns: [vc] }
      LogicalProject { exprs: [$1, $2, $0, $3] }
        LogicalJoin { type: Inner, on: ($1 = $3) }
          LogicalJoin { type: Inner, on: ($1 = $0) }
            LogicalScan { table: b, columns: [vb] }
            LogicalScan { table: a, columns: [v1, v2] }
          LogicalScan { table: c, columns: [vc] }
      LogicalProject { exprs: [$1, $2, $3, $0] }
        LogicalJoin { type: Inner, on: ($1 = $3) }
          LogicalJoin { type: Inner, on: ($1 = $0) }
            LogicalScan { table: c, columns: [vc] }
            LogicalScan { table: a, columns: [v1, v2] }
          LogicalScan { table: b, columns: [vb] }
- id: 3-way-join-two-keys
  sql: |
    create table a (v1 int, v2 int);
    create table b (vb int);
    create table c (vc int);
    create index a_v1 on a(v1);
    create index a_v2 on a(v2);
    create index b_vb on b(vb);
    create index c_vc on c(vc);
    /* filter is not added, tracked at https://github.com/singularity-data/risingwave/issues/2711 */
    select * from a, b, c where a.v1 = b.vb /* and a.v2 = c.vc and a.v1 > 10 and b.vb > c.vc */;
  optimized_logical_plan: |
    LogicalJoin { type: Inner, on: true }
      LogicalJoin { type: Inner, on: ($0 = $2) }
        LogicalScan { table: a, columns: [v1, v2] }
        LogicalScan { table: b, columns: [vb] }
      LogicalScan { table: c, columns: [vc] }
- id: index_slt
  sql: |
    create table iii_t1 (v1 int, v2 int);
    create table iii_t2 (v3 int, v4 int);
    create table iii_t3 (v5 int, v6 int);
    create materialized view iii_mv1 as select * from iii_t1, iii_t2, iii_t3 where iii_t1.v1 = iii_t2.v3 and iii_t1.v1 = iii_t3.v5;
    create index iii_index_1 on iii_t1(v1);
    create index iii_index_2 on iii_t2(v3);
- before:
    - index_slt
  sql: |
    select * from iii_t1, iii_t2 where iii_t1.v1 = iii_t2.v3;
  optimized_logical_plan: |
    LogicalLookupUnion
      LogicalJoin { type: Inner, on: ($0 = $2) }
        LogicalScan { table: iii_t1, columns: [v1, v2] }
        LogicalScan { table: iii_t2, columns: [v3, v4] }
      LogicalProject { exprs: [$2, $3, $0, $1] }
        LogicalJoin { type: Inner, on: ($2 = $0) }
          LogicalScan { table: iii_t2, columns: [v3, v4] }
          LogicalScan { table: iii_t1, columns: [v1, v2] }
- before:
    - index_slt
  sql: |
    select v4 from iii_t1, iii_t2 where iii_t1.v1 = iii_t2.v3;
  optimized_logical_plan: |
    LogicalLookupUnion
      LogicalProject { exprs: [$2] }
        LogicalJoin { type: Inner, on: ($0 = $1) }
          LogicalScan { table: iii_t1, columns: [v1] }
          LogicalScan { table: iii_t2, columns: [v3, v4] }
      LogicalProject { exprs: [$1] }
        LogicalJoin { type: Inner, on: ($2 = $0) }
          LogicalScan { table: iii_t2, columns: [v3, v4] }
          LogicalScan { table: iii_t1, columns: [v1] }
```

Where `LogicalJoin` and `LogicalScan` will be rewritten into `Lookup` and `IndexScan` separately, in future PRs.

The new `IndexDeltaJoin` rule is applied after MultiJoin rule and before Reorder rule. It will look for multi way joins, and try converting them into delta join plans by looking at the indices and using the delta join solver.

There are also some other changes including:

* Derive schema and pk for multi join. Otherwise no optimizer rule other than JoinReorder will be able to run after MultiJoin.
* Fix some comments
* Add a new LookupUnion node (maybe rename to Union in the future?)

## Checklist

- [x] I have written necessary docs and comments
- [x] I have added necessary unit tests and integration tests

## Refer to a related PR or issue link (optional)

https://github.com/singularity-data/risingwave/issues/2688