### PR TITLE
feat(pgwire): introduce extended query mode init

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5696,6 +5696,8 @@ dependencies = [
  "cc",
  "crossbeam-deque",
  "crossbeam-utils 0.8.8",
+ "crypto-common",
+ "digest",
  "either",
  "fail",
  "fixedbitset",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -991,6 +991,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5827cebf4670468b8772dd191856768aedcb1b0278a04f989f7766351917b9dc"
 
 [[package]]
+name = "cpufeatures"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "59a6001667ab124aebae2a495118e11d30984c3a653e99d86d58971708cf5e4b"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "crc"
 version = "1.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1383,6 +1392,7 @@ checksum = "f2fb860ca6fafa5552fb6d0e816a69c8e49f0908bf524e30a90d97c85892d506"
 dependencies = [
  "block-buffer",
  "crypto-common",
+ "subtle",
 ]
 
 [[package]]
@@ -1525,6 +1535,12 @@ dependencies = [
  "log 0.4.17",
  "rand 0.8.5",
 ]
+
+[[package]]
+name = "fallible-iterator"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4443176a9f2c162692bd3d352d745ef9413eec5782a80d8fd6f8a1ac692a07f7"
 
 [[package]]
 name = "farmhash"
@@ -1865,6 +1881,15 @@ name = "hex"
 version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
+
+[[package]]
+name = "hmac"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c49c37c09c17a53d937dfbb742eb3a961d65a994e6bcdcf37e7399d0cc8ab5e"
+dependencies = [
+ "digest",
+]
 
 [[package]]
 name = "http"
@@ -2372,6 +2397,15 @@ name = "maybe-uninit"
 version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "60302e4db3a61da70c0cb7991976248362f30319e88850c487b9b95bbf059e00"
+
+[[package]]
+name = "md-5"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "658646b21e0b72f7866c7038ab086d3d5e1cd6271f060fd37defb241949d0582"
+dependencies = [
+ "digest",
+]
 
 [[package]]
 name = "md5"
@@ -2900,8 +2934,27 @@ dependencies = [
  "madsim",
  "madsim-tokio",
  "thiserror",
+ "tokio-postgres",
  "tracing",
  "workspace-hack",
+]
+
+[[package]]
+name = "phf"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fabbf1ead8a5bcbc20f5f8b939ee3f5b0f6f281b6ad3468b84656b658b455259"
+dependencies = [
+ "phf_shared",
+]
+
+[[package]]
+name = "phf_shared"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6796ad771acdc0123d2a88dc428b5e38ef24456743ddb1744ed628f9815c096"
+dependencies = [
+ "siphasher",
 ]
 
 [[package]]
@@ -2981,6 +3034,35 @@ dependencies = [
  "log 0.4.17",
  "wepoll-ffi",
  "winapi",
+]
+
+[[package]]
+name = "postgres-protocol"
+version = "0.6.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "878c6cbf956e03af9aa8204b407b9cbf47c072164800aa918c516cd4b056c50c"
+dependencies = [
+ "base64",
+ "byteorder 1.4.3",
+ "bytes",
+ "fallible-iterator",
+ "hmac",
+ "md-5",
+ "memchr",
+ "rand 0.8.5",
+ "sha2",
+ "stringprep",
+]
+
+[[package]]
+name = "postgres-types"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ebd6e8b7189a73169290e89bd24c771071f1012d8fe6f738f5226531f0b03d89"
+dependencies = [
+ "bytes",
+ "fallible-iterator",
+ "postgres-protocol",
 ]
 
 [[package]]
@@ -4493,6 +4575,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "sha2"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "55deaec60f81eefe3cce0dc50bda92d6d8e88f2a27df7c5033b42afeb1ed2676"
+dependencies = [
+ "cfg-if 1.0.0",
+ "cpufeatures",
+ "digest",
+]
+
+[[package]]
 name = "sharded-slab"
 version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4536,6 +4629,12 @@ name = "similar"
 version = "2.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2e24979f63a11545f5f2c60141afe249d4f19f84581ea2138065e400941d83d3"
+
+[[package]]
+name = "siphasher"
+version = "0.3.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7bd3e3206899af3f8b12af284fafc038cc1dc2b41d1b89dd17297221c5d225de"
 
 [[package]]
 name = "skeptic"
@@ -4616,6 +4715,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
 
 [[package]]
+name = "stringprep"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ee348cb74b87454fff4b551cbf727025810a004f88aeacae7f85b87f4e9a1c1"
+dependencies = [
+ "unicode-bidi",
+ "unicode-normalization",
+]
+
+[[package]]
 name = "strsim"
 version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4658,6 +4767,12 @@ dependencies = [
  "rustversion",
  "syn",
 ]
+
+[[package]]
+name = "subtle"
+version = "2.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6bdef32e8150c2a081110b42772ffe7d7c9032b606bc226c8260fd97e0976601"
 
 [[package]]
 name = "syn"
@@ -4918,6 +5033,29 @@ checksum = "f7d995660bd2b7f8c1568414c1126076c13fbb725c40112dc0120b78eb9b717b"
 dependencies = [
  "native-tls",
  "tokio",
+]
+
+[[package]]
+name = "tokio-postgres"
+version = "0.7.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "19c88a47a23c5d2dc9ecd28fb38fba5fc7e5ddc1fe64488ec145076b0c71c8ae"
+dependencies = [
+ "async-trait",
+ "byteorder 1.4.3",
+ "bytes",
+ "fallible-iterator",
+ "futures",
+ "log 0.4.17",
+ "parking_lot 0.12.0",
+ "percent-encoding",
+ "phf",
+ "pin-project-lite",
+ "postgres-protocol",
+ "postgres-types",
+ "socket2",
+ "tokio",
+ "tokio-util 0.7.1",
 ]
 
 [[package]]

--- a/src/utils/pgwire/Cargo.toml
+++ b/src/utils/pgwire/Cargo.toml
@@ -15,3 +15,4 @@ tracing = { version = "0.1" }
 workspace-hack = { version = "0.1", path = "../../workspace-hack" }
 
 [dev-dependencies]
+tokio-postgres = "0.7"

--- a/src/utils/pgwire/src/pg_message.rs
+++ b/src/utils/pgwire/src/pg_message.rs
@@ -21,7 +21,6 @@ use bytes::{Buf, BufMut, Bytes, BytesMut};
 use tokio::io::{AsyncRead, AsyncReadExt};
 
 use crate::pg_field_descriptor::PgFieldDescriptor;
-use crate::pg_message::FeMessage::Bind;
 use crate::pg_response::StatementType;
 use crate::pg_server::BoxedError;
 use crate::types::Row;

--- a/src/utils/pgwire/src/pg_message.rs
+++ b/src/utils/pgwire/src/pg_message.rs
@@ -17,10 +17,11 @@ use std::io::{Error, ErrorKind, IoSlice, Result, Write};
 
 use byteorder::{BigEndian, ByteOrder};
 /// Part of code learned from https://github.com/zenithdb/zenith/blob/main/zenith_utils/src/pq_proto.rs.
-use bytes::{BufMut, Bytes, BytesMut};
+use bytes::{Buf, BufMut, Bytes, BytesMut};
 use tokio::io::{AsyncRead, AsyncReadExt};
 
 use crate::pg_field_descriptor::PgFieldDescriptor;
+use crate::pg_message::FeMessage::Bind;
 use crate::pg_response::StatementType;
 use crate::pg_server::BoxedError;
 use crate::types::Row;
@@ -30,6 +31,11 @@ pub enum FeMessage {
     Ssl,
     Startup(FeStartupMessage),
     Query(FeQueryMessage),
+    Parse(FeParseMessage),
+    Describe(FeDescribeMessage),
+    Bind(FeBindMessage),
+    Execute(FeExecuteMessage),
+    Sync,
     CancelQuery,
     Terminate,
 }
@@ -39,6 +45,82 @@ pub struct FeStartupMessage {}
 /// Query message contains the string sql.
 pub struct FeQueryMessage {
     pub sql_bytes: Bytes,
+}
+
+#[derive(Debug)]
+pub struct FeBindMessage {}
+
+#[derive(Debug)]
+pub struct FeExecuteMessage {
+    pub max_rows: i32,
+}
+
+#[derive(Debug)]
+pub struct FeParseMessage {
+    pub query_string: Bytes,
+}
+
+#[derive(Debug)]
+pub struct FeDescribeMessage {
+    // 'S' to describe a prepared statement; or 'P' to describe a portal.
+    pub kind: u8,
+}
+
+impl FeDescribeMessage {
+    pub fn parse(mut buf: Bytes) -> Result<FeMessage> {
+        let kind = buf.get_u8();
+        let _pstmt_name = read_null_terminated(&mut buf)?;
+
+        if kind != b'S' {
+            unimplemented!("only prepared statement Describe is implemented");
+        }
+
+        Ok(FeMessage::Describe(FeDescribeMessage { kind }))
+    }
+}
+
+impl FeBindMessage {
+    pub fn parse(mut buf: Bytes) -> Result<FeMessage> {
+        let portal_name = read_null_terminated(&mut buf)?;
+        let _pstmt_name = read_null_terminated(&mut buf)?;
+
+        if !portal_name.is_empty() {
+            unimplemented!("named portals not implemented");
+        }
+
+        Ok(FeMessage::Bind(FeBindMessage {}))
+    }
+}
+
+impl FeExecuteMessage {
+    pub fn parse(mut buf: Bytes) -> Result<FeMessage> {
+        let portal_name = read_null_terminated(&mut buf)?;
+        let max_rows = buf.get_i32();
+
+        if !portal_name.is_empty() {
+            unimplemented!("named portals not implemented");
+        }
+
+        if max_rows != 0 {
+            unimplemented!("row limit in Execute message not supported");
+        }
+
+        Ok(FeMessage::Execute(FeExecuteMessage { max_rows }))
+    }
+}
+
+impl FeParseMessage {
+    pub fn parse(mut buf: Bytes) -> Result<FeMessage> {
+        let _pstmt_name = read_null_terminated(&mut buf)?;
+        let query_string = read_null_terminated(&mut buf)?;
+        let nparams = buf.get_i16();
+
+        if nparams != 0 {
+            unimplemented!("query params not implemented");
+        }
+
+        Ok(FeMessage::Parse(FeParseMessage { query_string }))
+    }
 }
 
 impl FeQueryMessage {
@@ -73,6 +155,11 @@ impl FeMessage {
 
         match val {
             b'Q' => Ok(FeMessage::Query(FeQueryMessage { sql_bytes })),
+            b'P' => FeParseMessage::parse(sql_bytes),
+            b'D' => FeDescribeMessage::parse(sql_bytes),
+            b'B' => FeBindMessage::parse(sql_bytes),
+            b'E' => FeExecuteMessage::parse(sql_bytes),
+            b'S' => Ok(FeMessage::Sync),
             b'X' => Ok(FeMessage::Terminate),
             _ => Err(std::io::Error::new(
                 ErrorKind::InvalidInput,
@@ -109,6 +196,25 @@ impl FeStartupMessage {
     }
 }
 
+/// Continue read until reached a \0. Used in reading string from Bytes.
+fn read_null_terminated(buf: &mut Bytes) -> Result<Bytes> {
+    let mut result = BytesMut::new();
+
+    loop {
+        if !buf.has_remaining() {
+            panic!("no null-terminator in string");
+        }
+
+        let byte = buf.get_u8();
+
+        if byte == 0 {
+            break;
+        }
+        result.put_u8(byte);
+    }
+    Ok(result.freeze())
+}
+
 /// Message sent from server to psql client. Implement `write` (how to serialize it into psql
 /// buffer).
 #[derive(Debug)]
@@ -118,6 +224,10 @@ pub enum BeMessage<'a> {
     // Single byte - used in response to SSLRequest/GSSENCRequest.
     EncryptionResponse,
     EmptyQueryResponse,
+    ParseComplete,
+    BindComplete,
+    ParameterDescription,
+    NoData,
     DataRow(&'a Row),
     ParameterStatus(BeParameterStatusMessage<'a>),
     ReadyForQuery,
@@ -285,6 +395,31 @@ impl<'a> BeMessage<'a> {
                 buf.put_i32(5);
                 // TODO: add transaction status
                 buf.put_u8(b'I');
+            }
+
+            BeMessage::ParseComplete => {
+                buf.put_u8(b'1');
+                write_body(buf, |_| Ok(()))?;
+            }
+
+            BeMessage::BindComplete => {
+                buf.put_u8(b'2');
+                write_body(buf, |_| Ok(()))?;
+            }
+
+            BeMessage::ParameterDescription => {
+                buf.put_u8(b't');
+                write_body(buf, |buf| {
+                    // we don't support params, so always 0
+                    buf.put_i16(0);
+                    Ok(())
+                })
+                .unwrap();
+            }
+
+            BeMessage::NoData => {
+                buf.put_u8(b'n');
+                write_body(buf, |_| Ok(())).unwrap();
             }
 
             BeMessage::EncryptionResponse => {

--- a/src/utils/pgwire/src/pg_protocol.rs
+++ b/src/utils/pgwire/src/pg_protocol.rs
@@ -17,14 +17,11 @@ use std::sync::Arc;
 
 use bytes::{Bytes, BytesMut};
 use tokio::io::{AsyncRead, AsyncWrite, AsyncWriteExt};
-use tracing::error;
-use tracing::log::trace;
 
 use crate::error::PsqlError;
 use crate::pg_field_descriptor::{PgFieldDescriptor, TypeOid};
 use crate::pg_message::{
-    BeCommandCompleteMessage, BeMessage, BeParameterStatusMessage, FeMessage, FeQueryMessage,
-    FeStartupMessage,
+    BeCommandCompleteMessage, BeMessage, BeParameterStatusMessage, FeMessage, FeStartupMessage,
 };
 use crate::pg_response::PgResponse;
 use crate::pg_server::{Session, SessionManager};

--- a/src/utils/pgwire/src/pg_server.rs
+++ b/src/utils/pgwire/src/pg_server.rs
@@ -13,7 +13,7 @@
 // limitations under the License.
 
 use std::io;
-use std::io::{Bytes, ErrorKind};
+use std::io::ErrorKind;
 use std::result::Result;
 use std::sync::Arc;
 
@@ -92,7 +92,7 @@ mod tests {
     use std::error::Error;
     use std::sync::Arc;
 
-    use tokio_postgres::{Client, NoTls};
+    use tokio_postgres::NoTls;
 
     use crate::pg_field_descriptor::{PgFieldDescriptor, TypeOid};
     use crate::pg_response::{PgResponse, StatementType};
@@ -106,7 +106,7 @@ mod tests {
 
         fn connect(
             &self,
-            database: &str,
+            _database: &str,
         ) -> Result<Arc<Self::Session>, Box<dyn Error + Send + Sync>> {
             Ok(Arc::new(MockSession {}))
         }
@@ -118,7 +118,7 @@ mod tests {
     impl Session for MockSession {
         async fn run_statement(
             self: Arc<Self>,
-            sql: &str,
+            _sql: &str,
         ) -> Result<PgResponse, Box<dyn Error + Send + Sync>> {
             Ok(PgResponse::new(
                 StatementType::SELECT,
@@ -136,7 +136,7 @@ mod tests {
     /// The test below is copied from tokio-postgres doc.
     async fn test_psql_extended_mode_connect() {
         let session_mgr = Arc::new(MockSessionManager {});
-        let future = tokio::spawn(async move { pg_serve("127.0.0.1:10000", session_mgr).await });
+        tokio::spawn(async move { pg_serve("127.0.0.1:10000", session_mgr).await });
 
         // Connect to the database.
         let (client, connection) = tokio_postgres::connect("host=localhost port=10000", NoTls)

--- a/src/workspace-hack/Cargo.toml
+++ b/src/workspace-hack/Cargo.toml
@@ -19,6 +19,8 @@ bstr = { version = "0.2", features = ["lazy_static", "regex-automata", "serde", 
 bytes = { version = "1", features = ["serde", "std"] }
 crossbeam-deque = { version = "0.8", features = ["crossbeam-epoch", "crossbeam-utils", "std"] }
 crossbeam-utils = { version = "0.8", features = ["lazy_static", "std"] }
+crypto-common = { version = "0.1", default-features = false, features = ["std"] }
+digest = { version = "0.10", features = ["alloc", "block-buffer", "core-api", "mac", "std", "subtle"] }
 either = { version = "1", features = ["use_std"] }
 fail = { version = "0.5", default-features = false, features = ["failpoints"] }
 fixedbitset = { version = "0.4", features = ["std"] }
@@ -69,6 +71,8 @@ bytes = { version = "1", features = ["serde", "std"] }
 cc = { version = "1", default-features = false, features = ["jobserver", "parallel"] }
 crossbeam-deque = { version = "0.8", features = ["crossbeam-epoch", "crossbeam-utils", "std"] }
 crossbeam-utils = { version = "0.8", features = ["lazy_static", "std"] }
+crypto-common = { version = "0.1", default-features = false, features = ["std"] }
+digest = { version = "0.10", features = ["alloc", "block-buffer", "core-api", "mac", "std", "subtle"] }
 either = { version = "1", features = ["use_std"] }
 fail = { version = "0.5", default-features = false, features = ["failpoints"] }
 fixedbitset = { version = "0.4", features = ["std"] }


### PR DESCRIPTION
## What's changed and what's your intention?

ref: #2621. 

This is PR init the extended query mode. The feature is very limited. We do not support prepared statement or portal. Just hard code the return type of DataRow and returned result sets.

## Checklist

- [x] I have written necessary docs and comments
- [x] I have added necessary unit tests and integration tests

## Refer to a related PR or issue link (optional)
