### PR TITLE
feat(batch): abort task

### DIFF
--- a/proto/task_service.proto
+++ b/proto/task_service.proto
@@ -33,6 +33,7 @@ message TaskInfo {
     FINISHED = 5;
     FAILED = 6;
     ABORTED = 7;
+    ABORTING = 8;
   }
   batch_plan.TaskId task_id = 1;
   TaskStatus task_status = 2;

--- a/proto/task_service.proto
+++ b/proto/task_service.proto
@@ -32,6 +32,7 @@ message TaskInfo {
     CANCELLING = 4;
     FINISHED = 5;
     FAILED = 6;
+    ABORTED = 7;
   }
   batch_plan.TaskId task_id = 1;
   TaskStatus task_status = 2;
@@ -49,10 +50,17 @@ message CreateTaskResponse {
 
 message AbortTaskRequest {
   batch_plan.TaskId task_id = 1;
-  bool force = 2;
 }
 
 message AbortTaskResponse {
+  common.Status status = 1;
+}
+
+message RemoveTaskRequest {
+  batch_plan.TaskId task_id = 1;
+}
+
+message RemoveTaskResponse {
   common.Status status = 1;
 }
 
@@ -79,6 +87,7 @@ service TaskService {
   rpc CreateTask(CreateTaskRequest) returns (CreateTaskResponse);
   rpc GetTaskInfo(GetTaskInfoRequest) returns (GetTaskInfoResponse);
   rpc AbortTask(AbortTaskRequest) returns (AbortTaskResponse);
+  rpc RemoveTask(RemoveTaskRequest) returns (RemoveTaskResponse);
 }
 
 message GetDataRequest {

--- a/src/batch/src/rpc/service/task_service.rs
+++ b/src/batch/src/rpc/service/task_service.rs
@@ -17,7 +17,7 @@ use std::sync::Arc;
 use risingwave_pb::task_service::task_service_server::TaskService;
 use risingwave_pb::task_service::{
     AbortTaskRequest, AbortTaskResponse, CreateTaskRequest, CreateTaskResponse, GetTaskInfoRequest,
-    GetTaskInfoResponse,
+    GetTaskInfoResponse, RemoveTaskRequest, RemoveTaskResponse,
 };
 use tonic::{Request, Response, Status};
 
@@ -70,8 +70,36 @@ impl TaskService for BatchServiceImpl {
     #[cfg_attr(coverage, no_coverage)]
     async fn abort_task(
         &self,
-        _: Request<AbortTaskRequest>,
+        req: Request<AbortTaskRequest>,
     ) -> Result<Response<AbortTaskResponse>, Status> {
-        todo!()
+        let req = req.into_inner();
+        let res = self
+            .mgr
+            .abort_task(req.get_task_id().expect("no task id found"));
+        match res {
+            Ok(_) => Ok(Response::new(AbortTaskResponse { status: None })),
+            Err(e) => {
+                error!("failed to abort task {}", e);
+                Err(e.to_grpc_status())
+            }
+        }
+    }
+
+    #[cfg_attr(coverage, no_coverage)]
+    async fn remove_task(
+        &self,
+        req: Request<RemoveTaskRequest>,
+    ) -> Result<Response<RemoveTaskResponse>, Status> {
+        let req = req.into_inner();
+        let res = self
+            .mgr
+            .remove_task(req.get_task_id().expect("no task id found"));
+        match res {
+            Ok(_) => Ok(Response::new(RemoveTaskResponse { status: None })),
+            Err(e) => {
+                error!("failed to remove task {}", e);
+                Err(e.to_grpc_status())
+            }
+        }
     }
 }

--- a/src/batch/src/task/task_.rs
+++ b/src/batch/src/task/task_.rs
@@ -15,7 +15,7 @@
 use std::fmt::{Debug, Formatter};
 use std::sync::Arc;
 
-use futures_async_stream::for_await;
+use futures::{Stream, StreamExt};
 use parking_lot::Mutex;
 use risingwave_common::array::DataChunk;
 use risingwave_common::error::{ErrorCode, Result, RwError};
@@ -24,6 +24,8 @@ use risingwave_pb::batch_plan::{
 };
 use risingwave_pb::task_service::task_info::TaskStatus;
 use risingwave_pb::task_service::GetDataResponse;
+use tokio::sync::mpsc::UnboundedSender;
+use tokio_stream::wrappers::UnboundedReceiverStream;
 use tracing_futures::Instrument;
 
 use crate::executor::ExecutorBuilder;
@@ -182,6 +184,9 @@ pub struct BatchTaskExecution<C> {
     /// The execution failure.
     failure: Arc<Mutex<Option<RwError>>>,
 
+    /// Shutdown signal sender.
+    shutdown_tx: Mutex<Option<UnboundedSender<u64>>>,
+
     epoch: u64,
 }
 
@@ -200,6 +205,7 @@ impl<C: BatchTaskContext> BatchTaskExecution<C> {
             context,
             failure: Arc::new(Mutex::new(None)),
             epoch,
+            shutdown_tx: Mutex::new(None),
         })
     }
 
