### PR TITLE
feat(test): deterministic testing for more crates

### DIFF
--- a/.github/workflow-template/jobs/compute-node-test.yml
+++ b/.github/workflow-template/jobs/compute-node-test.yml
@@ -62,7 +62,7 @@ jobs:
       - name: Run deterministic test
         continue-on-error: true
         run: |
-          cargo test --no-fail-fast --features=tokio/sim,tonic/sim,risingwave_pb/sim -p risingwave_batch -p risingwave_stream -p risingwave_storage -p risingwave_connector -p risingwave_source -p risingwave_compute
+          RUSTFLAGS="--cfg madsim" cargo test --target-dir target/sim --no-fail-fast -p risingwave_batch -p risingwave_stream -p risingwave_storage -p risingwave_connector -p risingwave_source -p risingwave_compute
 
       - uses: codecov/codecov-action@v2
         with:

--- a/.github/workflow-template/jobs/compute-node-test.yml
+++ b/.github/workflow-template/jobs/compute-node-test.yml
@@ -54,10 +54,15 @@ jobs:
       - name: Run rust doc check
         run: |
           cargo test --doc
-      
+
       - name: Run rust test with coverage
         run: |
           cargo llvm-cov nextest --lcov --output-path lcov.info -- --no-fail-fast
+
+      - name: Run deterministic test
+        continue-on-error: true
+        run: |
+          cargo test --no-fail-fast --features=tokio/sim,tonic/sim,risingwave_pb/sim -p risingwave_batch -p risingwave_stream -p risingwave_storage -p risingwave_connector -p risingwave_source -p risingwave_compute
 
       - uses: codecov/codecov-action@v2
         with:

--- a/.github/workflow-template/jobs/compute-node-test.yml
+++ b/.github/workflow-template/jobs/compute-node-test.yml
@@ -59,11 +59,6 @@ jobs:
         run: |
           cargo llvm-cov nextest --lcov --output-path lcov.info -- --no-fail-fast
 
-      - name: Run deterministic test
-        continue-on-error: true
-        run: |
-          RUSTFLAGS="--cfg madsim" cargo test --target-dir target/sim --no-fail-fast -p risingwave_batch -p risingwave_stream -p risingwave_storage -p risingwave_connector -p risingwave_source -p risingwave_compute
-
       - uses: codecov/codecov-action@v2
         with:
           token: ${{ secrets.CODECOV_TOKEN }}

--- a/.github/workflows/main-cron.yml
+++ b/.github/workflows/main-cron.yml
@@ -437,6 +437,10 @@ jobs:
       - name: Run rust test with coverage
         run: |
           cargo llvm-cov nextest --lcov --output-path lcov.info -- --no-fail-fast
+      - name: Run deterministic test
+        continue-on-error: true
+        run: |
+          cargo test --no-fail-fast --features=tokio/sim,tonic/sim,risingwave_pb/sim -p risingwave_batch -p risingwave_stream -p risingwave_storage -p risingwave_connector -p risingwave_source -p risingwave_compute
       - uses: codecov/codecov-action@v2
         with:
           token: ${{ secrets.CODECOV_TOKEN }}

--- a/.github/workflows/main-cron.yml
+++ b/.github/workflows/main-cron.yml
@@ -440,7 +440,7 @@ jobs:
       - name: Run deterministic test
         continue-on-error: true
         run: |
-          cargo test --no-fail-fast --features=tokio/sim,tonic/sim,risingwave_pb/sim -p risingwave_batch -p risingwave_stream -p risingwave_storage -p risingwave_connector -p risingwave_source -p risingwave_compute
+          RUSTFLAGS="--cfg madsim" cargo test --target-dir target/sim --no-fail-fast -p risingwave_batch -p risingwave_stream -p risingwave_storage -p risingwave_connector -p risingwave_source -p risingwave_compute
       - uses: codecov/codecov-action@v2
         with:
           token: ${{ secrets.CODECOV_TOKEN }}

--- a/.github/workflows/main-cron.yml
+++ b/.github/workflows/main-cron.yml
@@ -437,10 +437,6 @@ jobs:
       - name: Run rust test with coverage
         run: |
           cargo llvm-cov nextest --lcov --output-path lcov.info -- --no-fail-fast
-      - name: Run deterministic test
-        continue-on-error: true
-        run: |
-          RUSTFLAGS="--cfg madsim" cargo test --target-dir target/sim --no-fail-fast -p risingwave_batch -p risingwave_stream -p risingwave_storage -p risingwave_connector -p risingwave_source -p risingwave_compute
       - uses: codecov/codecov-action@v2
         with:
           token: ${{ secrets.CODECOV_TOKEN }}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -655,6 +655,10 @@ jobs:
       - name: Run rust test with coverage
         run: |
           cargo llvm-cov nextest --lcov --output-path lcov.info -- --no-fail-fast
+      - name: Run deterministic test
+        continue-on-error: true
+        run: |
+          cargo test --no-fail-fast --features=tokio/sim,tonic/sim,risingwave_pb/sim -p risingwave_batch -p risingwave_stream -p risingwave_storage -p risingwave_connector -p risingwave_source -p risingwave_compute
       - uses: codecov/codecov-action@v2
         with:
           token: ${{ secrets.CODECOV_TOKEN }}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -655,10 +655,6 @@ jobs:
       - name: Run rust test with coverage
         run: |
           cargo llvm-cov nextest --lcov --output-path lcov.info -- --no-fail-fast
-      - name: Run deterministic test
-        continue-on-error: true
-        run: |
-          RUSTFLAGS="--cfg madsim" cargo test --target-dir target/sim --no-fail-fast -p risingwave_batch -p risingwave_stream -p risingwave_storage -p risingwave_connector -p risingwave_source -p risingwave_compute
       - uses: codecov/codecov-action@v2
         with:
           token: ${{ secrets.CODECOV_TOKEN }}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -658,7 +658,7 @@ jobs:
       - name: Run deterministic test
         continue-on-error: true
         run: |
-          cargo test --no-fail-fast --features=tokio/sim,tonic/sim,risingwave_pb/sim -p risingwave_batch -p risingwave_stream -p risingwave_storage -p risingwave_connector -p risingwave_source -p risingwave_compute
+          RUSTFLAGS="--cfg madsim" cargo test --target-dir target/sim --no-fail-fast -p risingwave_batch -p risingwave_stream -p risingwave_storage -p risingwave_connector -p risingwave_source -p risingwave_compute
       - uses: codecov/codecov-action@v2
         with:
           token: ${{ secrets.CODECOV_TOKEN }}

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -440,10 +440,6 @@ jobs:
       - name: Run rust test with coverage
         run: |
           cargo llvm-cov nextest --lcov --output-path lcov.info -- --no-fail-fast
-      - name: Run deterministic test
-        continue-on-error: true
-        run: |
-          RUSTFLAGS="--cfg madsim" cargo test --target-dir target/sim --no-fail-fast -p risingwave_batch -p risingwave_stream -p risingwave_storage -p risingwave_connector -p risingwave_source -p risingwave_compute
       - uses: codecov/codecov-action@v2
         with:
           token: ${{ secrets.CODECOV_TOKEN }}

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -440,6 +440,10 @@ jobs:
       - name: Run rust test with coverage
         run: |
           cargo llvm-cov nextest --lcov --output-path lcov.info -- --no-fail-fast
+      - name: Run deterministic test
+        continue-on-error: true
+        run: |
+          cargo test --no-fail-fast --features=tokio/sim,tonic/sim,risingwave_pb/sim -p risingwave_batch -p risingwave_stream -p risingwave_storage -p risingwave_connector -p risingwave_source -p risingwave_compute
       - uses: codecov/codecov-action@v2
         with:
           token: ${{ secrets.CODECOV_TOKEN }}

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -443,7 +443,7 @@ jobs:
       - name: Run deterministic test
         continue-on-error: true
         run: |
