### PR TITLE
feat(ci): migrating ci services to buildkite.

### DIFF
--- a/ci/Dockerfile
+++ b/ci/Dockerfile
@@ -1,0 +1,30 @@
+FROM ubuntu:20.04 AS risingwave-build-env
+
+ENV LANG en_US.utf8
+
+RUN apt-get update && \
+    DEBIAN_FRONTEND=noninteractive apt-get -y install make build-essential cmake protobuf-compiler curl \
+    openssl libssl-dev pkg-config bash openjdk-11-jdk wget unzip git tmux lld
+
+SHELL ["/bin/bash", "-c"]
+
+RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- --no-modify-path --default-toolchain none -y
+
+RUN curl -sSL "https://github.com/bufbuild/buf/releases/download/v1.4.0/buf-$(uname -s)-$(uname -m).tar.gz" | \
+    tar -xvzf - -C /usr/local --strip-components 1
+
+RUN mkdir -p /risingwave
+
+WORKDIR /risingwave
+
+ENV PATH /root/.cargo/bin/:$PATH
+
+RUN wget https://github.com/risinglightdb/sqllogictest-rs/releases/download/v0.3.4/sqllogictest-linux-amd64.tar.gz -O - | tar xz && \
+    mv sqllogictest /usr/local/bin/sqllogictest && \
+    chmod +x /usr/local/bin/sqllogictest
+
+RUN curl -fL https://github.com/sagiegurari/cargo-make/releases/download/0.35.10/cargo-make-v0.35.10-x86_64-unknown-linux-musl.zip -o ~/cargo-make.zip && \
+    unzip ~/cargo-make.zip -d ~ && \
+    mv ~/cargo-make-v0.35.10-x86_64-unknown-linux-musl ~/cargo-make
+
+RUN curl -LsSf https://get.nexte.st/latest/linux | tar zxf - -C ${CARGO_HOME:-~/.cargo}/bin

--- a/ci/docker-compose.yml
+++ b/ci/docker-compose.yml
@@ -1,0 +1,12 @@
+version: "3.9"
+services:
+  rw-build-env:
+    image: public.ecr.aws/x5u3w5h6/rw-build-env:latest
+#    build:
+#      context: ..
+#      dockerfile: ./ci/Dockerfile
+#      target: risingwave-build-env
+    volumes:
+      - ..:/risingwave
+
+

--- a/ci/scripts/compute-node-build.sh
+++ b/ci/scripts/compute-node-build.sh
@@ -1,0 +1,50 @@
+#!/bin/bash
+
+# Exits as soon as any line fails.
+set -euo pipefail
+
+while getopts 't:p:' opt; do
+    case ${opt} in
+        t )
+            target=$OPTARG
+            ;;
+        p )
+            profile=$OPTARG
+            ;;
+        \? )
+            echo "Invalid Option: -$OPTARG" 1>&2
+            exit 1
+            ;;
+        : )
+            echo "Invalid option: $OPTARG requires an arguemnt" 1>&2
+            ;;
+    esac
+done
+shift $((OPTIND -1))
+
+echo "--- Install required tools"
+rustup default "$(cat ./rust-toolchain)" && rustup component add rustfmt
+cargo install cargo-sort cargo-hakari
+
+echo "--- Rust cargo-sort check"
+cargo sort -c -w
+
+echo "--- Rust cargo-hakari check"
+cargo hakari verify
+
+echo "--- Rust format check"
+cargo fmt --all -- --check
+
+echo "--- Build Rust components"
+cargo build -p risingwave_cmd_all -p risedev -p risingwave_regress_test --profile "$profile"
+
+echo "--- Compress RisingWave debug info"
+objcopy --compress-debug-sections=zlib-gnu target/"$target"/risingwave
+
+echo "--- Upload artifacts"
+cp target/"$target"/risingwave ./risingwave-"$profile"
+cp target/"$target"/risedev-playground ./risedev-playground-"$profile"
+cp target/"$target"/risingwave_regress_test ./risingwave_regress_test-"$profile"
+buildkite-agent artifact upload risingwave-"$profile"
+buildkite-agent artifact upload risedev-playground-"$profile"
+buildkite-agent artifact upload risingwave_regress_test-"$profile"

