### PR TITLE
refactor(frontend): use compute client pool to get ComputeClient

### DIFF
--- a/src/frontend/src/lib.rs
+++ b/src/frontend/src/lib.rs
@@ -59,6 +59,7 @@ use std::sync::Arc;
 
 use clap::Parser;
 use pgwire::pg_server::pg_serve;
+use risingwave_rpc_client::ComputeClientPool;
 use session::SessionManagerImpl;
 
 #[derive(Parser, Clone, Debug)]
@@ -93,4 +94,9 @@ impl Default for FrontendOpts {
 pub async fn start(opts: FrontendOpts) {
     let session_mgr = Arc::new(SessionManagerImpl::new(&opts).await.unwrap());
     pg_serve(&opts.host, session_mgr).await.unwrap();
+}
+
+lazy_static::lazy_static! {
+    /// A compute client pool
+    pub static ref COMPUTE_CLIENT_POOL: ComputeClientPool = ComputeClientPool::new(1024);
 }

--- a/src/rpc_client/src/compute_client_pool.rs
+++ b/src/rpc_client/src/compute_client_pool.rs
@@ -12,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use std::sync::Arc;
+
 use moka::future::Cache;
 use risingwave_common::error::Result;
 use risingwave_common::util::addr::HostAddr;
@@ -41,3 +43,5 @@ impl ComputeClientPool {
             })
     }
 }
+
+pub type ComputeClientPoolRef = Arc<ComputeClientPool>;

--- a/src/rpc_client/src/lib.rs
+++ b/src/rpc_client/src/lib.rs
@@ -32,7 +32,7 @@ pub use meta_client::{GrpcMetaClient, MetaClient, NotificationStream};
 mod compute_client;
 pub use compute_client::{ComputeClient, ExchangeSource, GrpcExchangeSource};
 mod compute_client_pool;
-pub use compute_client_pool::ComputeClientPool;
+pub use compute_client_pool::{ComputeClientPool, ComputeClientPoolRef};
 mod hummock_meta_client;
 pub use hummock_meta_client::HummockMetaClient;
 mod stream_client_pool;


### PR DESCRIPTION
## What's changed and what's your intention?
Create a static `ComputeClientPool` to be used.

## Checklist

- [ ] I have written necessary docs and comments

## Refer to a related PR or issue link (optional)
closes #2719 