@@ -213,7 +219,7 @@ impl<C: BatchTaskContext> BatchTaskExecution<C> {
     /// hash partitioned across multiple channels.
     /// To obtain the result, one must pick one of the channels to consume via [`TaskOutputId`]. As
     /// such, parallel consumers are able to consume the result idependently.
-    pub fn async_execute(&self) -> Result<()> {
+    pub fn async_execute(self: Arc<Self>) -> Result<()> {
         trace!(
             "Prepare executing plan [{:?}]: {}",
             self.task_id,
@@ -229,6 +235,9 @@ impl<C: BatchTaskContext> BatchTaskExecution<C> {
         .build2()?;
 
         let (sender, receivers) = create_output_channel(self.plan.get_exchange_info()?)?;
+        let (shutdown_tx, shutdown_rx) = tokio::sync::mpsc::unbounded_channel::<u64>();
+        *self.shutdown_tx.lock() = Some(shutdown_tx);
+        let shutdown_rx = UnboundedReceiverStream::new(shutdown_rx);
         self.receivers
             .lock()
             .extend(receivers.into_iter().map(Some));
@@ -243,7 +252,8 @@ impl<C: BatchTaskContext> BatchTaskExecution<C> {
             let join_handle = tokio::spawn(async move {
                 // We should only pass a reference of sender to execution because we should only
                 // close it after task error has been set.
-                if let Err(e) = try_execute(exec, &mut sender)
+                if let Err(e) = self
+                    .try_execute(exec, &mut sender, shutdown_rx)
                     .instrument(tracing::trace_span!(
                         "batch_execute",
                         task_id = ?task_id.task_id,
@@ -255,6 +265,7 @@ impl<C: BatchTaskContext> BatchTaskExecution<C> {
                     // Prints the entire backtrace of error.
                     error!("Execution failed [{:?}]: {:?}", &task_id, &e);
                     *failure.lock() = Some(e);
+                    *self.state.lock() = TaskStatus::Failed;
                 }
             });
 
@@ -263,6 +274,60 @@ impl<C: BatchTaskContext> BatchTaskExecution<C> {
             }
         });
         Ok(())
+    }
+
+    pub async fn try_execute<S: Stream<Item = u64>>(
+        &self,
+        root: BoxedExecutor2,
+        sender: &mut ChanSenderImpl,
+        shutdown_rx: S,
+    ) -> Result<()> {
+        let mut shutdown_stream = Box::pin(shutdown_rx);
+        let mut data_chunk_stream = root.execute();
+        loop {
+            tokio::select! {
+                // We prioritize abort signal over normal data chunks.
+                biased;
+                _ = shutdown_stream.next() => {
+                    sender.send(None).await?;
+                    *self.state.lock() = TaskStatus::Aborted;
+                    break;
+                }
+                res = data_chunk_stream.next() => {
+                    match res {
+                        Some(data_chunk) => {
+                            sender.send(Some(data_chunk?)).await?;
+                        }
+                        None => {
+                            debug!("data chunk stream shuts down");
+                            sender.send(None).await?;
+                            break;
+                        }
+                    }
+                }
+            }
+        }
+        Ok(())
+    }
+
+    pub fn abort_task(&self) -> Result<()> {
+        self.shutdown_tx
+            .lock()
+            .as_mut()
+            .ok_or_else(|| {
+                ErrorCode::InternalError(format!(
+                    "Task{:?}'s shutdown channel does not exist.",
+                    self.task_id
+                ))
+            })?
+            .send(0)
+            .map_err(|err| {
+                ErrorCode::InternalError(format!(
+                    "Task{:?};s shutdown channel send error:{:?}",
+                    self.task_id, err
+                ))
+                .into()
+            })
     }
 
     pub fn get_task_output(&self, output_id: &ProstOutputId) -> Result<TaskOutput<C>> {
@@ -298,18 +363,17 @@ impl<C: BatchTaskContext> BatchTaskExecution<C> {
         }
         Ok(())
     }
-}
 
-pub async fn try_execute(root: BoxedExecutor2, sender: &mut ChanSenderImpl) -> Result<()> {
-    #[for_await]
-    for chunk in root.execute() {
-        let chunk = chunk?;
-        if chunk.cardinality() > 0 {
-            sender.send(Some(chunk)).await?;
+    pub fn check_if_aborted(&self) -> Result<()> {
+        if *self.state.lock() != TaskStatus::Aborted {
+            return Err(ErrorCode::InternalError(format!(
+                "task {:?} has not been aborted",
+                self.get_task_id()
+            ))
+            .into());
         }
+        Ok(())
     }
-    sender.send(None).await?;
-    Ok(())
 }
 
 #[cfg(test)]

--- a/src/batch/src/task/task_manager.rs
+++ b/src/batch/src/task/task_manager.rs
@@ -14,7 +14,6 @@
 
 use std::collections::{hash_map, HashMap};
 use std::sync::Arc;
-use std::time::Duration;
 
 use parking_lot::Mutex;
 use risingwave_common::error::ErrorCode::{self, TaskNotFound};
@@ -108,7 +107,9 @@ impl BatchManager {
         }
     }
 
-    pub async fn wait_until_task_aborted(&self, task_id: &TaskId) -> Result<()> {
+    #[cfg(test)]
+    async fn wait_until_task_aborted(&self, task_id: &TaskId) -> Result<()> {
+        use std::time::Duration;
         loop {
             match self.tasks.lock().get(task_id) {
                 Some(task) => {

--- a/src/expr/src/expr/expr_field.rs
+++ b/src/expr/src/expr/expr_field.rs
@@ -87,38 +87,10 @@ mod tests {
     use risingwave_common::array::{DataChunk, F32Array, I32Array, StructArray};
     use risingwave_common::types::{DataType, ScalarImpl};
     use risingwave_pb::data::data_type::TypeName;
-    use risingwave_pb::data::DataType as ProstDataType;
-    use risingwave_pb::expr::expr_node::Type::Field;
-    use risingwave_pb::expr::expr_node::{RexNode, Type};
-    use risingwave_pb::expr::{ConstantValue, ExprNode, FunctionCall};
 
     use crate::expr::expr_field::FieldExpression;
-    use crate::expr::test_utils::make_input_ref;
+    use crate::expr::test_utils::{make_field_function, make_i32_literal, make_input_ref};
     use crate::expr::Expression;
-
-    pub fn make_i32_literal(data: i32) -> ExprNode {
-        ExprNode {
-            expr_type: Type::ConstantValue as i32,
-            return_type: Some(ProstDataType {
-                type_name: TypeName::Int32 as i32,
-                ..Default::default()
-            }),
-            rex_node: Some(RexNode::Constant(ConstantValue {
-                body: data.to_be_bytes().to_vec(),
-            })),
-        }
-    }
-
-    pub fn make_field_function(children: Vec<ExprNode>, ret: TypeName) -> ExprNode {
-        ExprNode {
-            expr_type: Field as i32,
-            return_type: Some(ProstDataType {
-                type_name: ret as i32,
-                ..Default::default()
-            }),
-            rex_node: Some(RexNode::FuncCall(FunctionCall { children })),
-        }
-    }
 
     #[test]
     fn test_field_expr() {

--- a/src/expr/src/expr/mod.rs
+++ b/src/expr/src/expr/mod.rs
@@ -128,5 +128,5 @@ impl RowExpression {
     }
 }
 
-#[cfg(test)]
 mod test_utils;
+pub use test_utils::*;

--- a/src/expr/src/expr/test_utils.rs
+++ b/src/expr/src/expr/test_utils.rs
@@ -14,10 +14,10 @@
 
 use itertools::Itertools;
 use risingwave_pb::data::data_type::TypeName;
-use risingwave_pb::data::DataType;
-use risingwave_pb::expr::expr_node::Type::InputRef;
+use risingwave_pb::data::{DataType as ProstDataType, DataType};
+use risingwave_pb::expr::expr_node::Type::{Field, InputRef};
 use risingwave_pb::expr::expr_node::{RexNode, Type};
-use risingwave_pb::expr::{ExprNode, FunctionCall, InputRefExpr};
+use risingwave_pb::expr::{ConstantValue, ExprNode, FunctionCall, InputRefExpr};
 
 pub fn make_expression(kind: Type, rets: &[TypeName], indices: &[i32]) -> ExprNode {
     let mut exprs = Vec::new();
@@ -44,5 +44,29 @@ pub fn make_input_ref(idx: i32, ret: TypeName) -> ExprNode {
             ..Default::default()
         }),
         rex_node: Some(RexNode::InputRef(InputRefExpr { column_idx: idx })),
+    }
+}
+
+pub fn make_i32_literal(data: i32) -> ExprNode {
+    ExprNode {
+        expr_type: Type::ConstantValue as i32,
+        return_type: Some(ProstDataType {
+            type_name: TypeName::Int32 as i32,
+            ..Default::default()
+        }),
+        rex_node: Some(RexNode::Constant(ConstantValue {
+            body: data.to_be_bytes().to_vec(),
+        })),
+    }
+}
+
+pub fn make_field_function(children: Vec<ExprNode>, ret: TypeName) -> ExprNode {
+    ExprNode {
+        expr_type: Field as i32,
+        return_type: Some(ProstDataType {
+            type_name: ret as i32,
+            ..Default::default()
+        }),
+        rex_node: Some(RexNode::FuncCall(FunctionCall { children })),
     }
 }

--- a/src/stream/src/executor/managed_state/join/mod.rs
+++ b/src/stream/src/executor/managed_state/join/mod.rs
@@ -190,7 +190,9 @@ impl<K: HashKey, S: StateStore> JoinHashMap<K, S> {
 
     /// Returns a mutable reference to the value of the key in the memory, if does not exist, look
     /// up in remote storage and return, if still not exist, return None.
-    pub async fn get_mut<'a>(&'a mut self, key: &K) -> Option<&'a mut HashValueType<S>> {
+    /// FIXME(lmatz): Lifetime 'b is added due to some weird errors, possibly compiler error. May
+    /// double check after bumping the toolchain.
+    pub async fn get_mut<'a, 'b>(&'a mut self, key: &'b K) -> Option<&'a mut HashValueType<S>> {
         let state = self.inner.get(key);
         // TODO: we should probably implement a entry function for `LruCache`
         match state {
@@ -280,7 +282,10 @@ impl<K: HashKey, S: StateStore> JoinHashMap<K, S> {
 
     /// Get or create a [`JoinEntryState`] without cached state. Should only be called if the key
     /// does not exist in memory or remote storage.
-    pub async fn get_or_init_without_cache(&mut self, key: &K) -> RwResult<&mut JoinEntryState<S>> {
+    pub async fn get_or_init_without_cache<'a>(
+        &'a mut self,
+        key: &K,
+    ) -> RwResult<&'a mut JoinEntryState<S>> {
         // TODO: we should probably implement a entry function for `LruCache`
         let contains = self.inner.contains(key);
         if contains {


### PR DESCRIPTION
## What's changed and what's your intention?

Abort batch tasks on CN. The RPC just sends the message to notify the task that it should abort, but it does not wait for the task to abort successfully.

Part of handling task execution failure, i.e. when one task fails, the scheduler should be able to notify other batch tasks of the same query to abort and thus release the resources.

Introduce a new channel in the `TaskExeuction` to notify the spawned execution that its task needs to be aborted.
The spawned execution `select` on both the stream of a data chunk and the stream of this new channel's receiver, so that whenever the abort message is sent, the task will immediately be aborted.

Turn `try_execute` into a member function by making `self` a `Arc<Self>` so that the task's `state` can be set more easily.

## Checklist

- [x] I have written necessary docs and comments
- [x] I have added necessary unit tests and integration tests

## Refer to a related PR or issue link (optional)
#1977