--- a/ci/scripts/compute-node-test.sh
+++ b/ci/scripts/compute-node-test.sh
@@ -1,0 +1,27 @@
+#!/bin/bash
+
+# Exits as soon as any line fails.
+set -euo pipefail
+
+echo "--- Install required tools"
+rustup default "$(cat ./rust-toolchain)" && rustup component add llvm-tools-preview clippy
+cargo install cargo-llvm-cov
+
+echo "--- Run rust clippy check"
+cargo clippy --all-targets --all-features --locked -- -D warnings
+
+echo "--- Build documentation"
+cargo doc --document-private-items --no-deps
+
+echo "--- Run rust failpoints test"
+cargo nextest run failpoints  --features failpoints --no-fail-fast
+
+echo "--- Run rust doc check"
+cargo test --doc
+
+echo "--- Run rust test with coverage"
+cargo llvm-cov nextest --lcov --output-path lcov.info -- --no-fail-fast
+
+echo "--- Codecov upload coverage reports"
+curl -Os https://uploader.codecov.io/latest/linux/codecov && chmod +x codecov
+./codecov -t "$CODECOV_TOKEN" -s . -F rust

--- a/ci/scripts/e2e-risedev.sh
+++ b/ci/scripts/e2e-risedev.sh
@@ -1,0 +1,60 @@
+#!/bin/bash
+
+# Exits as soon as any line fails.
+set -euo pipefail
+
+while getopts 'p:' opt; do
+    case ${opt} in
+        p )
+            profile=$OPTARG
+            ;;
+        \? )
+            echo "Invalid Option: -$OPTARG" 1>&2
+            exit 1
+            ;;
+        : )
+            echo "Invalid option: $OPTARG requires an arguemnt" 1>&2
+            ;;
+    esac
+done
+shift $((OPTIND -1))
+
+echo "--- Download artifacts"
+mkdir -p target/debug
+buildkite-agent artifact download risingwave-"$profile" target/debug/
+buildkite-agent artifact download risedev-playground-"$profile" target/debug/
+mv target/debug/risingwave-"$profile" target/debug/risingwave
+mv target/debug/risedev-playground-"$profile" target/debug/risedev-playground
+
+echo "--- Adjust permission"
+chmod +x ./target/debug/risingwave
+chmod +x ./target/debug/risedev-playground
+
+echo "--- Generate RiseDev CI config"
+cp risedev-components.ci.env risedev-components.user.env
+
+echo "--- Prepare RiseDev playground"
+~/cargo-make/makers pre-start-playground
+~/cargo-make/makers link-all-in-one-binaries
+
+echo "--- e2e, ci-3cn-1fe, streaming"
+~/cargo-make/makers ci-start ci-3cn-1fe
+timeout 5m sqllogictest -p 4566 './e2e_test/streaming/**/*.slt'
+
+echo "--- Kill cluster"
+~/cargo-make/makers ci-kill
+
+echo "--- e2e, ci-3cn-1fe, delta join"
+~/cargo-make/makers ci-start ci-3cn-1fe
+timeout 3m sqllogictest -p 4566 './e2e_test/streaming_delta_join/**/*.slt'
+
+echo "--- Kill cluster"
+~/cargo-make/makers ci-kill
+
+echo "--- e2e, ci-3cn-1fe, batch distributed"
+~/cargo-make/makers ci-start ci-3cn-1fe
+timeout 2m sqllogictest -p 4566 './e2e_test/ddl/**/*.slt'
+timeout 2m sqllogictest -p 4566 './e2e_test/batch/**/*.slt'
+
+echo "--- Kill cluster"
+~/cargo-make/makers ci-kill

--- a/ci/scripts/e2e-source.sh
+++ b/ci/scripts/e2e-source.sh
@@ -1,0 +1,31 @@
+#!/bin/bash
+
+# Exits as soon as any line fails.
+set -euo pipefail
+
+echo "--- Download artifacts"
+mkdir -p target/debug
+buildkite-agent artifact download risingwave-dev target/debug/
+buildkite-agent artifact download risedev-playground-dev target/debug/
+buildkite-agent artifact download risingwave_regress_test-dev target/debug/
+mv target/debug/risingwave-dev target/debug/risingwave
+mv target/debug/risedev-playground-dev target/debug/risedev-playground
+mv target/debug/risingwave_regress_test-dev target/debug/risingwave_regress_test
+
+echo "--- Adjust permission"
+chmod +x ./target/debug/risingwave
+chmod +x ./target/debug/risedev-playground
+chmod +x ./target/debug/risingwave_regress_test
+
+echo "--- Generate RiseDev CI config"
+cp risedev-components.ci.env risedev-components.user.env
+
+echo "--- Prepare RiseDev playground"
+~/cargo-make/makers pre-start-playground
+~/cargo-make/makers link-all-in-one-binaries
+
+echo "--- e2e test w/ Rust frontend - source with kafka"
+~/cargo-make/makers clean-data
+~/cargo-make/makers ci-start ci-kafka
+./scripts/source/prepare_ci_kafka.sh
+timeout 2m sqllogictest -p 4566 './e2e_test/source/**/*.slt'

