### PR TITLE
feat(frontend): add common table expression

### DIFF
--- a/src/frontend/src/binder/mod.rs
+++ b/src/frontend/src/binder/mod.rs
@@ -12,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use std::collections::HashMap;
+
 use risingwave_common::error::Result;
 use risingwave_sqlparser::ast::Statement;
 
@@ -44,6 +46,7 @@ pub use values::BoundValues;
 
 use crate::catalog::catalog_service::CatalogReadGuard;
 
+
 /// `Binder` binds the identifiers in AST to columns in relations
 pub struct Binder {
     // TODO: maybe we can only lock the database, but not the whole catalog.
@@ -56,6 +59,8 @@ pub struct Binder {
     upper_contexts: Vec<BindContext>,
 
     next_subquery_id: usize,
+    /// Map the cte's name to its Relation::Subquery.
+    cte_to_relation: HashMap<String, Relation>,
 }
 
 impl Binder {
@@ -66,6 +71,7 @@ impl Binder {
             context: BindContext::new(),
             upper_contexts: vec![],
             next_subquery_id: 0,
+            cte_to_relation: HashMap::new(),
         }
     }
 

--- a/src/frontend/src/binder/query.rs
+++ b/src/frontend/src/binder/query.rs
@@ -17,15 +17,16 @@ use std::collections::HashMap;
 use risingwave_common::catalog::Schema;
 use risingwave_common::error::{ErrorCode, Result};
 use risingwave_common::types::DataType;
-use risingwave_sqlparser::ast::{Expr, OrderByExpr, Query, Value};
+use risingwave_sqlparser::ast::{Cte, Expr, OrderByExpr, Query, Value, With};
 
+use super::Relation;
 use crate::binder::{Binder, BoundSetExpr};
 use crate::expr::ExprImpl;
 use crate::optimizer::property::{Direction, FieldOrder};
 
 /// A validated sql query, including order and union.
 /// An example of its relationship with `BoundSetExpr` and `BoundSelect` can be found here: <https://bit.ly/3GQwgPz>
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct BoundQuery {
     pub body: BoundSetExpr,
     pub order: Vec<FieldOrder>,
@@ -68,6 +69,9 @@ impl Binder {
     pub(super) fn bind_query_inner(&mut self, query: Query) -> Result<BoundQuery> {
         let limit = query.get_limit_value();
         let offset = query.get_offset_value();
+        if let Some(with) = query.with {
+            self.bind_with(with)?;
+        }
         let body = self.bind_set_expr(query.body)?;
         let mut name_to_index = HashMap::new();
         body.schema()
@@ -138,5 +142,20 @@ impl Binder {
             }
         };
         Ok(FieldOrder { index, direct })
+    }
+
+    fn bind_with(&mut self, with: With) -> Result<()> {
+        if with.recursive {
+            return Err(ErrorCode::NotImplemented("recursive cte".into(), None.into()).into());
+        } else {
+            for cte_table in with.cte_tables {
+                let Cte { alias, query, .. } = cte_table;
+                let table_name = alias.name.value.clone();
+                let subquery =
+                    Relation::Subquery(Box::new(self.bind_subquery_relation(query, Some(alias))?));
+                self.cte_to_relation.insert(table_name, subquery);
+            }
+            Ok(())
+        }
     }
 }

--- a/src/frontend/src/binder/relation/generate_series.rs
+++ b/src/frontend/src/binder/relation/generate_series.rs
@@ -21,7 +21,7 @@ use risingwave_sqlparser::ast::FunctionArg;
 use super::{Binder, Result};
 use crate::expr::{Expr, ExprImpl};
 
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct BoundGenerateSeriesFunction {
     pub(crate) args: Vec<ExprImpl>,
     pub(crate) data_type: DataType,

--- a/src/frontend/src/binder/relation/join.rs
+++ b/src/frontend/src/binder/relation/join.rs
@@ -20,7 +20,7 @@ use risingwave_sqlparser::ast::{JoinConstraint, JoinOperator, TableWithJoins};
 use crate::binder::{Binder, Relation};
 use crate::expr::{Expr as _, ExprImpl};
 
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct BoundJoin {
     pub join_type: JoinType,
     pub left: Relation,

--- a/src/frontend/src/binder/relation/subquery.rs
+++ b/src/frontend/src/binder/relation/subquery.rs
@@ -17,7 +17,7 @@ use risingwave_sqlparser::ast::{Query, TableAlias};
 
 use crate::binder::{Binder, BoundQuery, UNNAMED_SUBQUERY};
 
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct BoundSubquery {
     pub query: BoundQuery,
 }
@@ -27,7 +27,7 @@ impl Binder {
     /// [`BindContext`](crate::binder::BindContext) for it.
     ///
     /// After finishing binding, we update the current context with the output of the subquery.
-    pub(super) fn bind_subquery_relation(
+    pub fn bind_subquery_relation(
         &mut self,
         query: Query,
         alias: Option<TableAlias>,

--- a/src/frontend/src/binder/relation/table_or_source.rs
+++ b/src/frontend/src/binder/relation/table_or_source.rs
@@ -23,7 +23,7 @@ use crate::catalog::source_catalog::SourceCatalog;
 use crate::catalog::table_catalog::TableCatalog;
 use crate::catalog::{CatalogError, TableId};
 
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct BoundBaseTable {
     pub name: String, // explain-only
     pub table_id: TableId,
@@ -39,7 +39,7 @@ pub struct BoundTableSource {
     pub columns: Vec<ColumnDesc>,
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct BoundSource {
     pub catalog: SourceCatalog,
 }

--- a/src/frontend/src/binder/relation/window_table_function.rs
+++ b/src/frontend/src/binder/relation/window_table_function.rs
@@ -43,7 +43,7 @@ impl FromStr for WindowTableFunctionKind {
     }
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct BoundWindowTableFunction {
     pub(crate) input: Relation,
     pub(crate) kind: WindowTableFunctionKind,

--- a/src/frontend/src/binder/select.rs
+++ b/src/frontend/src/binder/select.rs
@@ -26,7 +26,7 @@ use crate::binder::{Binder, Relation};
 use crate::catalog::check_valid_column_name;
 use crate::expr::{Expr as _, ExprImpl, InputRef};
 
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct BoundSelect {
     pub distinct: bool,
     pub select_items: Vec<ExprImpl>,

--- a/src/frontend/src/binder/set_expr.rs
+++ b/src/frontend/src/binder/set_expr.rs
@@ -20,7 +20,7 @@ use crate::binder::{Binder, BoundSelect, BoundValues};
 
 /// Part of a validated query, without order or limit clause. It may be composed of smaller
 /// `BoundSetExpr`s via set operators (e.g. union).
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub enum BoundSetExpr {
     Select(Box<BoundSelect>),
     Values(Box<BoundValues>),

--- a/src/frontend/src/binder/values.rs
+++ b/src/frontend/src/binder/values.rs
@@ -23,7 +23,7 @@ use super::bind_context::Clause;
 use crate::binder::Binder;
 use crate::expr::{align_types, Expr as _, ExprImpl, Literal};
 
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct BoundValues {
     pub rows: Vec<Vec<ExprImpl>>,
     pub schema: Schema,


### PR DESCRIPTION
## What's changed and what's your intention?

implement common table expressions by replacing cte table with subquery.

## Current Problems
For this kind of query `with cte as (select a from ab) select * from bc inner join cte on bc.b = cte.a;`. The plan showed by explain is inconsistent with directly using subquery `select * from bc inner join (select a from ab) as cte on bc.b = cte.a`. 
```
test=> explain select * from bc inner join (select a from ab) as cte on bc.b = cte.a;
                      QUERY PLAN
-------------------------------------------------------
 BatchExchange { order: [], dist: Single }
   BatchHashJoin { type: Inner, predicate: $0 = $2 }
     BatchExchange { order: [], dist: HashShard([0]) }
       BatchScan { table: bc, columns: [b, c] }
     BatchExchange { order: [], dist: HashShard([0]) }
       BatchScan { table: ab, columns: [a] }
```
```
test=> explain with cte as (select a from ab) select * from bc inner join cte on bc.b = cte.a;
                       QUERY PLAN
--------------------------------------------------------
 BatchProject { exprs: [$0, $1, $2] }
   BatchNestedLoopJoin { type: Inner, predicate: true }
     BatchExchange { order: [], dist: Single }
       BatchFilter { predicate: ($1 = $0) }
         BatchScan { table: bc, columns: [_row_id, c] }
     BatchExchange { order: [], dist: Single }
       BatchScan { table: ab, columns: [a] }
(7 rows)
```
However, their `Relation` after `bind_vec_table_with_joins` are nearly same except the column index in the `BindContext` differ since cte `bind_subquery` before handling `query.body`.
## Checklist

- [ ] I have written necessary docs and comments
- [ ] I have added necessary unit tests and integration tests

## Refer to a related PR or issue link (optional)
close #2708 