### PR TITLE
refactor(storage): remove add_sstables RPC.

### DIFF
--- a/proto/hummock.proto
+++ b/proto/hummock.proto
@@ -56,7 +56,6 @@ message HummockVersionRefId {
 message HummockVersion {
   uint64 id = 1;
   repeated Level levels = 2;
-  repeated UncommittedEpoch uncommitted_epochs = 3;
   uint64 max_committed_epoch = 4;
   // Snapshots with epoch less than the safe epoch have been GCed.
   // Reads against such an epoch will fail.
@@ -65,17 +64,6 @@ message HummockVersion {
 
 message HummockSnapshot {
   uint64 epoch = 1;
-}
-
-message AddTablesRequest {
-  uint32 context_id = 1;
-  repeated SstableInfo tables = 2;
-  uint64 epoch = 3;
-}
-
-message AddTablesResponse {
-  common.Status status = 1;
-  HummockVersion version = 2;
 }
 
 message PinVersionRequest {
@@ -223,22 +211,6 @@ message HummockStaleSstables {
   repeated uint64 id = 2;
 }
 
-message CommitEpochRequest {
-  uint64 epoch = 1;
-}
-
-message CommitEpochResponse {
-  common.Status status = 1;
-}
-
-message AbortEpochRequest {
-  uint64 epoch = 1;
-}
-
-message AbortEpochResponse {
-  common.Status status = 1;
-}
-
 message GetNewTableIdRequest {}
 
 message GetNewTableIdResponse {
@@ -270,12 +242,9 @@ message ReportVacuumTaskResponse {
 service HummockManagerService {
   rpc PinVersion(PinVersionRequest) returns (PinVersionResponse);
   rpc UnpinVersion(UnpinVersionRequest) returns (UnpinVersionResponse);
-  rpc AddTables(AddTablesRequest) returns (AddTablesResponse);
   rpc ReportCompactionTasks(ReportCompactionTasksRequest) returns (ReportCompactionTasksResponse);
   rpc PinSnapshot(PinSnapshotRequest) returns (PinSnapshotResponse);
   rpc UnpinSnapshot(UnpinSnapshotRequest) returns (UnpinSnapshotResponse);
-  rpc CommitEpoch(CommitEpochRequest) returns (CommitEpochResponse);
-  rpc AbortEpoch(AbortEpochRequest) returns (AbortEpochResponse);
   rpc GetNewTableId(GetNewTableIdRequest) returns (GetNewTableIdResponse);
   rpc SubscribeCompactTasks(SubscribeCompactTasksRequest) returns (stream SubscribeCompactTasksResponse);
   rpc ReportVacuumTask(ReportVacuumTaskRequest) returns (ReportVacuumTaskResponse);

--- a/proto/stream_service.proto
+++ b/proto/stream_service.proto
@@ -5,6 +5,7 @@ package stream_service;
 import "catalog.proto";
 import "common.proto";
 import "data.proto";
+import "hummock.proto";
 import "stream_plan.proto";
 
 option optimize_for = SPEED;
@@ -75,6 +76,7 @@ message InjectBarrierResponse {
   string request_id = 1;
   common.Status status = 2;
   repeated FinishedCreateMview finished_create_mviews = 3;
+  repeated hummock.SstableInfo sycned_sstables = 4;
 }
 
 // Before starting streaming, the leader node broadcast the actor-host table to needed workers.

--- a/src/bench/ss_bench/operations/write_batch.rs
+++ b/src/bench/ss_bench/operations/write_batch.rs
@@ -193,7 +193,11 @@ impl Operations {
                     let last_batch = i + 1 == l;
                     if ctx.epoch_barrier_finish(last_batch) {
                         store.sync(Some(epoch)).await.unwrap();
-                        ctx.meta_client.commit_epoch(epoch).await.unwrap();
+                        let synced_sst = store.get_uncommitted_ssts(epoch);
+                        ctx.meta_client
+                            .commit_epoch(epoch, synced_sst)
+                            .await
+                            .unwrap();
                         ctx.epoch.fetch_add(1, Ordering::SeqCst);
                     }
                     store.wait_epoch(epoch).await.unwrap();

--- a/src/compute/src/rpc/service/stream_service.rs
+++ b/src/compute/src/rpc/service/stream_service.rs
@@ -160,6 +160,7 @@ impl StreamService for StreamServiceImpl {
             request_id: req.request_id,
             finished_create_mviews,
             status: None,
+            sycned_sstables: collect_result.synced_sstables,
         }))
     }
 

--- a/src/meta/src/barrier/mod.rs
+++ b/src/meta/src/barrier/mod.rs
@@ -317,19 +317,25 @@ where
         let result = self.inject_barrier(command_context).await;
         // Commit this epoch to Hummock
         if command_context.prev_epoch.0 != INVALID_EPOCH {
-            match result {
-                Ok(_) => {
+            match &result {
+                Ok(resps) => {
                     // We must ensure all epochs are committed in ascending order, because
                     // the storage engine will query from new to old in the order in which
                     // the L0 layer files are generated. see https://github.com/singularity-data/risingwave/issues/1251
+                    let synced_ssts = resps
+                        .iter()
+                        .flat_map(|resp| resp.sycned_sstables.clone())
+                        .collect_vec();
                     self.hummock_manager
-                        .commit_epoch(command_context.prev_epoch.0)
+                        .commit_epoch(command_context.prev_epoch.0, synced_ssts)
                         .await?;
                 }
-                Err(_) => {
-                    self.hummock_manager
-                        .abort_epoch(command_context.prev_epoch.0)
-                        .await?;
+                Err(err) => {
+                    tracing::warn!(
+                        "Failed to commit epoch {}: {:#?}",
+                        command_context.prev_epoch.0,
+                        err
+                    );
                 }
             };
         }

--- a/src/meta/src/hummock/compactor_manager.rs
+++ b/src/meta/src/hummock/compactor_manager.rs
@@ -140,7 +140,7 @@ mod tests {
 
     async fn add_compact_task<S>(
         hummock_manager_ref: &HummockManager<S>,
-        context_id: u32,
+        _context_id: u32,
         epoch: u64,
     ) where
         S: MetaStore,
@@ -150,10 +150,9 @@ mod tests {
             vec![hummock_manager_ref.get_new_table_id().await.unwrap()],
         );
         hummock_manager_ref
-            .add_tables(context_id, original_tables.clone(), epoch)
+            .commit_epoch(epoch, original_tables)
             .await
             .unwrap();
-        hummock_manager_ref.commit_epoch(epoch).await.unwrap();
     }
 
     fn dummy_compact_task(task_id: u64) -> CompactTask {

--- a/src/meta/src/hummock/hummock_manager.rs
+++ b/src/meta/src/hummock/hummock_manager.rs
@@ -32,7 +32,7 @@ use risingwave_pb::common::ParallelUnitMapping;
 use risingwave_pb::hummock::{
     CompactTask, CompactTaskAssignment, HummockPinnedSnapshot, HummockPinnedVersion,
     HummockSnapshot, HummockStaleSstables, HummockVersion, Level, LevelType, SstableIdInfo,
-    SstableInfo, UncommittedEpoch,
+    SstableInfo,
 };
 use risingwave_pb::meta::subscribe_response::{Info, Operation};
 use tokio::sync::RwLock;
@@ -209,7 +209,6 @@ where
                     level_type: LevelType::Overlapping as i32,
                     table_infos: vec![],
                 }],
-                uncommitted_epochs: vec![],
                 max_committed_epoch: INVALID_EPOCH,
                 safe_epoch: INVALID_EPOCH,
             };
@@ -358,102 +357,6 @@ where
         }
 
         Ok(())
-    }
-
-    pub async fn add_tables(
-        &self,
-        context_id: HummockContextId,
-        sstables: Vec<SstableInfo>,
-        epoch: HummockEpoch,
-    ) -> Result<HummockVersion> {
-        let mut versioning_guard = self.versioning.write().await;
-
-        let versioning = versioning_guard.deref_mut();
-        let mut current_version_id = VarTransaction::new(&mut versioning.current_version_id);
-        let mut hummock_versions = VarTransaction::new(&mut versioning.hummock_versions);
-        let mut sstable_id_infos = VarTransaction::new(&mut versioning.sstable_id_infos);
-
-        let current_hummock_version = hummock_versions
-            .get(&current_version_id.id())
-            .unwrap()
-            .clone();
-
-        // Track SST in meta.
-        for sst_id in sstables.iter().map(|s| s.id) {
-            match sstable_id_infos.get_mut(&sst_id) {
-                None => {
-                    return Err(Error::InternalError(format!(
-                        "Invalid SST id {}, may have been vacuumed",
-                        sst_id
-                    )));
-                }
-                Some(sst_id_info) => {
-                    if sst_id_info.meta_delete_timestamp != INVALID_TIMESTAMP {
-                        return Err(Error::InternalError(format!(
-                            "SST id {} has been marked for vacuum",
-                            sst_id
-                        )));
-                    }
-                    if sst_id_info.meta_create_timestamp != INVALID_TIMESTAMP {
-                        // This is a duplicate request.
-                        return Ok(current_hummock_version);
-                    }
-                    sst_id_info.meta_create_timestamp = sstable_id_info::get_timestamp_now();
-                }
-            }
-        }
-
-        // Check whether the epoch is valid
-        // TODO: return error instead of panic
-        if epoch <= current_hummock_version.max_committed_epoch {
-            panic!(
-                "Epoch {} <= max_committed_epoch {}",
-                epoch, current_hummock_version.max_committed_epoch
-            );
-        }
-
-        current_version_id.increase();
-        let mut new_hummock_version = hummock_versions
-            .new_entry_txn_or_default(current_version_id.id(), current_hummock_version);
-        new_hummock_version.id = current_version_id.id();
-
-        // Create new_version by adding tables in UncommittedEpoch
-        match new_hummock_version
-            .uncommitted_epochs
-            .iter_mut()
-            .find(|e| e.epoch == epoch)
-        {
-            Some(uncommitted_epoch) => {
-                uncommitted_epoch.tables.extend(sstables);
-            }
-            None => new_hummock_version
-                .uncommitted_epochs
-                .push(UncommittedEpoch {
-                    epoch,
-                    tables: sstables,
-                }),
-        };
-
-        let ret_hummock_version = new_hummock_version.clone();
-
-        commit_multi_var!(
-            self,
-            Some(context_id),
-            current_version_id,
-            sstable_id_infos,
-            new_hummock_version
-        )?;
-
-        // Update metrics
-        trigger_commit_stat(&self.metrics, &ret_hummock_version);
-
-        #[cfg(test)]
-        {
-            drop(versioning_guard);
-            self.check_state_consistency().await;
-        }
-
-        Ok(ret_hummock_version)
     }
 
     /// Make sure `max_commited_epoch` is pinned and return it.
@@ -773,12 +676,17 @@ where
         Ok(true)
     }
 
-    pub async fn commit_epoch(&self, epoch: HummockEpoch) -> Result<()> {
+    pub async fn commit_epoch(
+        &self,
+        epoch: HummockEpoch,
+        sstables: Vec<SstableInfo>,
+    ) -> Result<()> {
         let mut versioning_guard = self.versioning.write().await;
         let old_version = versioning_guard.current_version();
         let versioning = versioning_guard.deref_mut();
         let mut current_version_id = VarTransaction::new(&mut versioning.current_version_id);
         let mut hummock_versions = VarTransaction::new(&mut versioning.hummock_versions);
+        let mut sstable_id_infos = VarTransaction::new(&mut versioning.sstable_id_infos);
         current_version_id.increase();
         let mut new_hummock_version =
             hummock_versions.new_entry_txn_or_default(current_version_id.id(), old_version);
@@ -791,35 +699,54 @@ where
             );
         }
 
-        // TODO #447: the epoch should fail and rollback if any precedent epoch is uncommitted.
-        // get tables in the committing epoch
-        if let Some(idx) = new_hummock_version
-            .uncommitted_epochs
-            .iter()
-            .position(|e| e.epoch == epoch)
-        {
-            // deref mut here so that we can mutably borrow different fields in new_hummock_version
-            let new_hummock_version = new_hummock_version.deref_mut();
-            let uncommitted_epoch = &new_hummock_version.uncommitted_epochs[idx];
-
-            // Commit tables by moving them into level0
-            let version_first_level = new_hummock_version.levels.first_mut().unwrap();
-            if version_first_level.level_idx == 0 {
-                uncommitted_epoch
-                    .tables
-                    .iter()
-                    .for_each(|t| version_first_level.table_infos.push(t.clone()));
-            } else {
-                return Err(Error::InternalError(
-                    "unsupported LevelType::Nonoverlapping".to_owned(),
-                ));
+        // Track SSTs in meta.
+        // TODO: If a epoch contains many SSTs, modifying sstable_id_infos will result many KVs in
+        // the meta store transaction. To avoid etcd errors if the aforementioned case
+        // happens, we temporarily set a large value for etcd's max-txn-ops. But we need to
+        // formally fix this because the performance degradation is not acceptable anyway.
+        for sst_id in sstables.iter().map(|s| s.id) {
+            match sstable_id_infos.get_mut(&sst_id) {
+                None => {
+                    return Err(Error::InternalError(format!(
+                        "Invalid SST id {}, may have been vacuumed",
+                        sst_id
+                    )));
+                }
+                Some(sst_id_info) => {
+                    if sst_id_info.meta_delete_timestamp != INVALID_TIMESTAMP {
+                        return Err(Error::InternalError(format!(
+                            "SST id {} has been marked for vacuum",
+                            sst_id
+                        )));
+                    }
+                    if sst_id_info.meta_create_timestamp != INVALID_TIMESTAMP {
+                        // This is a duplicate request.
+                        return Ok(());
+                    }
+                    sst_id_info.meta_create_timestamp = sstable_id_info::get_timestamp_now();
+                }
             }
-            // Remove the epoch from uncommitted_epochs
-            new_hummock_version.uncommitted_epochs.swap_remove(idx);
         }
+
         // Create a new_version, possibly merely to bump up the version id and max_committed_epoch.
+        let version_first_level = new_hummock_version
+            .levels
+            .first_mut()
+            .expect("Expect at least one level");
+        assert_eq!(version_first_level.level_idx, 0);
+        assert_eq!(
+            version_first_level.level_type,
+            LevelType::Overlapping as i32
+        );
+        version_first_level.table_infos.extend(sstables);
         new_hummock_version.max_committed_epoch = epoch;
-        commit_multi_var!(self, None, new_hummock_version, current_version_id)?;
+        commit_multi_var!(
+            self,
+            None,
+            new_hummock_version,
+            current_version_id,
+            sstable_id_infos
+        )?;
 
         // Update metrics
         trigger_commit_stat(&self.metrics, versioning.current_version_ref());
@@ -835,59 +762,6 @@ where
 
         // TODO: use correct id after compaction group is supported.
         self.try_send_compaction_request(0.into());
-
-        #[cfg(test)]
-        {
-            drop(versioning_guard);
-            self.check_state_consistency().await;
-        }
-
-        Ok(())
-    }
-
-    pub async fn abort_epoch(&self, epoch: HummockEpoch) -> Result<()> {
-        let mut versioning_guard = self.versioning.write().await;
-        let old_version = versioning_guard.current_version();
-        let versioning = versioning_guard.deref_mut();
-        let mut current_version_id = VarTransaction::new(&mut versioning.current_version_id);
-        let mut hummock_versions = VarTransaction::new(&mut versioning.hummock_versions);
-        let mut stale_sstables = VarTransaction::new(&mut versioning.stale_sstables);
-        let old_version_id = old_version.id;
-        current_version_id.increase();
-        let mut new_hummock_version =
-            hummock_versions.new_entry_txn_or_default(current_version_id.id(), old_version);
-        new_hummock_version.id = current_version_id.id();
-
-        // Get and remove tables in the committing epoch
-        let uncommitted_epoch = new_hummock_version
-            .uncommitted_epochs
-            .iter()
-            .position(|e| e.epoch == epoch)
-            .map(|idx| new_hummock_version.uncommitted_epochs.swap_remove(idx));
-
-        if let Some(epoch_info) = uncommitted_epoch {
-            // Remove tables of the aborting epoch
-            let mut version_stale_sstables = stale_sstables.new_entry_txn_or_default(
-                old_version_id,
-                HummockStaleSstables {
-                    version_id: old_version_id,
-                    id: vec![],
-                },
-            );
-            version_stale_sstables
-                .id
-                .extend(epoch_info.tables.iter().map(|t| t.id));
-
-            commit_multi_var!(
-                self,
-                None,
-                current_version_id,
-                new_hummock_version,
-                version_stale_sstables
-            )?;
-        } else {
-            abort_multi_var!(current_version_id, new_hummock_version, stale_sstables);
-        }
 
         #[cfg(test)]
         {

--- a/src/meta/src/hummock/hummock_manager_tests.rs
+++ b/src/meta/src/hummock/hummock_manager_tests.rs
@@ -134,15 +134,9 @@ async fn test_hummock_compaction_task() {
     let epoch: u64 = 1;
     let original_tables = generate_test_tables(epoch, get_sst_ids(&hummock_manager, sst_num).await);
     hummock_manager
-        .add_tables(context_id, original_tables.clone(), epoch)
+        .commit_epoch(epoch, original_tables.clone())
         .await
         .unwrap();
-
-    // No compaction task available. Uncommitted sst won't be compacted.
-    let task = hummock_manager.get_compact_task().await.unwrap();
-    assert_eq!(task, None);
-
-    hummock_manager.commit_epoch(epoch).await.unwrap();
 
     // check safe epoch in hummock version
     let version_id1 = CurrentHummockVersionId::get(env.meta_store())
@@ -261,10 +255,9 @@ async fn test_hummock_table() {
     let epoch: u64 = 1;
     let original_tables = generate_test_tables(epoch, get_sst_ids(&hummock_manager, 2).await);
     hummock_manager
-        .add_tables(context_id, original_tables.clone(), epoch)
+        .commit_epoch(epoch, original_tables.clone())
         .await
         .unwrap();
-    hummock_manager.commit_epoch(epoch).await.unwrap();
 
     let pinned_version = hummock_manager
         .pin_version(context_id, u64::MAX)
@@ -295,28 +288,18 @@ async fn test_hummock_transaction() {
     let mut committed_tables = vec![];
 
     // Add and commit tables in epoch1.
-    // BEFORE:  uncommitted_epochs = [], committed_epochs = []
-    // RUNNING: uncommitted_epochs = [epoch1], committed_epochs = []
-    // AFTER:   uncommitted_epochs = [], committed_epochs = [epoch1]
+    // BEFORE:  committed_epochs = []
+    // AFTER:   committed_epochs = [epoch1]
     let epoch1: u64 = 1;
     {
         // Add tables in epoch1
         let tables_in_epoch1 = generate_test_tables(epoch1, get_sst_ids(&hummock_manager, 2).await);
-        hummock_manager
-            .add_tables(context_id, tables_in_epoch1.clone(), epoch1)
-            .await
-            .unwrap();
-
         // Get tables before committing epoch1. No tables should be returned.
-        let mut pinned_version = hummock_manager
+        let pinned_version = hummock_manager
             .pin_version(context_id, u64::MAX)
             .await
             .unwrap();
-        let uncommitted_epoch = pinned_version.uncommitted_epochs.first_mut().unwrap();
-        assert_eq!(epoch1, uncommitted_epoch.epoch);
         assert_eq!(pinned_version.max_committed_epoch, INVALID_EPOCH);
-        uncommitted_epoch.tables.sort_unstable_by_key(|e| e.id);
-        assert_eq!(tables_in_epoch1, uncommitted_epoch.tables);
         assert!(get_sorted_committed_sstable_ids(&pinned_version).is_empty());
 
         hummock_manager
@@ -325,7 +308,10 @@ async fn test_hummock_transaction() {
             .unwrap();
 
         // Commit epoch1
-        hummock_manager.commit_epoch(epoch1).await.unwrap();
+        hummock_manager
+            .commit_epoch(epoch1, tables_in_epoch1.clone())
+            .await
+            .unwrap();
         committed_tables.extend(tables_in_epoch1.clone());
 
         // Get tables after committing epoch1. All tables committed in epoch1 should be returned
@@ -333,7 +319,6 @@ async fn test_hummock_transaction() {
             .pin_version(context_id, u64::MAX)
             .await
             .unwrap();
-        assert!(pinned_version.uncommitted_epochs.is_empty());
         assert_eq!(pinned_version.max_committed_epoch, epoch1);
         assert_eq!(
             get_sorted_sstable_ids(&committed_tables),
@@ -347,28 +332,18 @@ async fn test_hummock_transaction() {
     }
 
     // Add and commit tables in epoch2.
-    // BEFORE:  uncommitted_epochs = [], committed_epochs = [epoch1]
-    // RUNNING: uncommitted_epochs = [epoch2], committed_epochs = [epoch1]
-    // AFTER:   uncommitted_epochs = [], committed_epochs = [epoch1, epoch2]
+    // BEFORE:  committed_epochs = [epoch1]
+    // AFTER:   committed_epochs = [epoch1, epoch2]
     let epoch2 = epoch1 + 1;
     {
         // Add tables in epoch2
         let tables_in_epoch2 = generate_test_tables(epoch2, get_sst_ids(&hummock_manager, 2).await);
-        hummock_manager
-            .add_tables(context_id, tables_in_epoch2.clone(), epoch2)
-            .await
-            .unwrap();
-
         // Get tables before committing epoch2. tables_in_epoch1 should be returned and
         // tables_in_epoch2 should be invisible.
-        let mut pinned_version = hummock_manager
+        let pinned_version = hummock_manager
             .pin_version(context_id, u64::MAX)
             .await
             .unwrap();
-        let uncommitted_epoch = pinned_version.uncommitted_epochs.first_mut().unwrap();
-        assert_eq!(epoch2, uncommitted_epoch.epoch);
-        uncommitted_epoch.tables.sort_unstable_by_key(|e| e.id);
-        assert_eq!(tables_in_epoch2, uncommitted_epoch.tables);
         assert_eq!(pinned_version.max_committed_epoch, epoch1);
         assert_eq!(
             get_sorted_sstable_ids(&committed_tables),
@@ -380,7 +355,10 @@ async fn test_hummock_transaction() {
             .unwrap();
 
         // Commit epoch2
-        hummock_manager.commit_epoch(epoch2).await.unwrap();
+        hummock_manager
+            .commit_epoch(epoch2, tables_in_epoch2.clone())
+            .await
+            .unwrap();
         committed_tables.extend(tables_in_epoch2);
 
         // Get tables after committing epoch2. tables_in_epoch1 and tables_in_epoch2 should be
@@ -389,121 +367,7 @@ async fn test_hummock_transaction() {
             .pin_version(context_id, u64::MAX)
             .await
             .unwrap();
-        assert!(pinned_version.uncommitted_epochs.is_empty());
         assert_eq!(pinned_version.max_committed_epoch, epoch2);
-        assert_eq!(
-            get_sorted_sstable_ids(&committed_tables),
-            get_sorted_committed_sstable_ids(&pinned_version)
-        );
-        hummock_manager
-            .unpin_version(context_id, vec![pinned_version.id])
-            .await
-            .unwrap();
-    }
-
-    // Add tables in epoch3 and epoch4. Abort epoch3, commit epoch4.
-    // BEFORE:  uncommitted_epochs = [], committed_epochs = [epoch1, epoch2]
-    // RUNNING: uncommitted_epochs = [epoch3, epoch4], committed_epochs = [epoch1, epoch2]
-    // AFTER:   uncommitted_epochs = [], committed_epochs = [epoch1, epoch2, epoch4]
-    let epoch3 = epoch2 + 1;
-    let epoch4 = epoch3 + 1;
-    {
-        // Add tables in epoch3 and epoch4
-        let tables_in_epoch3 = generate_test_tables(epoch3, get_sst_ids(&hummock_manager, 2).await);
-        hummock_manager
-            .add_tables(context_id, tables_in_epoch3.clone(), epoch3)
-            .await
-            .unwrap();
-        let tables_in_epoch4 = generate_test_tables(epoch4, get_sst_ids(&hummock_manager, 2).await);
-        hummock_manager
-            .add_tables(context_id, tables_in_epoch4.clone(), epoch4)
-            .await
-            .unwrap();
-
-        // Get tables before committing epoch3 and epoch4. tables_in_epoch1 and tables_in_epoch2
-        // should be returned
-        let mut pinned_version = hummock_manager
-            .pin_version(context_id, u64::MAX)
-            .await
-            .unwrap();
-        let uncommitted_epoch3 = pinned_version
-            .uncommitted_epochs
-            .iter_mut()
-            .find(|e| e.epoch == epoch3)
-            .unwrap();
-        uncommitted_epoch3.tables.sort_unstable_by_key(|e| e.id);
-        assert_eq!(tables_in_epoch3, uncommitted_epoch3.tables);
-        let uncommitted_epoch4 = pinned_version
-            .uncommitted_epochs
-            .iter_mut()
-            .find(|e| e.epoch == epoch4)
-            .unwrap();
-        uncommitted_epoch4.tables.sort_unstable_by_key(|e| e.id);
-        assert_eq!(tables_in_epoch4, uncommitted_epoch4.tables);
-        assert_eq!(pinned_version.max_committed_epoch, epoch2);
-        assert_eq!(
-            get_sorted_sstable_ids(&committed_tables),
-            get_sorted_committed_sstable_ids(&pinned_version)
-        );
-
-        // Abort epoch3
-        hummock_manager.abort_epoch(epoch3).await.unwrap();
-
-        // Uncommitted SSTs should be marked for deletion
-        println!("{}", pinned_version.id);
-        let mut sstables_to_delete = hummock_manager
-            .get_ssts_to_delete(pinned_version.id)
-            .await
-            .unwrap();
-        sstables_to_delete.sort_unstable();
-        assert_eq!(
-            get_sorted_sstable_ids(&tables_in_epoch3),
-            sstables_to_delete
-        );
-        hummock_manager
-            .unpin_version(context_id, vec![pinned_version.id])
-            .await
-            .unwrap();
-
-        // Get tables after aborting epoch3. tables_in_epoch1 and tables_in_epoch2 should be
-        // returned
-        let mut pinned_version = hummock_manager
-            .pin_version(context_id, u64::MAX)
-            .await
-            .unwrap();
-        assert!(pinned_version
-            .uncommitted_epochs
-            .iter_mut()
-            .all(|e| e.epoch != epoch3));
-        let uncommitted_epoch4 = pinned_version
-            .uncommitted_epochs
-            .iter_mut()
-            .find(|e| e.epoch == epoch4)
-            .unwrap();
-        uncommitted_epoch4.tables.sort_unstable_by_key(|e| e.id);
-        assert_eq!(tables_in_epoch4, uncommitted_epoch4.tables);
-        assert_eq!(pinned_version.max_committed_epoch, epoch2);
-        assert_eq!(
-            get_sorted_sstable_ids(&committed_tables),
-            get_sorted_committed_sstable_ids(&pinned_version)
-        );
-        hummock_manager
-            .unpin_version(context_id, vec![pinned_version.id])
-            .await
-            .unwrap();
-
-        // Commit epoch4
-        hummock_manager.commit_epoch(epoch4).await.unwrap();
-        committed_tables.extend(tables_in_epoch4);
-
-        // Get tables after committing epoch4. tables_in_epoch1, tables_in_epoch2, tables_in_epoch4
-        // should be returned.
-        let pinned_version = hummock_manager
-            .pin_version(context_id, u64::MAX)
-            .await
-            .unwrap();
-        assert!(pinned_version.uncommitted_epochs.is_empty());
-        assert_eq!(pinned_version.max_committed_epoch, epoch4);
         assert_eq!(
             get_sorted_sstable_ids(&committed_tables),
             get_sorted_committed_sstable_ids(&pinned_version)
@@ -597,21 +461,16 @@ async fn test_context_id_validation() {
     let invalid_context_id = HummockContextId::MAX;
     let context_id = worker_node.id;
     let epoch: u64 = 1;
-    let original_tables = generate_test_tables(epoch, get_sst_ids(&hummock_manager, 2).await);
+    let _original_tables = generate_test_tables(epoch, get_sst_ids(&hummock_manager, 2).await);
 
     // Invalid context id is rejected.
     let error = hummock_manager
-        .add_tables(invalid_context_id, original_tables.clone(), epoch)
+        .pin_version(invalid_context_id, u64::MAX)
         .await
         .unwrap_err();
     assert!(matches!(error, Error::InvalidContext(_)));
 
     // Valid context id is accepted.
-    hummock_manager
-        .add_tables(context_id, original_tables.clone(), epoch)
-        .await
-        .unwrap();
-
     hummock_manager
         .pin_version(context_id, u64::MAX)
         .await
@@ -660,7 +519,7 @@ async fn test_hummock_manager_basic() {
     let epoch: u64 = 1;
     let original_tables = generate_test_tables(epoch, get_sst_ids(&hummock_manager, 2).await);
     hummock_manager
-        .add_tables(context_id_1, original_tables.clone(), epoch)
+        .commit_epoch(epoch, original_tables.clone())
         .await
         .unwrap();
 
@@ -761,7 +620,7 @@ async fn test_retryable_pin_version() {
         );
         // Increase the version
         hummock_manager
-            .add_tables(context_id, test_tables.clone(), epoch)
+            .commit_epoch(epoch, test_tables.clone())
             .await
             .unwrap();
         epoch += 1;
@@ -794,7 +653,7 @@ async fn test_retryable_pin_version() {
         );
         // Increase the version
         hummock_manager
-            .add_tables(context_id, test_tables.clone(), epoch)
+            .commit_epoch(epoch, test_tables.clone())
             .await
             .unwrap();
         epoch += 1;
@@ -830,12 +689,11 @@ async fn test_pin_snapshot_response_lost() {
             hummock_manager.get_new_table_id().await.unwrap(),
         ],
     );
+    // [ ] -> [ e0 ]
     hummock_manager
-        .add_tables(context_id, test_tables.clone(), epoch)
+        .commit_epoch(epoch, test_tables.clone())
         .await
         .unwrap();
-    // [ ] -> [ e0 ]
-    hummock_manager.commit_epoch(epoch).await.unwrap();
     epoch += 1;
 
     // Pin a snapshot with smallest last_pin
@@ -858,12 +716,11 @@ async fn test_pin_snapshot_response_lost() {
             hummock_manager.get_new_table_id().await.unwrap(),
         ],
     );
+    // [ e0:pinned ] -> [ e0:pinned, e1 ]
     hummock_manager
-        .add_tables(context_id, test_tables.clone(), epoch)
+        .commit_epoch(epoch, test_tables.clone())
         .await
         .unwrap();
-    // [ e0:pinned ] -> [ e0:pinned, e1 ]
-    hummock_manager.commit_epoch(epoch).await.unwrap();
     epoch += 1;
 
     // Assume the response of the previous rpc is lost.
@@ -895,12 +752,11 @@ async fn test_pin_snapshot_response_lost() {
             hummock_manager.get_new_table_id().await.unwrap(),
         ],
     );
+    // [ e0, e1:pinned ] -> [ e0, e1:pinned, e2 ]
     hummock_manager
-        .add_tables(context_id, test_tables.clone(), epoch)
+        .commit_epoch(epoch, test_tables.clone())
         .await
         .unwrap();
-    // [ e0, e1:pinned ] -> [ e0, e1:pinned, e2 ]
-    hummock_manager.commit_epoch(epoch).await.unwrap();
     epoch += 1;
 
     // Use correct snapshot id.
@@ -923,12 +779,11 @@ async fn test_pin_snapshot_response_lost() {
             hummock_manager.get_new_table_id().await.unwrap(),
         ],
     );
+    // [ e0, e1:pinned, e2:pinned ] -> [ e0, e1:pinned, e2:pinned, e3 ]
     hummock_manager
-        .add_tables(context_id, test_tables.clone(), epoch)
+        .commit_epoch(epoch, test_tables.clone())
         .await
         .unwrap();
-    // [ e0, e1:pinned, e2:pinned ] -> [ e0, e1:pinned, e2:pinned, e3 ]
-    hummock_manager.commit_epoch(epoch).await.unwrap();
     epoch += 1;
 
     // Use u64::MAX as epoch to pin greatest snapshot
@@ -947,17 +802,14 @@ async fn test_pin_snapshot_response_lost() {
 
 #[tokio::test]
 async fn test_print_compact_task() {
-    let (_, hummock_manager, _cluster_manager, worker_node) = setup_compute_env(80).await;
-    let context_id = worker_node.id;
-
+    let (_, hummock_manager, _cluster_manager, _) = setup_compute_env(80).await;
     // Add some sstables and commit.
     let epoch: u64 = 1;
     let original_tables = generate_test_tables(epoch, get_sst_ids(&hummock_manager, 2).await);
     hummock_manager
-        .add_tables(context_id, original_tables.clone(), epoch)
+        .commit_epoch(epoch, original_tables.clone())
         .await
         .unwrap();
-    hummock_manager.commit_epoch(epoch).await.unwrap();
 
     // Get a compaction task.
     let compact_task = hummock_manager.get_compact_task().await.unwrap().unwrap();
@@ -976,12 +828,11 @@ async fn test_print_compact_task() {
 
 #[tokio::test]
 async fn test_invalid_sst_id() {
-    let (_, hummock_manager, _cluster_manager, worker_node) = setup_compute_env(80).await;
-    let context_id = worker_node.id;
+    let (_, hummock_manager, _cluster_manager, _) = setup_compute_env(80).await;
     let epoch = 1;
     let ssts = generate_test_tables(epoch, vec![HummockSSTableId::MAX]);
     let error = hummock_manager
-        .add_tables(context_id, ssts.clone(), epoch)
+        .commit_epoch(epoch, ssts.clone())
         .await
         .unwrap_err();
     assert!(matches!(error, Error::InternalError(_)));
@@ -989,24 +840,15 @@ async fn test_invalid_sst_id() {
 
 #[tokio::test]
 async fn test_mark_orphan_ssts() {
-    let (_, hummock_manager, _cluster_manager, worker_node) = setup_compute_env(80).await;
-    let context_id = worker_node.id;
+    let (_, hummock_manager, _cluster_manager, _) = setup_compute_env(80).await;
     let epoch = 1;
 
-    let ssts = generate_test_tables(
-        epoch,
-        vec![hummock_manager.get_new_table_id().await.unwrap()],
-    );
     // No SST is marked.
     let marked = hummock_manager
         .mark_orphan_ssts(Duration::from_secs(3600))
         .await
         .unwrap();
     assert!(marked.is_empty());
-    hummock_manager
-        .add_tables(context_id, ssts.clone(), epoch)
-        .await
-        .unwrap();
 
     let ssts = generate_test_tables(
         epoch,
@@ -1022,9 +864,9 @@ async fn test_mark_orphan_ssts() {
         marked.first().as_ref().unwrap().id,
         ssts.first().as_ref().unwrap().id
     );
-    // Cannot add_tables for marked SST ids.
+    // Cannot commit_epoch for marked SST ids.
     let error = hummock_manager
-        .add_tables(context_id, ssts.clone(), epoch)
+        .commit_epoch(epoch, ssts.clone())
         .await
         .unwrap_err();
     assert!(matches!(error, Error::InternalError(_)));

--- a/src/meta/src/hummock/metrics_utils.rs
+++ b/src/meta/src/hummock/metrics_utils.rs
@@ -27,11 +27,6 @@ pub fn trigger_commit_stat(metrics: &MetaMetrics, current_version: &HummockVersi
     metrics
         .max_committed_epoch
         .set(current_version.max_committed_epoch as i64);
-    let uncommitted_sst_num = current_version
-        .uncommitted_epochs
-        .iter()
-        .fold(0, |accum, elem| accum + elem.tables.len());
-    metrics.uncommitted_sst_num.set(uncommitted_sst_num as i64);
     metrics
         .version_size
         .set(current_version.encoded_len() as i64);

--- a/src/meta/src/hummock/mock_hummock_meta_client.rs
+++ b/src/meta/src/hummock/mock_hummock_meta_client.rs
@@ -95,17 +95,6 @@ impl HummockMetaClient for MockHummockMetaClient {
             .map_err(|e| e.into())
     }
 
-    async fn add_tables(
-        &self,
-        epoch: HummockEpoch,
-        sstables: Vec<SstableInfo>,
-    ) -> Result<HummockVersion> {
-        self.hummock_manager
-            .add_tables(self.context_id, sstables, epoch)
-            .await
-            .map_err(|e| e.into())
-    }
-
     async fn report_compaction_task(&self, compact_task: CompactTask) -> Result<()> {
         self.hummock_manager
             .report_compact_task(&compact_task)
@@ -114,16 +103,9 @@ impl HummockMetaClient for MockHummockMetaClient {
             .map_err(|e| e.into())
     }
 
-    async fn commit_epoch(&self, epoch: HummockEpoch) -> Result<()> {
+    async fn commit_epoch(&self, epoch: HummockEpoch, sstables: Vec<SstableInfo>) -> Result<()> {
         self.hummock_manager
-            .commit_epoch(epoch)
-            .await
-            .map_err(|e| e.into())
-    }
-
-    async fn abort_epoch(&self, epoch: HummockEpoch) -> Result<()> {
-        self.hummock_manager
-            .abort_epoch(epoch)
+            .commit_epoch(epoch, sstables)
             .await
             .map_err(|e| e.into())
     }

--- a/src/meta/src/hummock/test_utils.rs
+++ b/src/meta/src/hummock/test_utils.rs
@@ -43,11 +43,10 @@ where
     ];
     let test_tables = generate_test_tables(epoch, table_ids);
     hummock_manager
-        .add_tables(context_id, test_tables.clone(), epoch)
+        .commit_epoch(epoch, test_tables.clone())
         .await
         .unwrap();
-    hummock_manager.commit_epoch(epoch).await.unwrap();
-    // Current state: {v0: [], v1: [test_tables uncommitted], v2: [test_tables]}
+    // Current state: {v0: [], v1: [test_tables]}
 
     // Simulate a compaction and increase version by 1.
     let mut compact_task = hummock_manager.get_compact_task().await.unwrap().unwrap();
@@ -65,8 +64,7 @@ where
         .report_compact_task(&compact_task)
         .await
         .unwrap();
-    // Current state: {v0: [], v1: [test_tables uncommitted], v2: [test_tables], v3: [test_tables_2,
-    // test_tables to_delete]}
+    // Current state: {v0: [], v1: [test_tables], v2: [test_tables_2, test_tables to_delete]}
 
     // Increase version by 1.
     epoch += 1;
@@ -75,11 +73,11 @@ where
         vec![hummock_manager.get_new_table_id().await.unwrap()],
     );
     hummock_manager
-        .add_tables(context_id, test_tables_3.clone(), epoch)
+        .commit_epoch(epoch, test_tables_3.clone())
         .await
         .unwrap();
-    // Current state: {v0: [], v1: [test_tables uncommitted], v2: [test_tables], v3: [test_tables_2,
-    // to_delete:test_tables], v4: [test_tables_2, test_tables_3 uncommitted]}
+    // Current state: {v0: [], v1: [test_tables], v2: [test_tables_2, to_delete:test_tables], v3:
+    // [test_tables_2, test_tables_3]}
     vec![test_tables, test_tables_2, test_tables_3]
 }
 

--- a/src/meta/src/hummock/vacuum.rs
+++ b/src/meta/src/hummock/vacuum.rs
@@ -286,15 +286,15 @@ mod tests {
             .unwrap();
 
         add_test_tables(hummock_manager.as_ref(), context_id).await;
-        // Current state: {v0: [], v1: [test_tables uncommitted], v2: [test_tables], v3:
-        // [test_tables_2, to_delete:test_tables], v4: [test_tables_2, test_tables_3 uncommitted]}
+        // Current state: {v0: [], v1: [test_tables], v2: [test_tables_2, to_delete:test_tables],
+        // v3: [test_tables_2, test_tables_3]}
 
-        // Vacuum v0, v1, v2, v3
+        // Vacuum v0, v1, v2
         assert_eq!(
             VacuumTrigger::vacuum_version_metadata(&vacuum)
                 .await
                 .unwrap(),
-            4
+            3
         );
     }
 
@@ -362,15 +362,15 @@ mod tests {
         let _receiver = compactor_manager.add_compactor(0);
 
         let sst_infos = add_test_tables(hummock_manager.as_ref(), context_id).await;
-        // Current state: {v0: [], v1: [test_tables uncommitted], v2: [test_tables], v3:
-        // [test_tables_2, to_delete:test_tables], v4: [test_tables_2, test_tables_3 uncommitted]}
+        // Current state: {v0: [], v1: [test_tables], v2: [test_tables_2, to_delete:test_tables],
+        // v3: [test_tables_2, test_tables_3]}
 
-        // Vacuum v0, v1, v2, v3
+        // Vacuum v0, v1, v2
         assert_eq!(
             VacuumTrigger::vacuum_version_metadata(&vacuum)
                 .await
                 .unwrap(),
-            4
+            3
         );
 
         // Found test_table is marked for deletion.

--- a/src/meta/src/rpc/service/hummock_service.rs
+++ b/src/meta/src/rpc/service/hummock_service.rs
@@ -89,24 +89,6 @@ where
         }
     }
 
-    async fn add_tables(
-        &self,
-        request: Request<AddTablesRequest>,
-    ) -> Result<Response<AddTablesResponse>, Status> {
-        let req = request.into_inner();
-        let result = self
-            .hummock_manager
-            .add_tables(req.context_id, req.tables, req.epoch)
-            .await;
-        match result {
-            Ok(version) => Ok(Response::new(AddTablesResponse {
-                status: None,
-                version: Some(version),
-            })),
-            Err(e) => Err(tonic_err(e)),
-        }
-    }
-
     async fn report_compaction_tasks(
         &self,
         request: Request<ReportCompactionTasksRequest>,
@@ -162,30 +144,6 @@ where
             return Err(tonic_err(e));
         }
         Ok(Response::new(UnpinSnapshotResponse { status: None }))
-    }
-
-    async fn commit_epoch(
-        &self,
-        request: Request<CommitEpochRequest>,
-    ) -> Result<Response<CommitEpochResponse>, Status> {
-        let req = request.into_inner();
-        let result = self.hummock_manager.commit_epoch(req.epoch).await;
-        match result {
-            Ok(_) => Ok(Response::new(CommitEpochResponse { status: None })),
-            Err(e) => Err(tonic_err(e)),
-        }
-    }
-
-    async fn abort_epoch(
-        &self,
-        request: Request<AbortEpochRequest>,
-    ) -> Result<Response<AbortEpochResponse>, Status> {
-        let req = request.into_inner();
-        let result = self.hummock_manager.abort_epoch(req.epoch).await;
-        match result {
-            Ok(_) => Ok(Response::new(AbortEpochResponse { status: None })),
-            Err(e) => Err(tonic_err(e)),
-        }
     }
 
     async fn get_new_table_id(

--- a/src/rpc_client/src/hummock_meta_client.rs
+++ b/src/rpc_client/src/hummock_meta_client.rs
@@ -27,14 +27,9 @@ pub trait HummockMetaClient: Send + Sync + 'static {
     async fn pin_snapshot(&self, last_pinned: HummockEpoch) -> Result<HummockEpoch>;
     async fn unpin_snapshot(&self, pinned_epochs: &[HummockEpoch]) -> Result<()>;
     async fn get_new_table_id(&self) -> Result<HummockSSTableId>;
-    async fn add_tables(
-        &self,
-        epoch: HummockEpoch,
-        sstables: Vec<SstableInfo>,
-    ) -> Result<HummockVersion>;
     async fn report_compaction_task(&self, compact_task: CompactTask) -> Result<()>;
-    async fn commit_epoch(&self, epoch: HummockEpoch) -> Result<()>;
-    async fn abort_epoch(&self, epoch: HummockEpoch) -> Result<()>;
+    // We keep `commit_epoch` only for test/benchmark like ssbench.
+    async fn commit_epoch(&self, epoch: HummockEpoch, sstables: Vec<SstableInfo>) -> Result<()>;
     async fn subscribe_compact_tasks(&self) -> Result<Streaming<SubscribeCompactTasksResponse>>;
     async fn report_vacuum_task(&self, vacuum_task: VacuumTask) -> Result<()>;
 }

--- a/src/storage/src/hummock/compactor_tests.rs
+++ b/src/storage/src/hummock/compactor_tests.rs
@@ -93,7 +93,13 @@ mod tests {
                 .await
                 .unwrap();
             storage.sync(Some(epoch)).await.unwrap();
-            hummock_meta_client.commit_epoch(epoch).await.unwrap();
+            hummock_meta_client
+                .commit_epoch(
+                    epoch,
+                    storage.local_version_manager.get_uncommitted_ssts(epoch),
+                )
+                .await
+                .unwrap();
         }
 
         // 2. get compact task

--- a/src/storage/src/hummock/local_version.rs
+++ b/src/storage/src/hummock/local_version.rs
@@ -114,7 +114,6 @@ impl LocalVersion {
         }
     }
 
-    #[cfg(test)]
     pub fn get_uncommitted_ssts(&self) -> UncommittedSsts {
         self.uncommitted_ssts.clone()
     }

--- a/src/storage/src/hummock/local_version_manager.rs
+++ b/src/storage/src/hummock/local_version_manager.rs
@@ -381,6 +381,15 @@ impl LocalVersionManager {
         self.local_version.read().pinned_version().clone()
     }
 
+    pub fn get_uncommitted_ssts(&self, epoch: HummockEpoch) -> Vec<SstableInfo> {
+        self.local_version
+            .read()
+            .get_uncommitted_ssts()
+            .get(&epoch)
+            .cloned()
+            .unwrap_or_default()
+    }
+
     /// Pin a version with retry.
     ///
     /// Return:

--- a/src/storage/src/hummock/shared_buffer/shared_buffer_uploader.rs
+++ b/src/storage/src/hummock/shared_buffer/shared_buffer_uploader.rs
@@ -194,12 +194,6 @@ impl SharedBufferUploader {
             })
             .collect();
 
-        // Add all tables at once.
-        self.hummock_meta_client
-            .add_tables(epoch, uploaded_sst_info.clone())
-            .await
-            .map_err(HummockError::meta_error)?;
-
         if let Some(detector) = &self.write_conflict_detector {
             for batch in batches {
                 detector.check_conflict_and_track_write_batch(batch.get_payload(), epoch);

--- a/src/storage/src/hummock/snapshot_tests.rs
+++ b/src/storage/src/hummock/snapshot_tests.rs
@@ -90,7 +90,15 @@ async fn test_snapshot_inner(enable_sync: bool, enable_commit: bool) {
     if enable_sync {
         hummock_storage.sync(Some(epoch1)).await.unwrap();
         if enable_commit {
-            mock_hummock_meta_client.commit_epoch(epoch1).await.unwrap();
+            mock_hummock_meta_client
+                .commit_epoch(
+                    epoch1,
+                    hummock_storage
+                        .local_version_manager
+                        .get_uncommitted_ssts(epoch1),
+                )
+                .await
+                .unwrap();
             vm.refresh_version(mock_hummock_meta_client.as_ref()).await;
         }
     }
@@ -111,7 +119,15 @@ async fn test_snapshot_inner(enable_sync: bool, enable_commit: bool) {
     if enable_sync {
         hummock_storage.sync(Some(epoch2)).await.unwrap();
         if enable_commit {
-            mock_hummock_meta_client.commit_epoch(epoch2).await.unwrap();
+            mock_hummock_meta_client
+                .commit_epoch(
+                    epoch2,
+                    hummock_storage
+                        .local_version_manager
+                        .get_uncommitted_ssts(epoch2),
+                )
+                .await
+                .unwrap();
             vm.refresh_version(mock_hummock_meta_client.as_ref()).await;
         }
     }
@@ -133,7 +149,15 @@ async fn test_snapshot_inner(enable_sync: bool, enable_commit: bool) {
     if enable_sync {
         hummock_storage.sync(Some(epoch3)).await.unwrap();
         if enable_commit {
-            mock_hummock_meta_client.commit_epoch(epoch3).await.unwrap();
+            mock_hummock_meta_client
+                .commit_epoch(
+                    epoch3,
+                    hummock_storage
+                        .local_version_manager
+                        .get_uncommitted_ssts(epoch3),
+                )
+                .await
+                .unwrap();
             vm.refresh_version(mock_hummock_meta_client.as_ref()).await;
         }
     }
@@ -178,7 +202,15 @@ async fn test_snapshot_range_scan_inner(enable_sync: bool, enable_commit: bool) 
     if enable_sync {
         hummock_storage.sync(Some(epoch)).await.unwrap();
         if enable_commit {
-            mock_hummock_meta_client.commit_epoch(epoch).await.unwrap();
+            mock_hummock_meta_client
+                .commit_epoch(
+                    epoch,
+                    hummock_storage
+                        .local_version_manager
+                        .get_uncommitted_ssts(epoch),
+                )
+                .await
+                .unwrap();
             vm.refresh_version(mock_hummock_meta_client.as_ref()).await;
         }
     }
@@ -233,7 +265,15 @@ async fn test_snapshot_backward_range_scan_inner(enable_sync: bool, enable_commi
     if enable_sync {
         hummock_storage.sync(Some(epoch)).await.unwrap();
         if enable_commit {
-            mock_hummock_meta_client.commit_epoch(epoch).await.unwrap();
+            mock_hummock_meta_client
+                .commit_epoch(
+                    epoch,
+                    hummock_storage
+                        .local_version_manager
+                        .get_uncommitted_ssts(epoch),
+                )
+                .await
+                .unwrap();
             vm.refresh_version(mock_hummock_meta_client.as_ref()).await;
         }
     }
@@ -253,7 +293,12 @@ async fn test_snapshot_backward_range_scan_inner(enable_sync: bool, enable_commi
         hummock_storage.sync(Some(epoch + 1)).await.unwrap();
         if enable_commit {
             mock_hummock_meta_client
-                .commit_epoch(epoch + 1)
+                .commit_epoch(
+                    epoch + 1,
+                    hummock_storage
+                        .local_version_manager
+                        .get_uncommitted_ssts(epoch + 1),
+                )
                 .await
                 .unwrap();
             vm.refresh_version(mock_hummock_meta_client.as_ref()).await;

--- a/src/storage/src/hummock/state_store.rs
+++ b/src/storage/src/hummock/state_store.rs
@@ -20,7 +20,7 @@ use std::sync::Arc;
 use bytes::Bytes;
 use itertools::Itertools;
 use risingwave_hummock_sdk::key::key_with_epoch;
-use risingwave_pb::hummock::VNodeBitmap;
+use risingwave_pb::hummock::{SstableInfo, VNodeBitmap};
 
 use super::iterator::{
     BackwardConcatIterator, BackwardMergeIterator, BackwardUserIterator,
@@ -415,6 +415,10 @@ impl StateStore for HummockStorage {
                 .await?;
             Ok(())
         }
+    }
+
+    fn get_uncommitted_ssts(&self, epoch: u64) -> Vec<SstableInfo> {
+        self.local_version_manager.get_uncommitted_ssts(epoch)
     }
 }
 

--- a/src/storage/src/hummock/state_store_tests.rs
+++ b/src/storage/src/hummock/state_store_tests.rs
@@ -154,7 +154,15 @@ async fn test_basic() {
     let len = count_iter(&mut iter).await;
     assert_eq!(len, 4);
     hummock_storage.sync(Some(epoch1)).await.unwrap();
-    meta_client.commit_epoch(epoch1).await.unwrap();
+    meta_client
+        .commit_epoch(
+            epoch1,
+            hummock_storage
+                .local_version_manager
+                .get_uncommitted_ssts(epoch1),
+        )
+        .await
+        .unwrap();
     hummock_storage.wait_epoch(epoch1).await.unwrap();
     let value = hummock_storage
         .get(&Bytes::from("bb"), epoch2)
@@ -200,7 +208,13 @@ async fn test_vnode_filter() {
     let epoch: u64 = 1;
     storage.ingest_batch(batch, epoch).await.unwrap();
     storage.sync(Some(epoch)).await.unwrap();
-    meta_client.commit_epoch(epoch).await.unwrap();
+    meta_client
+        .commit_epoch(
+            epoch,
+            storage.local_version_manager.get_uncommitted_ssts(epoch),
+        )
+        .await
+        .unwrap();
 
     let value_with_dummy_filter = storage
         .get_with_vnode_set(

--- a/src/storage/src/monitor/monitored_store.rs
+++ b/src/storage/src/monitor/monitored_store.rs
@@ -17,6 +17,7 @@ use std::sync::Arc;
 
 use bytes::Bytes;
 use futures::Future;
+use risingwave_pb::hummock::SstableInfo;
 use tracing::error;
 
 use super::StateStoreMetrics;
@@ -229,6 +230,10 @@ where
                 .await
                 .inspect_err(|e| error!("Failed in replicate_batch: {:?}", e))
         }
+    }
+
+    fn get_uncommitted_ssts(&self, epoch: u64) -> Vec<SstableInfo> {
+        self.inner.get_uncommitted_ssts(epoch)
     }
 }
 

--- a/src/storage/src/storage_failpoints/test_hummock.rs
+++ b/src/storage/src/storage_failpoints/test_hummock.rs
@@ -73,7 +73,15 @@ async fn test_failpoint_state_store_read_upload() {
 
     // sync epoch1 test the read_error
     hummock_storage.sync(Some(1)).await.unwrap();
-    meta_client.commit_epoch(1).await.unwrap();
+    meta_client
+        .commit_epoch(
+            1,
+            hummock_storage
+                .local_version_manager()
+                .get_uncommitted_ssts(1),
+        )
+        .await
+        .unwrap();
     local_version_manager
         .refresh_version(meta_client.as_ref())
         .await;
@@ -94,8 +102,15 @@ async fn test_failpoint_state_store_read_upload() {
 
     let result = hummock_storage.sync(Some(3)).await;
     assert!(result.is_err());
-    meta_client.abort_epoch(3).await.unwrap();
-    meta_client.commit_epoch(4).await.unwrap();
+    meta_client
+        .commit_epoch(
+            4,
+            hummock_storage
+                .local_version_manager()
+                .get_uncommitted_ssts(4),
+        )
+        .await
+        .unwrap();
     local_version_manager
         .refresh_version(meta_client.as_ref())
         .await;

--- a/src/storage/src/store.rs
+++ b/src/storage/src/store.rs
@@ -16,6 +16,7 @@ use std::ops::RangeBounds;
 use std::sync::Arc;
 
 use bytes::Bytes;
+use risingwave_pb::hummock::SstableInfo;
 
 use crate::error::StorageResult;
 use crate::monitor::{MonitoredStateStore, StateStoreMetrics};
@@ -158,6 +159,11 @@ pub trait StateStore: Send + Sync + 'static + Clone {
     /// Creates a [`MonitoredStateStore`] from this state store, with given `stats`.
     fn monitored(self, stats: Arc<StateStoreMetrics>) -> MonitoredStateStore<Self> {
         MonitoredStateStore::new(self, stats)
+    }
+
+    /// Gets `epoch`'s uncommitted `SSTables`.
+    fn get_uncommitted_ssts(&self, _epoch: u64) -> Vec<SstableInfo> {
+        vec![]
     }
 }
 

--- a/src/stream/src/task/barrier_manager.rs
+++ b/src/stream/src/task/barrier_manager.rs
@@ -16,6 +16,7 @@ use std::sync::Arc;
 
 use madsim::collections::{HashMap, HashSet};
 use risingwave_common::error::Result;
+use risingwave_pb::hummock::SstableInfo;
 use risingwave_pb::stream_service::inject_barrier_response::FinishedCreateMview as ProstFinishedCreateMview;
 use tokio::sync::mpsc::UnboundedSender;
 use tokio::sync::oneshot;
@@ -79,6 +80,7 @@ impl std::fmt::Debug for FinishCreateMviewNotifier {
 pub struct CollectResult {
     /// Finished Create MV DDLs in current epoch.
     pub finished_create_mviews: Vec<FinishedCreateMview>,
+    pub synced_sstables: Vec<SstableInfo>,
 }
 
 enum BarrierState {

--- a/src/stream/src/task/barrier_manager/managed_state.rs
+++ b/src/stream/src/task/barrier_manager/managed_state.rs
@@ -103,6 +103,8 @@ impl ManagedBarrierState {
                     // Notify about barrier finishing.
                     let result = CollectResult {
                         finished_create_mviews,
+
+                        synced_sstables: vec![],
                     };
                     if collect_notifier.send(result).is_err() {
                         warn!("failed to notify barrier collection with epoch {}", epoch)

--- a/src/stream/src/task/stream_manager.rs
+++ b/src/stream/src/task/stream_manager.rs
@@ -178,13 +178,16 @@ impl LocalStreamManager {
         let rx = self.send_barrier(barrier, actor_ids_to_send, actor_ids_to_collect)?;
 
         // Wait for all actors finishing this barrier.
-        let collect_result = rx.await.unwrap();
+        let mut collect_result = rx.await.unwrap();
 
         // Sync states from shared buffer to S3 before telling meta service we've done.
         if need_sync {
             dispatch_state_store!(self.state_store(), store, {
                 match store.sync(Some(barrier.epoch.prev)).await {
-                    Ok(_) => {}
+                    Ok(_) => {
+                        collect_result.synced_sstables =
+                            store.get_uncommitted_ssts(barrier.epoch.prev);
+                    }
                     // TODO: Handle sync failure by propagating it
                     // back to global barrier manager
                     Err(e) => panic!(


### PR DESCRIPTION
## What's changed and what's your intention?
This PR removes the `add_(ss)tables` RPC. Shared buffer no longer calls `add_tables` to track uncommitted SSTs in meta. Instead it commits these SSTS directly via `commit_epoch`. 
It reduces ~N RPCs per checkpoint, where N=number of CNs.

Major changes:
- Remove `add_tables`.
- Remove `abort_epoch`. We no longer need `abort_epoch` unless we want to vacuum orhpan SSTs sooner. Anyway they will be vacuumed after `orphan_sst_retention_interval`.
- CNs will inform meta SSTs that has been synced to s3, when replying checkpoint barrier.

## Checklist

- [x] I have added necessary unit tests and integration tests

## Refer to a related PR or issue link (optional)
https://github.com/singularity-data/risingwave/issues/2414