--- a/ci/scripts/misc-check.sh
+++ b/ci/scripts/misc-check.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+
+# Exits as soon as any line fails.
+set -euo pipefail
+
+echo "--- Check protobuf code format && Lint protobuf"
+cd proto
+buf format -d --exit-code
+buf lint
+

--- a/ci/workflows/main-cron.yml
+++ b/ci/workflows/main-cron.yml
@@ -1,0 +1,53 @@
+steps:
+  - label: "compute node build dev"
+    command: "ci/scripts/compute-node-build.sh -t debug -p dev"
+    key: "build"
+    plugins:
+      - docker-compose#v3.9.0:
+          run: rw-build-env
+          config: ci/docker-compose.yml
+          mount-buildkite-agent: true
+    timeout_in_minutes: 10
+
+  - label: "e2e risedev"
+    command: "ci/scripts/e2e-risedev.sh -p dev"
+    depends_on: "build"
+    plugins:
+      - docker-compose#v3.9.0:
+          run: rw-build-env
+          config: ci/docker-compose.yml
+          mount-buildkite-agent: true
+    timeout_in_minutes: 10
+
+  - label: "e2e source"
+    command: "ci/scripts/e2e-source.sh"
+    depends_on: "build"
+    plugins:
+      - docker-compose#v3.9.0:
+          run: rw-build-env
+          config: ci/docker-compose.yml
+          mount-buildkite-agent: true
+    timeout_in_minutes: 5
+
+  - label: "compute node test"
+    command: "ci/scripts/compute-node-test.sh"
+    plugins:
+      - seek-oss/aws-sm#v2.3.1:
+            env:
+              CODECOV_TOKEN: my-codecov-token
+      - docker-compose#v3.9.0:
+          run: rw-build-env
+          config: ci/docker-compose.yml
+          environment:
+            - CODECOV_TOKEN
+    timeout_in_minutes: 15
+
+  - label: "misc check"
+    command: "ci/scripts/misc-check.sh"
+    plugins:
+      - docker-compose#v3.9.0:
+          run: rw-build-env
+          config: ci/docker-compose.yml
+      - shellcheck#v1.2.0:
+          files: ./**/*.sh
+    timeout_in_minutes: 5

--- a/ci/workflows/main.yml
+++ b/ci/workflows/main.yml
@@ -1,0 +1,76 @@
+steps:
+  - label: "compute node build {{matrix.profile}}"
+    command: "ci/scripts/compute-node-build.sh -t {{matrix.target}} -p {{matrix.profile}}"
+    key: "build"
+    timeout_in_minutes: 15
+    plugins:
+      - docker-compose#v3.9.0:
+          run: rw-build-env
+          config: ci/docker-compose.yml
+          mount-buildkite-agent: true
+    matrix:
+      setup:
+        target:
+          - "debug"
+          - "release"
+        profile:
+          - "dev"
+          - "release"
+      adjustments:
+        - with:
+            target: "debug"
+            profile: "release"
+          skip: true
+        - with:
+            target: "release"
+            profile: "dev"
+          skip: true
+
+  - label: " {{matrix.profile}}: e2e risedev"
+    command: "ci/scripts/e2e-risedev.sh -p {{matrix.profile}}"
+    depends_on: "build"
+    timeout_in_minutes: 10
+    plugins:
+      - docker-compose#v3.9.0:
+          run: rw-build-env
+          config: ci/docker-compose.yml
+          mount-buildkite-agent: true
+    matrix:
+      setup:
+        profile:
+          - "dev"
+          - "release"
+
+  - label: "e2e source"
+    command: "ci/scripts/e2e-source.sh"
+    depends_on: "build"
+    plugins:
+      - docker-compose#v3.9.0:
+          run: rw-build-env
+          config: ci/docker-compose.yml
+          mount-buildkite-agent: true
+    timeout_in_minutes: 5
+
+  - label: "compute node test"
+    command: "ci/scripts/compute-node-test.sh"
+    plugins:
+      - seek-oss/aws-sm#v2.3.1:
+          env:
+            CODECOV_TOKEN: my-codecov-token
+      - docker-compose#v3.9.0:
+          run: rw-build-env
+          config: ci/docker-compose.yml
+          environment:
+            - CODECOV_TOKEN
+    timeout_in_minutes: 15
+
+  - label: "misc check"
+    command: "ci/scripts/misc-check.sh"
+    plugins:
+      - docker-compose#v3.9.0:
+          run: rw-build-env
+          config: ci/docker-compose.yml
+      - shellcheck#v1.2.0:
+            files: ./**/*.sh
+    timeout_in_minutes: 10
+