-          cargo test --no-fail-fast --features=tokio/sim,tonic/sim,risingwave_pb/sim -p risingwave_batch -p risingwave_stream -p risingwave_storage -p risingwave_connector -p risingwave_source -p risingwave_compute
+          RUSTFLAGS="--cfg madsim" cargo test --target-dir target/sim --no-fail-fast -p risingwave_batch -p risingwave_stream -p risingwave_storage -p risingwave_connector -p risingwave_source -p risingwave_compute
       - uses: codecov/codecov-action@v2
         with:
           token: ${{ secrets.CODECOV_TOKEN }}

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -195,12 +195,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "async-task"
-version = "4.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "30696a84d817107fc028e049980e09d5e140e8da8f1caeb17e8e950658a3cea9"
-
-[[package]]
 name = "async-trait"
 version = "0.1.53"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2266,32 +2260,27 @@ dependencies = [
 
 [[package]]
 name = "madsim"
-version = "0.2.0-alpha.1"
+version = "0.2.0-alpha.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0388d0406d38a382335ee9c55d8277c43cb0a6a02b879f5705795ab373712fc8"
+checksum = "5c4f5135124b576c509856c495a2a5c7892b7e0c9152c9e7bd747bd4df062cdb"
 dependencies = [
- "ahash",
- "async-task",
  "bincode",
  "bytes",
- "downcast-rs",
  "env_logger",
  "futures",
  "log 0.4.17",
  "madsim-macros",
- "naive-timer",
  "rand 0.8.5",
  "serde",
  "tokio",
  "tokio-util 0.7.1",
- "toml",
 ]
 
 [[package]]
 name = "madsim-macros"
-version = "0.2.0-alpha.1"
+version = "0.2.0-alpha.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e89839c0c226f4ef524e2760983b24f09c4a3358ae12ac7a4c6533fbaecf43c4"
+checksum = "cacf5cb4f802c780f4a1bd888c4bf6099af5917a5e7dcbeafdaff0c5b1203dc0"
 dependencies = [
  "darling 0.14.1",
  "proc-macro2",
@@ -2300,16 +2289,27 @@ dependencies = [
 ]
 
 [[package]]
-name = "madsim-tonic"
-version = "0.2.0-alpha.1"
+name = "madsim-tokio"
+version = "0.2.0-alpha.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e2dbc733c4b8d83f679c5386254912811962595b72ebd67349ddd14d7fcd89b2"
+checksum = "aed42b4655e5d1badf560bee6bd22326aa31a7f087346f10959da746bf84d60a"
+dependencies = [
+ "madsim",
+ "tokio",
+]
+
+[[package]]
+name = "madsim-tonic"
+version = "0.2.0-alpha.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3d367bbac2c12a9ea13bb2ecbb85543a6b37ada7acd1dca1d78829371acee85e"
 dependencies = [
  "async-stream",
  "futures",
  "log 0.4.17",
  "madsim",
  "tonic",
+ "tower",
 ]
 
 [[package]]
@@ -2471,12 +2471,6 @@ name = "multimap"
 version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e5ce46fe64a9d73be07dcbe690a38ce1b293be448fd8ce1e6c1b8062c9f72c6a"
-
-[[package]]
-name = "naive-timer"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "034a0ad7deebf0c2abcf2435950a6666c3c15ea9d8fad0c0f48efa8a7f843fed"
 
 [[package]]
 name = "native-tls"
@@ -2874,8 +2868,9 @@ dependencies = [
  "async-trait",
  "byteorder 1.4.3",
  "bytes",
+ "madsim",
+ "madsim-tokio",
  "thiserror",
- "tokio",
  "tracing",
  "workspace-hack",
 ]
@@ -3471,6 +3466,8 @@ dependencies = [
  "itertools",
  "lazy_static",
  "log 0.4.17",
+ "madsim",
+ "madsim-tokio",
  "madsim-tonic",
  "memcomparable",
  "num-traits",
@@ -3494,7 +3491,6 @@ dependencies = [
  "static_assertions",
  "tempfile",
  "thiserror",
- "tokio",
  "tokio-stream",
  "tracing",
  "tracing-futures",
@@ -3514,6 +3510,8 @@ dependencies = [
  "futures",
  "itertools",
  "log 0.4.17",
+ "madsim",
+ "madsim-tokio",
  "moka",
  "prometheus",
  "rand 0.8.5",
@@ -3524,7 +3522,6 @@ dependencies = [
  "risingwave_rpc_client",
  "risingwave_storage",
  "serde",
- "tokio",
  "toml",
  "workspace-hack",
 ]
@@ -3535,6 +3532,8 @@ version = "0.1.7"
 dependencies = [
  "clap 3.1.17",
  "log 0.4.17",
+ "madsim",
+ "madsim-tokio",
  "risingwave_compactor",
  "risingwave_compute",
  "risingwave_ctl",
@@ -3542,7 +3541,6 @@ dependencies = [
  "risingwave_logging",
  "risingwave_meta",
  "tikv-jemallocator",
- "tokio",
  "tracing",
  "workspace-hack",
 ]
@@ -3554,6 +3552,8 @@ dependencies = [
  "anyhow",
  "clap 3.1.17",
  "log 0.4.17",
+ "madsim",
+ "madsim-tokio",
  "risedev",
  "risingwave_compactor",
  "risingwave_compute",
@@ -3562,7 +3562,6 @@ dependencies = [
  "risingwave_logging",
  "risingwave_meta",
  "tikv-jemallocator",
- "tokio",
  "tracing",
  "workspace-hack",
 ]
@@ -3586,6 +3585,8 @@ dependencies = [
  "lazy_static",
  "log 0.4.17",
  "lru",
+ "madsim",
+ "madsim-tokio",
  "madsim-tonic",
  "memcomparable",
  "more-asserts",
@@ -3599,7 +3600,6 @@ dependencies = [
  "serde",
  "smallvec",
  "thiserror",
- "tokio",
  "tokio-stream",
  "toml",
  "tower",
@@ -3615,6 +3615,8 @@ name = "risingwave_compactor"
 version = "0.1.0"
 dependencies = [
  "clap 3.1.17",
+ "madsim",
+ "madsim-tokio",
  "madsim-tonic",
  "prometheus",
  "risingwave_common",
@@ -3622,7 +3624,6 @@ dependencies = [
  "risingwave_rpc_client",
  "risingwave_storage",
  "serde",
- "tokio",
  "tokio-retry",
  "tokio-stream",
  "toml",
@@ -3650,6 +3651,8 @@ dependencies = [
  "itertools",
  "lazy_static",
  "log 0.4.17",
+ "madsim",
+ "madsim-tokio",
  "madsim-tonic",
  "memcomparable",
  "num-traits",
@@ -3672,7 +3675,6 @@ dependencies = [
  "static_assertions",
  "tempfile",
  "thiserror",
- "tokio",
  "tokio-stream",
  "tower",
  "tower-http",
@@ -3711,6 +3713,8 @@ dependencies = [
  "hyper",
  "itertools",
  "log 0.4.17",
+ "madsim",
+ "madsim-tokio",
  "madsim-tonic",
  "maplit",
  "memcomparable",
@@ -3731,7 +3735,6 @@ dependencies = [
  "static_assertions",
  "tempfile",
  "thiserror",
- "tokio",
  "tokio-stream",
  "tokio-util 0.7.1",
  "twox-hash",
@@ -3773,6 +3776,8 @@ dependencies = [
  "lazy_static",
  "log 0.4.17",
  "lru",
+ "madsim",
+ "madsim-tokio",
  "madsim-tonic",
  "memcomparable",
  "num-traits",
@@ -3784,7 +3789,6 @@ dependencies = [
  "serde",
  "smallvec",
  "thiserror",
- "tokio",
  "tokio-stream",
  "toml",
  "value-encoding",
@@ -3813,6 +3817,8 @@ dependencies = [
  "itertools",
  "lazy_static",
  "log 0.4.17",
+ "madsim",
+ "madsim-tokio",
  "madsim-tonic",
  "maplit",
  "num-integer",
@@ -3834,7 +3840,6 @@ dependencies = [
  "smallvec",
  "tempfile",
  "thiserror",
- "tokio",
  "tracing",
  "uuid 1.0.0",
  "workspace-hack",
@@ -3848,13 +3853,14 @@ dependencies = [
  "console",
  "futures",
  "itertools",
+ "madsim",
+ "madsim-tokio",
  "risingwave_frontend",
  "risingwave_sqlparser",
  "serde",
  "serde_with",
  "serde_yaml",
  "tempfile",
- "tokio",
  "walkdir",
  "workspace-hack",
 ]
@@ -3866,9 +3872,10 @@ dependencies = [
  "bytes",
  "hex",
  "log 0.4.17",
+ "madsim",
+ "madsim-tokio",
  "prost",
  "risingwave_pb",
- "tokio",
 ]
 
 [[package]]
@@ -3878,11 +3885,12 @@ dependencies = [
  "async-trait",
  "futures",
  "isahc",
+ "madsim",
+ "madsim-tokio",
  "opentelemetry",
  "opentelemetry-jaeger",
  "parking_lot 0.12.0",
  "thrift",
- "tokio",
  "tokio-stream",
  "tracing",
  "tracing-opentelemetry",
@@ -3914,6 +3922,8 @@ dependencies = [
  "itertools",
  "lazy_static",
  "log 0.4.17",
+ "madsim",
+ "madsim-tokio",
  "madsim-tonic",
  "memcomparable",
  "num-integer",
@@ -3935,7 +3945,6 @@ dependencies = [
  "smallvec",
  "tempfile",
  "thiserror",
- "tokio",
  "tokio-retry",
  "tokio-stream",
  "tower",
@@ -3969,9 +3978,10 @@ dependencies = [
  "clap 3.1.17",
  "env_logger",
  "log 0.4.17",
+ "madsim",
+ "madsim-tokio",
  "path-absolutize",
  "similar",
- "tokio",
  "workspace-hack",
 ]
 
@@ -3982,13 +3992,14 @@ dependencies = [
  "async-trait",
  "futures",
  "log 0.4.17",
+ "madsim",
+ "madsim-tokio",
  "madsim-tonic",
  "moka",
  "paste",
  "risingwave_common",
  "risingwave_hummock_sdk",
  "risingwave_pb",
- "tokio",
  "tracing",
  "workspace-hack",
 ]
@@ -4014,6 +4025,8 @@ dependencies = [
  "itertools",
  "lazy_static",
  "log 0.4.17",
+ "madsim",
+ "madsim-tokio",
  "madsim-tonic",
  "maplit",
  "memcomparable",
@@ -4039,7 +4052,6 @@ dependencies = [
  "static_assertions",
  "tempfile",
  "thiserror",
- "tokio",
  "tokio-stream",
  "tracing",
  "twox-hash",
@@ -4105,6 +4117,8 @@ dependencies = [
  "libc",
  "log 0.4.17",
  "lz4",
+ "madsim",
+ "madsim-tokio",
  "madsim-tonic",
  "memcomparable",
  "moka",
@@ -4127,7 +4141,6 @@ dependencies = [
  "spin 0.9.3",
  "tempfile",
  "thiserror",
- "tokio",
  "tokio-retry",
  "tokio-stream",
  "tracing",
@@ -4161,6 +4174,7 @@ dependencies = [
  "lazy_static",
  "log 0.4.17",
  "madsim",
+ "madsim-tokio",
  "madsim-tonic",
  "memcomparable",
  "num-traits",
@@ -4182,7 +4196,6 @@ dependencies = [
  "smallvec",
  "static_assertions",
  "thiserror",
- "tokio",
  "tokio-stream",
  "tower",
  "tracing",
@@ -5518,10 +5531,9 @@ dependencies = [
  "either",
  "fail",
  "fixedbitset",
- "futures",
+ "futures-channel",
  "futures-executor",
  "futures-io",
- "futures-sink",
  "futures-util",
  "hashbrown 0.11.2",
  "hyper",
@@ -5530,6 +5542,7 @@ dependencies = [
  "libz-sys",
  "lock_api",
  "log 0.4.17",
+ "madsim-tokio",
  "num-integer",
  "num-traits",
  "parking_lot 0.12.0",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -195,6 +195,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "async-task"
+version = "4.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "30696a84d817107fc028e049980e09d5e140e8da8f1caeb17e8e950658a3cea9"
+
+[[package]]
 name = "async-trait"
 version = "0.1.53"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2264,16 +2270,21 @@ version = "0.2.0-alpha.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0388d0406d38a382335ee9c55d8277c43cb0a6a02b879f5705795ab373712fc8"
 dependencies = [
+ "ahash",
+ "async-task",
  "bincode",
  "bytes",
+ "downcast-rs",
  "env_logger",
  "futures",
  "log 0.4.17",
  "madsim-macros",
+ "naive-timer",
  "rand 0.8.5",
  "serde",
  "tokio",
  "tokio-util 0.7.1",
+ "toml",
 ]
 
 [[package]]
@@ -2460,6 +2471,12 @@ name = "multimap"
 version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e5ce46fe64a9d73be07dcbe690a38ce1b293be448fd8ce1e6c1b8062c9f72c6a"
+
+[[package]]
+name = "naive-timer"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "034a0ad7deebf0c2abcf2435950a6666c3c15ea9d8fad0c0f48efa8a7f843fed"
 
 [[package]]
 name = "native-tls"
@@ -3940,7 +3957,6 @@ dependencies = [
  "prost",
  "prost-helpers",
  "prost-types",
- "quote",
  "serde",
  "workspace-hack",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -195,6 +195,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "async-task"
+version = "4.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "30696a84d817107fc028e049980e09d5e140e8da8f1caeb17e8e950658a3cea9"
+
+[[package]]
 name = "async-trait"
 version = "0.1.53"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2260,27 +2266,32 @@ dependencies = [
 
 [[package]]
 name = "madsim"
-version = "0.2.0-alpha.2"
+version = "0.2.0-alpha.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5c4f5135124b576c509856c495a2a5c7892b7e0c9152c9e7bd747bd4df062cdb"
+checksum = "972a96fe6454e9ae8f8be37469a54439ce606de7e1ab81a5fa35f27e3b9f562a"
 dependencies = [
+ "ahash",
+ "async-task",
  "bincode",
  "bytes",
+ "downcast-rs",
  "env_logger",
  "futures",
  "log 0.4.17",
  "madsim-macros",
+ "naive-timer",
  "rand 0.8.5",
  "serde",
  "tokio",
  "tokio-util 0.7.1",
+ "toml",
 ]
 
 [[package]]
 name = "madsim-macros"
-version = "0.2.0-alpha.2"
+version = "0.2.0-alpha.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cacf5cb4f802c780f4a1bd888c4bf6099af5917a5e7dcbeafdaff0c5b1203dc0"
+checksum = "c28d2e056c057b6414485a1026f399c704ad8ab32365c4e507cc8390d149e057"
 dependencies = [
  "darling 0.14.1",
  "proc-macro2",
@@ -2290,9 +2301,9 @@ dependencies = [
 
 [[package]]
 name = "madsim-tokio"
-version = "0.2.0-alpha.2"
+version = "0.2.0-alpha.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aed42b4655e5d1badf560bee6bd22326aa31a7f087346f10959da746bf84d60a"
+checksum = "42e6fd191e302ca7f8319e1efbd10434ca5e83db2170ab0184742de580b2d87f"
 dependencies = [
  "madsim",
  "tokio",
@@ -2300,9 +2311,9 @@ dependencies = [
 
 [[package]]
 name = "madsim-tonic"
-version = "0.2.0-alpha.2"
+version = "0.2.0-alpha.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3d367bbac2c12a9ea13bb2ecbb85543a6b37ada7acd1dca1d78829371acee85e"
+checksum = "cd4b7aba0420d6eabfad6a986f7c5a6c73f819b02ffbe94cc678f84a96a6a148"
 dependencies = [
  "async-stream",
  "futures",
@@ -2471,6 +2482,12 @@ name = "multimap"
 version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e5ce46fe64a9d73be07dcbe690a38ce1b293be448fd8ce1e6c1b8062c9f72c6a"
+
+[[package]]
+name = "naive-timer"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "034a0ad7deebf0c2abcf2435950a6666c3c15ea9d8fad0c0f48efa8a7f843fed"
 
 [[package]]
 name = "native-tls"
@@ -5532,8 +5549,11 @@ dependencies = [
  "fail",
  "fixedbitset",
  "futures-channel",
+ "futures-core",
  "futures-executor",
  "futures-io",
+ "futures-sink",
+ "futures-task",
  "futures-util",
  "hashbrown 0.11.2",
  "hyper",

--- a/src/batch/Cargo.toml
+++ b/src/batch/Cargo.toml
@@ -18,7 +18,7 @@ futures-async-stream = "0.2"
 itertools = "0.10"
 lazy_static = "1"
 log = "0.4"
-madsim = "=0.2.0-alpha.2"
+madsim = "=0.2.0-alpha.3"
 memcomparable = { path = "../utils/memcomparable" }
 num-traits = "0.2"
 parking_lot = { version = "0.12", features = ["arc_lock"] }
@@ -40,7 +40,7 @@ smallvec = "1"
 static_assertions = "1"
 tempfile = "3"
 thiserror = "1"
-tokio = { version = "=0.2.0-alpha.2", package = "madsim-tokio", features = [
+tokio = { version = "=0.2.0-alpha.3", package = "madsim-tokio", features = [
     "rt",
     "rt-multi-thread",
     "sync",
@@ -50,7 +50,7 @@ tokio = { version = "=0.2.0-alpha.2", package = "madsim-tokio", features = [
     "fs",
 ] }
 tokio-stream = "0.1"
-tonic = { version = "=0.2.0-alpha.2", package = "madsim-tonic" }
+tonic = { version = "=0.2.0-alpha.3", package = "madsim-tonic" }
 tracing = { version = "0.1" }
 tracing-futures = "0.2"
 twox-hash = "1"

--- a/src/batch/Cargo.toml
+++ b/src/batch/Cargo.toml
@@ -18,6 +18,7 @@ futures-async-stream = "0.2"
 itertools = "0.10"
 lazy_static = "1"
 log = "0.4"
+madsim = "=0.2.0-alpha.2"
 memcomparable = { path = "../utils/memcomparable" }
 num-traits = "0.2"
 parking_lot = { version = "0.12", features = ["arc_lock"] }
@@ -39,7 +40,7 @@ smallvec = "1"
 static_assertions = "1"
 tempfile = "3"
 thiserror = "1"
-tokio = { version = "1", features = [
+tokio = { version = "=0.2.0-alpha.2", package = "madsim-tokio", features = [
     "rt",
     "rt-multi-thread",
     "sync",
@@ -49,7 +50,7 @@ tokio = { version = "1", features = [
     "fs",
 ] }
 tokio-stream = "0.1"
-tonic = { version = "=0.2.0-alpha.1", package = "madsim-tonic" }
+tonic = { version = "=0.2.0-alpha.2", package = "madsim-tonic" }
 tracing = { version = "0.1" }
 tracing-futures = "0.2"
 twox-hash = "1"

--- a/src/bench/Cargo.toml
+++ b/src/bench/Cargo.toml
@@ -11,7 +11,7 @@ env_logger = "0.9"
 futures = { version = "0.3", default-features = false, features = ["alloc"] }
 itertools = "0.10"
 log = "0.4"
-madsim = "=0.2.0-alpha.2"
+madsim = "=0.2.0-alpha.3"
 moka = { version = "0.8", features = ["future"] }
 prometheus = { version = "0.13", features = ["process"] }
 rand = "0.8"
@@ -22,7 +22,7 @@ risingwave_pb = { path = "../prost" }
 risingwave_rpc_client = { path = "../rpc_client" }
 risingwave_storage = { path = "../storage" }
 serde = { version = "1", features = ["derive"] }
-tokio = { version = "=0.2.0-alpha.2", package = "madsim-tokio", features = [
+tokio = { version = "=0.2.0-alpha.3", package = "madsim-tokio", features = [
     "fs",
     "rt",
     "rt-multi-thread",

--- a/src/bench/Cargo.toml
+++ b/src/bench/Cargo.toml
@@ -11,6 +11,7 @@ env_logger = "0.9"
 futures = { version = "0.3", default-features = false, features = ["alloc"] }
 itertools = "0.10"
 log = "0.4"
+madsim = "=0.2.0-alpha.2"
 moka = { version = "0.8", features = ["future"] }
 prometheus = { version = "0.13", features = ["process"] }
 rand = "0.8"
@@ -21,7 +22,7 @@ risingwave_pb = { path = "../prost" }
 risingwave_rpc_client = { path = "../rpc_client" }
 risingwave_storage = { path = "../storage" }
 serde = { version = "1", features = ["derive"] }
-tokio = { version = "1", features = [
+tokio = { version = "=0.2.0-alpha.2", package = "madsim-tokio", features = [
     "fs",
     "rt",
     "rt-multi-thread",

--- a/src/cmd/Cargo.toml
+++ b/src/cmd/Cargo.toml
@@ -6,6 +6,7 @@ edition = "2021"
 [dependencies]
 clap = { version = "3", features = ["derive"] }
 log = { version = "0.4", features = ["release_max_level_info"] }
+madsim = "=0.2.0-alpha.2"
 risingwave_compactor = { path = "../storage/compactor" }
 risingwave_compute = { path = "../compute" }
 risingwave_ctl = { path = "../ctl" }
@@ -13,7 +14,7 @@ risingwave_frontend = { path = "../frontend" }
 risingwave_logging = { path = "../utils/logging" }
 risingwave_meta = { path = "../meta" }
 tikv-jemallocator = "0.4"
-tokio = { version = "1", features = [
+tokio = { version = "=0.2.0-alpha.2", package = "madsim-tokio", features = [
     "rt",
     "rt-multi-thread",
     "sync",

--- a/src/cmd/Cargo.toml
+++ b/src/cmd/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2021"
 [dependencies]
 clap = { version = "3", features = ["derive"] }
 log = { version = "0.4", features = ["release_max_level_info"] }
-madsim = "=0.2.0-alpha.2"
+madsim = "=0.2.0-alpha.3"
 risingwave_compactor = { path = "../storage/compactor" }
 risingwave_compute = { path = "../compute" }
 risingwave_ctl = { path = "../ctl" }
@@ -14,7 +14,7 @@ risingwave_frontend = { path = "../frontend" }
 risingwave_logging = { path = "../utils/logging" }
 risingwave_meta = { path = "../meta" }
 tikv-jemallocator = "0.4"
-tokio = { version = "=0.2.0-alpha.2", package = "madsim-tokio", features = [
+tokio = { version = "=0.2.0-alpha.3", package = "madsim-tokio", features = [
     "rt",
     "rt-multi-thread",
     "sync",

--- a/src/cmd_all/Cargo.toml
+++ b/src/cmd_all/Cargo.toml
@@ -7,6 +7,7 @@ edition = "2021"
 anyhow = "1"
 clap = { version = "3", features = ["derive"] }
 log = { version = "0.4", features = ["release_max_level_info"] }
+madsim = "=0.2.0-alpha.2"
 risedev = { path = "../risedevtool" }
 risingwave_compactor = { path = "../storage/compactor" }
 risingwave_compute = { path = "../compute" }
@@ -15,7 +16,7 @@ risingwave_frontend = { path = "../frontend" }
 risingwave_logging = { path = "../utils/logging" }
 risingwave_meta = { path = "../meta" }
 tikv-jemallocator = "0.4"
-tokio = { version = "1", features = [
+tokio = { version = "=0.2.0-alpha.2", package = "madsim-tokio", features = [
     "rt",
     "rt-multi-thread",
     "sync",

--- a/src/cmd_all/Cargo.toml
+++ b/src/cmd_all/Cargo.toml
@@ -7,7 +7,7 @@ edition = "2021"
 anyhow = "1"
 clap = { version = "3", features = ["derive"] }
 log = { version = "0.4", features = ["release_max_level_info"] }
-madsim = "=0.2.0-alpha.2"
+madsim = "=0.2.0-alpha.3"
 risedev = { path = "../risedevtool" }
 risingwave_compactor = { path = "../storage/compactor" }
 risingwave_compute = { path = "../compute" }
@@ -16,7 +16,7 @@ risingwave_frontend = { path = "../frontend" }
 risingwave_logging = { path = "../utils/logging" }
 risingwave_meta = { path = "../meta" }
 tikv-jemallocator = "0.4"
-tokio = { version = "=0.2.0-alpha.2", package = "madsim-tokio", features = [
+tokio = { version = "=0.2.0-alpha.3", package = "madsim-tokio", features = [
     "rt",
     "rt-multi-thread",
     "sync",

--- a/src/cmd_all/src/playground.rs
+++ b/src/cmd_all/src/playground.rs
@@ -113,6 +113,8 @@ pub async fn playground() -> Result<()> {
                 let opts = risingwave_meta::MetaNodeOpts::parse_from(opts);
                 tracing::info!("opts: {:#?}", opts);
                 let _meta_handle = tokio::spawn(async move { risingwave_meta::start(opts).await });
+                // wait for the service to be ready
+                tokio::time::sleep(std::time::Duration::from_secs(1)).await;
             }
             RisingWaveService::Compute(mut opts) => {
                 opts.insert(0, "compute-node".into());

--- a/src/common/Cargo.toml
+++ b/src/common/Cargo.toml
@@ -19,7 +19,7 @@ itertools = "0.10"
 lazy_static = "1"
 log = "0.4"
 lru = "0.7"
-madsim = "=0.2.0-alpha.2"
+madsim = "=0.2.0-alpha.3"
 memcomparable = { path = "../utils/memcomparable" }
 more-asserts = "0.2"
 num-traits = "0.2"
@@ -31,10 +31,10 @@ rust_decimal = "1"
 serde = { version = "1", features = ["derive"] }
 smallvec = "1"
 thiserror = "1"
-tokio = { version = "=0.2.0-alpha.2", package = "madsim-tokio", features = ["rt", "rt-multi-thread", "sync", "macros", "time", "signal"] }
+tokio = { version = "=0.2.0-alpha.3", package = "madsim-tokio", features = ["rt", "rt-multi-thread", "sync", "macros", "time", "signal"] }
 tokio-stream = "0.1"
 toml = "0.5"
-tonic = { version = "=0.2.0-alpha.2", package = "madsim-tonic" }
+tonic = { version = "=0.2.0-alpha.3", package = "madsim-tonic" }
 tower = { version = "0.4", features = ["util", "load-shed"] }
 tower-http = { version = "0.3", features = ["add-extension", "cors"] }
 tracing = { version = "0.1" }

--- a/src/common/Cargo.toml
+++ b/src/common/Cargo.toml
@@ -19,6 +19,7 @@ itertools = "0.10"
 lazy_static = "1"
 log = "0.4"
 lru = "0.7"
+madsim = "=0.2.0-alpha.2"
 memcomparable = { path = "../utils/memcomparable" }
 more-asserts = "0.2"
 num-traits = "0.2"
@@ -30,10 +31,10 @@ rust_decimal = "1"
 serde = { version = "1", features = ["derive"] }
 smallvec = "1"
 thiserror = "1"
-tokio = { version = "1", features = ["rt", "rt-multi-thread", "sync", "macros", "time", "signal"] }
+tokio = { version = "=0.2.0-alpha.2", package = "madsim-tokio", features = ["rt", "rt-multi-thread", "sync", "macros", "time", "signal"] }
 tokio-stream = "0.1"
 toml = "0.5"
-tonic = { version = "=0.2.0-alpha.1", package = "madsim-tonic" }
+tonic = { version = "=0.2.0-alpha.2", package = "madsim-tonic" }
 tower = { version = "0.4", features = ["util", "load-shed"] }
 tower-http = { version = "0.3", features = ["add-extension", "cors"] }
 tracing = { version = "0.1" }

--- a/src/compute/Cargo.toml
+++ b/src/compute/Cargo.toml
@@ -20,7 +20,7 @@ hyper = "0.14"
 itertools = "0.10"
 lazy_static = "1"
 log = "0.4"
-madsim = "=0.2.0-alpha.2"
+madsim = "=0.2.0-alpha.3"
 memcomparable = { path = "../utils/memcomparable" }
 num-traits = "0.2"
 paste = "1"
@@ -40,7 +40,7 @@ serde_json = "1"
 smallvec = "1"
 static_assertions = "1"
 thiserror = "1"
-tokio = { version = "=0.2.0-alpha.2", package = "madsim-tokio", features = [
+tokio = { version = "=0.2.0-alpha.3", package = "madsim-tokio", features = [
     "rt",
     "rt-multi-thread",
     "sync",
@@ -50,7 +50,7 @@ tokio = { version = "=0.2.0-alpha.2", package = "madsim-tokio", features = [
     "fs",
 ] }
 tokio-stream = "0.1"
-tonic = { version = "=0.2.0-alpha.2", package = "madsim-tonic" }
+tonic = { version = "=0.2.0-alpha.3", package = "madsim-tonic" }
 tower = { version = "0.4", features = ["util", "load-shed"] }
 tower-http = { version = "0.3", features = ["add-extension", "cors"] }
 tracing = { version = "0.1" }

--- a/src/compute/Cargo.toml
+++ b/src/compute/Cargo.toml
@@ -20,6 +20,7 @@ hyper = "0.14"
 itertools = "0.10"
 lazy_static = "1"
 log = "0.4"
+madsim = "=0.2.0-alpha.2"
 memcomparable = { path = "../utils/memcomparable" }
 num-traits = "0.2"
 paste = "1"
@@ -39,7 +40,7 @@ serde_json = "1"
 smallvec = "1"
 static_assertions = "1"
 thiserror = "1"
-tokio = { version = "1", features = [
+tokio = { version = "=0.2.0-alpha.2", package = "madsim-tokio", features = [
     "rt",
     "rt-multi-thread",
     "sync",
@@ -49,7 +50,7 @@ tokio = { version = "1", features = [
     "fs",
 ] }
 tokio-stream = "0.1"
-tonic = { version = "=0.2.0-alpha.1", package = "madsim-tonic" }
+tonic = { version = "=0.2.0-alpha.2", package = "madsim-tonic" }
 tower = { version = "0.4", features = ["util", "load-shed"] }
 tower-http = { version = "0.3", features = ["add-extension", "cors"] }
 tracing = { version = "0.1" }

--- a/src/connector/Cargo.toml
+++ b/src/connector/Cargo.toml
@@ -29,7 +29,7 @@ http-serde = "1.1.0"
 hyper = "0.14"
 itertools = "0.10"
 log = "0.4"
-madsim = "=0.2.0-alpha.2"
+madsim = "=0.2.0-alpha.3"
 maplit = "1.0.2"
 memcomparable = { path = "../utils/memcomparable" }
 num-traits = "0.2"
@@ -49,10 +49,10 @@ smallvec = "1"
 static_assertions = "1"
 tempfile = "3"
 thiserror = "1"
-tokio = { version = "=0.2.0-alpha.2", package = "madsim-tokio", features = ["rt", "rt-multi-thread", "sync", "macros", "time", "signal", "fs"] }
+tokio = { version = "=0.2.0-alpha.3", package = "madsim-tokio", features = ["rt", "rt-multi-thread", "sync", "macros", "time", "signal", "fs"] }
 tokio-stream = "0.1"
 tokio-util = { version = "0.7", features = ["codec", "io"] }
-tonic = { version = "=0.2.0-alpha.2", package = "madsim-tonic" }
+tonic = { version = "=0.2.0-alpha.3", package = "madsim-tonic" }
 twox-hash = "1"
 url = "2"
 urlencoding = "2"

--- a/src/connector/Cargo.toml
+++ b/src/connector/Cargo.toml
@@ -29,6 +29,7 @@ http-serde = "1.1.0"
 hyper = "0.14"
 itertools = "0.10"
 log = "0.4"
+madsim = "=0.2.0-alpha.2"
 maplit = "1.0.2"
 memcomparable = { path = "../utils/memcomparable" }
 num-traits = "0.2"
@@ -48,10 +49,10 @@ smallvec = "1"
 static_assertions = "1"
 tempfile = "3"
 thiserror = "1"
-tokio = { version = "1", features = ["rt", "rt-multi-thread", "sync", "macros", "time", "signal", "fs"] }
+tokio = { version = "=0.2.0-alpha.2", package = "madsim-tokio", features = ["rt", "rt-multi-thread", "sync", "macros", "time", "signal", "fs"] }
 tokio-stream = "0.1"
 tokio-util = { version = "0.7", features = ["codec", "io"] }
-tonic = { version = "=0.2.0-alpha.1", package = "madsim-tonic" }
+tonic = { version = "=0.2.0-alpha.2", package = "madsim-tonic" }
 twox-hash = "1"
 url = "2"
 urlencoding = "2"

--- a/src/expr/Cargo.toml
+++ b/src/expr/Cargo.toml
@@ -17,7 +17,7 @@ itertools = "0.10"
 lazy_static = "1"
 log = "0.4"
 lru = "0.7"
-madsim = "=0.2.0-alpha.2"
+madsim = "=0.2.0-alpha.3"
 memcomparable = { path = "../utils/memcomparable" }
 num-traits = "0.2"
 paste = "1"
@@ -28,9 +28,9 @@ rust_decimal = "1"
 serde = { version = "1", features = ["derive"] }
 smallvec = "1"
 thiserror = "1"
-tokio = { version = "=0.2.0-alpha.2", package = "madsim-tokio", features = ["rt", "rt-multi-thread", "sync", "macros", "time", "signal"] }
+tokio = { version = "=0.2.0-alpha.3", package = "madsim-tokio", features = ["rt", "rt-multi-thread", "sync", "macros", "time", "signal"] }
 tokio-stream = "0.1"
 toml = "0.5"
-tonic = { version = "=0.2.0-alpha.2", package = "madsim-tonic" }
+tonic = { version = "=0.2.0-alpha.3", package = "madsim-tonic" }
 value-encoding = { path = "../utils/value-encoding" }
 workspace-hack = { version = "0.1", path = "../workspace-hack" }

--- a/src/expr/Cargo.toml
+++ b/src/expr/Cargo.toml
@@ -17,6 +17,7 @@ itertools = "0.10"
 lazy_static = "1"
 log = "0.4"
 lru = "0.7"
+madsim = "=0.2.0-alpha.2"
 memcomparable = { path = "../utils/memcomparable" }
 num-traits = "0.2"
 paste = "1"
@@ -27,9 +28,9 @@ rust_decimal = "1"
 serde = { version = "1", features = ["derive"] }
 smallvec = "1"
 thiserror = "1"
-tokio = { version = "1", features = ["rt", "rt-multi-thread", "sync", "macros", "time", "signal"] }
+tokio = { version = "=0.2.0-alpha.2", package = "madsim-tokio", features = ["rt", "rt-multi-thread", "sync", "macros", "time", "signal"] }
 tokio-stream = "0.1"
 toml = "0.5"
-tonic = { version = "=0.2.0-alpha.1", package = "madsim-tonic" }
+tonic = { version = "=0.2.0-alpha.2", package = "madsim-tonic" }
 value-encoding = { path = "../utils/value-encoding" }
 workspace-hack = { version = "0.1", path = "../workspace-hack" }

--- a/src/frontend/Cargo.toml
+++ b/src/frontend/Cargo.toml
@@ -22,6 +22,7 @@ futures-async-stream = "0.2"
 itertools = "0.10"
 lazy_static = "1"
 log = "0.4"
+madsim = "=0.2.0-alpha.2"
 maplit = "1"
 num-integer = "0.1"
 num-traits = "0.2"
@@ -42,7 +43,7 @@ serde_json = "1"
 smallvec = { version = "1.6.1", features = ["serde"] }
 tempfile = "3"
 thiserror = "1"
-tokio = { version = "1", features = [
+tokio = { version = "=0.2.0-alpha.2", package = "madsim-tokio", features = [
     "rt",
     "rt-multi-thread",
     "sync",
@@ -51,7 +52,7 @@ tokio = { version = "1", features = [
     "signal",
     "fs",
 ] }
-tonic = { version = "=0.2.0-alpha.1", package = "madsim-tonic" }
+tonic = { version = "=0.2.0-alpha.2", package = "madsim-tonic" }
 tracing = { version = "0.1" }
 uuid = "1"
 workspace-hack = { version = "0.1", path = "../workspace-hack" }

--- a/src/frontend/Cargo.toml
+++ b/src/frontend/Cargo.toml
@@ -22,7 +22,7 @@ futures-async-stream = "0.2"
 itertools = "0.10"
 lazy_static = "1"
 log = "0.4"
-madsim = "=0.2.0-alpha.2"
+madsim = "=0.2.0-alpha.3"
 maplit = "1"
 num-integer = "0.1"
 num-traits = "0.2"
@@ -43,7 +43,7 @@ serde_json = "1"
 smallvec = { version = "1.6.1", features = ["serde"] }
 tempfile = "3"
 thiserror = "1"
-tokio = { version = "=0.2.0-alpha.2", package = "madsim-tokio", features = [
+tokio = { version = "=0.2.0-alpha.3", package = "madsim-tokio", features = [
     "rt",
     "rt-multi-thread",
     "sync",
@@ -52,7 +52,7 @@ tokio = { version = "=0.2.0-alpha.2", package = "madsim-tokio", features = [
     "signal",
     "fs",
 ] }
-tonic = { version = "=0.2.0-alpha.2", package = "madsim-tonic" }
+tonic = { version = "=0.2.0-alpha.3", package = "madsim-tonic" }
 tracing = { version = "0.1" }
 uuid = "1"
 workspace-hack = { version = "0.1", path = "../workspace-hack" }

--- a/src/frontend/test_runner/Cargo.toml
+++ b/src/frontend/test_runner/Cargo.toml
@@ -9,13 +9,13 @@ anyhow = "1"
 console = "0.15"
 futures = { version = "0.3", default-features = false, features = ["alloc"] }
 itertools = "0.10"
-madsim = "=0.2.0-alpha.2"
+madsim = "=0.2.0-alpha.3"
 risingwave_frontend = { path = ".." }
 risingwave_sqlparser = { path = "../../sqlparser" }
 serde = { version = "1", features = ["derive"] }
 serde_with = "1"
 serde_yaml = "0.8"
-tokio = { version = "=0.2.0-alpha.2", package = "madsim-tokio", features = [
+tokio = { version = "=0.2.0-alpha.3", package = "madsim-tokio", features = [
     "rt",
     "rt-multi-thread",
     "sync",

--- a/src/frontend/test_runner/Cargo.toml
+++ b/src/frontend/test_runner/Cargo.toml
@@ -9,12 +9,13 @@ anyhow = "1"
 console = "0.15"
 futures = { version = "0.3", default-features = false, features = ["alloc"] }
 itertools = "0.10"
+madsim = "=0.2.0-alpha.2"
 risingwave_frontend = { path = ".." }
 risingwave_sqlparser = { path = "../../sqlparser" }
 serde = { version = "1", features = ["derive"] }
 serde_with = "1"
 serde_yaml = "0.8"
-tokio = { version = "1", features = [
+tokio = { version = "=0.2.0-alpha.2", package = "madsim-tokio", features = [
     "rt",
     "rt-multi-thread",
     "sync",

--- a/src/meta/Cargo.toml
+++ b/src/meta/Cargo.toml
@@ -24,6 +24,7 @@ hyper = "0.14"
 itertools = "0.10"
 lazy_static = "1"
 log = "0.4"
+madsim = "=0.2.0-alpha.2"
 memcomparable = { path = "../utils/memcomparable" }
 num-integer = "0.1"
 num-traits = "0.2"
@@ -42,7 +43,7 @@ serde_derive = "1"
 serde_json = "1"
 smallvec = "1"
 thiserror = "1"
-tokio = { version = "1", features = [
+tokio = { version = "=0.2.0-alpha.2", package = "madsim-tokio", features = [
     "rt",
     "rt-multi-thread",
     "sync",
@@ -52,7 +53,7 @@ tokio = { version = "1", features = [
 ] }
 tokio-retry = "0.3"
 tokio-stream = { version = "0.1", features = ["net"] }
-tonic = { version = "=0.2.0-alpha.1", package = "madsim-tonic" }
+tonic = { version = "=0.2.0-alpha.2", package = "madsim-tonic" }
 tower = { version = "0.4", features = ["util", "load-shed"] }
 tower-http = { version = "0.3", features = ["add-extension", "cors", "fs"] }
 tracing = { version = "0.1" }

--- a/src/meta/Cargo.toml
+++ b/src/meta/Cargo.toml
@@ -24,7 +24,7 @@ hyper = "0.14"
 itertools = "0.10"
 lazy_static = "1"
 log = "0.4"
-madsim = "=0.2.0-alpha.2"
+madsim = "=0.2.0-alpha.3"
 memcomparable = { path = "../utils/memcomparable" }
 num-integer = "0.1"
 num-traits = "0.2"
@@ -43,7 +43,7 @@ serde_derive = "1"
 serde_json = "1"
 smallvec = "1"
 thiserror = "1"
-tokio = { version = "=0.2.0-alpha.2", package = "madsim-tokio", features = [
+tokio = { version = "=0.2.0-alpha.3", package = "madsim-tokio", features = [
     "rt",
     "rt-multi-thread",
     "sync",
@@ -53,7 +53,7 @@ tokio = { version = "=0.2.0-alpha.2", package = "madsim-tokio", features = [
 ] }
 tokio-retry = "0.3"
 tokio-stream = { version = "0.1", features = ["net"] }
-tonic = { version = "=0.2.0-alpha.2", package = "madsim-tonic" }
+tonic = { version = "=0.2.0-alpha.3", package = "madsim-tonic" }
 tower = { version = "0.4", features = ["util", "load-shed"] }
 tower-http = { version = "0.3", features = ["add-extension", "cors", "fs"] }
 tracing = { version = "0.1" }

--- a/src/meta/src/rpc/server.rs
+++ b/src/meta/src/rpc/server.rs
@@ -25,7 +25,6 @@ use risingwave_pb::meta::cluster_service_server::ClusterServiceServer;
 use risingwave_pb::meta::heartbeat_service_server::HeartbeatServiceServer;
 use risingwave_pb::meta::notification_service_server::NotificationServiceServer;
 use risingwave_pb::meta::stream_manager_service_server::StreamManagerServiceServer;
-use tokio::net::TcpListener;
 use tokio::sync::oneshot::Sender;
 use tokio::task::JoinHandle;
 
@@ -109,7 +108,6 @@ pub async fn rpc_serve_with_store<S: MetaStore>(
     ui_path: Option<String>,
     opts: MetaOpts,
 ) -> (JoinHandle<()>, Sender<()>) {
-    let listener = TcpListener::bind(addr).await.unwrap();
     let env = MetaSrvEnv::<S>::new(opts, meta_store.clone()).await;
 
     let fragment_manager = Arc::new(FragmentManager::new(env.clone()).await.unwrap());
@@ -241,25 +239,22 @@ pub async fn rpc_serve_with_store<S: MetaStore>(
             .add_service(HummockManagerServiceServer::new(hummock_srv))
             .add_service(NotificationServiceServer::new(notification_srv))
             .add_service(DdlServiceServer::new(ddl_srv))
-            .serve_with_incoming_shutdown(
-                tokio_stream::wrappers::TcpListenerStream::new(listener),
-                async move {
-                    tokio::select! {
-                        _ = tokio::signal::ctrl_c() => {},
-                        _ = &mut shutdown_recv => {
-                            for (join_handle, shutdown_sender) in sub_tasks {
-                                if let Err(err) = shutdown_sender.send(()) {
-                                    tracing::warn!("Failed to send shutdown: {:?}", err);
-                                    continue;
-                                }
-                                if let Err(err) = join_handle.await {
-                                    tracing::warn!("Failed to join shutdown: {:?}", err);
-                                }
+            .serve_with_shutdown(addr, async move {
+                tokio::select! {
+                    _ = tokio::signal::ctrl_c() => {},
+                    _ = &mut shutdown_recv => {
+                        for (join_handle, shutdown_sender) in sub_tasks {
+                            if let Err(err) = shutdown_sender.send(()) {
+                                tracing::warn!("Failed to send shutdown: {:?}", err);
+                                continue;
                             }
-                        },
-                    }
-                },
-            )
+                            if let Err(err) = join_handle.await {
+                                tracing::warn!("Failed to join shutdown: {:?}", err);
+                            }
+                        }
+                    },
+                }
+            })
             .await
             .unwrap();
     });

--- a/src/prost/Cargo.toml
+++ b/src/prost/Cargo.toml
@@ -3,9 +3,6 @@ edition = "2021"
 name = "risingwave_pb"
 version = "0.1.0"
 
-[features]
-sim = []
-
 [dependencies]
 bytes = "1"
 pbjson = "0.3"
@@ -13,7 +10,7 @@ prost = "0.10"
 prost-helpers = { path = "helpers" }
 prost-types = "0.10"
 serde = { version = "1", features = ["derive"] }
-tonic = { version = "=0.2.0-alpha.2", package = "madsim-tonic" }
+tonic = { version = "=0.2.0-alpha.3", package = "madsim-tonic" }
 workspace-hack = { version = "0.1", path = "../workspace-hack" }
 
 [build-dependencies]

--- a/src/prost/Cargo.toml
+++ b/src/prost/Cargo.toml
@@ -3,6 +3,9 @@ edition = "2021"
 name = "risingwave_pb"
 version = "0.1.0"
 
+[features]
+sim = ["tonic/sim"]
+
 [dependencies]
 bytes = "1"
 pbjson = "0.3"
@@ -15,7 +18,4 @@ workspace-hack = { version = "0.1", path = "../workspace-hack" }
 
 [build-dependencies]
 pbjson-build = "0.3"
-prost = "0.10"
-prost-types = "0.10"
-quote = "1"
 tonic-build = { version = "=0.2.0-alpha.1", package = "madsim-tonic-build" }

--- a/src/prost/Cargo.toml
+++ b/src/prost/Cargo.toml
@@ -4,7 +4,7 @@ name = "risingwave_pb"
 version = "0.1.0"
 
 [features]
-sim = ["tonic/sim"]
+sim = []
 
 [dependencies]
 bytes = "1"
@@ -13,7 +13,7 @@ prost = "0.10"
 prost-helpers = { path = "helpers" }
 prost-types = "0.10"
 serde = { version = "1", features = ["derive"] }
-tonic = { version = "=0.2.0-alpha.1", package = "madsim-tonic" }
+tonic = { version = "=0.2.0-alpha.2", package = "madsim-tonic" }
 workspace-hack = { version = "0.1", path = "../workspace-hack" }
 
 [build-dependencies]

--- a/src/prost/src/lib.rs
+++ b/src/prost/src/lib.rs
@@ -2,43 +2,43 @@
 #![allow(rustdoc::bare_urls)]
 
 #[rustfmt::skip]
-#[cfg_attr(feature = "sim", path = "sim/catalog.rs")]
+#[cfg_attr(madsim, path = "sim/catalog.rs")]
 pub mod catalog;
 #[rustfmt::skip]
-#[cfg_attr(feature = "sim", path = "sim/common.rs")]
+#[cfg_attr(madsim, path = "sim/common.rs")]
 pub mod common;
 #[rustfmt::skip]
-#[cfg_attr(feature = "sim", path = "sim/data.rs")]
+#[cfg_attr(madsim, path = "sim/data.rs")]
 pub mod data;
 #[rustfmt::skip]
-#[cfg_attr(feature = "sim", path = "sim/ddl_service.rs")]
+#[cfg_attr(madsim, path = "sim/ddl_service.rs")]
 pub mod ddl_service;
 #[rustfmt::skip]
-#[cfg_attr(feature = "sim", path = "sim/expr.rs")]
+#[cfg_attr(madsim, path = "sim/expr.rs")]
 pub mod expr;
 #[rustfmt::skip]
-#[cfg_attr(feature = "sim", path = "sim/meta.rs")]
+#[cfg_attr(madsim, path = "sim/meta.rs")]
 pub mod meta;
 #[rustfmt::skip]
-#[cfg_attr(feature = "sim", path = "sim/plan_common.rs")]
+#[cfg_attr(madsim, path = "sim/plan_common.rs")]
 pub mod plan_common;
 #[rustfmt::skip]
-#[cfg_attr(feature = "sim", path = "sim/batch_plan.rs")]
+#[cfg_attr(madsim, path = "sim/batch_plan.rs")]
 pub mod batch_plan;
 #[rustfmt::skip]
-#[cfg_attr(feature = "sim", path = "sim/task_service.rs")]
+#[cfg_attr(madsim, path = "sim/task_service.rs")]
 pub mod task_service;
 #[rustfmt::skip]
-#[cfg_attr(feature = "sim", path = "sim/stream_plan.rs")]
+#[cfg_attr(madsim, path = "sim/stream_plan.rs")]
 pub mod stream_plan;
 #[rustfmt::skip]
-#[cfg_attr(feature = "sim", path = "sim/stream_service.rs")]
+#[cfg_attr(madsim, path = "sim/stream_service.rs")]
 pub mod stream_service;
 #[rustfmt::skip]
-#[cfg_attr(feature = "sim", path = "sim/hummock.rs")]
+#[cfg_attr(madsim, path = "sim/hummock.rs")]
 pub mod hummock;
 #[rustfmt::skip]
-#[cfg_attr(feature = "sim", path = "sim/user.rs")]
+#[cfg_attr(madsim, path = "sim/user.rs")]
 pub mod user;
 
 #[rustfmt::skip]

--- a/src/prost/src/lib.rs
+++ b/src/prost/src/lib.rs
@@ -2,30 +2,43 @@
 #![allow(rustdoc::bare_urls)]
 
 #[rustfmt::skip]
+#[cfg_attr(feature = "sim", path = "sim/catalog.rs")]
 pub mod catalog;
 #[rustfmt::skip]
+#[cfg_attr(feature = "sim", path = "sim/common.rs")]
 pub mod common;
 #[rustfmt::skip]
+#[cfg_attr(feature = "sim", path = "sim/data.rs")]
 pub mod data;
 #[rustfmt::skip]
+#[cfg_attr(feature = "sim", path = "sim/ddl_service.rs")]
 pub mod ddl_service;
 #[rustfmt::skip]
+#[cfg_attr(feature = "sim", path = "sim/expr.rs")]
 pub mod expr;
 #[rustfmt::skip]
+#[cfg_attr(feature = "sim", path = "sim/meta.rs")]
 pub mod meta;
 #[rustfmt::skip]
+#[cfg_attr(feature = "sim", path = "sim/plan_common.rs")]
 pub mod plan_common;
 #[rustfmt::skip]
+#[cfg_attr(feature = "sim", path = "sim/batch_plan.rs")]
 pub mod batch_plan;
 #[rustfmt::skip]
+#[cfg_attr(feature = "sim", path = "sim/task_service.rs")]
 pub mod task_service;
 #[rustfmt::skip]
+#[cfg_attr(feature = "sim", path = "sim/stream_plan.rs")]
 pub mod stream_plan;
 #[rustfmt::skip]
+#[cfg_attr(feature = "sim", path = "sim/stream_service.rs")]
 pub mod stream_service;
 #[rustfmt::skip]
+#[cfg_attr(feature = "sim", path = "sim/hummock.rs")]
 pub mod hummock;
 #[rustfmt::skip]
+#[cfg_attr(feature = "sim", path = "sim/user.rs")]
 pub mod user;
 
 #[rustfmt::skip]

--- a/src/rpc_client/Cargo.toml
+++ b/src/rpc_client/Cargo.toml
@@ -7,12 +7,13 @@ edition = "2021"
 async-trait = "0.1"
 futures = { version = "0.3", default-features = false, features = ["alloc"] }
 log = "0.4"
+madsim = "=0.2.0-alpha.2"
 moka = { version = "0.8", features = ["future"] }
 paste = "1"
 risingwave_common = { path = "../common" }
 risingwave_hummock_sdk = { path = "../storage/hummock_sdk" }
 risingwave_pb = { path = "../prost" }
-tokio = { version = "1", features = [
+tokio = { version = "=0.2.0-alpha.2", package = "madsim-tokio", features = [
     "rt",
     "rt-multi-thread",
     "sync",
@@ -20,6 +21,6 @@ tokio = { version = "1", features = [
     "time",
     "signal",
 ] }
-tonic = { version = "=0.2.0-alpha.1", package = "madsim-tonic" }
+tonic = { version = "=0.2.0-alpha.2", package = "madsim-tonic" }
 tracing = { version = "0.1" }
 workspace-hack = { version = "0.1", path = "../workspace-hack" }

--- a/src/rpc_client/Cargo.toml
+++ b/src/rpc_client/Cargo.toml
@@ -7,13 +7,13 @@ edition = "2021"
 async-trait = "0.1"
 futures = { version = "0.3", default-features = false, features = ["alloc"] }
 log = "0.4"
-madsim = "=0.2.0-alpha.2"
+madsim = "=0.2.0-alpha.3"
 moka = { version = "0.8", features = ["future"] }
 paste = "1"
 risingwave_common = { path = "../common" }
 risingwave_hummock_sdk = { path = "../storage/hummock_sdk" }
 risingwave_pb = { path = "../prost" }
-tokio = { version = "=0.2.0-alpha.2", package = "madsim-tokio", features = [
+tokio = { version = "=0.2.0-alpha.3", package = "madsim-tokio", features = [
     "rt",
     "rt-multi-thread",
     "sync",
@@ -21,6 +21,6 @@ tokio = { version = "=0.2.0-alpha.2", package = "madsim-tokio", features = [
     "time",
     "signal",
 ] }
-tonic = { version = "=0.2.0-alpha.2", package = "madsim-tonic" }
+tonic = { version = "=0.2.0-alpha.3", package = "madsim-tonic" }
 tracing = { version = "0.1" }
 workspace-hack = { version = "0.1", path = "../workspace-hack" }

--- a/src/source/Cargo.toml
+++ b/src/source/Cargo.toml
@@ -20,7 +20,7 @@ futures = { version = "0.3", default-features = false, features = ["alloc"] }
 itertools = "0.10"
 lazy_static = "1"
 log = "0.4"
-madsim = "=0.2.0-alpha.2"
+madsim = "=0.2.0-alpha.3"
 maplit = "1"
 memcomparable = { path = "../utils/memcomparable" }
 num-traits = "0.2"
@@ -45,9 +45,9 @@ smallvec = "1"
 static_assertions = "1"
 tempfile = "3"
 thiserror = "1"
-tokio = { version = "=0.2.0-alpha.2", package = "madsim-tokio", features = ["rt", "rt-multi-thread", "sync", "macros", "time", "signal", "fs"] }
+tokio = { version = "=0.2.0-alpha.3", package = "madsim-tokio", features = ["rt", "rt-multi-thread", "sync", "macros", "time", "signal", "fs"] }
 tokio-stream = "0.1"
-tonic = { version = "=0.2.0-alpha.2", package = "madsim-tonic" }
+tonic = { version = "=0.2.0-alpha.3", package = "madsim-tonic" }
 tracing = { version = "0.1", features = ["release_max_level_info"] }
 twox-hash = "1"
 url = "2"

--- a/src/source/Cargo.toml
+++ b/src/source/Cargo.toml
@@ -20,6 +20,7 @@ futures = { version = "0.3", default-features = false, features = ["alloc"] }
 itertools = "0.10"
 lazy_static = "1"
 log = "0.4"
+madsim = "=0.2.0-alpha.2"
 maplit = "1"
 memcomparable = { path = "../utils/memcomparable" }
 num-traits = "0.2"
@@ -44,9 +45,9 @@ smallvec = "1"
 static_assertions = "1"
 tempfile = "3"
 thiserror = "1"
-tokio = { version = "1", features = ["rt", "rt-multi-thread", "sync", "macros", "time", "signal", "fs"] }
+tokio = { version = "=0.2.0-alpha.2", package = "madsim-tokio", features = ["rt", "rt-multi-thread", "sync", "macros", "time", "signal", "fs"] }
 tokio-stream = "0.1"
-tonic = { version = "=0.2.0-alpha.1", package = "madsim-tonic" }
+tonic = { version = "=0.2.0-alpha.2", package = "madsim-tonic" }
 tracing = { version = "0.1", features = ["release_max_level_info"] }
 twox-hash = "1"
 url = "2"

--- a/src/storage/Cargo.toml
+++ b/src/storage/Cargo.toml
@@ -30,6 +30,7 @@ lazy_static = "1"
 libc = "0.2"
 log = "0.4"
 lz4 = "1.23.1"
+madsim = "=0.2.0-alpha.2"
 memcomparable = { path = "../utils/memcomparable" }
 moka = { version = "0.8", features = ["future"] }
 num-integer = "0.1"
@@ -53,7 +54,7 @@ spin = "0.9"
 tempfile = "3"
 thiserror = "1"
 # tikv-client = { git = "https://github.com/tikv/client-rust", rev = "5714b2", optional = true }
-tokio = { version = "1", features = [
+tokio = { version = "=0.2.0-alpha.2", package = "madsim-tokio", features = [
     "fs",
     "rt",
     "rt-multi-thread",
@@ -64,7 +65,7 @@ tokio = { version = "1", features = [
 ] }
 tokio-retry = "0.3"
 tokio-stream = "0.1"
-tonic = { version = "=0.2.0-alpha.1", package = "madsim-tonic" }
+tonic = { version = "=0.2.0-alpha.2", package = "madsim-tonic" }
 tracing = { version = "0.1" }
 twox-hash = "1"
 value-encoding = { path = "../utils/value-encoding" }

--- a/src/storage/Cargo.toml
+++ b/src/storage/Cargo.toml
@@ -30,7 +30,7 @@ lazy_static = "1"
 libc = "0.2"
 log = "0.4"
 lz4 = "1.23.1"
-madsim = "=0.2.0-alpha.2"
+madsim = "=0.2.0-alpha.3"
 memcomparable = { path = "../utils/memcomparable" }
 moka = { version = "0.8", features = ["future"] }
 num-integer = "0.1"
@@ -54,7 +54,7 @@ spin = "0.9"
 tempfile = "3"
 thiserror = "1"
 # tikv-client = { git = "https://github.com/tikv/client-rust", rev = "5714b2", optional = true }
-tokio = { version = "=0.2.0-alpha.2", package = "madsim-tokio", features = [
+tokio = { version = "=0.2.0-alpha.3", package = "madsim-tokio", features = [
     "fs",
     "rt",
     "rt-multi-thread",
@@ -65,7 +65,7 @@ tokio = { version = "=0.2.0-alpha.2", package = "madsim-tokio", features = [
 ] }
 tokio-retry = "0.3"
 tokio-stream = "0.1"
-tonic = { version = "=0.2.0-alpha.2", package = "madsim-tonic" }
+tonic = { version = "=0.2.0-alpha.3", package = "madsim-tonic" }
 tracing = { version = "0.1" }
 twox-hash = "1"
 value-encoding = { path = "../utils/value-encoding" }

--- a/src/storage/compactor/Cargo.toml
+++ b/src/storage/compactor/Cargo.toml
@@ -6,14 +6,14 @@ edition = "2021"
 
 [dependencies]
 clap = { version = "3", features = ["derive"] }
-madsim = "=0.2.0-alpha.2"
+madsim = "=0.2.0-alpha.3"
 prometheus = { version = "0.13" }
 risingwave_common = { path = "../../common" }
 risingwave_pb = { path = "../../prost" }
 risingwave_rpc_client = { path = "../../rpc_client" }
 risingwave_storage = { path = "../../storage" }
 serde = { version = "1", features = ["derive"] }
-tokio = { version = "=0.2.0-alpha.2", package = "madsim-tokio", features = [
+tokio = { version = "=0.2.0-alpha.3", package = "madsim-tokio", features = [
     "fs",
     "rt",
     "rt-multi-thread",
@@ -25,5 +25,5 @@ tokio = { version = "=0.2.0-alpha.2", package = "madsim-tokio", features = [
 tokio-retry = "0.3"
 tokio-stream = "0.1"
 toml = "0.5"
-tonic = { version = "=0.2.0-alpha.2", package = "madsim-tonic" }
+tonic = { version = "=0.2.0-alpha.3", package = "madsim-tonic" }
 tracing = { version = "0.1" }

--- a/src/storage/compactor/Cargo.toml
+++ b/src/storage/compactor/Cargo.toml
@@ -6,13 +6,14 @@ edition = "2021"
 
 [dependencies]
 clap = { version = "3", features = ["derive"] }
+madsim = "=0.2.0-alpha.2"
 prometheus = { version = "0.13" }
 risingwave_common = { path = "../../common" }
 risingwave_pb = { path = "../../prost" }
 risingwave_rpc_client = { path = "../../rpc_client" }
 risingwave_storage = { path = "../../storage" }
 serde = { version = "1", features = ["derive"] }
-tokio = { version = "1", features = [
+tokio = { version = "=0.2.0-alpha.2", package = "madsim-tokio", features = [
     "fs",
     "rt",
     "rt-multi-thread",
@@ -24,5 +25,5 @@ tokio = { version = "1", features = [
 tokio-retry = "0.3"
 tokio-stream = "0.1"
 toml = "0.5"
-tonic = { version = "=0.2.0-alpha.1", package = "madsim-tonic" }
+tonic = { version = "=0.2.0-alpha.2", package = "madsim-tonic" }
 tracing = { version = "0.1" }

--- a/src/storage/hummock_sdk/Cargo.toml
+++ b/src/storage/hummock_sdk/Cargo.toml
@@ -7,7 +7,7 @@ edition = "2021"
 bytes = "1"
 hex = "0.4"
 log = "0.4"
-madsim = "=0.2.0-alpha.2"
+madsim = "=0.2.0-alpha.3"
 prost = "0.10"
 risingwave_pb = { path = "../../prost" }
-tokio = { version = "=0.2.0-alpha.2", package = "madsim-tokio", features = ["rt", "rt-multi-thread", "sync", "macros", "time", "signal"] }
+tokio = { version = "=0.2.0-alpha.3", package = "madsim-tokio", features = ["rt", "rt-multi-thread", "sync", "macros", "time", "signal"] }

--- a/src/storage/hummock_sdk/Cargo.toml
+++ b/src/storage/hummock_sdk/Cargo.toml
@@ -7,6 +7,7 @@ edition = "2021"
 bytes = "1"
 hex = "0.4"
 log = "0.4"
+madsim = "=0.2.0-alpha.2"
 prost = "0.10"
 risingwave_pb = { path = "../../prost" }
-tokio = { version = "1", features = ["rt", "rt-multi-thread", "sync", "macros", "time", "signal"] }
+tokio = { version = "=0.2.0-alpha.2", package = "madsim-tokio", features = ["rt", "rt-multi-thread", "sync", "macros", "time", "signal"] }

--- a/src/storage/src/hummock/compaction_executor.rs
+++ b/src/storage/src/hummock/compaction_executor.rs
@@ -24,10 +24,12 @@ type CompactionRequest = Pin<Box<dyn Future<Output = ()> + Send + 'static>>;
 pub struct CompactionExecutor {
     requests: tokio::sync::mpsc::UnboundedSender<CompactionRequest>,
     // TODO: graceful shutdown
+    #[cfg(not(madsim))]
     _runtime_thread: std::thread::JoinHandle<()>,
 }
 
 impl CompactionExecutor {
+    #[cfg(not(madsim))]
     pub fn new(worker_threads_num: Option<usize>) -> Self {
         let (tx, mut rx) = tokio::sync::mpsc::unbounded_channel();
         Self {
@@ -45,6 +47,19 @@ impl CompactionExecutor {
                 });
             }),
         }
+    }
+
+    // FIXME: simulation doesn't support new thread or tokio runtime.
+    //        this is a workaround to make it compile.
+    #[cfg(madsim)]
+    pub fn new(_worker_threads_num: Option<usize>) -> Self {
+        let (tx, mut rx) = tokio::sync::mpsc::unbounded_channel();
+        tokio::spawn(async move {
+            while let Some(request) = rx.recv().await {
+                request.await;
+            }
+        });
+        Self { requests: tx }
     }
 
     pub fn send_request<T>(

--- a/src/stream/Cargo.toml
+++ b/src/stream/Cargo.toml
@@ -23,7 +23,7 @@ iter-chunks = "0.1"
 itertools = "0.10"
 lazy_static = "1"
 log = "0.4"
-madsim = "=0.2.0-alpha.1"
+madsim = "=0.2.0-alpha.2"
 memcomparable = { path = "../utils/memcomparable" }
 num-traits = "0.2"
 parking_lot = "0.12"
@@ -44,7 +44,7 @@ serde_json = "1"
 smallvec = "1"
 static_assertions = "1"
 thiserror = "1"
-tokio = { version = "1", features = [
+tokio = { version = "=0.2.0-alpha.2", package = "madsim-tokio", features = [
     "rt",
     "rt-multi-thread",
     "sync",
@@ -54,7 +54,7 @@ tokio = { version = "1", features = [
     "fs",
 ] }
 tokio-stream = "0.1"
-tonic = { version = "=0.2.0-alpha.1", package = "madsim-tonic" }
+tonic = { version = "=0.2.0-alpha.2", package = "madsim-tonic" }
 tower = { version = "0.4", features = ["util", "load-shed"] }
 tracing = { version = "0.1" }
 tracing-futures = "0.2"

--- a/src/stream/Cargo.toml
+++ b/src/stream/Cargo.toml
@@ -23,7 +23,7 @@ iter-chunks = "0.1"
 itertools = "0.10"
 lazy_static = "1"
 log = "0.4"
-madsim = "=0.2.0-alpha.2"
+madsim = "=0.2.0-alpha.3"
 memcomparable = { path = "../utils/memcomparable" }
 num-traits = "0.2"
 parking_lot = "0.12"
@@ -44,7 +44,7 @@ serde_json = "1"
 smallvec = "1"
 static_assertions = "1"
 thiserror = "1"
-tokio = { version = "=0.2.0-alpha.2", package = "madsim-tokio", features = [
+tokio = { version = "=0.2.0-alpha.3", package = "madsim-tokio", features = [
     "rt",
     "rt-multi-thread",
     "sync",
@@ -54,7 +54,7 @@ tokio = { version = "=0.2.0-alpha.2", package = "madsim-tokio", features = [
     "fs",
 ] }
 tokio-stream = "0.1"
-tonic = { version = "=0.2.0-alpha.2", package = "madsim-tonic" }
+tonic = { version = "=0.2.0-alpha.3", package = "madsim-tonic" }
 tower = { version = "0.4", features = ["util", "load-shed"] }
 tracing = { version = "0.1" }
 tracing-futures = "0.2"

--- a/src/stream/src/executor/barrier_align.rs
+++ b/src/stream/src/executor/barrier_align.rs
@@ -91,12 +91,12 @@ mod tests {
 
     use async_stream::try_stream;
     use futures::TryStreamExt;
-    use madsim::time::sleep;
     use risingwave_common::array::stream_chunk::StreamChunkTestExt;
+    use tokio::time::sleep;
 
     use super::*;
 
-    #[madsim::test]
+    #[tokio::test]
     async fn test_barrier_align() {
         let left = try_stream! {
             yield Message::Chunk(StreamChunk::from_pretty("I\n + 1"));
@@ -127,7 +127,7 @@ mod tests {
         );
     }
 
-    #[madsim::test]
+    #[tokio::test]
     #[should_panic]
     async fn left_barrier_right_end_1() {
         let left = try_stream! {
@@ -143,7 +143,7 @@ mod tests {
         let _output: Vec<_> = barrier_align(left, right).try_collect().await.unwrap();
     }
 
-    #[madsim::test]
+    #[tokio::test]
     #[should_panic]
     async fn left_barrier_right_end_2() {
         let left = try_stream! {

--- a/src/stream/src/executor/batch_query.rs
+++ b/src/stream/src/executor/batch_query.rs
@@ -148,7 +148,7 @@ mod test {
     use super::*;
     use crate::executor::mview::test_utils::gen_basic_table;
 
-    #[madsim::test]
+    #[tokio::test]
     async fn test_basic() {
         let test_batch_size = 50;
         let test_batch_count = 5;

--- a/src/stream/src/executor/chain.rs
+++ b/src/stream/src/executor/chain.rs
@@ -150,7 +150,7 @@ mod test {
     use crate::executor::{Barrier, Executor, Message, PkIndices};
     use crate::task::{FinishCreateMviewNotifier, LocalBarrierManager};
 
-    #[madsim::test]
+    #[tokio::test]
     async fn test_basic() {
         let schema = Schema::new(vec![Field::unnamed(DataType::Int64)]);
         let first = Box::new(

--- a/src/stream/src/executor/debug/epoch_check.rs
+++ b/src/stream/src/executor/debug/epoch_check.rs
@@ -67,7 +67,7 @@ mod tests {
     use crate::executor::test_utils::MockSource;
     use crate::executor::Executor;
 
-    #[madsim::test]
+    #[tokio::test]
     async fn test_epoch_ok() {
         let (mut tx, source) = MockSource::channel(Default::default(), vec![]);
         tx.push_barrier(100, false);
@@ -87,7 +87,7 @@ mod tests {
     }
 
     #[should_panic]
-    #[madsim::test]
+    #[tokio::test]
     async fn test_epoch_bad() {
         let (mut tx, source) = MockSource::channel(Default::default(), vec![]);
         tx.push_barrier(100, false);
@@ -108,7 +108,7 @@ mod tests {
     }
 
     #[should_panic]
-    #[madsim::test]
+    #[tokio::test]
     async fn test_epoch_first_not_barrier() {
         let (mut tx, source) = MockSource::channel(Default::default(), vec![]);
         tx.push_chunk(StreamChunk::default());
@@ -120,7 +120,7 @@ mod tests {
         checked.next().await.unwrap().unwrap(); // should panic
     }
 
-    #[madsim::test]
+    #[tokio::test]
     async fn test_empty() {
         let (_, mut source) = MockSource::channel(Default::default(), vec![]);
         source = source.stop_on_finish(false);

--- a/src/stream/src/executor/debug/schema_check.rs
+++ b/src/stream/src/executor/debug/schema_check.rs
@@ -88,7 +88,7 @@ mod tests {
     use crate::executor::test_utils::MockSource;
     use crate::executor::Executor;
 
-    #[madsim::test]
+    #[tokio::test]
     async fn test_schema_ok() {
         let schema = Schema {
             fields: vec![
@@ -114,7 +114,7 @@ mod tests {
     }
 
     #[should_panic]
-    #[madsim::test]
+    #[tokio::test]
     async fn test_schema_bad() {
         let schema = Schema {
             fields: vec![

--- a/src/stream/src/executor/debug/update_check.rs
+++ b/src/stream/src/executor/debug/update_check.rs
@@ -65,7 +65,7 @@ mod tests {
     use crate::executor::Executor;
 
     #[should_panic]
-    #[madsim::test]
+    #[tokio::test]
     async fn test_not_next_to_each_other() {
         let (mut tx, source) = MockSource::channel(Default::default(), vec![]);
         tx.push_chunk(StreamChunk::from_pretty(
@@ -83,7 +83,7 @@ mod tests {
     }
 
     #[should_panic]
-    #[madsim::test]
+    #[tokio::test]
     async fn test_first_one_update_insert() {
         let (mut tx, source) = MockSource::channel(Default::default(), vec![]);
         tx.push_chunk(StreamChunk::from_pretty(
@@ -98,7 +98,7 @@ mod tests {
     }
 
     #[should_panic]
-    #[madsim::test]
+    #[tokio::test]
     async fn test_last_one_update_delete() {
         let (mut tx, source) = MockSource::channel(Default::default(), vec![]);
         tx.push_chunk(StreamChunk::from_pretty(
@@ -114,7 +114,7 @@ mod tests {
         checked.next().await.unwrap().unwrap(); // should panic
     }
 
-    #[madsim::test]
+    #[tokio::test]
     async fn test_empty_chunk() {
         let (mut tx, source) = MockSource::channel(Default::default(), vec![]);
         tx.push_chunk(StreamChunk::default());

--- a/src/stream/src/executor/dispatch.rs
+++ b/src/stream/src/executor/dispatch.rs
@@ -809,7 +809,7 @@ mod tests {
         }
     }
 
-    #[madsim::test]
+    #[tokio::test]
     async fn test_hash_dispatcher_complex() {
         test_hash_dispatcher_complex_inner().await
     }
@@ -916,7 +916,7 @@ mod tests {
         }
     }
 
-    #[madsim::test]
+    #[tokio::test]
     async fn test_configuration_change() {
         let schema = Schema { fields: vec![] };
         let (mut tx, rx) = channel(16);
@@ -996,7 +996,7 @@ mod tests {
         }
     }
 
-    #[madsim::test]
+    #[tokio::test]
     async fn test_hash_dispatcher() {
         let num_outputs = 5; // actor id ranges from 1 to 5
         let cardinality = 10;

--- a/src/stream/src/executor/filter.rs
+++ b/src/stream/src/executor/filter.rs
@@ -188,7 +188,7 @@ mod tests {
     use super::super::*;
     use super::*;
 
-    #[madsim::test]
+    #[tokio::test]
     async fn test_filter() {
         let chunk1 = StreamChunk::from_pretty(
             " I I

--- a/src/stream/src/executor/global_simple_agg.rs
+++ b/src/stream/src/executor/global_simple_agg.rs
@@ -295,7 +295,7 @@ mod tests {
     use crate::executor::test_utils::*;
     use crate::executor::*;
 
-    #[madsim::test]
+    #[tokio::test]
     async fn test_local_simple_aggregation_in_memory() {
         test_local_simple_aggregation(create_in_memory_keyspace_agg(4)).await
     }

--- a/src/stream/src/executor/hash_agg.rs
+++ b/src/stream/src/executor/hash_agg.rs
@@ -498,22 +498,22 @@ mod tests {
 
     // --- Test HashAgg with in-memory KeyedState ---
 
-    #[madsim::test]
+    #[tokio::test]
     async fn test_local_hash_aggregation_count_in_memory() {
         test_local_hash_aggregation_count(create_in_memory_keyspace_agg(3)).await
     }
 
-    #[madsim::test]
+    #[tokio::test]
     async fn test_global_hash_aggregation_count_in_memory() {
         test_global_hash_aggregation_count(create_in_memory_keyspace_agg(3)).await
     }
 
-    #[madsim::test]
+    #[tokio::test]
     async fn test_local_hash_aggregation_min_in_memory() {
         test_local_hash_aggregation_min(create_in_memory_keyspace_agg(2)).await
     }
 
-    #[madsim::test]
+    #[tokio::test]
     async fn test_local_hash_aggregation_min_append_only_in_memory() {
         test_local_hash_aggregation_min_append_only(create_in_memory_keyspace_agg(2)).await
     }

--- a/src/stream/src/executor/hash_join.rs
+++ b/src/stream/src/executor/hash_join.rs
@@ -844,7 +844,7 @@ mod tests {
         (tx_l, tx_r, Box::new(executor).execute())
     }
 
-    #[madsim::test]
+    #[tokio::test]
     async fn test_streaming_hash_inner_join() {
         let chunk_l1 = StreamChunk::from_pretty(
             "  I I
@@ -919,7 +919,7 @@ mod tests {
         );
     }
 
-    #[madsim::test]
+    #[tokio::test]
     async fn test_streaming_hash_left_semi_join() {
         let chunk_l1 = StreamChunk::from_pretty(
             "  I I
@@ -1029,7 +1029,7 @@ mod tests {
         );
     }
 
-    #[madsim::test]
+    #[tokio::test]
     async fn test_streaming_hash_inner_join_append_only() {
         let chunk_l1 = StreamChunk::from_pretty(
             "  I I I
@@ -1108,7 +1108,7 @@ mod tests {
         );
     }
 
-    #[madsim::test]
+    #[tokio::test]
     async fn test_streaming_hash_left_semi_join_append_only() {
         let chunk_l1 = StreamChunk::from_pretty(
             "  I I I
@@ -1187,7 +1187,7 @@ mod tests {
         );
     }
 
-    #[madsim::test]
+    #[tokio::test]
     async fn test_streaming_hash_right_semi_join_append_only() {
         let chunk_l1 = StreamChunk::from_pretty(
             "  I I I
@@ -1266,7 +1266,7 @@ mod tests {
         );
     }
 
-    #[madsim::test]
+    #[tokio::test]
     async fn test_streaming_hash_right_semi_join() {
         let chunk_r1 = StreamChunk::from_pretty(
             "  I I
@@ -1376,7 +1376,7 @@ mod tests {
         );
     }
 
-    #[madsim::test]
+    #[tokio::test]
     async fn test_streaming_hash_left_anti_join() {
         let chunk_l1 = StreamChunk::from_pretty(
             "  I I
@@ -1504,7 +1504,7 @@ mod tests {
         );
     }
 
-    #[madsim::test]
+    #[tokio::test]
     async fn test_streaming_hash_right_anti_join() {
         let chunk_r1 = StreamChunk::from_pretty(
             "  I I
@@ -1632,7 +1632,7 @@ mod tests {
         );
     }
 
-    #[madsim::test]
+    #[tokio::test]
     async fn test_streaming_hash_inner_join_with_barrier() {
         let chunk_l1 = StreamChunk::from_pretty(
             "  I I
@@ -1728,7 +1728,7 @@ mod tests {
         );
     }
 
-    #[madsim::test]
+    #[tokio::test]
     async fn test_streaming_hash_inner_join_with_null_and_barrier() {
         let chunk_l1 = StreamChunk::from_pretty(
             "  I I
@@ -1824,7 +1824,7 @@ mod tests {
         );
     }
 
-    #[madsim::test]
+    #[tokio::test]
     async fn test_streaming_hash_left_join() {
         let chunk_l1 = StreamChunk::from_pretty(
             "  I I
@@ -1905,7 +1905,7 @@ mod tests {
         );
     }
 
-    #[madsim::test]
+    #[tokio::test]
     async fn test_streaming_hash_right_join() {
         let chunk_l1 = StreamChunk::from_pretty(
             "  I I
@@ -1979,7 +1979,7 @@ mod tests {
         );
     }
 
-    #[madsim::test]
+    #[tokio::test]
     async fn test_streaming_hash_left_join_append_only() {
         let chunk_l1 = StreamChunk::from_pretty(
             "  I I I
@@ -2066,7 +2066,7 @@ mod tests {
         );
     }
 
-    #[madsim::test]
+    #[tokio::test]
     async fn test_streaming_hash_right_join_append_only() {
         let chunk_l1 = StreamChunk::from_pretty(
             "  I I I
@@ -2143,7 +2143,7 @@ mod tests {
         );
     }
 
-    #[madsim::test]
+    #[tokio::test]
     async fn test_streaming_hash_full_outer_join() {
         let chunk_l1 = StreamChunk::from_pretty(
             "  I I
@@ -2226,7 +2226,7 @@ mod tests {
         );
     }
 
-    #[madsim::test]
+    #[tokio::test]
     async fn test_streaming_hash_full_outer_join_with_nonequi_condition() {
         let chunk_l1 = StreamChunk::from_pretty(
             "  I I
@@ -2318,7 +2318,7 @@ mod tests {
         );
     }
 
-    #[madsim::test]
+    #[tokio::test]
     async fn test_streaming_hash_inner_join_with_nonequi_condition() {
         let chunk_l1 = StreamChunk::from_pretty(
             "  I I

--- a/src/stream/src/executor/hop_window.rs
+++ b/src/stream/src/executor/hop_window.rs
@@ -215,7 +215,7 @@ mod tests {
     use crate::executor::test_utils::MockSource;
     use crate::executor::{Executor, ExecutorInfo, StreamChunk};
 
-    #[madsim::test]
+    #[tokio::test]
     async fn test_execute() {
         let field1 = Field::unnamed(DataType::Int64);
         let field2 = Field::unnamed(DataType::Int64);

--- a/src/stream/src/executor/local_simple_agg.rs
+++ b/src/stream/src/executor/local_simple_agg.rs
@@ -181,7 +181,7 @@ mod tests {
     use crate::executor::test_utils::MockSource;
     use crate::executor::{Executor, LocalSimpleAggExecutor};
 
-    #[madsim::test]
+    #[tokio::test]
     async fn test_no_chunk() -> Result<()> {
         let schema = schema_test_utils::ii();
         let (mut tx, source) = MockSource::channel(schema, vec![2]);
@@ -220,7 +220,7 @@ mod tests {
         Ok(())
     }
 
-    #[madsim::test]
+    #[tokio::test]
     async fn test_local_simple_agg() -> Result<()> {
         let schema = schema_test_utils::iii();
         let (mut tx, source) = MockSource::channel(schema, vec![2]); // pk\

--- a/src/stream/src/executor/lookup/tests.rs
+++ b/src/stream/src/executor/lookup/tests.rs
@@ -205,7 +205,7 @@ fn check_chunk_eq(chunk1: &StreamChunk, chunk2: &StreamChunk) {
     assert_eq!(format!("{:?}", chunk1), format!("{:?}", chunk2));
 }
 
-#[madsim::test]
+#[tokio::test]
 async fn test_lookup_this_epoch() {
     // TODO: memory state store doesn't support read epoch yet, so it is possible that this test
     // fails because read epoch doesn't take effect in memory state store.
@@ -275,7 +275,7 @@ async fn test_lookup_this_epoch() {
     check_chunk_eq(chunk2, &expected_chunk2);
 }
 
-#[madsim::test]
+#[tokio::test]
 async fn test_lookup_last_epoch() {
     let store = MemoryStateStore::new();
     let table_id = TableId::new(1);

--- a/src/stream/src/executor/lookup_union.rs
+++ b/src/stream/src/executor/lookup_union.rs
@@ -149,7 +149,7 @@ mod tests {
     use super::*;
     use crate::executor::test_utils::MockSource;
 
-    #[madsim::test]
+    #[tokio::test]
     async fn lookup_union() {
         let schema = Schema {
             fields: vec![Field::unnamed(DataType::Int64)],

--- a/src/stream/src/executor/managed_state/aggregation/extreme.rs
+++ b/src/stream/src/executor/managed_state/aggregation/extreme.rs
@@ -492,7 +492,7 @@ mod tests {
 
     use super::*;
 
-    #[madsim::test]
+    #[tokio::test]
     async fn test_managed_extreme_state() {
         let store = MemoryStateStore::new();
         let keyspace = Keyspace::executor_root(store.clone(), 0x2333);
@@ -657,22 +657,22 @@ mod tests {
         );
     }
 
-    #[madsim::test]
+    #[tokio::test]
     async fn test_replicated_value_min() {
         test_replicated_value_not_null::<{ variants::EXTREME_MIN }>().await
     }
 
-    #[madsim::test]
+    #[tokio::test]
     async fn test_replicated_value_max() {
         test_replicated_value_not_null::<{ variants::EXTREME_MAX }>().await
     }
 
-    #[madsim::test]
+    #[tokio::test]
     async fn test_replicated_value_min_with_null() {
         test_replicated_value_with_null::<{ variants::EXTREME_MIN }>().await
     }
 
-    #[madsim::test]
+    #[tokio::test]
     async fn test_replicated_value_max_with_null() {
         test_replicated_value_with_null::<{ variants::EXTREME_MAX }>().await
     }
@@ -865,7 +865,7 @@ mod tests {
         assert_eq!(managed_state.get_output(epoch).await.unwrap(), extreme);
     }
 
-    #[madsim::test]
+    #[tokio::test]
     async fn test_same_group_of_value() {
         let store = MemoryStateStore::new();
         let keyspace = Keyspace::executor_root(store.clone(), 0x2333);
@@ -931,12 +931,12 @@ mod tests {
         }
     }
 
-    #[madsim::test]
+    #[tokio::test]
     async fn chaos_test_min() {
         chaos_test::<{ variants::EXTREME_MIN }>().await;
     }
 
-    #[madsim::test]
+    #[tokio::test]
     async fn chaos_test_max() {
         chaos_test::<{ variants::EXTREME_MAX }>().await;
     }
@@ -1038,7 +1038,7 @@ mod tests {
         write_batch.ingest(epoch).await.unwrap();
     }
 
-    #[madsim::test]
+    #[tokio::test]
     async fn test_same_value_delete() {
         // In this test, we test this case:
         //

--- a/src/stream/src/executor/managed_state/aggregation/string_agg.rs
+++ b/src/stream/src/executor/managed_state/aggregation/string_agg.rs
@@ -304,7 +304,7 @@ mod tests {
         managed_state
     }
 
-    #[madsim::test]
+    #[tokio::test]
     async fn test_managed_string_agg_state() {
         let keyspace = create_in_memory_keyspace();
         let store = keyspace.state_store();

--- a/src/stream/src/executor/managed_state/aggregation/value.rs
+++ b/src/stream/src/executor/managed_state/aggregation/value.rs
@@ -134,7 +134,7 @@ mod tests {
         }
     }
 
-    #[madsim::test]
+    #[tokio::test]
     async fn test_managed_value_state() {
         let keyspace = create_in_memory_keyspace();
         let mut managed_state =

--- a/src/stream/src/executor/managed_state/join/join_entry_state.rs
+++ b/src/stream/src/executor/managed_state/join/join_entry_state.rs
@@ -221,7 +221,7 @@ mod tests {
 
     use super::*;
 
-    #[madsim::test]
+    #[tokio::test]
     async fn test_managed_all_or_none_state() {
         let store = MemoryStateStore::new();
         let keyspace = Keyspace::executor_root(store.clone(), 0x2333);

--- a/src/stream/src/executor/managed_state/top_n/top_n_bottom_n_state.rs
+++ b/src/stream/src/executor/managed_state/top_n/top_n_bottom_n_state.rs
@@ -368,7 +368,7 @@ mod tests {
         )
     }
 
-    #[madsim::test]
+    #[tokio::test]
     async fn test_managed_top_n_bottom_n_state() {
         let data_types = vec![DataType::Varchar, DataType::Int64];
         let order_types = vec![OrderType::Descending, OrderType::Ascending];

--- a/src/stream/src/executor/managed_state/top_n/top_n_state.rs
+++ b/src/stream/src/executor/managed_state/top_n/top_n_state.rs
@@ -416,7 +416,7 @@ mod tests {
         )
     }
 
-    #[madsim::test]
+    #[tokio::test]
     async fn test_managed_top_n_state() {
         let store = MemoryStateStore::new();
         let data_types = vec![DataType::Varchar, DataType::Int64];

--- a/src/stream/src/executor/merge.rs
+++ b/src/stream/src/executor/merge.rs
@@ -207,7 +207,6 @@ mod tests {
     use futures::SinkExt;
     use itertools::Itertools;
     use madsim::collections::HashSet;
-    use madsim::time::sleep;
     use risingwave_common::array::{Op, StreamChunk};
     use risingwave_pb::data::StreamMessage;
     use risingwave_pb::task_service::exchange_service_server::{
@@ -217,6 +216,7 @@ mod tests {
         GetDataRequest, GetDataResponse, GetStreamRequest, GetStreamResponse,
     };
     use risingwave_rpc_client::ComputeClient;
+    use tokio::time::sleep;
     use tokio_stream::wrappers::ReceiverStream;
     use tonic::{Request, Response, Status};
 
@@ -230,7 +230,7 @@ mod tests {
         StreamChunk::new(ops, vec![], None)
     }
 
-    #[madsim::test]
+    #[tokio::test]
     async fn test_merger() {
         const CHANNEL_NUMBER: usize = 10;
         let mut txs = Vec::with_capacity(CHANNEL_NUMBER);
@@ -247,7 +247,7 @@ mod tests {
 
         for mut tx in txs {
             let epochs = epochs.clone();
-            let handle = madsim::task::spawn(async move {
+            let handle = tokio::spawn(async move {
                 for epoch in epochs {
                     tx.send(Message::Chunk(build_test_chunk(epoch)))
                         .await
@@ -289,7 +289,7 @@ mod tests {
         );
 
         for handle in handles {
-            handle.await;
+            handle.await.unwrap();
         }
     }
 
@@ -345,7 +345,7 @@ mod tests {
         }
     }
 
-    #[madsim::test(flavor = "multi_thread")]
+    #[tokio::test(flavor = "multi_thread")]
     async fn test_stream_exchange_client() {
         let rpc_called = Arc::new(AtomicBool::new(false));
         let server_run = Arc::new(AtomicBool::new(false));
@@ -357,7 +357,7 @@ mod tests {
             rpc_called: rpc_called.clone(),
         });
         let cp_server_run = server_run.clone();
-        let join_handle = madsim::task::spawn(async move {
+        let join_handle = tokio::spawn(async move {
             cp_server_run.store(true, Ordering::SeqCst);
             tonic::transport::Server::builder()
                 .add_service(exchange_svc)
@@ -371,7 +371,7 @@ mod tests {
         sleep(Duration::from_secs(1)).await;
         assert!(server_run.load(Ordering::SeqCst));
         let (tx, mut rx) = channel(16);
-        let input_handle = madsim::task::spawn(async move {
+        let input_handle = tokio::spawn(async move {
             let remote_input =
                 RemoteInput::create(ComputeClient::new(addr.into()).await.unwrap(), (0, 0), tx)
                     .await
@@ -388,8 +388,8 @@ mod tests {
             assert_eq!(barrier_epoch.curr, 12345);
         });
         assert!(rpc_called.load(Ordering::SeqCst));
-        input_handle.await;
+        input_handle.await.unwrap();
         shutdown_send.send(()).unwrap();
-        join_handle.await;
+        join_handle.await.unwrap();
     }
 }

--- a/src/stream/src/executor/mview/materialize.rs
+++ b/src/stream/src/executor/mview/materialize.rs
@@ -190,7 +190,7 @@ mod tests {
     use crate::executor::test_utils::*;
     use crate::executor::*;
 
-    #[madsim::test]
+    #[tokio::test]
     async fn test_materialize_executor() {
         // Prepare storage and memtable.
         let memory_state_store = MemoryStateStore::new();

--- a/src/stream/src/executor/mview/state.rs
+++ b/src/stream/src/executor/mview/state.rs
@@ -112,7 +112,7 @@ mod tests {
 
     use super::*;
 
-    #[madsim::test]
+    #[tokio::test]
     async fn test_mview_state() {
         // Only assert pk and columns can be successfully put/delete/flush,
         // and the amount of rows is expected.

--- a/src/stream/src/executor/project.rs
+++ b/src/stream/src/executor/project.rs
@@ -143,7 +143,7 @@ mod tests {
     use super::super::*;
     use super::*;
 
-    #[madsim::test]
+    #[tokio::test]
     async fn test_projection() {
         let chunk1 = StreamChunk::from_pretty(
             " I I

--- a/src/stream/src/executor/source.rs
+++ b/src/stream/src/executor/source.rs
@@ -19,7 +19,6 @@ use either::Either;
 use futures::stream::{select_with_strategy, PollNext};
 use futures::{Stream, StreamExt};
 use futures_async_stream::try_stream;
-use madsim::time::Instant;
 use risingwave_common::array::column::Column;
 use risingwave_common::array::{ArrayBuilder, ArrayImpl, I64ArrayBuilder, StreamChunk};
 use risingwave_common::catalog::{ColumnId, Schema, TableId};
@@ -32,6 +31,7 @@ use risingwave_source::*;
 use risingwave_storage::{Keyspace, StateStore};
 use tokio::sync::mpsc::UnboundedReceiver;
 use tokio::sync::Notify;
+use tokio::time::Instant;
 
 use super::error::StreamExecutorError;
 use super::monitor::StreamingMetrics;
@@ -347,7 +347,7 @@ mod tests {
 
     use super::*;
 
-    #[madsim::test]
+    #[tokio::test]
     async fn test_table_source() -> Result<()> {
         let table_id = TableId::default();
 
@@ -430,11 +430,10 @@ mod tests {
 
         let write_chunk = |chunk: StreamChunk| {
             let source = source.clone();
-            madsim::task::spawn(async move {
+            tokio::spawn(async move {
                 let table_source = source.as_table_v2().unwrap();
                 table_source.blocking_write_chunk(chunk).await.unwrap();
-            })
-            .detach();
+            });
         };
 
         barrier_sender.send(Barrier::new_test_barrier(1)).unwrap();
@@ -476,7 +475,7 @@ mod tests {
         Ok(())
     }
 
-    #[madsim::test]
+    #[tokio::test]
     async fn test_table_dropped() -> Result<()> {
         let table_id = TableId::default();
 
@@ -553,11 +552,10 @@ mod tests {
 
         let write_chunk = |chunk: StreamChunk| {
             let source = source.clone();
-            madsim::task::spawn(async move {
+            tokio::spawn(async move {
                 let table_source = source.as_table_v2().unwrap();
                 table_source.blocking_write_chunk(chunk).await.unwrap();
-            })
-            .detach();
+            });
         };
 
         write_chunk(chunk.clone());

--- a/src/stream/src/executor/top_n.rs
+++ b/src/stream/src/executor/top_n.rs
@@ -556,7 +556,7 @@ mod tests {
         ))
     }
 
-    #[madsim::test]
+    #[tokio::test]
     async fn test_top_n_executor_with_offset() {
         let order_types = create_order_pairs();
         let source = create_source();
@@ -652,7 +652,7 @@ mod tests {
         );
     }
 
-    #[madsim::test]
+    #[tokio::test]
     async fn test_top_n_executor_with_limit() {
         let order_types = create_order_pairs();
         let source = create_source();
@@ -757,7 +757,7 @@ mod tests {
         );
     }
 
-    #[madsim::test]
+    #[tokio::test]
     async fn test_top_n_executor_with_offset_and_limit() {
         let order_types = create_order_pairs();
         let source = create_source();

--- a/src/stream/src/executor/top_n_appendonly.rs
+++ b/src/stream/src/executor/top_n_appendonly.rs
@@ -389,7 +389,7 @@ mod tests {
         ))
     }
 
-    #[madsim::test]
+    #[tokio::test]
     async fn test_append_only_top_n_executor_with_offset() {
         let order_pairs = create_order_pairs();
         let source = create_source();
@@ -463,7 +463,7 @@ mod tests {
         // Now (1, 1, 1) -> (1, 2, 2, 3, 3, 3, 7, 8, 9, 10)
     }
 
-    #[madsim::test]
+    #[tokio::test]
     async fn test_append_only_top_n_executor_with_limit() {
         let order_pairs = create_order_pairs();
         let source = create_source();
@@ -543,7 +543,7 @@ mod tests {
         // Now (1, 1, 1, 1, 2)
     }
 
-    #[madsim::test]
+    #[tokio::test]
     async fn test_append_only_top_n_executor_with_offset_and_limit() {
         let order_pairs = create_order_pairs();
         let source = create_source();

--- a/src/stream/src/executor/union.rs
+++ b/src/stream/src/executor/union.rs
@@ -104,7 +104,7 @@ mod tests {
 
     use super::*;
 
-    #[madsim::test]
+    #[tokio::test]
     async fn union() {
         let streams = vec![
             try_stream! {

--- a/src/stream/src/task/stream_manager.rs
+++ b/src/stream/src/task/stream_manager.rs
@@ -18,7 +18,6 @@ use std::sync::Arc;
 use futures::channel::mpsc::{channel, Receiver};
 use itertools::Itertools;
 use madsim::collections::{HashMap, HashSet};
-use madsim::task::JoinHandle;
 use parking_lot::Mutex;
 use risingwave_common::config::StreamingConfig;
 use risingwave_common::error::{ErrorCode, Result, RwError};
@@ -31,6 +30,7 @@ use risingwave_pb::{stream_plan, stream_service};
 use risingwave_rpc_client::ComputeClientPool;
 use risingwave_storage::{dispatch_state_store, StateStore, StateStoreImpl};
 use tokio::sync::oneshot;
+use tokio::task::JoinHandle;
 
 use super::{unique_executor_id, unique_operator_id, CollectResult};
 use crate::executor::dispatch::*;
@@ -266,7 +266,7 @@ impl LocalStreamManager {
     pub async fn wait_all(self) -> Result<()> {
         let handles = self.core.lock().take_all_handles()?;
         for (_id, handle) in handles {
-            handle.await;
+            handle.await.unwrap();
         }
         Ok(())
     }
@@ -275,7 +275,7 @@ impl LocalStreamManager {
     pub async fn wait_actors(&self, actor_ids: &[ActorId]) -> Result<()> {
         let handles = self.core.lock().remove_actor_handles(actor_ids)?;
         for handle in handles {
-            handle.await;
+            handle.await.unwrap();
         }
         Ok(())
     }
@@ -549,7 +549,7 @@ impl LocalStreamManagerCore {
 
                         let pool = self.compute_client_pool.clone();
 
-                        madsim::task::spawn(async move {
+                        tokio::spawn(async move {
                             let init_client = async move {
                                 let remote_input = RemoteInput::create(
                                     pool.get_client_for_addr(upstream_addr).await?,
@@ -565,8 +565,7 @@ impl LocalStreamManagerCore {
                                     error!("Spawn remote input fails:{}", e);
                                 }
                             }
-                        })
-                        .detach();
+                        });
                     }
                     Ok::<_, RwError>(self.context.take_receiver(&(*up_id, actor_id))?)
                 }
@@ -596,7 +595,7 @@ impl LocalStreamManagerCore {
             let actor = Actor::new(dispatcher, actor_id, self.context.clone());
             self.handles.insert(
                 actor_id,
-                madsim::task::spawn(async move {
+                tokio::spawn(async move {
                     // unwrap the actor result to panic on error
                     actor.run().await.expect("actor failed");
                 }),
@@ -644,7 +643,7 @@ impl LocalStreamManagerCore {
     /// `drop_actor` is invoked by meta node via RPC once the stop barrier arrives at the
     /// sink. All the actors in the actors should stop themselves before this method is invoked.
     fn drop_actor(&mut self, actor_id: ActorId) {
-        let mut handle = self.handles.remove(&actor_id).unwrap();
+        let handle = self.handles.remove(&actor_id).unwrap();
         self.context.retain(|&(up_id, _)| up_id != actor_id);
 
         self.actor_infos.remove(&actor_id);
@@ -656,7 +655,7 @@ impl LocalStreamManagerCore {
     /// `drop_all_actors` is invoked by meta node via RPC once the stop barrier arrives at all the
     /// sink. All the actors in the actors should stop themselves before this method is invoked.
     fn drop_all_actors(&mut self) {
-        for (actor_id, mut handle) in self.handles.drain() {
+        for (actor_id, handle) in self.handles.drain() {
             self.context.retain(|&(up_id, _)| up_id != actor_id);
             self.actors.remove(&actor_id);
             // Task should have already stopped when this method is invoked.

--- a/src/tests/regress/Cargo.toml
+++ b/src/tests/regress/Cargo.toml
@@ -8,9 +8,10 @@ anyhow = { version = "1", features = ["backtrace"] }
 clap = { version = "3", features = ["derive"] }
 env_logger = "0.9"
 log = "0.4"
+madsim = "=0.2.0-alpha.2"
 path-absolutize = "3.0"
 similar = "2"
-tokio = { version = "1", features = ["rt", "rt-multi-thread", "sync", "macros", "time", "signal", "process"] }
+tokio = { version = "=0.2.0-alpha.2", package = "madsim-tokio", features = ["rt", "rt-multi-thread", "sync", "macros", "time", "signal", "process"] }
 workspace-hack = { version = "0.1", path = "../../workspace-hack" }
 
 [[bin]]

--- a/src/tests/regress/Cargo.toml
+++ b/src/tests/regress/Cargo.toml
@@ -8,10 +8,10 @@ anyhow = { version = "1", features = ["backtrace"] }
 clap = { version = "3", features = ["derive"] }
 env_logger = "0.9"
 log = "0.4"
-madsim = "=0.2.0-alpha.2"
+madsim = "=0.2.0-alpha.3"
 path-absolutize = "3.0"
 similar = "2"
-tokio = { version = "=0.2.0-alpha.2", package = "madsim-tokio", features = ["rt", "rt-multi-thread", "sync", "macros", "time", "signal", "process"] }
+tokio = { version = "=0.2.0-alpha.3", package = "madsim-tokio", features = ["rt", "rt-multi-thread", "sync", "macros", "time", "signal", "process"] }
 workspace-hack = { version = "0.1", path = "../../workspace-hack" }
 
 [[bin]]

--- a/src/utils/logging/Cargo.toml
+++ b/src/utils/logging/Cargo.toml
@@ -8,7 +8,7 @@ edition = "2021"
 async-trait = "0.1"
 futures = { version = "0.3", default-features = false, features = ["alloc"] }
 isahc = "1" # isahc is the http client used for tracing. Always set it as the same version as opentelemetry-jaeger's.
-madsim = "=0.2.0-alpha.2"
+madsim = "=0.2.0-alpha.3"
 opentelemetry = { version = "0.17", features = ["rt-tokio", "trace"] }
 opentelemetry-jaeger = { version = "0.16", features = [
     "rt-tokio",
@@ -18,7 +18,7 @@ opentelemetry-jaeger = { version = "0.16", features = [
 ] }
 parking_lot = { version = "0.12", features = ["deadlock_detection"] }
 thrift = "0.15" # thift is used for our implementation of `RwTokio` runtime. Always set it as the same version as opentelemetry-jaeger's.
-tokio = { version = "=0.2.0-alpha.2", package = "madsim-tokio", features = [
+tokio = { version = "=0.2.0-alpha.3", package = "madsim-tokio", features = [
     "rt",
     "rt-multi-thread",
     "sync",

--- a/src/utils/logging/Cargo.toml
+++ b/src/utils/logging/Cargo.toml
@@ -8,6 +8,7 @@ edition = "2021"
 async-trait = "0.1"
 futures = { version = "0.3", default-features = false, features = ["alloc"] }
 isahc = "1" # isahc is the http client used for tracing. Always set it as the same version as opentelemetry-jaeger's.
+madsim = "=0.2.0-alpha.2"
 opentelemetry = { version = "0.17", features = ["rt-tokio", "trace"] }
 opentelemetry-jaeger = { version = "0.16", features = [
     "rt-tokio",
@@ -17,7 +18,7 @@ opentelemetry-jaeger = { version = "0.16", features = [
 ] }
 parking_lot = { version = "0.12", features = ["deadlock_detection"] }
 thrift = "0.15" # thift is used for our implementation of `RwTokio` runtime. Always set it as the same version as opentelemetry-jaeger's.
-tokio = { version = "1", features = [
+tokio = { version = "=0.2.0-alpha.2", package = "madsim-tokio", features = [
     "rt",
     "rt-multi-thread",
     "sync",

--- a/src/utils/pgwire/Cargo.toml
+++ b/src/utils/pgwire/Cargo.toml
@@ -8,9 +8,9 @@ edition = "2021"
 async-trait = "0.1"
 byteorder = "1.4"
 bytes = "1"
-madsim = "=0.2.0-alpha.2"
+madsim = "=0.2.0-alpha.3"
 thiserror = "1"
-tokio = { version = "=0.2.0-alpha.2", package = "madsim-tokio", features = ["rt", "macros"] }
+tokio = { version = "=0.2.0-alpha.3", package = "madsim-tokio", features = ["rt", "macros"] }
 tracing = { version = "0.1" }
 workspace-hack = { version = "0.1", path = "../../workspace-hack" }
 

--- a/src/utils/pgwire/Cargo.toml
+++ b/src/utils/pgwire/Cargo.toml
@@ -8,8 +8,9 @@ edition = "2021"
 async-trait = "0.1"
 byteorder = "1.4"
 bytes = "1"
+madsim = "=0.2.0-alpha.2"
 thiserror = "1"
-tokio = { version = "1", features = ["rt", "macros"] }
+tokio = { version = "=0.2.0-alpha.2", package = "madsim-tokio", features = ["rt", "macros"] }
 tracing = { version = "0.1" }
 workspace-hack = { version = "0.1", path = "../../workspace-hack" }
 

--- a/src/workspace-hack/Cargo.toml
+++ b/src/workspace-hack/Cargo.toml
@@ -23,8 +23,11 @@ either = { version = "1", features = ["use_std"] }
 fail = { version = "0.5", default-features = false, features = ["failpoints"] }
 fixedbitset = { version = "0.4", features = ["std"] }
 futures-channel = { version = "0.3", features = ["alloc", "futures-sink", "sink", "std"] }
+futures-core = { version = "0.3", features = ["alloc", "std"] }
 futures-executor = { version = "0.3", features = ["std"] }
 futures-io = { version = "0.3", features = ["std"] }
+futures-sink = { version = "0.3", features = ["alloc", "std"] }
+futures-task = { version = "0.3", default-features = false, features = ["alloc", "std"] }
 futures-util = { version = "0.3", features = ["alloc", "async-await", "async-await-macro", "channel", "futures-channel", "futures-io", "futures-macro", "futures-sink", "io", "memchr", "sink", "slab", "std"] }
 hashbrown = { version = "0.11", features = ["ahash", "inline-more", "raw"] }
 hyper = { version = "0.14", features = ["client", "full", "h2", "http1", "http2", "runtime", "server", "socket2", "stream", "tcp"] }
@@ -33,7 +36,7 @@ libc = { version = "0.2", features = ["std"] }
 libz-sys = { version = "1", features = ["libc", "stock-zlib"] }
 lock_api = { version = "0.4", default-features = false, features = ["arc_lock"] }
 log = { version = "0.4", default-features = false, features = ["release_max_level_info", "std"] }
-madsim-tokio = { version = "0.2.0-alpha.2", default-features = false, features = ["fs", "macros", "process", "rt", "rt-multi-thread", "signal", "sync", "time"] }
+madsim-tokio = { version = "0.2.0-alpha.3", default-features = false, features = ["fs", "macros", "process", "rt", "rt-multi-thread", "signal", "sync", "time"] }
 num-integer = { version = "0.1", features = ["i128", "std"] }
 num-traits = { version = "0.2", features = ["i128", "std"] }
 parking_lot = { version = "0.12", features = ["arc_lock", "deadlock_detection"] }
@@ -70,8 +73,11 @@ either = { version = "1", features = ["use_std"] }
 fail = { version = "0.5", default-features = false, features = ["failpoints"] }
 fixedbitset = { version = "0.4", features = ["std"] }
 futures-channel = { version = "0.3", features = ["alloc", "futures-sink", "sink", "std"] }
+futures-core = { version = "0.3", features = ["alloc", "std"] }
 futures-executor = { version = "0.3", features = ["std"] }
 futures-io = { version = "0.3", features = ["std"] }
+futures-sink = { version = "0.3", features = ["alloc", "std"] }
+futures-task = { version = "0.3", default-features = false, features = ["alloc", "std"] }
 futures-util = { version = "0.3", features = ["alloc", "async-await", "async-await-macro", "channel", "futures-channel", "futures-io", "futures-macro", "futures-sink", "io", "memchr", "sink", "slab", "std"] }
 hashbrown = { version = "0.11", features = ["ahash", "inline-more", "raw"] }
 hyper = { version = "0.14", features = ["client", "full", "h2", "http1", "http2", "runtime", "server", "socket2", "stream", "tcp"] }
@@ -80,7 +86,7 @@ libc = { version = "0.2", features = ["std"] }
 libz-sys = { version = "1", features = ["libc", "stock-zlib"] }
 lock_api = { version = "0.4", default-features = false, features = ["arc_lock"] }
 log = { version = "0.4", default-features = false, features = ["release_max_level_info", "std"] }
-madsim-tokio = { version = "0.2.0-alpha.2", default-features = false, features = ["fs", "macros", "process", "rt", "rt-multi-thread", "signal", "sync", "time"] }
+madsim-tokio = { version = "0.2.0-alpha.3", default-features = false, features = ["fs", "macros", "process", "rt", "rt-multi-thread", "signal", "sync", "time"] }
 num-integer = { version = "0.1", features = ["i128", "std"] }
 num-traits = { version = "0.2", features = ["i128", "std"] }
 parking_lot = { version = "0.12", features = ["arc_lock", "deadlock_detection"] }

--- a/src/workspace-hack/Cargo.toml
+++ b/src/workspace-hack/Cargo.toml
@@ -22,10 +22,9 @@ crossbeam-utils = { version = "0.8", features = ["lazy_static", "std"] }
 either = { version = "1", features = ["use_std"] }
 fail = { version = "0.5", default-features = false, features = ["failpoints"] }
 fixedbitset = { version = "0.4", features = ["std"] }
-futures = { version = "0.3", features = ["alloc", "async-await", "executor", "futures-executor", "std"] }
+futures-channel = { version = "0.3", features = ["alloc", "futures-sink", "sink", "std"] }
 futures-executor = { version = "0.3", features = ["std"] }
 futures-io = { version = "0.3", features = ["std"] }
-futures-sink = { version = "0.3", features = ["alloc", "std"] }
 futures-util = { version = "0.3", features = ["alloc", "async-await", "async-await-macro", "channel", "futures-channel", "futures-io", "futures-macro", "futures-sink", "io", "memchr", "sink", "slab", "std"] }
 hashbrown = { version = "0.11", features = ["ahash", "inline-more", "raw"] }
 hyper = { version = "0.14", features = ["client", "full", "h2", "http1", "http2", "runtime", "server", "socket2", "stream", "tcp"] }
@@ -34,6 +33,7 @@ libc = { version = "0.2", features = ["std"] }
 libz-sys = { version = "1", features = ["libc", "stock-zlib"] }
 lock_api = { version = "0.4", default-features = false, features = ["arc_lock"] }
 log = { version = "0.4", default-features = false, features = ["release_max_level_info", "std"] }
+madsim-tokio = { version = "0.2.0-alpha.2", default-features = false, features = ["fs", "macros", "process", "rt", "rt-multi-thread", "signal", "sync", "time"] }
 num-integer = { version = "0.1", features = ["i128", "std"] }
 num-traits = { version = "0.2", features = ["i128", "std"] }
 parking_lot = { version = "0.12", features = ["arc_lock", "deadlock_detection"] }
@@ -69,10 +69,9 @@ crossbeam-utils = { version = "0.8", features = ["lazy_static", "std"] }
 either = { version = "1", features = ["use_std"] }
 fail = { version = "0.5", default-features = false, features = ["failpoints"] }
 fixedbitset = { version = "0.4", features = ["std"] }
-futures = { version = "0.3", features = ["alloc", "async-await", "executor", "futures-executor", "std"] }
+futures-channel = { version = "0.3", features = ["alloc", "futures-sink", "sink", "std"] }
 futures-executor = { version = "0.3", features = ["std"] }
 futures-io = { version = "0.3", features = ["std"] }
-futures-sink = { version = "0.3", features = ["alloc", "std"] }
 futures-util = { version = "0.3", features = ["alloc", "async-await", "async-await-macro", "channel", "futures-channel", "futures-io", "futures-macro", "futures-sink", "io", "memchr", "sink", "slab", "std"] }
 hashbrown = { version = "0.11", features = ["ahash", "inline-more", "raw"] }
 hyper = { version = "0.14", features = ["client", "full", "h2", "http1", "http2", "runtime", "server", "socket2", "stream", "tcp"] }
@@ -81,6 +80,7 @@ libc = { version = "0.2", features = ["std"] }
 libz-sys = { version = "1", features = ["libc", "stock-zlib"] }
 lock_api = { version = "0.4", default-features = false, features = ["arc_lock"] }
 log = { version = "0.4", default-features = false, features = ["release_max_level_info", "std"] }
+madsim-tokio = { version = "0.2.0-alpha.2", default-features = false, features = ["fs", "macros", "process", "rt", "rt-multi-thread", "signal", "sync", "time"] }
 num-integer = { version = "0.1", features = ["i128", "std"] }
 num-traits = { version = "0.2", features = ["i128", "std"] }
 parking_lot = { version = "0.12", features = ["arc_lock", "deadlock_detection"] }


### PR DESCRIPTION
## What's changed and what's your intention?

This PR makes deterministic testing available for more crates.

Now developers can try it with the following command:
```
RUSTFLAGS="--cfg madsim" cargo test --target-dir target/sim -p risingwave_stream
```

(Setting a new target-dir to avoid conflicts with normal builds)

Changes in details:
- Fix simulation build of the prost crate.
  Remove all `sim` features and switch to a global `#[cfg(madsim)]` way.

- Redirect `tokio` to `madsim-tokio` in all Cargo.toml files.
  It works just like tonic. Developers can directly use tokio API instead of rewriting them to madsim.
  So I also reverted all `#[madsim::test]` to `#[tokio::test]` in the stream crate.

- Remove `TcpListener` in the meta service since it's not supported in the simulation.
  This change, however, will lead to a panic in the playground. The reason is that other services won't wait for the meta service to be ready. So I added a short sleep there to fix that.

- Add available deterministic testings to CI.
  Now some of them will fail so I added a `continue-on-error` flag to ignore these errors.
  My intention is to only run these tests but not make it a required check.
  I'm not sure whether I'm doing it right and efficiently. @skyzh plz take a look.

## Next step

Currently, it still does not work with the `frontend` and `meta` crate. They depend on `pgwire`, which depends on TCP which is not yet implemented in madsim. This is a blocker to e2e simulation testing. We can either support simulating TCP or bypass `pgwire` in tests.

## Checklist

- [x] I have written necessary docs and comments
- [x] I have added necessary unit tests and integration tests

## Refer to a related PR or issue link (optional)
Following #2477