--- a/ci/workflows/pull-request.yml
+++ b/ci/workflows/pull-request.yml
@@ -1,0 +1,54 @@
+steps:
+  - label: "compute node build dev"
+    command: "ci/scripts/compute-node-build.sh -t debug -p dev"
+    key: "build"
+    plugins:
+      - docker-compose#v3.9.0:
+          run: rw-build-env
+          config: ci/docker-compose.yml
+          mount-buildkite-agent: true
+    timeout_in_minutes: 10
+
+  - label: "e2e risedev"
+    command: "ci/scripts/e2e-risedev.sh -p dev"
+    depends_on: "build"
+    plugins:
+      - docker-compose#v3.9.0:
+          run: rw-build-env
+          config: ci/docker-compose.yml
+          mount-buildkite-agent: true
+    timeout_in_minutes: 10
+
+  - label: "e2e source"
+    command: "ci/scripts/e2e-source.sh"
+    depends_on: "build"
+    plugins:
+      - docker-compose#v3.9.0:
+          run: rw-build-env
+          config: ci/docker-compose.yml
+          mount-buildkite-agent: true
+    timeout_in_minutes: 5
+
+  - label: "compute node test"
+    command: "ci/scripts/compute-node-test.sh"
+    plugins:
+      - seek-oss/aws-sm#v2.3.1:
+          env:
+            CODECOV_TOKEN: my-codecov-token
+      - docker-compose#v3.9.0:
+          run: rw-build-env
+          config: ci/docker-compose.yml
+          environment:
+            - CODECOV_TOKEN
+    timeout_in_minutes: 15
+
+  - label: "misc check"
+    command: "ci/scripts/misc-check.sh"
+    plugins:
+      - docker-compose#v3.9.0:
+          run: rw-build-env
+          config: ci/docker-compose.yml
+      - shellcheck#v1.2.0:
+          files: ./**/*.sh
+    timeout_in_minutes: 5
+

--- a/src/risedevtool/etcd.toml
+++ b/src/risedevtool/etcd.toml
@@ -26,7 +26,7 @@ if [ "$ETCD_SYSTEM" = "darwin-amd64" ] || [ "$ETCD_SYSTEM" = "darwin-arm64" ] ||
     unzip "${ETCD_DOWNLOAD_PATH_OTHER}" -d "${PREFIX_TMP}"
 else
     curl -L "${ETCD_DOWNLOAD_URL_LINUX}" -o "${ETCD_DOWNLOAD_PATH_LINUX}"
-    tar -xf "${ETCD_DOWNLOAD_PATH_LINUX}" -C "${PREFIX_TMP}"
+    tar -xf "${ETCD_DOWNLOAD_PATH_LINUX}" -C "${PREFIX_TMP}" --no-same-owner
 fi
 
 mv "${PREFIX_TMP}/${ETCD_RELEASE}" "${PREFIX_BIN}/etcd"

--- a/src/risedevtool/src/bin/risedev-playground.rs
+++ b/src/risedevtool/src/bin/risedev-playground.rs
@@ -367,7 +367,7 @@ fn main() -> Result<()> {
 
     match task_result {
         Ok((stat, log_buffer)) => {
-            println!("--- summary of startup time ---");
+            println!("---- summary of startup time ----");
             for (task_name, duration) in stat {
                 println!("{}: {:.2}s", task_name, duration.as_secs_f64());
             }


### PR DESCRIPTION
## What's changed and what's your intention?

The ci service is migrated from github to buildkite.
The migration workflows include:
1. main.yml
2. main-cron.yml
3. pull-request.yml

Please explain **IN DETAIL** what the changes are in this PR and why they are needed:

- ci folder is for migration to buildkite.
- src/risedevtool/etcd.toml: because the tar command here may report an error when executed in a container, I add the --no-same-owner parameter to avoid this problem.

## Refer to a related PR or issue link (optional)
issue: https://github.com/singularity-data/risingwave/issues/2100