### PR TITLE
feat(metrics): add metric for compaction to measure compaction time cost and write-amplification

### DIFF
--- a/grafana/risingwave-dashboard.json
+++ b/grafana/risingwave-dashboard.json
@@ -22,12 +22,12 @@
 	"fiscalYearStartMonth": 0,
 	"graphTooltip": 0,
 	"id": 2,
-	"iteration": 1653032725452,
+	"iteration": 1653316559775,
 	"links": [],
 	"liveNow": true,
 	"panels": [
 		{
-			"collapsed": false,
+			"collapsed": true,
 			"gridPos": {
 				"h": 1,
 				"w": 24,
@@ -35,175 +35,176 @@
 				"y": 0
 			},
 			"id": 144,
-			"panels": [],
+			"panels": [
+				{
+					"aliasColors": {},
+					"bars": false,
+					"dashLength": 10,
+					"dashes": false,
+					"fill": 1,
+					"fillGradient": 0,
+					"gridPos": {
+						"h": 8,
+						"w": 12,
+						"x": 0,
+						"y": 1
+					},
+					"hiddenSeries": false,
+					"id": 145,
+					"legend": {
+						"avg": false,
+						"current": false,
+						"max": false,
+						"min": false,
+						"show": true,
+						"total": false,
+						"values": false
+					},
+					"lines": true,
+					"linewidth": 1,
+					"nullPointMode": "null",
+					"options": {
+						"alertThreshold": true
+					},
+					"percentage": false,
+					"pluginVersion": "8.3.3",
+					"pointradius": 2,
+					"points": false,
+					"renderer": "flot",
+					"seriesOverrides": [],
+					"spaceLength": 10,
+					"stack": false,
+					"steppedLine": false,
+					"targets": [
+						{
+							"expr": "avg(process_resident_memory_bytes) by (instance)",
+							"format": "time_series",
+							"hide": false,
+							"intervalFactor": 2,
+							"legendFormat": "",
+							"refId": "A"
+						}
+					],
+					"thresholds": [],
+					"timeRegions": [],
+					"title": "Node Memory",
+					"tooltip": {
+						"shared": true,
+						"sort": 0,
+						"value_type": "individual"
+					},
+					"type": "graph",
+					"xaxis": {
+						"mode": "time",
+						"show": true,
+						"values": []
+					},
+					"yaxes": [
+						{
+							"$$hashKey": "object:37",
+							"format": "decbytes",
+							"logBase": 1,
+							"show": true
+						},
+						{
+							"$$hashKey": "object:38",
+							"format": "short",
+							"logBase": 1,
+							"show": true
+						}
+					],
+					"yaxis": {
+						"align": false
+					}
+				},
+				{
+					"aliasColors": {},
+					"bars": false,
+					"dashLength": 10,
+					"dashes": false,
+					"fill": 1,
+					"fillGradient": 0,
+					"gridPos": {
+						"h": 8,
+						"w": 12,
+						"x": 12,
+						"y": 1
+					},
+					"hiddenSeries": false,
+					"id": 146,
+					"legend": {
+						"avg": false,
+						"current": false,
+						"max": false,
+						"min": false,
+						"show": true,
+						"total": false,
+						"values": false
+					},
+					"lines": true,
+					"linewidth": 1,
+					"nullPointMode": "null",
+					"options": {
+						"alertThreshold": true
+					},
+					"percentage": false,
+					"pluginVersion": "8.3.3",
+					"pointradius": 2,
+					"points": false,
+					"renderer": "flot",
+					"seriesOverrides": [],
+					"spaceLength": 10,
+					"stack": false,
+					"steppedLine": false,
+					"targets": [
+						{
+							"datasource": {
+								"type": "prometheus",
+								"uid": "risedev-prometheus"
+							},
+							"exemplar": true,
+							"expr": "sum(rate(process_cpu_seconds_total[1m])) by (instance)",
+							"hide": false,
+							"interval": "",
+							"legendFormat": "{{instance}}",
+							"refId": "B"
+						}
+					],
+					"thresholds": [],
+					"timeRegions": [],
+					"title": "Node CPU",
+					"tooltip": {
+						"shared": true,
+						"sort": 0,
+						"value_type": "individual"
+					},
+					"type": "graph",
+					"xaxis": {
+						"mode": "time",
+						"show": true,
+						"values": []
+					},
+					"yaxes": [
+						{
+							"$$hashKey": "object:98",
+							"format": "percentunit",
+							"logBase": 1,
+							"show": true
+						},
+						{
+							"$$hashKey": "object:99",
+							"format": "short",
+							"logBase": 1,
+							"show": true
+						}
+					],
+					"yaxis": {
+						"align": false
+					}
+				}
+			],
 			"title": "Cluster Node",
 			"type": "row"
-		},
-		{
-			"aliasColors": {},
-			"bars": false,
-			"dashLength": 10,
-			"dashes": false,
-			"fill": 1,
-			"fillGradient": 0,
-			"gridPos": {
-				"h": 8,
-				"w": 12,
-				"x": 0,
-				"y": 1
-			},
-			"hiddenSeries": false,
-			"id": 145,
-			"legend": {
-				"avg": false,
-				"current": false,
-				"max": false,
-				"min": false,
-				"show": true,
-				"total": false,
-				"values": false
-			},
-			"lines": true,
-			"linewidth": 1,
-			"nullPointMode": "null",
-			"options": {
-				"alertThreshold": true
-			},
-			"percentage": false,
-			"pluginVersion": "8.3.3",
-			"pointradius": 2,
-			"points": false,
-			"renderer": "flot",
-			"seriesOverrides": [],
-			"spaceLength": 10,
-			"stack": false,
-			"steppedLine": false,
-			"targets": [
-				{
-					"expr": "avg(process_resident_memory_bytes) by (instance)",
-					"format": "time_series",
-					"hide": false,
-					"intervalFactor": 2,
-					"legendFormat": "",
-					"refId": "A"
-				}
-			],
-			"thresholds": [],
-			"timeRegions": [],
-			"title": "Node Memory",
-			"tooltip": {
-				"shared": true,
-				"sort": 0,
-				"value_type": "individual"
-			},
-			"type": "graph",
-			"xaxis": {
-				"mode": "time",
-				"show": true,
-				"values": []
-			},
-			"yaxes": [
-				{
-					"$$hashKey": "object:37",
-					"format": "decbytes",
-					"logBase": 1,
-					"show": true
-				},
-				{
-					"$$hashKey": "object:38",
-					"format": "short",
-					"logBase": 1,
-					"show": true
-				}
-			],
-			"yaxis": {
-				"align": false
-			}
-		},
-		{
-			"aliasColors": {},
-			"bars": false,
-			"dashLength": 10,
-			"dashes": false,
-			"fill": 1,
-			"fillGradient": 0,
-			"gridPos": {
-				"h": 8,
-				"w": 12,
-				"x": 12,
-				"y": 1
-			},
-			"hiddenSeries": false,
-			"id": 146,
-			"legend": {
-				"avg": false,
-				"current": false,
-				"max": false,
-				"min": false,
-				"show": true,
-				"total": false,
-				"values": false
-			},
-			"lines": true,
-			"linewidth": 1,
-			"nullPointMode": "null",
-			"options": {
-				"alertThreshold": true
-			},
-			"percentage": false,
-			"pluginVersion": "8.3.3",
-			"pointradius": 2,
-			"points": false,
-			"renderer": "flot",
-			"seriesOverrides": [],
-			"spaceLength": 10,
-			"stack": false,
-			"steppedLine": false,
-			"targets": [
-				{
-					"datasource": {
-						"type": "prometheus",
-						"uid": "risedev-prometheus"
-					},
-					"exemplar": true,
-					"expr": "sum(rate(process_cpu_seconds_total[1m])) by (instance)",
-					"hide": false,
-					"interval": "",
-					"legendFormat": "{{instance}}",
-					"refId": "B"
-				}
-			],
-			"thresholds": [],
-			"timeRegions": [],
-			"title": "Node CPU",
-			"tooltip": {
-				"shared": true,
-				"sort": 0,
-				"value_type": "individual"
-			},
-			"type": "graph",
-			"xaxis": {
-				"mode": "time",
-				"show": true,
-				"values": []
-			},
-			"yaxes": [
-				{
-					"$$hashKey": "object:98",
-					"format": "percentunit",
-					"logBase": 1,
-					"show": true
-				},
-				{
-					"$$hashKey": "object:99",
-					"format": "short",
-					"logBase": 1,
-					"show": true
-				}
-			],
-			"yaxis": {
-				"align": false
-			}
 		},
 		{
 			"collapsed": false,
@@ -211,7 +212,7 @@
 				"h": 1,
 				"w": 24,
 				"x": 0,
-				"y": 9
+				"y": 1
 			},
 			"id": 142,
 			"panels": [],
@@ -267,13 +268,38 @@
 						]
 					}
 				},
-				"overrides": []
+				"overrides": [
+					{
+						"__systemRef": "hideSeriesFrom",
+						"matcher": {
+							"id": "byNames",
+							"options": {
+								"mode": "exclude",
+								"names": [
+									"127.0.0.1:1250-L6"
+								],
+								"prefix": "All except:",
+								"readOnly": true
+							}
+						},
+						"properties": [
+							{
+								"id": "custom.hideFrom",
+								"value": {
+									"legend": false,
+									"tooltip": false,
+									"viz": true
+								}
+							}
+						]
+					}
+				]
 			},
 			"gridPos": {
 				"h": 8,
 				"w": 12,
 				"x": 0,
-				"y": 10
+				"y": 2
 			},
 			"id": 140,
 			"options": {
@@ -359,7 +385,7 @@
 				"h": 8,
 				"w": 12,
 				"x": 12,
-				"y": 10
+				"y": 2
 			},
 			"id": 164,
 			"options": {
@@ -444,7 +470,7 @@
 				"h": 8,
 				"w": 12,
 				"x": 0,
-				"y": 18
+				"y": 10
 			},
 			"id": 190,
 			"options": {
@@ -455,7 +481,7 @@
 					"displayMode": "table",
 					"placement": "right",
 					"sortBy": "Max",
-					"sortDesc": true
+					"sortDesc": false
 				},
 				"tooltip": {
 					"mode": "single"
@@ -522,6 +548,30 @@
 					"interval": "",
 					"legendFormat": "compact-key-range p90",
 					"refId": "E"
+				},
+				{
+					"datasource": {
+						"type": "prometheus",
+						"uid": "PEDE6B306CC9C0CD0"
+					},
+					"exemplar": true,
+					"expr": "histogram_quantile(0.9, sum(rate(state_store_get_table_id_total_time_duration_bucket[1m])) by (le, instance))",
+					"hide": false,
+					"interval": "",
+					"legendFormat": "get-table-id p90 {{instance}}",
+					"refId": "F"
+				},
+				{
+					"datasource": {
+						"type": "prometheus",
+						"uid": "PEDE6B306CC9C0CD0"
+					},
+					"exemplar": true,
+					"expr": "histogram_quantile(0.9, sum(rate(state_store_remote_read_time_per_task_bucket[1m])) by (le, instance))",
+					"hide": false,
+					"interval": "",
+					"legendFormat": "remote-io p90 {{instance}}",
+					"refId": "G"
 				}
 			],
 			"title": "compact duration",
@@ -577,13 +627,38 @@
 					},
 					"unit": "Bps"
 				},
-				"overrides": []
+				"overrides": [
+					{
+						"__systemRef": "hideSeriesFrom",
+						"matcher": {
+							"id": "byNames",
+							"options": {
+								"mode": "exclude",
+								"names": [
+									"flush (cn: 127.0.0.1:1222)"
+								],
+								"prefix": "All except:",
+								"readOnly": true
+							}
+						},
+						"properties": [
+							{
+								"id": "custom.hideFrom",
+								"value": {
+									"legend": false,
+									"tooltip": false,
+									"viz": true
+								}
+							}
+						]
+					}
+				]
 			},
 			"gridPos": {
 				"h": 8,
 				"w": 12,
 				"x": 12,
-				"y": 18
+				"y": 10
 			},
 			"id": 182,
 			"options": {
@@ -620,6 +695,18 @@
 					"interval": "",
 					"legendFormat": "write (cn: {{instance}})",
 					"refId": "B"
+				},
+				{
+					"datasource": {
+						"type": "prometheus",
+						"uid": "PEDE6B306CC9C0CD0"
+					},
+					"exemplar": true,
+					"expr": "sum(rate(state_store_write_build_l0_bytes[1m]))by (instance)",
+					"hide": false,
+					"interval": "",
+					"legendFormat": "flush (cn: {{instance}})",
+					"refId": "C"
 				}
 			],
 			"title": "compact throughput",
@@ -681,7 +768,7 @@
 				"h": 8,
 				"w": 12,
 				"x": 0,
-				"y": 26
+				"y": 18
 			},
 			"id": 166,
 			"options": {
@@ -766,7 +853,7 @@
 				"h": 8,
 				"w": 12,
 				"x": 12,
-				"y": 26
+				"y": 18
 			},
 			"id": 180,
 			"options": {
@@ -860,7 +947,7 @@
 				"h": 8,
 				"w": 12,
 				"x": 0,
-				"y": 34
+				"y": 26
 			},
 			"id": 170,
 			"options": {
@@ -945,7 +1032,7 @@
 				"h": 8,
 				"w": 12,
 				"x": 12,
-				"y": 34
+				"y": 26
 			},
 			"id": 168,
 			"options": {
@@ -1030,7 +1117,7 @@
 				"h": 8,
 				"w": 12,
 				"x": 0,
-				"y": 42
+				"y": 34
 			},
 			"id": 174,
 			"options": {
@@ -1115,7 +1202,7 @@
 				"h": 8,
 				"w": 12,
 				"x": 12,
-				"y": 42
+				"y": 34
 			},
 			"id": 172,
 			"options": {
@@ -1200,7 +1287,7 @@
 				"h": 8,
 				"w": 12,
 				"x": 0,
-				"y": 50
+				"y": 42
 			},
 			"id": 178,
 			"options": {
@@ -1285,7 +1372,7 @@
 				"h": 8,
 				"w": 12,
 				"x": 12,
-				"y": 50
+				"y": 42
 			},
 			"id": 176,
 			"options": {
@@ -1320,7 +1407,7 @@
 				"h": 1,
 				"w": 24,
 				"x": 0,
-				"y": 58
+				"y": 50
 			},
 			"id": 184,
 			"panels": [
@@ -1363,8 +1450,7 @@
 								"mode": "absolute",
 								"steps": [
 									{
-										"color": "green",
-										"value": null
+										"color": "green"
 									},
 									{
 										"color": "red",
@@ -1464,8 +1550,7 @@
 								"mode": "absolute",
 								"steps": [
 									{
-										"color": "green",
-										"value": null
+										"color": "green"
 									},
 									{
 										"color": "red",
@@ -1616,8 +1701,7 @@
 								"mode": "absolute",
 								"steps": [
 									{
-										"color": "green",
-										"value": null
+										"color": "green"
 									},
 									{
 										"color": "red",
@@ -1768,326 +1852,327 @@
 			"type": "row"
 		},
 		{
-			"collapsed": false,
+			"collapsed": true,
 			"gridPos": {
 				"h": 1,
 				"w": 24,
 				"x": 0,
-				"y": 59
+				"y": 51
 			},
 			"id": 38,
-			"panels": [],
+			"panels": [
+				{
+					"aliasColors": {},
+					"bars": false,
+					"dashLength": 10,
+					"dashes": false,
+					"fill": 1,
+					"fillGradient": 0,
+					"gridPos": {
+						"h": 8,
+						"w": 12,
+						"x": 0,
+						"y": 4
+					},
+					"hiddenSeries": false,
+					"id": 124,
+					"legend": {
+						"avg": false,
+						"current": false,
+						"max": false,
+						"min": false,
+						"show": true,
+						"total": false,
+						"values": false
+					},
+					"lines": true,
+					"linewidth": 1,
+					"nullPointMode": "null",
+					"options": {
+						"alertThreshold": true
+					},
+					"percentage": false,
+					"pluginVersion": "8.3.3",
+					"pointradius": 2,
+					"points": false,
+					"renderer": "flot",
+					"seriesOverrides": [],
+					"spaceLength": 10,
+					"stack": false,
+					"steppedLine": false,
+					"targets": [
+						{
+							"datasource": {
+								"type": "prometheus",
+								"uid": "risedev-prometheus"
+							},
+							"exemplar": true,
+							"expr": "histogram_quantile(0.5, sum(rate(meta_barrier_duration_seconds_bucket[1m])) by (le))",
+							"interval": "",
+							"legendFormat": "barrier_latency_p50",
+							"refId": "A"
+						},
+						{
+							"datasource": {
+								"type": "prometheus",
+								"uid": "risedev-prometheus"
+							},
+							"exemplar": true,
+							"expr": "histogram_quantile(0.9, sum(rate(meta_barrier_duration_seconds_bucket[1m])) by (le))",
+							"hide": false,
+							"interval": "",
+							"legendFormat": "barrier_latency_p90",
+							"refId": "B"
+						},
+						{
+							"datasource": {
+								"type": "prometheus",
+								"uid": "risedev-prometheus"
+							},
+							"exemplar": true,
+							"expr": "histogram_quantile(0.99, sum(rate(meta_barrier_duration_seconds_bucket[1m])) by (le))",
+							"hide": false,
+							"interval": "",
+							"legendFormat": "barrier_latency_p99",
+							"refId": "C"
+						},
+						{
+							"datasource": {
+								"type": "prometheus",
+								"uid": "risedev-prometheus"
+							},
+							"exemplar": true,
+							"expr": "rate(meta_barrier_duration_seconds_sum[1m]) / rate(meta_barrier_duration_seconds_count[1m])",
+							"hide": false,
+							"interval": "",
+							"legendFormat": "barrier_latency_avg",
+							"refId": "D"
+						},
+						{
+							"datasource": {
+								"type": "prometheus",
+								"uid": "risedev-prometheus"
+							},
+							"exemplar": true,
+							"expr": "histogram_quantile(0.999, sum(rate(meta_barrier_duration_seconds_bucket[1m])) by (le))",
+							"hide": false,
+							"interval": "",
+							"legendFormat": "barrier_latency_p999",
+							"refId": "E"
+						}
+					],
+					"thresholds": [],
+					"timeRegions": [],
+					"title": "barrier latency",
+					"tooltip": {
+						"shared": true,
+						"sort": 0,
+						"value_type": "individual"
+					},
+					"type": "graph",
+					"xaxis": {
+						"mode": "time",
+						"show": true,
+						"values": []
+					},
+					"yaxes": [
+						{
+							"$$hashKey": "object:437",
+							"format": "s",
+							"logBase": 1,
+							"show": true
+						},
+						{
+							"$$hashKey": "object:438",
+							"format": "short",
+							"logBase": 1,
+							"show": true
+						}
+					],
+					"yaxis": {
+						"align": false
+					}
+				},
+				{
+					"aliasColors": {},
+					"bars": false,
+					"dashLength": 10,
+					"dashes": false,
+					"fill": 1,
+					"fillGradient": 0,
+					"gridPos": {
+						"h": 8,
+						"w": 12,
+						"x": 12,
+						"y": 4
+					},
+					"hiddenSeries": false,
+					"id": 14,
+					"legend": {
+						"avg": false,
+						"current": false,
+						"max": false,
+						"min": false,
+						"show": true,
+						"total": false,
+						"values": false
+					},
+					"lines": true,
+					"linewidth": 1,
+					"nullPointMode": "null",
+					"options": {
+						"alertThreshold": true
+					},
+					"percentage": false,
+					"pluginVersion": "8.3.3",
+					"pointradius": 2,
+					"points": false,
+					"renderer": "flot",
+					"seriesOverrides": [],
+					"spaceLength": 10,
+					"stack": false,
+					"steppedLine": false,
+					"targets": [
+						{
+							"datasource": {
+								"type": "prometheus",
+								"uid": "risedev-prometheus"
+							},
+							"exemplar": true,
+							"expr": "rate(stream_actor_row_count[15s])",
+							"interval": "",
+							"legendFormat": "actor_id = {{actor_id}}",
+							"refId": "A"
+						}
+					],
+					"thresholds": [],
+					"timeRegions": [],
+					"title": "actor throughput",
+					"tooltip": {
+						"shared": true,
+						"sort": 0,
+						"value_type": "individual"
+					},
+					"type": "graph",
+					"xaxis": {
+						"mode": "time",
+						"show": true,
+						"values": []
+					},
+					"yaxes": [
+						{
+							"$$hashKey": "object:627",
+							"format": "short",
+							"logBase": 1,
+							"show": true
+						},
+						{
+							"$$hashKey": "object:628",
+							"format": "short",
+							"logBase": 1,
+							"show": true
+						}
+					],
+					"yaxis": {
+						"align": false
+					}
+				},
+				{
+					"aliasColors": {},
+					"bars": false,
+					"dashLength": 10,
+					"dashes": false,
+					"fill": 1,
+					"fillGradient": 0,
+					"gridPos": {
+						"h": 8,
+						"w": 12,
+						"x": 0,
+						"y": 12
+					},
+					"hiddenSeries": false,
+					"id": 16,
+					"legend": {
+						"avg": false,
+						"current": false,
+						"max": false,
+						"min": false,
+						"show": true,
+						"total": false,
+						"values": false
+					},
+					"lines": true,
+					"linewidth": 1,
+					"nullPointMode": "null",
+					"options": {
+						"alertThreshold": true
+					},
+					"percentage": false,
+					"pluginVersion": "8.3.3",
+					"pointradius": 2,
+					"points": false,
+					"renderer": "flot",
+					"seriesOverrides": [],
+					"spaceLength": 10,
+					"stack": false,
+					"steppedLine": false,
+					"targets": [
+						{
+							"datasource": {
+								"type": "prometheus",
+								"uid": "risedev-prometheus"
+							},
+							"exemplar": true,
+							"expr": "rate(stream_source_output_rows_counts[15s])",
+							"hide": false,
+							"interval": "",
+							"legendFormat": "source_id = {{source_id}}",
+							"refId": "B"
+						}
+					],
+					"thresholds": [],
+					"timeRegions": [],
+					"title": "source throughput",
+					"tooltip": {
+						"shared": true,
+						"sort": 0,
+						"value_type": "individual"
+					},
+					"type": "graph",
+					"xaxis": {
+						"mode": "time",
+						"show": true,
+						"values": []
+					},
+					"yaxes": [
+						{
+							"$$hashKey": "object:439",
+							"format": "rows/s",
+							"logBase": 1,
+							"show": true
+						},
+						{
+							"$$hashKey": "object:440",
+							"format": "short",
+							"logBase": 1,
+							"show": true
+						}
+					],
+					"yaxis": {
+						"align": false
+					}
+				}
+			],
 			"title": "Streaming",
 			"type": "row"
 		},
 		{
-			"aliasColors": {},
-			"bars": false,
-			"dashLength": 10,
-			"dashes": false,
-			"fill": 1,
-			"fillGradient": 0,
-			"gridPos": {
-				"h": 8,
-				"w": 12,
-				"x": 0,
-				"y": 60
-			},
-			"hiddenSeries": false,
-			"id": 124,
-			"legend": {
-				"avg": false,
-				"current": false,
-				"max": false,
-				"min": false,
-				"show": true,
-				"total": false,
-				"values": false
-			},
-			"lines": true,
-			"linewidth": 1,
-			"nullPointMode": "null",
-			"options": {
-				"alertThreshold": true
-			},
-			"percentage": false,
-			"pluginVersion": "8.3.3",
-			"pointradius": 2,
-			"points": false,
-			"renderer": "flot",
-			"seriesOverrides": [],
-			"spaceLength": 10,
-			"stack": false,
-			"steppedLine": false,
-			"targets": [
-				{
-					"datasource": {
-						"type": "prometheus",
-						"uid": "risedev-prometheus"
-					},
-					"exemplar": true,
-					"expr": "histogram_quantile(0.5, sum(rate(meta_barrier_duration_seconds_bucket[1m])) by (le))",
-					"interval": "",
-					"legendFormat": "barrier_latency_p50",
-					"refId": "A"
-				},
-				{
-					"datasource": {
-						"type": "prometheus",
-						"uid": "risedev-prometheus"
-					},
-					"exemplar": true,
-					"expr": "histogram_quantile(0.9, sum(rate(meta_barrier_duration_seconds_bucket[1m])) by (le))",
-					"hide": false,
-					"interval": "",
-					"legendFormat": "barrier_latency_p90",
-					"refId": "B"
-				},
-				{
-					"datasource": {
-						"type": "prometheus",
-						"uid": "risedev-prometheus"
-					},
-					"exemplar": true,
-					"expr": "histogram_quantile(0.99, sum(rate(meta_barrier_duration_seconds_bucket[1m])) by (le))",
-					"hide": false,
-					"interval": "",
-					"legendFormat": "barrier_latency_p99",
-					"refId": "C"
-				},
-				{
-					"datasource": {
-						"type": "prometheus",
-						"uid": "risedev-prometheus"
-					},
-					"exemplar": true,
-					"expr": "rate(meta_barrier_duration_seconds_sum[1m]) / rate(meta_barrier_duration_seconds_count[1m])",
-					"hide": false,
-					"interval": "",
-					"legendFormat": "barrier_latency_avg",
-					"refId": "D"
-				},
-				{
-					"datasource": {
-						"type": "prometheus",
-						"uid": "risedev-prometheus"
-					},
-					"exemplar": true,
-					"expr": "histogram_quantile(0.999, sum(rate(meta_barrier_duration_seconds_bucket[1m])) by (le))",
-					"hide": false,
-					"interval": "",
-					"legendFormat": "barrier_latency_p999",
-					"refId": "E"
-				}
-			],
-			"thresholds": [],
-			"timeRegions": [],
-			"title": "barrier latency",
-			"tooltip": {
-				"shared": true,
-				"sort": 0,
-				"value_type": "individual"
-			},
-			"type": "graph",
-			"xaxis": {
-				"mode": "time",
-				"show": true,
-				"values": []
-			},
-			"yaxes": [
-				{
-					"$$hashKey": "object:437",
-					"format": "s",
-					"logBase": 1,
-					"show": true
-				},
-				{
-					"$$hashKey": "object:438",
-					"format": "short",
-					"logBase": 1,
-					"show": true
-				}
-			],
-			"yaxis": {
-				"align": false
-			}
-		},
-		{
-			"aliasColors": {},
-			"bars": false,
-			"dashLength": 10,
-			"dashes": false,
-			"fill": 1,
-			"fillGradient": 0,
-			"gridPos": {
-				"h": 8,
-				"w": 12,
-				"x": 12,
-				"y": 60
-			},
-			"hiddenSeries": false,
-			"id": 14,
-			"legend": {
-				"avg": false,
-				"current": false,
-				"max": false,
-				"min": false,
-				"show": true,
-				"total": false,
-				"values": false
-			},
-			"lines": true,
-			"linewidth": 1,
-			"nullPointMode": "null",
-			"options": {
-				"alertThreshold": true
-			},
-			"percentage": false,
-			"pluginVersion": "8.3.3",
-			"pointradius": 2,
-			"points": false,
-			"renderer": "flot",
-			"seriesOverrides": [],
-			"spaceLength": 10,
-			"stack": false,
-			"steppedLine": false,
-			"targets": [
-				{
-					"datasource": {
-						"type": "prometheus",
-						"uid": "risedev-prometheus"
-					},
-					"exemplar": true,
-					"expr": "rate(stream_actor_row_count[15s])",
-					"interval": "",
-					"legendFormat": "actor_id = {{actor_id}}",
-					"refId": "A"
-				}
-			],
-			"thresholds": [],
-			"timeRegions": [],
-			"title": "actor throughput",
-			"tooltip": {
-				"shared": true,
-				"sort": 0,
-				"value_type": "individual"
-			},
-			"type": "graph",
-			"xaxis": {
-				"mode": "time",
-				"show": true,
-				"values": []
-			},
-			"yaxes": [
-				{
-					"$$hashKey": "object:627",
-					"format": "short",
-					"logBase": 1,
-					"show": true
-				},
-				{
-					"$$hashKey": "object:628",
-					"format": "short",
-					"logBase": 1,
-					"show": true
-				}
-			],
-			"yaxis": {
-				"align": false
-			}
-		},
-		{
-			"aliasColors": {},
-			"bars": false,
-			"dashLength": 10,
-			"dashes": false,
-			"fill": 1,
-			"fillGradient": 0,
-			"gridPos": {
-				"h": 8,
-				"w": 12,
-				"x": 0,
-				"y": 68
-			},
-			"hiddenSeries": false,
-			"id": 16,
-			"legend": {
-				"avg": false,
-				"current": false,
-				"max": false,
-				"min": false,
-				"show": true,
-				"total": false,
-				"values": false
-			},
-			"lines": true,
-			"linewidth": 1,
-			"nullPointMode": "null",
-			"options": {
-				"alertThreshold": true
-			},
-			"percentage": false,
-			"pluginVersion": "8.3.3",
-			"pointradius": 2,
-			"points": false,
-			"renderer": "flot",
-			"seriesOverrides": [],
-			"spaceLength": 10,
-			"stack": false,
-			"steppedLine": false,
-			"targets": [
-				{
-					"datasource": {
-						"type": "prometheus",
-						"uid": "risedev-prometheus"
-					},
-					"exemplar": true,
-					"expr": "rate(stream_source_output_rows_counts[15s])",
-					"hide": false,
-					"interval": "",
-					"legendFormat": "source_id = {{source_id}}",
-					"refId": "B"
-				}
-			],
-			"thresholds": [],
-			"timeRegions": [],
-			"title": "source throughput",
-			"tooltip": {
-				"shared": true,
-				"sort": 0,
-				"value_type": "individual"
-			},
-			"type": "graph",
-			"xaxis": {
-				"mode": "time",
-				"show": true,
-				"values": []
-			},
-			"yaxes": [
-				{
-					"$$hashKey": "object:439",
-					"format": "rows/s",
-					"logBase": 1,
-					"show": true
-				},
-				{
-					"$$hashKey": "object:440",
-					"format": "short",
-					"logBase": 1,
-					"show": true
-				}
-			],
-			"yaxis": {
-				"align": false
-			}
-		},
-		{
 			"collapsed": false,
 			"gridPos": {
 				"h": 1,
 				"w": 24,
 				"x": 0,
-				"y": 76
+				"y": 52
 			},
 			"id": 26,
 			"panels": [],
@@ -2175,7 +2260,7 @@
 				"h": 8,
 				"w": 12,
 				"x": 0,
-				"y": 77
+				"y": 53
 			},
 			"id": 30,
 			"options": {
@@ -2323,7 +2408,7 @@
 				"h": 8,
 				"w": 12,
 				"x": 12,
-				"y": 77
+				"y": 53
 			},
 			"id": 128,
 			"options": {
@@ -2410,7 +2495,7 @@
 				"h": 8,
 				"w": 12,
 				"x": 0,
-				"y": 85
+				"y": 61
 			},
 			"id": 28,
 			"options": {
@@ -2562,6 +2647,204 @@
 			"type": "timeseries"
 		},
 		{
+			"aliasColors": {},
+			"bars": false,
+			"dashLength": 10,
+			"dashes": false,
+			"fill": 1,
+			"fillGradient": 0,
+			"gridPos": {
+				"h": 8,
+				"w": 12,
+				"x": 12,
+				"y": 61
+			},
+			"hiddenSeries": false,
+			"id": 196,
+			"legend": {
+				"avg": false,
+				"current": false,
+				"max": false,
+				"min": false,
+				"show": true,
+				"total": false,
+				"values": false
+			},
+			"lines": true,
+			"linewidth": 1,
+			"nullPointMode": "null",
+			"options": {
+				"alertThreshold": true
+			},
+			"percentage": false,
+			"pluginVersion": "8.3.3",
+			"pointradius": 2,
+			"points": false,
+			"renderer": "flot",
+			"seriesOverrides": [],
+			"spaceLength": 10,
+			"stack": false,
+			"steppedLine": false,
+			"targets": [
+				{
+					"datasource": {
+						"type": "prometheus",
+						"uid": "risedev-prometheus"
+					},
+					"exemplar": true,
+					"expr": "avg(state_store_meta_cache_size) by (instance)",
+					"format": "time_series",
+					"hide": false,
+					"interval": "",
+					"intervalFactor": 2,
+					"legendFormat": "meta-cache (cn: {{instance}})",
+					"refId": "A"
+				},
+				{
+					"datasource": {
+						"type": "prometheus",
+						"uid": "risedev-prometheus"
+					},
+					"exemplar": true,
+					"expr": "avg(state_store_block_cache_size) by (instance)",
+					"hide": false,
+					"interval": "",
+					"legendFormat": "meta-cache (cn: {{instance}})",
+					"refId": "B"
+				}
+			],
+			"thresholds": [],
+			"timeRegions": [],
+			"title": "Cache Size",
+			"tooltip": {
+				"shared": true,
+				"sort": 0,
+				"value_type": "individual"
+			},
+			"type": "graph",
+			"xaxis": {
+				"mode": "time",
+				"show": true,
+				"values": []
+			},
+			"yaxes": [
+				{
+					"$$hashKey": "object:37",
+					"format": "decbytes",
+					"logBase": 1,
+					"show": true
+				},
+				{
+					"$$hashKey": "object:38",
+					"format": "short",
+					"logBase": 1,
+					"show": true
+				}
+			],
+			"yaxis": {
+				"align": false
+			}
+		},
+		{
+			"fieldConfig": {
+				"defaults": {
+					"color": {
+						"mode": "palette-classic"
+					},
+					"custom": {
+						"axisLabel": "",
+						"axisPlacement": "auto",
+						"barAlignment": 0,
+						"drawStyle": "line",
+						"fillOpacity": 10,
+						"gradientMode": "none",
+						"hideFrom": {
+							"legend": false,
+							"tooltip": false,
+							"viz": false
+						},
+						"lineInterpolation": "linear",
+						"lineWidth": 1,
+						"pointSize": 5,
+						"scaleDistribution": {
+							"type": "linear"
+						},
+						"showPoints": "never",
+						"spanNulls": true,
+						"stacking": {
+							"group": "A",
+							"mode": "none"
+						},
+						"thresholdsStyle": {
+							"mode": "off"
+						}
+					},
+					"mappings": [],
+					"thresholds": {
+						"mode": "absolute",
+						"steps": [
+							{
+								"color": "green",
+								"value": null
+							},
+							{
+								"color": "red",
+								"value": 80
+							}
+						]
+					},
+					"unit": "ops"
+				},
+				"overrides": []
+			},
+			"gridPos": {
+				"h": 8,
+				"w": 12,
+				"x": 0,
+				"y": 69
+			},
+			"id": 43,
+			"options": {
+				"legend": {
+					"calcs": [],
+					"displayMode": "list",
+					"placement": "bottom"
+				},
+				"tooltip": {
+					"mode": "single"
+				}
+			},
+			"pluginVersion": "8.3.3",
+			"targets": [
+				{
+					"datasource": {
+						"type": "prometheus",
+						"uid": "risedev-prometheus"
+					},
+					"exemplar": true,
+					"expr": "sum(rate(state_store_write_batch_duration_count[1m])) by (instance)",
+					"interval": "",
+					"intervalFactor": 2,
+					"legendFormat": "write batch cn= {{instance}} ",
+					"refId": "A"
+				},
+				{
+					"datasource": {
+						"type": "prometheus",
+						"uid": "risedev-prometheus"
+					},
+					"exemplar": true,
+					"expr": "sum(rate(state_store_shared_buffer_to_l0_duration_count[1m])) by (instance)",
+					"hide": false,
+					"interval": "",
+					"legendFormat": "l0 cn = {{instance}} ",
+					"refId": "B"
+				}
+			],
+			"title": "write ops",
+			"type": "timeseries"
+		},
+		{
 			"fieldConfig": {
 				"defaults": {
 					"color": {
@@ -2617,7 +2900,7 @@
 				"h": 8,
 				"w": 12,
 				"x": 12,
-				"y": 85
+				"y": 69
 			},
 			"id": 130,
 			"options": {
@@ -2744,239 +3027,6 @@
 							}
 						]
 					},
-					"unit": "ops"
-				},
-				"overrides": []
-			},
-			"gridPos": {
-				"h": 8,
-				"w": 12,
-				"x": 0,
-				"y": 93
-			},
-			"id": 43,
-			"options": {
-				"legend": {
-					"calcs": [],
-					"displayMode": "list",
-					"placement": "bottom"
-				},
-				"tooltip": {
-					"mode": "single"
-				}
-			},
-			"pluginVersion": "8.3.3",
-			"targets": [
-				{
-					"datasource": {
-						"type": "prometheus",
-						"uid": "risedev-prometheus"
-					},
-					"exemplar": true,
-					"expr": "sum(rate(state_store_write_batch_duration_count[1m])) by (instance)",
-					"interval": "",
-					"intervalFactor": 2,
-					"legendFormat": "write batch cn= {{instance}} ",
-					"refId": "A"
-				},
-				{
-					"datasource": {
-						"type": "prometheus",
-						"uid": "risedev-prometheus"
-					},
-					"exemplar": true,
-					"expr": "sum(rate(state_store_shared_buffer_to_l0_duration_count[1m])) by (instance)",
-					"hide": false,
-					"interval": "",
-					"legendFormat": "l0 cn = {{instance}} ",
-					"refId": "B"
-				}
-			],
-			"title": "write ops",
-			"type": "timeseries"
-		},
-		{
-			"fieldConfig": {
-				"defaults": {
-					"color": {
-						"mode": "palette-classic"
-					},
-					"custom": {
-						"axisLabel": "",
-						"axisPlacement": "auto",
-						"barAlignment": 0,
-						"drawStyle": "line",
-						"fillOpacity": 10,
-						"gradientMode": "none",
-						"hideFrom": {
-							"legend": false,
-							"tooltip": false,
-							"viz": false
-						},
-						"lineInterpolation": "linear",
-						"lineWidth": 1,
-						"pointSize": 5,
-						"scaleDistribution": {
-							"type": "linear"
-						},
-						"showPoints": "never",
-						"spanNulls": true,
-						"stacking": {
-							"group": "A",
-							"mode": "none"
-						},
-						"thresholdsStyle": {
-							"mode": "off"
-						}
-					},
-					"mappings": [],
-					"thresholds": {
-						"mode": "absolute",
-						"steps": [
-							{
-								"color": "green",
-								"value": null
-							},
-							{
-								"color": "red",
-								"value": 80
-							}
-						]
-					},
-					"unit": "Bps"
-				},
-				"overrides": []
-			},
-			"gridPos": {
-				"h": 8,
-				"w": 12,
-				"x": 12,
-				"y": 93
-			},
-			"id": 32,
-			"options": {
-				"legend": {
-					"calcs": [],
-					"displayMode": "list",
-					"placement": "bottom"
-				},
-				"tooltip": {
-					"mode": "single"
-				}
-			},
-			"pluginVersion": "8.3.3",
-			"targets": [
-				{
-					"datasource": {
-						"type": "prometheus",
-						"uid": "risedev-prometheus"
-					},
-					"exemplar": true,
-					"expr": "sum by(instance)(rate(state_store_get_key_size_sum[1m])+rate(state_store_get_value_size_sum[1m]))/sum by(instance)(rate(state_store_get_key_size_count[1m]))",
-					"interval": "",
-					"legendFormat": "get (cn:{{instance}})",
-					"refId": "A"
-				},
-				{
-					"datasource": {
-						"type": "prometheus",
-						"uid": "risedev-prometheus"
-					},
-					"exemplar": true,
-					"expr": "sum by(instance)(rate(state_store_get_key_size_sum[1m]))/sum by(instance)(rate(state_store_get_key_size_count[1m]))",
-					"hide": false,
-					"interval": "",
-					"legendFormat": "get key (cn:{{instance}})",
-					"refId": "B"
-				},
-				{
-					"datasource": {
-						"type": "prometheus",
-						"uid": "risedev-prometheus"
-					},
-					"exemplar": true,
-					"expr": "sum by(instance)(rate(state_store_get_value_size_sum[1m]))/sum by(instance)(rate(state_store_get_value_size_count[1m]))",
-					"hide": false,
-					"interval": "",
-					"legendFormat": "get value (cn:{{instance}})",
-					"refId": "C"
-				},
-				{
-					"datasource": {
-						"type": "prometheus",
-						"uid": "risedev-prometheus"
-					},
-					"exemplar": true,
-					"expr": "sum by(instance)(rate(state_store_range_scan_size_sum[1m]))/sum by(instance)(rate(state_store_range_scan_size_count[1m]))",
-					"hide": false,
-					"interval": "",
-					"legendFormat": "range_scan (cn:{{instance}})",
-					"refId": "D"
-				},
-				{
-					"datasource": {
-						"type": "prometheus",
-						"uid": "risedev-prometheus"
-					},
-					"exemplar": true,
-					"expr": "sum by(instance)(rate(state_store_range_reverse_scan_size_sum[1m]))/sum by(instance)(rate(state_store_range_reverse_scan_size_count[1m]))",
-					"hide": false,
-					"interval": "",
-					"legendFormat": "reverse_range_scan (cn:{{instance}})",
-					"refId": "E"
-				}
-			],
-			"title": "read throughput",
-			"type": "timeseries"
-		},
-		{
-			"fieldConfig": {
-				"defaults": {
-					"color": {
-						"mode": "palette-classic"
-					},
-					"custom": {
-						"axisLabel": "",
-						"axisPlacement": "auto",
-						"barAlignment": 0,
-						"drawStyle": "line",
-						"fillOpacity": 10,
-						"gradientMode": "none",
-						"hideFrom": {
-							"legend": false,
-							"tooltip": false,
-							"viz": false
-						},
-						"lineInterpolation": "linear",
-						"lineWidth": 1,
-						"pointSize": 5,
-						"scaleDistribution": {
-							"type": "linear"
-						},
-						"showPoints": "never",
-						"spanNulls": true,
-						"stacking": {
-							"group": "A",
-							"mode": "none"
-						},
-						"thresholdsStyle": {
-							"mode": "off"
-						}
-					},
-					"mappings": [],
-					"thresholds": {
-						"mode": "absolute",
-						"steps": [
-							{
-								"color": "green",
-								"value": null
-							},
-							{
-								"color": "red",
-								"value": 80
-							}
-						]
-					},
 					"unit": "s"
 				},
 				"overrides": []
@@ -2985,7 +3035,7 @@
 				"h": 8,
 				"w": 12,
 				"x": 0,
-				"y": 101
+				"y": 77
 			},
 			"id": 40,
 			"options": {
@@ -3147,7 +3197,7 @@
 							}
 						]
 					},
-					"unit": "ops"
+					"unit": "Bps"
 				},
 				"overrides": []
 			},
@@ -3155,9 +3205,9 @@
 				"h": 8,
 				"w": 12,
 				"x": 12,
-				"y": 101
+				"y": 77
 			},
-			"id": 132,
+			"id": 32,
 			"options": {
 				"legend": {
 					"calcs": [],
@@ -3176,11 +3226,10 @@
 						"uid": "risedev-prometheus"
 					},
 					"exemplar": true,
-					"expr": "sum(rate(state_store_iter_merge_seek_duration_count[1m])) by (instance)",
-					"hide": false,
+					"expr": "sum by(instance)(rate(state_store_get_key_size_sum[1m])+rate(state_store_get_value_size_sum[1m]))/sum by(instance)(rate(state_store_get_key_size_count[1m]))",
 					"interval": "",
-					"legendFormat": "MI seek (cn:{{instance}})",
-					"refId": "G"
+					"legendFormat": "get (cn:{{instance}})",
+					"refId": "A"
 				},
 				{
 					"datasource": {
@@ -3188,14 +3237,50 @@
 						"uid": "risedev-prometheus"
 					},
 					"exemplar": true,
-					"expr": "sum(rate(state_store_iter_merge_next_duration_count[1m])) by (instance)",
+					"expr": "sum by(instance)(rate(state_store_get_key_size_sum[1m]))/sum by(instance)(rate(state_store_get_key_size_count[1m]))",
 					"hide": false,
 					"interval": "",
-					"legendFormat": "MI next (cn:{{instance}})",
-					"refId": "H"
+					"legendFormat": "get key (cn:{{instance}})",
+					"refId": "B"
+				},
+				{
+					"datasource": {
+						"type": "prometheus",
+						"uid": "risedev-prometheus"
+					},
+					"exemplar": true,
+					"expr": "sum by(instance)(rate(state_store_get_value_size_sum[1m]))/sum by(instance)(rate(state_store_get_value_size_count[1m]))",
+					"hide": false,
+					"interval": "",
+					"legendFormat": "get value (cn:{{instance}})",
+					"refId": "C"
+				},
+				{
+					"datasource": {
+						"type": "prometheus",
+						"uid": "risedev-prometheus"
+					},
+					"exemplar": true,
+					"expr": "sum by(instance)(rate(state_store_range_scan_size_sum[1m]))/sum by(instance)(rate(state_store_range_scan_size_count[1m]))",
+					"hide": false,
+					"interval": "",
+					"legendFormat": "range_scan (cn:{{instance}})",
+					"refId": "D"
+				},
+				{
+					"datasource": {
+						"type": "prometheus",
+						"uid": "risedev-prometheus"
+					},
+					"exemplar": true,
+					"expr": "sum by(instance)(rate(state_store_range_reverse_scan_size_sum[1m]))/sum by(instance)(rate(state_store_range_reverse_scan_size_count[1m]))",
+					"hide": false,
+					"interval": "",
+					"legendFormat": "reverse_range_scan (cn:{{instance}})",
+					"refId": "E"
 				}
 			],
-			"title": "merge iterators ops",
+			"title": "read throughput",
 			"type": "timeseries"
 		},
 		{
@@ -3254,7 +3339,7 @@
 				"h": 8,
 				"w": 12,
 				"x": 0,
-				"y": 109
+				"y": 85
 			},
 			"id": 41,
 			"options": {
@@ -3369,7 +3454,7 @@
 							}
 						]
 					},
-					"unit": "s"
+					"unit": "ops"
 				},
 				"overrides": []
 			},
@@ -3377,9 +3462,9 @@
 				"h": 8,
 				"w": 12,
 				"x": 12,
-				"y": 109
+				"y": 85
 			},
-			"id": 48,
+			"id": 132,
 			"options": {
 				"legend": {
 					"calcs": [],
@@ -3398,34 +3483,10 @@
 						"uid": "risedev-prometheus"
 					},
 					"exemplar": true,
-					"expr": "histogram_quantile(0.5, sum(rate(state_store_iter_merge_seek_duration_bucket[1m])) by (le, instance))",
-					"hide": true,
+					"expr": "sum(rate(state_store_iter_merge_seek_duration_count[1m])) by (instance)",
+					"hide": false,
 					"interval": "",
-					"legendFormat": "mi_seek p50 (cn:{{instance}})",
-					"refId": "E"
-				},
-				{
-					"datasource": {
-						"type": "prometheus",
-						"uid": "risedev-prometheus"
-					},
-					"exemplar": true,
-					"expr": "histogram_quantile(0.9, sum(rate(state_store_iter_merge_seek_duration_bucket[1m])) by (le, instance))",
-					"hide": true,
-					"interval": "",
-					"legendFormat": "mi_seek p90 (cn:{{instance}})",
-					"refId": "F"
-				},
-				{
-					"datasource": {
-						"type": "prometheus",
-						"uid": "risedev-prometheus"
-					},
-					"exemplar": true,
-					"expr": "histogram_quantile(0.99, sum(rate(state_store_iter_merge_seek_duration_bucket[1m])) by (le, instance))",
-					"hide": true,
-					"interval": "",
-					"legendFormat": "mi_seek p99 (cn:{{instance}})",
+					"legendFormat": "MI seek (cn:{{instance}})",
 					"refId": "G"
 				},
 				{
@@ -3434,14 +3495,14 @@
 						"uid": "risedev-prometheus"
 					},
 					"exemplar": true,
-					"expr": "sum by(le, instance) (rate(state_store_iter_merge_seek_duration_sum[1m])) / sum by(le, instance) (rate(state_store_iter_merge_seek_duration_count[1m]))",
+					"expr": "sum(rate(state_store_iter_merge_next_duration_count[1m])) by (instance)",
 					"hide": false,
 					"interval": "",
-					"legendFormat": "mi_seek avg (cn:{{instance}})",
+					"legendFormat": "MI next (cn:{{instance}})",
 					"refId": "H"
 				}
 			],
-			"title": "merge iterators duration",
+			"title": "merge iterators ops",
 			"type": "timeseries"
 		},
 		{
@@ -3500,7 +3561,7 @@
 				"h": 8,
 				"w": 12,
 				"x": 0,
-				"y": 117
+				"y": 93
 			},
 			"id": 134,
 			"options": {
@@ -3615,6 +3676,129 @@
 							}
 						]
 					},
+					"unit": "s"
+				},
+				"overrides": []
+			},
+			"gridPos": {
+				"h": 8,
+				"w": 12,
+				"x": 12,
+				"y": 93
+			},
+			"id": 48,
+			"options": {
+				"legend": {
+					"calcs": [],
+					"displayMode": "list",
+					"placement": "bottom"
+				},
+				"tooltip": {
+					"mode": "single"
+				}
+			},
+			"pluginVersion": "8.3.3",
+			"targets": [
+				{
+					"datasource": {
+						"type": "prometheus",
+						"uid": "risedev-prometheus"
+					},
+					"exemplar": true,
+					"expr": "histogram_quantile(0.5, sum(rate(state_store_iter_merge_seek_duration_bucket[1m])) by (le, instance))",
+					"hide": true,
+					"interval": "",
+					"legendFormat": "mi_seek p50 (cn:{{instance}})",
+					"refId": "E"
+				},
+				{
+					"datasource": {
+						"type": "prometheus",
+						"uid": "risedev-prometheus"
+					},
+					"exemplar": true,
+					"expr": "histogram_quantile(0.9, sum(rate(state_store_iter_merge_seek_duration_bucket[1m])) by (le, instance))",
+					"hide": true,
+					"interval": "",
+					"legendFormat": "mi_seek p90 (cn:{{instance}})",
+					"refId": "F"
+				},
+				{
+					"datasource": {
+						"type": "prometheus",
+						"uid": "risedev-prometheus"
+					},
+					"exemplar": true,
+					"expr": "histogram_quantile(0.99, sum(rate(state_store_iter_merge_seek_duration_bucket[1m])) by (le, instance))",
+					"hide": true,
+					"interval": "",
+					"legendFormat": "mi_seek p99 (cn:{{instance}})",
+					"refId": "G"
+				},
+				{
+					"datasource": {
+						"type": "prometheus",
+						"uid": "risedev-prometheus"
+					},
+					"exemplar": true,
+					"expr": "sum by(le, instance) (rate(state_store_iter_merge_seek_duration_sum[1m])) / sum by(le, instance) (rate(state_store_iter_merge_seek_duration_count[1m]))",
+					"hide": false,
+					"interval": "",
+					"legendFormat": "mi_seek avg (cn:{{instance}})",
+					"refId": "H"
+				}
+			],
+			"title": "merge iterators duration",
+			"type": "timeseries"
+		},
+		{
+			"fieldConfig": {
+				"defaults": {
+					"color": {
+						"mode": "palette-classic"
+					},
+					"custom": {
+						"axisLabel": "",
+						"axisPlacement": "auto",
+						"barAlignment": 0,
+						"drawStyle": "line",
+						"fillOpacity": 10,
+						"gradientMode": "none",
+						"hideFrom": {
+							"legend": false,
+							"tooltip": false,
+							"viz": false
+						},
+						"lineInterpolation": "linear",
+						"lineWidth": 1,
+						"pointSize": 5,
+						"scaleDistribution": {
+							"type": "linear"
+						},
+						"showPoints": "never",
+						"spanNulls": true,
+						"stacking": {
+							"group": "A",
+							"mode": "none"
+						},
+						"thresholdsStyle": {
+							"mode": "off"
+						}
+					},
+					"mappings": [],
+					"thresholds": {
+						"mode": "absolute",
+						"steps": [
+							{
+								"color": "green",
+								"value": null
+							},
+							{
+								"color": "red",
+								"value": 80
+							}
+						]
+					},
 					"unit": "cps"
 				},
 				"overrides": []
@@ -3623,7 +3807,7 @@
 				"h": 8,
 				"w": 12,
 				"x": 12,
-				"y": 117
+				"y": 101
 			},
 			"id": 44,
 			"options": {
@@ -3710,7 +3894,7 @@
 				"h": 8,
 				"w": 12,
 				"x": 12,
-				"y": 125
+				"y": 109
 			},
 			"id": 45,
 			"options": {
@@ -3758,7 +3942,7 @@
 				"h": 1,
 				"w": 24,
 				"x": 0,
-				"y": 133
+				"y": 117
 			},
 			"id": 115,
 			"panels": [
@@ -4348,7 +4532,7 @@
 				"h": 1,
 				"w": 24,
 				"x": 0,
-				"y": 134
+				"y": 118
 			},
 			"id": 113,
 			"panels": [
@@ -4650,7 +4834,7 @@
 				"h": 1,
 				"w": 24,
 				"x": 0,
-				"y": 135
+				"y": 119
 			},
 			"id": 97,
 			"panels": [
@@ -5240,7 +5424,7 @@
 				"h": 1,
 				"w": 24,
 				"x": 0,
-				"y": 136
+				"y": 120
 			},
 			"id": 88,
 			"panels": [
@@ -5614,7 +5798,7 @@
 				"h": 1,
 				"w": 24,
 				"x": 0,
-				"y": 137
+				"y": 121
 			},
 			"id": 84,
 			"panels": [
@@ -5868,7 +6052,7 @@
 				"h": 1,
 				"w": 24,
 				"x": 0,
-				"y": 138
+				"y": 122
 			},
 			"id": 82,
 			"panels": [
@@ -6242,7 +6426,7 @@
 				"h": 1,
 				"w": 24,
 				"x": 0,
-				"y": 139
+				"y": 123
 			},
 			"id": 78,
 			"panels": [
@@ -6881,7 +7065,7 @@
 				"h": 1,
 				"w": 24,
 				"x": 0,
-				"y": 140
+				"y": 124
 			},
 			"id": 62,
 			"panels": [
@@ -7954,6 +8138,6 @@
 	"timezone": "",
 	"title": "risingwave_dashboard",
 	"uid": "Ecy3uV1nz",
-	"version": 28,
+	"version": 30,
 	"weekStart": ""
 }

--- a/grafana/risingwave-dashboard.json
+++ b/grafana/risingwave-dashboard.json
@@ -22,7 +22,7 @@
 	"fiscalYearStartMonth": 0,
 	"graphTooltip": 0,
 	"id": 2,
-	"iteration": 1653316559775,
+	"iteration": 1653372034993,
 	"links": [],
 	"liveNow": true,
 	"panels": [
@@ -552,7 +552,7 @@
 				{
 					"datasource": {
 						"type": "prometheus",
-						"uid": "PEDE6B306CC9C0CD0"
+						"uid": "risedev-prometheus"
 					},
 					"exemplar": true,
 					"expr": "histogram_quantile(0.9, sum(rate(state_store_get_table_id_total_time_duration_bucket[1m])) by (le, instance))",
@@ -564,7 +564,7 @@
 				{
 					"datasource": {
 						"type": "prometheus",
-						"uid": "PEDE6B306CC9C0CD0"
+						"uid": "risedev-prometheus"
 					},
 					"exemplar": true,
 					"expr": "histogram_quantile(0.9, sum(rate(state_store_remote_read_time_per_task_bucket[1m])) by (le, instance))",
@@ -699,7 +699,7 @@
 				{
 					"datasource": {
 						"type": "prometheus",
-						"uid": "PEDE6B306CC9C0CD0"
+						"uid": "risedev-prometheus"
 					},
 					"exemplar": true,
 					"expr": "sum(rate(state_store_write_build_l0_bytes[1m]))by (instance)",
@@ -939,7 +939,8 @@
 								"value": 80
 							}
 						]
-					}
+					},
+					"unit": "deckbytes"
 				},
 				"overrides": []
 			},
@@ -967,10 +968,22 @@
 						"uid": "risedev-prometheus"
 					},
 					"exemplar": true,
-					"expr": "storage_level_compact_read_next",
+					"expr": "histogram_quantile(0.5, sum(rate(storage_level_compact_read_next_bucket[1m])) by (le, level_index))",
 					"interval": "",
-					"legendFormat": "",
+					"legendFormat": "{{level_index}} read bytes p50",
 					"refId": "A"
+				},
+				{
+					"datasource": {
+						"type": "prometheus",
+						"uid": "risedev-prometheus"
+					},
+					"exemplar": true,
+					"expr": "histogram_quantile(0.99, sum(rate(storage_level_compact_read_next_bucket[1m])) by (le, level_index))",
+					"hide": false,
+					"interval": "",
+					"legendFormat": "{{level_index}} read bytes p99",
+					"refId": "B"
 				}
 			],
 			"title": "GBs read from next level",
@@ -1024,7 +1037,8 @@
 								"value": 80
 							}
 						]
-					}
+					},
+					"unit": "deckbytes"
 				},
 				"overrides": []
 			},
@@ -1052,10 +1066,22 @@
 						"uid": "risedev-prometheus"
 					},
 					"exemplar": true,
-					"expr": "storage_level_compact_read_curr",
+					"expr": "histogram_quantile(0.5, sum(rate(storage_level_compact_read_curr_bucket[1m])) by (le, level_index))",
 					"interval": "",
-					"legendFormat": "",
+					"legendFormat": "{{level_index}} read bytes p50",
 					"refId": "A"
+				},
+				{
+					"datasource": {
+						"type": "prometheus",
+						"uid": "risedev-prometheus"
+					},
+					"exemplar": true,
+					"expr": "histogram_quantile(0.99, sum(rate(storage_level_compact_read_curr_bucket[1m])) by (le, level_index))",
+					"hide": false,
+					"interval": "",
+					"legendFormat": "{{level_index}} read bytes p99",
+					"refId": "B"
 				}
 			],
 			"title": "GBs read from current level",
@@ -1137,10 +1163,22 @@
 						"uid": "risedev-prometheus"
 					},
 					"exemplar": true,
-					"expr": "storage_level_compact_read_sstn_curr",
+					"expr": "histogram_quantile(0.5, sum(rate(storage_level_compact_read_sstn_curr_bucket[1m])) by (le, level_index))",
 					"interval": "",
-					"legendFormat": "",
+					"legendFormat": "{{level_index}} p50",
 					"refId": "A"
+				},
+				{
+					"datasource": {
+						"type": "prometheus",
+						"uid": "risedev-prometheus"
+					},
+					"exemplar": true,
+					"expr": "histogram_quantile(0.99, sum(rate(storage_level_compact_read_sstn_curr_bucket[1m])) by (le, level_index))",
+					"hide": false,
+					"interval": "",
+					"legendFormat": "{{level_index}} p99",
+					"refId": "B"
 				}
 			],
 			"title": "count of sst read from current level",
@@ -1194,7 +1232,8 @@
 								"value": 80
 							}
 						]
-					}
+					},
+					"unit": "deckbytes"
 				},
 				"overrides": []
 			},
@@ -1222,10 +1261,22 @@
 						"uid": "risedev-prometheus"
 					},
 					"exemplar": true,
-					"expr": "storage_level_compact_write",
+					"expr": "histogram_quantile(0.5, sum(rate(storage_level_compact_write_bucket[1m])) by (le, level_index))",
 					"interval": "",
-					"legendFormat": "",
+					"legendFormat": "{{level_index}} write bytes p50",
 					"refId": "A"
+				},
+				{
+					"datasource": {
+						"type": "prometheus",
+						"uid": "risedev-prometheus"
+					},
+					"exemplar": true,
+					"expr": "histogram_quantile(0.99, sum(rate(storage_level_compact_write_bucket[1m])) by (le, level_index))",
+					"hide": false,
+					"interval": "",
+					"legendFormat": "{{level_index}} write bytes p99",
+					"refId": "B"
 				}
 			],
 			"title": "GBs written to next level",
@@ -1281,7 +1332,32 @@
 						]
 					}
 				},
-				"overrides": []
+				"overrides": [
+					{
+						"__systemRef": "hideSeriesFrom",
+						"matcher": {
+							"id": "byNames",
+							"options": {
+								"mode": "exclude",
+								"names": [
+									"L0 write count p99"
+								],
+								"prefix": "All except:",
+								"readOnly": true
+							}
+						},
+						"properties": [
+							{
+								"id": "custom.hideFrom",
+								"value": {
+									"legend": false,
+									"tooltip": false,
+									"viz": true
+								}
+							}
+						]
+					}
+				]
 			},
 			"gridPos": {
 				"h": 8,
@@ -1307,10 +1383,22 @@
 						"uid": "risedev-prometheus"
 					},
 					"exemplar": true,
-					"expr": "storage_level_compact_write_sstn",
+					"expr": "histogram_quantile(0.5, sum(rate(storage_level_compact_write_sstn_bucket[1m])) by (le, level_index))",
 					"interval": "",
-					"legendFormat": "",
+					"legendFormat": "{{level_index}} write count p50",
 					"refId": "A"
+				},
+				{
+					"datasource": {
+						"type": "prometheus",
+						"uid": "risedev-prometheus"
+					},
+					"exemplar": true,
+					"expr": "histogram_quantile(0.99, sum(rate(storage_level_compact_write_sstn_bucket[1m])) by (le, level_index))",
+					"hide": false,
+					"interval": "",
+					"legendFormat": "{{level_index}} write count p99",
+					"refId": "B"
 				}
 			],
 			"title": "count of sst written to next level",
@@ -1392,10 +1480,22 @@
 						"uid": "risedev-prometheus"
 					},
 					"exemplar": true,
-					"expr": "storage_level_compact_read_sstn_next",
+					"expr": "histogram_quantile(0.5, sum(rate(storage_level_compact_read_sstn_next_bucket[1m])) by (le, level_index))",
 					"interval": "",
-					"legendFormat": "",
+					"legendFormat": "{{level_index}} read count p50",
 					"refId": "A"
+				},
+				{
+					"datasource": {
+						"type": "prometheus",
+						"uid": "risedev-prometheus"
+					},
+					"exemplar": true,
+					"expr": "histogram_quantile(0.99, sum(rate(storage_level_compact_read_sstn_next_bucket[1m])) by (le, level_index))",
+					"hide": false,
+					"interval": "",
+					"legendFormat": "{{level_index}} read count p99",
+					"refId": "B"
 				}
 			],
 			"title": "count of sst read from next level",
@@ -2167,7 +2267,7 @@
 			"type": "row"
 		},
 		{
-			"collapsed": false,
+			"collapsed": true,
 			"gridPos": {
 				"h": 1,
 				"w": 24,
@@ -2175,1766 +2275,1767 @@
 				"y": 52
 			},
 			"id": 26,
-			"panels": [],
+			"panels": [
+				{
+					"fieldConfig": {
+						"defaults": {
+							"color": {
+								"mode": "palette-classic"
+							},
+							"custom": {
+								"axisLabel": "",
+								"axisPlacement": "auto",
+								"barAlignment": 0,
+								"drawStyle": "line",
+								"fillOpacity": 10,
+								"gradientMode": "none",
+								"hideFrom": {
+									"legend": false,
+									"tooltip": false,
+									"viz": false
+								},
+								"lineInterpolation": "linear",
+								"lineWidth": 1,
+								"pointSize": 5,
+								"scaleDistribution": {
+									"type": "linear"
+								},
+								"showPoints": "never",
+								"spanNulls": true,
+								"stacking": {
+									"group": "A",
+									"mode": "none"
+								},
+								"thresholdsStyle": {
+									"mode": "off"
+								}
+							},
+							"mappings": [],
+							"thresholds": {
+								"mode": "absolute",
+								"steps": [
+									{
+										"color": "green",
+										"value": null
+									},
+									{
+										"color": "red",
+										"value": 80
+									}
+								]
+							},
+							"unit": "ops"
+						},
+						"overrides": [
+							{
+								"__systemRef": "hideSeriesFrom",
+								"matcher": {
+									"id": "byNames",
+									"options": {
+										"mode": "exclude",
+										"names": [
+											"range_scan (cn:127.0.0.1:1222)"
+										],
+										"prefix": "All except:",
+										"readOnly": true
+									}
+								},
+								"properties": [
+									{
+										"id": "custom.hideFrom",
+										"value": {
+											"legend": false,
+											"tooltip": false,
+											"viz": true
+										}
+									}
+								]
+							}
+						]
+					},
+					"gridPos": {
+						"h": 8,
+						"w": 12,
+						"x": 0,
+						"y": 53
+					},
+					"id": 30,
+					"options": {
+						"legend": {
+							"calcs": [],
+							"displayMode": "list",
+							"placement": "bottom"
+						},
+						"tooltip": {
+							"mode": "single"
+						}
+					},
+					"pluginVersion": "8.3.3",
+					"targets": [
+						{
+							"datasource": {
+								"type": "prometheus",
+								"uid": "risedev-prometheus"
+							},
+							"exemplar": true,
+							"expr": "sum(rate(state_store_get_duration_count[1m])) by (instance)",
+							"interval": "",
+							"intervalFactor": 2,
+							"legendFormat": "get (cn:{{instance}})",
+							"refId": "A"
+						},
+						{
+							"datasource": {
+								"type": "prometheus",
+								"uid": "risedev-prometheus"
+							},
+							"exemplar": true,
+							"expr": "sum(rate(state_store_range_scan_duration_count[1m])) by (instance)",
+							"hide": false,
+							"interval": "",
+							"legendFormat": "range_scan (cn:{{instance}})",
+							"refId": "B"
+						},
+						{
+							"datasource": {
+								"type": "prometheus",
+								"uid": "risedev-prometheus"
+							},
+							"exemplar": true,
+							"expr": "sum(rate(state_store_range_reverse_scan_duration_count[1m])) by (instance)",
+							"hide": false,
+							"interval": "",
+							"legendFormat": "reverse_range_scan (cn:{{instance}})",
+							"refId": "C"
+						},
+						{
+							"datasource": {
+								"type": "prometheus",
+								"uid": "risedev-prometheus"
+							},
+							"exemplar": true,
+							"expr": "sum(rate(state_store_get_shared_buffer_hit_counts[1m])) by (instance)",
+							"hide": false,
+							"interval": "",
+							"legendFormat": "shared_buffer hit (cn:{{instance}})",
+							"refId": "F"
+						}
+					],
+					"title": "read ops",
+					"type": "timeseries"
+				},
+				{
+					"fieldConfig": {
+						"defaults": {
+							"color": {
+								"mode": "palette-classic"
+							},
+							"custom": {
+								"axisLabel": "",
+								"axisPlacement": "auto",
+								"barAlignment": 0,
+								"drawStyle": "line",
+								"fillOpacity": 10,
+								"gradientMode": "none",
+								"hideFrom": {
+									"legend": false,
+									"tooltip": false,
+									"viz": false
+								},
+								"lineInterpolation": "linear",
+								"lineWidth": 1,
+								"pointSize": 5,
+								"scaleDistribution": {
+									"type": "linear"
+								},
+								"showPoints": "never",
+								"spanNulls": true,
+								"stacking": {
+									"group": "A",
+									"mode": "none"
+								},
+								"thresholdsStyle": {
+									"mode": "off"
+								}
+							},
+							"mappings": [],
+							"thresholds": {
+								"mode": "absolute",
+								"steps": [
+									{
+										"color": "green",
+										"value": null
+									},
+									{
+										"color": "red",
+										"value": 80
+									}
+								]
+							},
+							"unit": "s"
+						},
+						"overrides": []
+					},
+					"gridPos": {
+						"h": 8,
+						"w": 12,
+						"x": 12,
+						"y": 53
+					},
+					"id": 28,
+					"options": {
+						"legend": {
+							"calcs": [],
+							"displayMode": "list",
+							"placement": "bottom"
+						},
+						"tooltip": {
+							"mode": "single"
+						}
+					},
+					"pluginVersion": "8.3.3",
+					"targets": [
+						{
+							"datasource": {
+								"type": "prometheus",
+								"uid": "risedev-prometheus"
+							},
+							"exemplar": true,
+							"expr": "histogram_quantile(0.5, sum(rate(state_store_get_duration_bucket[1m])) by (le, instance))",
+							"hide": true,
+							"interval": "",
+							"legendFormat": "get p50 (cn: {{instance}})",
+							"refId": "A"
+						},
+						{
+							"datasource": {
+								"type": "prometheus",
+								"uid": "risedev-prometheus"
+							},
+							"exemplar": true,
+							"expr": "histogram_quantile(0.99, sum(rate(state_store_get_duration_bucket[1m])) by (le, instance))",
+							"hide": true,
+							"interval": "",
+							"legendFormat": "get p99 (cn: {{instance}})",
+							"refId": "B"
+						},
+						{
+							"datasource": {
+								"type": "prometheus",
+								"uid": "risedev-prometheus"
+							},
+							"exemplar": true,
+							"expr": "histogram_quantile(0.9, sum(rate(state_store_get_duration_bucket[1m])) by (le, instance))",
+							"hide": true,
+							"interval": "",
+							"legendFormat": "get p90 (cn: {{instance}})",
+							"refId": "C"
+						},
+						{
+							"datasource": {
+								"type": "prometheus",
+								"uid": "risedev-prometheus"
+							},
+							"exemplar": true,
+							"expr": "sum by(le, instance)(rate(state_store_get_duration_sum[1m])) / sum by(le, instance) (rate(state_store_get_duration_count[1m]))",
+							"hide": false,
+							"interval": "",
+							"legendFormat": "get avg (cn: {{instance}})",
+							"refId": "D"
+						},
+						{
+							"datasource": {
+								"type": "prometheus",
+								"uid": "risedev-prometheus"
+							},
+							"exemplar": true,
+							"expr": "histogram_quantile(0.5, sum(rate(state_store_range_scan_duration_bucket[1m])) by (le, instance))",
+							"hide": true,
+							"interval": "",
+							"legendFormat": "range_scan p50 (cn: {{instance}})",
+							"refId": "E"
+						},
+						{
+							"datasource": {
+								"type": "prometheus",
+								"uid": "risedev-prometheus"
+							},
+							"exemplar": true,
+							"expr": "histogram_quantile(0.99, sum(rate(state_store_range_scan_duration_bucket[1m])) by (le, instance))",
+							"hide": true,
+							"interval": "",
+							"legendFormat": "range_scan p99 (cn: {{instance}})",
+							"refId": "F"
+						},
+						{
+							"datasource": {
+								"type": "prometheus",
+								"uid": "risedev-prometheus"
+							},
+							"exemplar": true,
+							"expr": "histogram_quantile(0.9, sum(rate(state_store_range_scan_duration_bucket[1m])) by (le, instance))",
+							"hide": true,
+							"interval": "",
+							"legendFormat": "range_scan p90 (cn: {{instance}})",
+							"refId": "G"
+						},
+						{
+							"datasource": {
+								"type": "prometheus",
+								"uid": "risedev-prometheus"
+							},
+							"exemplar": true,
+							"expr": "sum by(le, instance)(rate(state_store_range_scan_duration_sum[1m])) / sum by(le, instance) (rate(state_store_range_scan_duration_count[1m]))",
+							"hide": false,
+							"interval": "",
+							"legendFormat": "range_scan avg (cn: {{instance}})",
+							"refId": "H"
+						},
+						{
+							"datasource": {
+								"type": "prometheus",
+								"uid": "risedev-prometheus"
+							},
+							"exemplar": true,
+							"expr": "histogram_quantile(0.5, sum(rate(state_store_range_reverse_scan_duration_bucket[1m])) by (le, instance))",
+							"hide": true,
+							"interval": "",
+							"legendFormat": "reverse_range_scan p50 (cn: {{instance}})",
+							"refId": "I"
+						},
+						{
+							"datasource": {
+								"type": "prometheus",
+								"uid": "risedev-prometheus"
+							},
+							"exemplar": true,
+							"expr": "histogram_quantile(0.99, sum(rate(state_store_range_reverse_scan_duration_bucket[1m])) by (le, instance))",
+							"hide": true,
+							"interval": "",
+							"legendFormat": "reverse_range_scan p99 (cn: {{instance}})",
+							"refId": "J"
+						},
+						{
+							"datasource": {
+								"type": "prometheus",
+								"uid": "risedev-prometheus"
+							},
+							"exemplar": true,
+							"expr": "sum by(le, instance)(rate(state_store_range_reverse_scan_duration_sum[1m])) / sum by(le, instance) (rate(state_store_range_reverse_scan_duration_count[1m]))",
+							"hide": false,
+							"interval": "",
+							"legendFormat": "reverse_range_scan avg (cn: {{instance}})",
+							"refId": "K"
+						}
+					],
+					"title": "read duration",
+					"type": "timeseries"
+				},
+				{
+					"fieldConfig": {
+						"defaults": {
+							"color": {
+								"mode": "palette-classic"
+							},
+							"custom": {
+								"axisLabel": "",
+								"axisPlacement": "auto",
+								"barAlignment": 0,
+								"drawStyle": "line",
+								"fillOpacity": 10,
+								"gradientMode": "none",
+								"hideFrom": {
+									"legend": false,
+									"tooltip": false,
+									"viz": false
+								},
+								"lineInterpolation": "linear",
+								"lineWidth": 1,
+								"pointSize": 5,
+								"scaleDistribution": {
+									"type": "linear"
+								},
+								"showPoints": "never",
+								"spanNulls": true,
+								"stacking": {
+									"group": "A",
+									"mode": "none"
+								},
+								"thresholdsStyle": {
+									"mode": "off"
+								}
+							},
+							"mappings": [],
+							"thresholds": {
+								"mode": "absolute",
+								"steps": [
+									{
+										"color": "green",
+										"value": null
+									},
+									{
+										"color": "red",
+										"value": 80
+									}
+								]
+							},
+							"unit": "ops"
+						},
+						"overrides": [
+							{
+								"__systemRef": "hideSeriesFrom",
+								"matcher": {
+									"id": "byNames",
+									"options": {
+										"mode": "exclude",
+										"names": [
+											"data_total  (cn:127.0.0.1:1222)"
+										],
+										"prefix": "All except:",
+										"readOnly": true
+									}
+								},
+								"properties": [
+									{
+										"id": "custom.hideFrom",
+										"value": {
+											"legend": false,
+											"tooltip": false,
+											"viz": true
+										}
+									}
+								]
+							}
+						]
+					},
+					"gridPos": {
+						"h": 8,
+						"w": 12,
+						"x": 0,
+						"y": 61
+					},
+					"id": 128,
+					"options": {
+						"legend": {
+							"calcs": [],
+							"displayMode": "list",
+							"placement": "bottom"
+						},
+						"tooltip": {
+							"mode": "single"
+						}
+					},
+					"pluginVersion": "8.3.3",
+					"targets": [
+						{
+							"datasource": {
+								"type": "prometheus",
+								"uid": "risedev-prometheus"
+							},
+							"exemplar": true,
+							"expr": "sum(rate(state_store_sst_store_block_request_counts[1m])) by (instance, type)",
+							"hide": false,
+							"interval": "",
+							"legendFormat": "{{type}}  (cn:{{instance}})",
+							"refId": "D"
+						}
+					],
+					"title": "block ops",
+					"type": "timeseries"
+				},
+				{
+					"aliasColors": {},
+					"bars": false,
+					"dashLength": 10,
+					"dashes": false,
+					"fill": 1,
+					"fillGradient": 0,
+					"gridPos": {
+						"h": 8,
+						"w": 12,
+						"x": 12,
+						"y": 61
+					},
+					"hiddenSeries": false,
+					"id": 196,
+					"legend": {
+						"avg": false,
+						"current": false,
+						"max": false,
+						"min": false,
+						"show": true,
+						"total": false,
+						"values": false
+					},
+					"lines": true,
+					"linewidth": 1,
+					"nullPointMode": "null",
+					"options": {
+						"alertThreshold": true
+					},
+					"percentage": false,
+					"pluginVersion": "8.3.3",
+					"pointradius": 2,
+					"points": false,
+					"renderer": "flot",
+					"seriesOverrides": [],
+					"spaceLength": 10,
+					"stack": false,
+					"steppedLine": false,
+					"targets": [
+						{
+							"datasource": {
+								"type": "prometheus",
+								"uid": "risedev-prometheus"
+							},
+							"exemplar": true,
+							"expr": "avg(state_store_meta_cache_size) by (instance)",
+							"format": "time_series",
+							"hide": false,
+							"interval": "",
+							"intervalFactor": 2,
+							"legendFormat": "meta-cache (cn: {{instance}})",
+							"refId": "A"
+						},
+						{
+							"datasource": {
+								"type": "prometheus",
+								"uid": "risedev-prometheus"
+							},
+							"exemplar": true,
+							"expr": "avg(state_store_block_cache_size) by (instance)",
+							"hide": false,
+							"interval": "",
+							"legendFormat": "meta-cache (cn: {{instance}})",
+							"refId": "B"
+						}
+					],
+					"thresholds": [],
+					"timeRegions": [],
+					"title": "Cache Size",
+					"tooltip": {
+						"shared": true,
+						"sort": 0,
+						"value_type": "individual"
+					},
+					"type": "graph",
+					"xaxis": {
+						"mode": "time",
+						"show": true,
+						"values": []
+					},
+					"yaxes": [
+						{
+							"$$hashKey": "object:37",
+							"format": "decbytes",
+							"logBase": 1,
+							"show": true
+						},
+						{
+							"$$hashKey": "object:38",
+							"format": "short",
+							"logBase": 1,
+							"show": true
+						}
+					],
+					"yaxis": {
+						"align": false
+					}
+				},
+				{
+					"fieldConfig": {
+						"defaults": {
+							"color": {
+								"mode": "palette-classic"
+							},
+							"custom": {
+								"axisLabel": "",
+								"axisPlacement": "auto",
+								"barAlignment": 0,
+								"drawStyle": "line",
+								"fillOpacity": 10,
+								"gradientMode": "none",
+								"hideFrom": {
+									"legend": false,
+									"tooltip": false,
+									"viz": false
+								},
+								"lineInterpolation": "linear",
+								"lineWidth": 1,
+								"pointSize": 5,
+								"scaleDistribution": {
+									"type": "linear"
+								},
+								"showPoints": "never",
+								"spanNulls": true,
+								"stacking": {
+									"group": "A",
+									"mode": "none"
+								},
+								"thresholdsStyle": {
+									"mode": "off"
+								}
+							},
+							"mappings": [],
+							"thresholds": {
+								"mode": "absolute",
+								"steps": [
+									{
+										"color": "green",
+										"value": null
+									},
+									{
+										"color": "red",
+										"value": 80
+									}
+								]
+							},
+							"unit": "ops"
+						},
+						"overrides": []
+					},
+					"gridPos": {
+						"h": 8,
+						"w": 12,
+						"x": 0,
+						"y": 69
+					},
+					"id": 43,
+					"options": {
+						"legend": {
+							"calcs": [],
+							"displayMode": "list",
+							"placement": "bottom"
+						},
+						"tooltip": {
+							"mode": "single"
+						}
+					},
+					"pluginVersion": "8.3.3",
+					"targets": [
+						{
+							"datasource": {
+								"type": "prometheus",
+								"uid": "risedev-prometheus"
+							},
+							"exemplar": true,
+							"expr": "sum(rate(state_store_write_batch_duration_count[1m])) by (instance)",
+							"interval": "",
+							"intervalFactor": 2,
+							"legendFormat": "write batch cn= {{instance}} ",
+							"refId": "A"
+						},
+						{
+							"datasource": {
+								"type": "prometheus",
+								"uid": "risedev-prometheus"
+							},
+							"exemplar": true,
+							"expr": "sum(rate(state_store_shared_buffer_to_l0_duration_count[1m])) by (instance)",
+							"hide": false,
+							"interval": "",
+							"legendFormat": "l0 cn = {{instance}} ",
+							"refId": "B"
+						}
+					],
+					"title": "write ops",
+					"type": "timeseries"
+				},
+				{
+					"fieldConfig": {
+						"defaults": {
+							"color": {
+								"mode": "palette-classic"
+							},
+							"custom": {
+								"axisLabel": "",
+								"axisPlacement": "auto",
+								"barAlignment": 0,
+								"drawStyle": "line",
+								"fillOpacity": 10,
+								"gradientMode": "none",
+								"hideFrom": {
+									"legend": false,
+									"tooltip": false,
+									"viz": false
+								},
+								"lineInterpolation": "linear",
+								"lineWidth": 1,
+								"pointSize": 5,
+								"scaleDistribution": {
+									"type": "linear"
+								},
+								"showPoints": "never",
+								"spanNulls": true,
+								"stacking": {
+									"group": "A",
+									"mode": "none"
+								},
+								"thresholdsStyle": {
+									"mode": "off"
+								}
+							},
+							"mappings": [],
+							"thresholds": {
+								"mode": "absolute",
+								"steps": [
+									{
+										"color": "green",
+										"value": null
+									},
+									{
+										"color": "red",
+										"value": 80
+									}
+								]
+							},
+							"unit": "s"
+						},
+						"overrides": []
+					},
+					"gridPos": {
+						"h": 8,
+						"w": 12,
+						"x": 12,
+						"y": 69
+					},
+					"id": 40,
+					"options": {
+						"legend": {
+							"calcs": [],
+							"displayMode": "list",
+							"placement": "bottom"
+						},
+						"tooltip": {
+							"mode": "single"
+						}
+					},
+					"pluginVersion": "8.3.3",
+					"targets": [
+						{
+							"datasource": {
+								"type": "prometheus",
+								"uid": "risedev-prometheus"
+							},
+							"exemplar": true,
+							"expr": "histogram_quantile(0.5, sum(rate(state_store_write_batch_duration_bucket[1m])) by (le, instance))",
+							"interval": "",
+							"legendFormat": "shared_buffer p50  (cn: {{instance}})",
+							"refId": "A"
+						},
+						{
+							"datasource": {
+								"type": "prometheus",
+								"uid": "risedev-prometheus"
+							},
+							"exemplar": true,
+							"expr": "histogram_quantile(0.9, sum(rate(state_store_write_batch_duration_bucket[1m])) by (le, instance))",
+							"hide": false,
+							"interval": "",
+							"legendFormat": "shared_buffer p90  (cn: {{instance}})",
+							"refId": "B"
+						},
+						{
+							"datasource": {
+								"type": "prometheus",
+								"uid": "risedev-prometheus"
+							},
+							"exemplar": true,
+							"expr": "histogram_quantile(0.99, sum(rate(state_store_write_batch_duration_bucket[1m])) by (le, instance))",
+							"hide": false,
+							"interval": "",
+							"legendFormat": "shared_buffer p99  (cn: {{instance}})",
+							"refId": "C"
+						},
+						{
+							"datasource": {
+								"type": "prometheus",
+								"uid": "risedev-prometheus"
+							},
+							"exemplar": true,
+							"expr": "sum by(le, instance)(rate(state_store_write_batch_duration_sum[1m]))  / sum by(le, instance)(rate(state_store_write_batch_duration_count[1m]))",
+							"hide": false,
+							"interval": "",
+							"legendFormat": "shared_buffer avg (cn: {{instance}})",
+							"refId": "D"
+						},
+						{
+							"datasource": {
+								"type": "prometheus",
+								"uid": "risedev-prometheus"
+							},
+							"exemplar": true,
+							"expr": "histogram_quantile(0.5, sum(rate(state_store_write_shared_buffer_sync_time_bucket[1m])) by (le, instance))",
+							"hide": false,
+							"interval": "",
+							"legendFormat": "sync_remote p50 (cn: {{instance}})",
+							"refId": "E"
+						},
+						{
+							"datasource": {
+								"type": "prometheus",
+								"uid": "risedev-prometheus"
+							},
+							"exemplar": true,
+							"expr": "histogram_quantile(0.9, sum(rate(state_store_write_shared_buffer_sync_time_bucket[1m])) by (le, instance))",
+							"hide": false,
+							"interval": "",
+							"legendFormat": "sync_remote p90 (cn: {{instance}})",
+							"refId": "F"
+						},
+						{
+							"datasource": {
+								"type": "prometheus",
+								"uid": "risedev-prometheus"
+							},
+							"exemplar": true,
+							"expr": "histogram_quantile(0.99, sum(rate(state_store_write_shared_buffer_sync_time_bucket[1m])) by (le, instance))",
+							"hide": false,
+							"interval": "",
+							"legendFormat": "sync_remote p99 (cn: {{instance}})",
+							"refId": "G"
+						},
+						{
+							"datasource": {
+								"type": "prometheus",
+								"uid": "risedev-prometheus"
+							},
+							"exemplar": true,
+							"expr": "sum by(le, instance)(rate(state_store_write_shared_buffer_sync_time_sum[1m]))  / sum by(le, instance)(rate(state_store_write_shared_buffer_sync_time_count[1m]))",
+							"hide": false,
+							"interval": "",
+							"legendFormat": "sync_remote avg (cn: {{instance}})",
+							"refId": "H"
+						}
+					],
+					"title": "write duration",
+					"type": "timeseries"
+				},
+				{
+					"fieldConfig": {
+						"defaults": {
+							"color": {
+								"mode": "palette-classic"
+							},
+							"custom": {
+								"axisLabel": "",
+								"axisPlacement": "auto",
+								"barAlignment": 0,
+								"drawStyle": "line",
+								"fillOpacity": 0,
+								"gradientMode": "none",
+								"hideFrom": {
+									"legend": false,
+									"tooltip": false,
+									"viz": false
+								},
+								"lineInterpolation": "linear",
+								"lineWidth": 1,
+								"pointSize": 5,
+								"scaleDistribution": {
+									"type": "linear"
+								},
+								"showPoints": "auto",
+								"spanNulls": false,
+								"stacking": {
+									"group": "A",
+									"mode": "none"
+								},
+								"thresholdsStyle": {
+									"mode": "off"
+								}
+							},
+							"mappings": [],
+							"thresholds": {
+								"mode": "absolute",
+								"steps": [
+									{
+										"color": "green",
+										"value": null
+									},
+									{
+										"color": "red",
+										"value": 80
+									}
+								]
+							},
+							"unit": "cpm"
+						},
+						"overrides": []
+					},
+					"gridPos": {
+						"h": 8,
+						"w": 12,
+						"x": 0,
+						"y": 77
+					},
+					"id": 130,
+					"options": {
+						"legend": {
+							"calcs": [],
+							"displayMode": "list",
+							"placement": "bottom"
+						},
+						"tooltip": {
+							"mode": "single"
+						}
+					},
+					"pluginVersion": "8.3.3",
+					"targets": [
+						{
+							"datasource": {
+								"type": "prometheus",
+								"uid": "risedev-prometheus"
+							},
+							"exemplar": true,
+							"expr": "sum(rate(state_store_bloom_filter_true_negative_counts[1m])) by (instance)",
+							"hide": false,
+							"interval": "",
+							"legendFormat": "bloom filter true negative (cn:{{instance}})",
+							"refId": "G"
+						},
+						{
+							"datasource": {
+								"type": "prometheus",
+								"uid": "risedev-prometheus"
+							},
+							"exemplar": true,
+							"expr": "sum(rate(state_store_bloom_filter_might_positive_counts[1m])) by (instance)",
+							"hide": false,
+							"interval": "",
+							"legendFormat": "bloom filter might positive (cn:{{instance}})",
+							"refId": "H"
+						},
+						{
+							"datasource": {
+								"type": "prometheus",
+								"uid": "risedev-prometheus"
+							},
+							"exemplar": true,
+							"expr": "histogram_quantile(0.9, sum(rate(state_store_iter_merge_sstable_counts_bucket[1m])) by (le, instance))",
+							"hide": true,
+							"interval": "",
+							"legendFormat": "# merged ssts p90 (cn:{{instance}})",
+							"refId": "A"
+						},
+						{
+							"datasource": {
+								"type": "prometheus",
+								"uid": "risedev-prometheus"
+							},
+							"exemplar": true,
+							"expr": "histogram_quantile(0.99, sum(rate(state_store_iter_merge_sstable_counts_bucket[1m])) by (le, instance))",
+							"hide": true,
+							"interval": "",
+							"legendFormat": "# merged ssts p99 (cn:{{instance}})",
+							"refId": "C"
+						},
+						{
+							"datasource": {
+								"type": "prometheus",
+								"uid": "risedev-prometheus"
+							},
+							"exemplar": true,
+							"expr": "sum by(le, instance)(rate(state_store_iter_merge_sstable_counts_sum[1m]))  / sum by(le, instance)(rate(state_store_iter_merge_sstable_counts_count[1m]))",
+							"hide": false,
+							"interval": "",
+							"legendFormat": "# merged ssts avg (cn:{{instance}})",
+							"refId": "B"
+						}
+					],
+					"title": "sst read counters",
+					"type": "timeseries"
+				},
+				{
+					"fieldConfig": {
+						"defaults": {
+							"color": {
+								"mode": "palette-classic"
+							},
+							"custom": {
+								"axisLabel": "",
+								"axisPlacement": "auto",
+								"barAlignment": 0,
+								"drawStyle": "line",
+								"fillOpacity": 10,
+								"gradientMode": "none",
+								"hideFrom": {
+									"legend": false,
+									"tooltip": false,
+									"viz": false
+								},
+								"lineInterpolation": "linear",
+								"lineWidth": 1,
+								"pointSize": 5,
+								"scaleDistribution": {
+									"type": "linear"
+								},
+								"showPoints": "never",
+								"spanNulls": true,
+								"stacking": {
+									"group": "A",
+									"mode": "none"
+								},
+								"thresholdsStyle": {
+									"mode": "off"
+								}
+							},
+							"mappings": [],
+							"thresholds": {
+								"mode": "absolute",
+								"steps": [
+									{
+										"color": "green",
+										"value": null
+									},
+									{
+										"color": "red",
+										"value": 80
+									}
+								]
+							},
+							"unit": "Bps"
+						},
+						"overrides": []
+					},
+					"gridPos": {
+						"h": 8,
+						"w": 12,
+						"x": 12,
+						"y": 77
+					},
+					"id": 32,
+					"options": {
+						"legend": {
+							"calcs": [],
+							"displayMode": "list",
+							"placement": "bottom"
+						},
+						"tooltip": {
+							"mode": "single"
+						}
+					},
+					"pluginVersion": "8.3.3",
+					"targets": [
+						{
+							"datasource": {
+								"type": "prometheus",
+								"uid": "risedev-prometheus"
+							},
+							"exemplar": true,
+							"expr": "sum by(instance)(rate(state_store_get_key_size_sum[1m])+rate(state_store_get_value_size_sum[1m]))/sum by(instance)(rate(state_store_get_key_size_count[1m]))",
+							"interval": "",
+							"legendFormat": "get (cn:{{instance}})",
+							"refId": "A"
+						},
+						{
+							"datasource": {
+								"type": "prometheus",
+								"uid": "risedev-prometheus"
+							},
+							"exemplar": true,
+							"expr": "sum by(instance)(rate(state_store_get_key_size_sum[1m]))/sum by(instance)(rate(state_store_get_key_size_count[1m]))",
+							"hide": false,
+							"interval": "",
+							"legendFormat": "get key (cn:{{instance}})",
+							"refId": "B"
+						},
+						{
+							"datasource": {
+								"type": "prometheus",
+								"uid": "risedev-prometheus"
+							},
+							"exemplar": true,
+							"expr": "sum by(instance)(rate(state_store_get_value_size_sum[1m]))/sum by(instance)(rate(state_store_get_value_size_count[1m]))",
+							"hide": false,
+							"interval": "",
+							"legendFormat": "get value (cn:{{instance}})",
+							"refId": "C"
+						},
+						{
+							"datasource": {
+								"type": "prometheus",
+								"uid": "risedev-prometheus"
+							},
+							"exemplar": true,
+							"expr": "sum by(instance)(rate(state_store_range_scan_size_sum[1m]))/sum by(instance)(rate(state_store_range_scan_size_count[1m]))",
+							"hide": false,
+							"interval": "",
+							"legendFormat": "range_scan (cn:{{instance}})",
+							"refId": "D"
+						},
+						{
+							"datasource": {
+								"type": "prometheus",
+								"uid": "risedev-prometheus"
+							},
+							"exemplar": true,
+							"expr": "sum by(instance)(rate(state_store_range_reverse_scan_size_sum[1m]))/sum by(instance)(rate(state_store_range_reverse_scan_size_count[1m]))",
+							"hide": false,
+							"interval": "",
+							"legendFormat": "reverse_range_scan (cn:{{instance}})",
+							"refId": "E"
+						}
+					],
+					"title": "read throughput",
+					"type": "timeseries"
+				},
+				{
+					"fieldConfig": {
+						"defaults": {
+							"color": {
+								"mode": "palette-classic"
+							},
+							"custom": {
+								"axisLabel": "",
+								"axisPlacement": "auto",
+								"barAlignment": 0,
+								"drawStyle": "line",
+								"fillOpacity": 10,
+								"gradientMode": "none",
+								"hideFrom": {
+									"legend": false,
+									"tooltip": false,
+									"viz": false
+								},
+								"lineInterpolation": "linear",
+								"lineWidth": 1,
+								"pointSize": 5,
+								"scaleDistribution": {
+									"type": "linear"
+								},
+								"showPoints": "never",
+								"spanNulls": true,
+								"stacking": {
+									"group": "A",
+									"mode": "none"
+								},
+								"thresholdsStyle": {
+									"mode": "off"
+								}
+							},
+							"mappings": [],
+							"thresholds": {
+								"mode": "absolute",
+								"steps": [
+									{
+										"color": "green",
+										"value": null
+									},
+									{
+										"color": "red",
+										"value": 80
+									}
+								]
+							},
+							"unit": "cps"
+						},
+						"overrides": []
+					},
+					"gridPos": {
+						"h": 8,
+						"w": 12,
+						"x": 0,
+						"y": 85
+					},
+					"id": 44,
+					"options": {
+						"legend": {
+							"calcs": [],
+							"displayMode": "list",
+							"placement": "bottom"
+						},
+						"tooltip": {
+							"mode": "single"
+						}
+					},
+					"pluginVersion": "8.3.3",
+					"targets": [
+						{
+							"datasource": {
+								"type": "prometheus",
+								"uid": "risedev-prometheus"
+							},
+							"exemplar": true,
+							"expr": "sum(rate(state_store_write_batch_tuple_counts[1m])) by (instance)",
+							"interval": "",
+							"intervalFactor": 2,
+							"legendFormat": "write_batch_kv_pair_count - {{instance}} ",
+							"refId": "A"
+						}
+					],
+					"title": "write kv pair counts",
+					"type": "timeseries"
+				},
+				{
+					"fieldConfig": {
+						"defaults": {
+							"color": {
+								"mode": "palette-classic"
+							},
+							"custom": {
+								"axisLabel": "",
+								"axisPlacement": "auto",
+								"barAlignment": 0,
+								"drawStyle": "line",
+								"fillOpacity": 10,
+								"gradientMode": "none",
+								"hideFrom": {
+									"legend": false,
+									"tooltip": false,
+									"viz": false
+								},
+								"lineInterpolation": "linear",
+								"lineWidth": 1,
+								"pointSize": 5,
+								"scaleDistribution": {
+									"type": "linear"
+								},
+								"showPoints": "never",
+								"spanNulls": true,
+								"stacking": {
+									"group": "A",
+									"mode": "none"
+								},
+								"thresholdsStyle": {
+									"mode": "off"
+								}
+							},
+							"mappings": [],
+							"thresholds": {
+								"mode": "absolute",
+								"steps": [
+									{
+										"color": "green",
+										"value": null
+									},
+									{
+										"color": "red",
+										"value": 80
+									}
+								]
+							},
+							"unit": "Bps"
+						},
+						"overrides": []
+					},
+					"gridPos": {
+						"h": 8,
+						"w": 12,
+						"x": 12,
+						"y": 85
+					},
+					"id": 45,
+					"options": {
+						"legend": {
+							"calcs": [],
+							"displayMode": "list",
+							"placement": "bottom"
+						},
+						"tooltip": {
+							"mode": "single"
+						}
+					},
+					"pluginVersion": "8.3.3",
+					"targets": [
+						{
+							"datasource": {
+								"type": "prometheus",
+								"uid": "risedev-prometheus"
+							},
+							"exemplar": true,
+							"expr": "sum(rate(state_store_write_batch_size_sum[1m]))by(instance) / sum(rate(state_store_write_batch_size_count[1m]))by(instance)",
+							"interval": "",
+							"legendFormat": "shared_buffer (cn: {{instance}})",
+							"refId": "A"
+						},
+						{
+							"datasource": {
+								"type": "prometheus",
+								"uid": "risedev-prometheus"
+							},
+							"exemplar": true,
+							"expr": "sum(rate(state_store_shared_buffer_to_sstable_size_sum[1m]))by(instance) / sum(rate(state_store_shared_buffer_to_sstable_size_count[1m]))by(instance)",
+							"hide": false,
+							"interval": "",
+							"legendFormat": "sync (cn: {{instance}})",
+							"refId": "B"
+						}
+					],
+					"title": "write throughput",
+					"type": "timeseries"
+				},
+				{
+					"fieldConfig": {
+						"defaults": {
+							"color": {
+								"mode": "palette-classic"
+							},
+							"custom": {
+								"axisLabel": "",
+								"axisPlacement": "auto",
+								"barAlignment": 0,
+								"drawStyle": "line",
+								"fillOpacity": 10,
+								"gradientMode": "none",
+								"hideFrom": {
+									"legend": false,
+									"tooltip": false,
+									"viz": false
+								},
+								"lineInterpolation": "linear",
+								"lineWidth": 1,
+								"pointSize": 5,
+								"scaleDistribution": {
+									"type": "linear"
+								},
+								"showPoints": "never",
+								"spanNulls": true,
+								"stacking": {
+									"group": "A",
+									"mode": "none"
+								},
+								"thresholdsStyle": {
+									"mode": "off"
+								}
+							},
+							"mappings": [],
+							"thresholds": {
+								"mode": "absolute",
+								"steps": [
+									{
+										"color": "green",
+										"value": null
+									},
+									{
+										"color": "red",
+										"value": 80
+									}
+								]
+							},
+							"unit": "s"
+						},
+						"overrides": []
+					},
+					"gridPos": {
+						"h": 8,
+						"w": 12,
+						"x": 0,
+						"y": 93
+					},
+					"id": 41,
+					"options": {
+						"legend": {
+							"calcs": [],
+							"displayMode": "list",
+							"placement": "bottom"
+						},
+						"tooltip": {
+							"mode": "single"
+						}
+					},
+					"pluginVersion": "8.3.3",
+					"targets": [
+						{
+							"datasource": {
+								"type": "prometheus",
+								"uid": "risedev-prometheus"
+							},
+							"exemplar": true,
+							"expr": "histogram_quantile(0.5, sum(rate(state_store_shared_buffer_to_l0_duration_bucket[1m])) by (le, instance))",
+							"hide": true,
+							"interval": "",
+							"legendFormat": "p50 (cn: {{instance}})",
+							"refId": "A"
+						},
+						{
+							"datasource": {
+								"type": "prometheus",
+								"uid": "risedev-prometheus"
+							},
+							"exemplar": true,
+							"expr": "histogram_quantile(0.9, sum(rate(state_store_shared_buffer_to_l0_duration_bucket[1m])) by (le, instance))",
+							"hide": true,
+							"interval": "",
+							"legendFormat": "p90 (cn: {{instance}})",
+							"refId": "B"
+						},
+						{
+							"datasource": {
+								"type": "prometheus",
+								"uid": "risedev-prometheus"
+							},
+							"exemplar": true,
+							"expr": "histogram_quantile(0.99, sum(rate(state_store_shared_buffer_to_l0_duration_bucket[1m])) by (le, instance))",
+							"hide": true,
+							"interval": "",
+							"legendFormat": "p99 (cn: {{instance}})",
+							"refId": "C"
+						},
+						{
+							"datasource": {
+								"type": "prometheus",
+								"uid": "risedev-prometheus"
+							},
+							"exemplar": true,
+							"expr": "sum by(le, instance) (rate(state_store_shared_buffer_to_l0_duration_sum[1m])) / sum by(le, instance) (rate(state_store_shared_buffer_to_l0_duration_count[1m]))",
+							"hide": false,
+							"interval": "",
+							"legendFormat": "avg (cn: {{instance}})",
+							"refId": "D"
+						}
+					],
+					"title": "build sstable duration",
+					"type": "timeseries"
+				},
+				{
+					"fieldConfig": {
+						"defaults": {
+							"color": {
+								"mode": "palette-classic"
+							},
+							"custom": {
+								"axisLabel": "",
+								"axisPlacement": "auto",
+								"barAlignment": 0,
+								"drawStyle": "line",
+								"fillOpacity": 10,
+								"gradientMode": "none",
+								"hideFrom": {
+									"legend": false,
+									"tooltip": false,
+									"viz": false
+								},
+								"lineInterpolation": "linear",
+								"lineWidth": 1,
+								"pointSize": 5,
+								"scaleDistribution": {
+									"type": "linear"
+								},
+								"showPoints": "never",
+								"spanNulls": true,
+								"stacking": {
+									"group": "A",
+									"mode": "none"
+								},
+								"thresholdsStyle": {
+									"mode": "off"
+								}
+							},
+							"mappings": [],
+							"thresholds": {
+								"mode": "absolute",
+								"steps": [
+									{
+										"color": "green",
+										"value": null
+									},
+									{
+										"color": "red",
+										"value": 80
+									}
+								]
+							},
+							"unit": "ops"
+						},
+						"overrides": []
+					},
+					"gridPos": {
+						"h": 8,
+						"w": 12,
+						"x": 12,
+						"y": 93
+					},
+					"id": 132,
+					"options": {
+						"legend": {
+							"calcs": [],
+							"displayMode": "list",
+							"placement": "bottom"
+						},
+						"tooltip": {
+							"mode": "single"
+						}
+					},
+					"pluginVersion": "8.3.3",
+					"targets": [
+						{
+							"datasource": {
+								"type": "prometheus",
+								"uid": "risedev-prometheus"
+							},
+							"exemplar": true,
+							"expr": "sum(rate(state_store_iter_merge_seek_duration_count[1m])) by (instance)",
+							"hide": false,
+							"interval": "",
+							"legendFormat": "MI seek (cn:{{instance}})",
+							"refId": "G"
+						},
+						{
+							"datasource": {
+								"type": "prometheus",
+								"uid": "risedev-prometheus"
+							},
+							"exemplar": true,
+							"expr": "sum(rate(state_store_iter_merge_next_duration_count[1m])) by (instance)",
+							"hide": false,
+							"interval": "",
+							"legendFormat": "MI next (cn:{{instance}})",
+							"refId": "H"
+						}
+					],
+					"title": "merge iterators ops",
+					"type": "timeseries"
+				},
+				{
+					"fieldConfig": {
+						"defaults": {
+							"color": {
+								"mode": "palette-classic"
+							},
+							"custom": {
+								"axisLabel": "",
+								"axisPlacement": "auto",
+								"barAlignment": 0,
+								"drawStyle": "line",
+								"fillOpacity": 10,
+								"gradientMode": "none",
+								"hideFrom": {
+									"legend": false,
+									"tooltip": false,
+									"viz": false
+								},
+								"lineInterpolation": "linear",
+								"lineWidth": 1,
+								"pointSize": 5,
+								"scaleDistribution": {
+									"type": "linear"
+								},
+								"showPoints": "never",
+								"spanNulls": true,
+								"stacking": {
+									"group": "A",
+									"mode": "none"
+								},
+								"thresholdsStyle": {
+									"mode": "off"
+								}
+							},
+							"mappings": [],
+							"thresholds": {
+								"mode": "absolute",
+								"steps": [
+									{
+										"color": "green",
+										"value": null
+									},
+									{
+										"color": "red",
+										"value": 80
+									}
+								]
+							},
+							"unit": "s"
+						},
+						"overrides": []
+					},
+					"gridPos": {
+						"h": 8,
+						"w": 12,
+						"x": 0,
+						"y": 101
+					},
+					"id": 134,
+					"options": {
+						"legend": {
+							"calcs": [],
+							"displayMode": "list",
+							"placement": "bottom"
+						},
+						"tooltip": {
+							"mode": "single"
+						}
+					},
+					"pluginVersion": "8.3.3",
+					"targets": [
+						{
+							"datasource": {
+								"type": "prometheus",
+								"uid": "risedev-prometheus"
+							},
+							"exemplar": true,
+							"expr": "histogram_quantile(0.5, sum(rate(batch_row_seq_scan_next_duration_bucket[1m])) by (le, instance))",
+							"hide": true,
+							"interval": "",
+							"legendFormat": "row_seq_scan next p50 (cn: {{instance}})",
+							"refId": "A"
+						},
+						{
+							"datasource": {
+								"type": "prometheus",
+								"uid": "risedev-prometheus"
+							},
+							"exemplar": true,
+							"expr": "histogram_quantile(0.9, sum(rate(batch_row_seq_scan_next_duration_bucket[1m])) by (le, instance))",
+							"hide": true,
+							"interval": "",
+							"legendFormat": "p90 (cn: {{instance}})",
+							"refId": "B"
+						},
+						{
+							"datasource": {
+								"type": "prometheus",
+								"uid": "risedev-prometheus"
+							},
+							"exemplar": true,
+							"expr": "histogram_quantile(0.99, sum(rate(batch_row_seq_scan_next_duration_bucket[1m])) by (le, instance))",
+							"hide": true,
+							"interval": "",
+							"legendFormat": "p99 (cn: {{instance}})",
+							"refId": "C"
+						},
+						{
+							"datasource": {
+								"type": "prometheus",
+								"uid": "risedev-prometheus"
+							},
+							"exemplar": true,
+							"expr": "sum by(le, instance) (rate(batch_row_seq_scan_next_duration_sum[1m])) / sum by(le, instance) (rate(batch_row_seq_scan_next_duration_count[1m]))",
+							"hide": false,
+							"interval": "",
+							"legendFormat": "row_seq_scan next avg (cn: {{instance}})",
+							"refId": "D"
+						}
+					],
+					"title": "row seq scan next duration",
+					"type": "timeseries"
+				},
+				{
+					"fieldConfig": {
+						"defaults": {
+							"color": {
+								"mode": "palette-classic"
+							},
+							"custom": {
+								"axisLabel": "",
+								"axisPlacement": "auto",
+								"barAlignment": 0,
+								"drawStyle": "line",
+								"fillOpacity": 10,
+								"gradientMode": "none",
+								"hideFrom": {
+									"legend": false,
+									"tooltip": false,
+									"viz": false
+								},
+								"lineInterpolation": "linear",
+								"lineWidth": 1,
+								"pointSize": 5,
+								"scaleDistribution": {
+									"type": "linear"
+								},
+								"showPoints": "never",
+								"spanNulls": true,
+								"stacking": {
+									"group": "A",
+									"mode": "none"
+								},
+								"thresholdsStyle": {
+									"mode": "off"
+								}
+							},
+							"mappings": [],
+							"thresholds": {
+								"mode": "absolute",
+								"steps": [
+									{
+										"color": "green",
+										"value": null
+									},
+									{
+										"color": "red",
+										"value": 80
+									}
+								]
+							},
+							"unit": "s"
+						},
+						"overrides": []
+					},
+					"gridPos": {
+						"h": 8,
+						"w": 12,
+						"x": 12,
+						"y": 101
+					},
+					"id": 48,
+					"options": {
+						"legend": {
+							"calcs": [],
+							"displayMode": "list",
+							"placement": "bottom"
+						},
+						"tooltip": {
+							"mode": "single"
+						}
+					},
+					"pluginVersion": "8.3.3",
+					"targets": [
+						{
+							"datasource": {
+								"type": "prometheus",
+								"uid": "risedev-prometheus"
+							},
+							"exemplar": true,
+							"expr": "histogram_quantile(0.5, sum(rate(state_store_iter_merge_seek_duration_bucket[1m])) by (le, instance))",
+							"hide": true,
+							"interval": "",
+							"legendFormat": "mi_seek p50 (cn:{{instance}})",
+							"refId": "E"
+						},
+						{
+							"datasource": {
+								"type": "prometheus",
+								"uid": "risedev-prometheus"
+							},
+							"exemplar": true,
+							"expr": "histogram_quantile(0.9, sum(rate(state_store_iter_merge_seek_duration_bucket[1m])) by (le, instance))",
+							"hide": true,
+							"interval": "",
+							"legendFormat": "mi_seek p90 (cn:{{instance}})",
+							"refId": "F"
+						},
+						{
+							"datasource": {
+								"type": "prometheus",
+								"uid": "risedev-prometheus"
+							},
+							"exemplar": true,
+							"expr": "histogram_quantile(0.99, sum(rate(state_store_iter_merge_seek_duration_bucket[1m])) by (le, instance))",
+							"hide": true,
+							"interval": "",
+							"legendFormat": "mi_seek p99 (cn:{{instance}})",
+							"refId": "G"
+						},
+						{
+							"datasource": {
+								"type": "prometheus",
+								"uid": "risedev-prometheus"
+							},
+							"exemplar": true,
+							"expr": "sum by(le, instance) (rate(state_store_iter_merge_seek_duration_sum[1m])) / sum by(le, instance) (rate(state_store_iter_merge_seek_duration_count[1m]))",
+							"hide": false,
+							"interval": "",
+							"legendFormat": "mi_seek avg (cn:{{instance}})",
+							"refId": "H"
+						}
+					],
+					"title": "merge iterators duration",
+					"type": "timeseries"
+				}
+			],
 			"title": "Hummock",
 			"type": "row"
-		},
-		{
-			"fieldConfig": {
-				"defaults": {
-					"color": {
-						"mode": "palette-classic"
-					},
-					"custom": {
-						"axisLabel": "",
-						"axisPlacement": "auto",
-						"barAlignment": 0,
-						"drawStyle": "line",
-						"fillOpacity": 10,
-						"gradientMode": "none",
-						"hideFrom": {
-							"legend": false,
-							"tooltip": false,
-							"viz": false
-						},
-						"lineInterpolation": "linear",
-						"lineWidth": 1,
-						"pointSize": 5,
-						"scaleDistribution": {
-							"type": "linear"
-						},
-						"showPoints": "never",
-						"spanNulls": true,
-						"stacking": {
-							"group": "A",
-							"mode": "none"
-						},
-						"thresholdsStyle": {
-							"mode": "off"
-						}
-					},
-					"mappings": [],
-					"thresholds": {
-						"mode": "absolute",
-						"steps": [
-							{
-								"color": "green",
-								"value": null
-							},
-							{
-								"color": "red",
-								"value": 80
-							}
-						]
-					},
-					"unit": "ops"
-				},
-				"overrides": [
-					{
-						"__systemRef": "hideSeriesFrom",
-						"matcher": {
-							"id": "byNames",
-							"options": {
-								"mode": "exclude",
-								"names": [
-									"range_scan (cn:127.0.0.1:1222)"
-								],
-								"prefix": "All except:",
-								"readOnly": true
-							}
-						},
-						"properties": [
-							{
-								"id": "custom.hideFrom",
-								"value": {
-									"legend": false,
-									"tooltip": false,
-									"viz": true
-								}
-							}
-						]
-					}
-				]
-			},
-			"gridPos": {
-				"h": 8,
-				"w": 12,
-				"x": 0,
-				"y": 53
-			},
-			"id": 30,
-			"options": {
-				"legend": {
-					"calcs": [],
-					"displayMode": "list",
-					"placement": "bottom"
-				},
-				"tooltip": {
-					"mode": "single"
-				}
-			},
-			"pluginVersion": "8.3.3",
-			"targets": [
-				{
-					"datasource": {
-						"type": "prometheus",
-						"uid": "risedev-prometheus"
-					},
-					"exemplar": true,
-					"expr": "sum(rate(state_store_get_duration_count[1m])) by (instance)",
-					"interval": "",
-					"intervalFactor": 2,
-					"legendFormat": "get (cn:{{instance}})",
-					"refId": "A"
-				},
-				{
-					"datasource": {
-						"type": "prometheus",
-						"uid": "risedev-prometheus"
-					},
-					"exemplar": true,
-					"expr": "sum(rate(state_store_range_scan_duration_count[1m])) by (instance)",
-					"hide": false,
-					"interval": "",
-					"legendFormat": "range_scan (cn:{{instance}})",
-					"refId": "B"
-				},
-				{
-					"datasource": {
-						"type": "prometheus",
-						"uid": "risedev-prometheus"
-					},
-					"exemplar": true,
-					"expr": "sum(rate(state_store_range_reverse_scan_duration_count[1m])) by (instance)",
-					"hide": false,
-					"interval": "",
-					"legendFormat": "reverse_range_scan (cn:{{instance}})",
-					"refId": "C"
-				},
-				{
-					"datasource": {
-						"type": "prometheus",
-						"uid": "risedev-prometheus"
-					},
-					"exemplar": true,
-					"expr": "sum(rate(state_store_get_shared_buffer_hit_counts[1m])) by (instance)",
-					"hide": false,
-					"interval": "",
-					"legendFormat": "shared_buffer hit (cn:{{instance}})",
-					"refId": "F"
-				}
-			],
-			"title": "read ops",
-			"type": "timeseries"
-		},
-		{
-			"fieldConfig": {
-				"defaults": {
-					"color": {
-						"mode": "palette-classic"
-					},
-					"custom": {
-						"axisLabel": "",
-						"axisPlacement": "auto",
-						"barAlignment": 0,
-						"drawStyle": "line",
-						"fillOpacity": 10,
-						"gradientMode": "none",
-						"hideFrom": {
-							"legend": false,
-							"tooltip": false,
-							"viz": false
-						},
-						"lineInterpolation": "linear",
-						"lineWidth": 1,
-						"pointSize": 5,
-						"scaleDistribution": {
-							"type": "linear"
-						},
-						"showPoints": "never",
-						"spanNulls": true,
-						"stacking": {
-							"group": "A",
-							"mode": "none"
-						},
-						"thresholdsStyle": {
-							"mode": "off"
-						}
-					},
-					"mappings": [],
-					"thresholds": {
-						"mode": "absolute",
-						"steps": [
-							{
-								"color": "green",
-								"value": null
-							},
-							{
-								"color": "red",
-								"value": 80
-							}
-						]
-					},
-					"unit": "ops"
-				},
-				"overrides": [
-					{
-						"__systemRef": "hideSeriesFrom",
-						"matcher": {
-							"id": "byNames",
-							"options": {
-								"mode": "exclude",
-								"names": [
-									"data_total  (cn:127.0.0.1:1222)"
-								],
-								"prefix": "All except:",
-								"readOnly": true
-							}
-						},
-						"properties": [
-							{
-								"id": "custom.hideFrom",
-								"value": {
-									"legend": false,
-									"tooltip": false,
-									"viz": true
-								}
-							}
-						]
-					}
-				]
-			},
-			"gridPos": {
-				"h": 8,
-				"w": 12,
-				"x": 12,
-				"y": 53
-			},
-			"id": 128,
-			"options": {
-				"legend": {
-					"calcs": [],
-					"displayMode": "list",
-					"placement": "bottom"
-				},
-				"tooltip": {
-					"mode": "single"
-				}
-			},
-			"pluginVersion": "8.3.3",
-			"targets": [
-				{
-					"datasource": {
-						"type": "prometheus",
-						"uid": "risedev-prometheus"
-					},
-					"exemplar": true,
-					"expr": "sum(rate(state_store_sst_store_block_request_counts[1m])) by (instance, type)",
-					"hide": false,
-					"interval": "",
-					"legendFormat": "{{type}}  (cn:{{instance}})",
-					"refId": "D"
-				}
-			],
-			"title": "block ops",
-			"type": "timeseries"
-		},
-		{
-			"fieldConfig": {
-				"defaults": {
-					"color": {
-						"mode": "palette-classic"
-					},
-					"custom": {
-						"axisLabel": "",
-						"axisPlacement": "auto",
-						"barAlignment": 0,
-						"drawStyle": "line",
-						"fillOpacity": 10,
-						"gradientMode": "none",
-						"hideFrom": {
-							"legend": false,
-							"tooltip": false,
-							"viz": false
-						},
-						"lineInterpolation": "linear",
-						"lineWidth": 1,
-						"pointSize": 5,
-						"scaleDistribution": {
-							"type": "linear"
-						},
-						"showPoints": "never",
-						"spanNulls": true,
-						"stacking": {
-							"group": "A",
-							"mode": "none"
-						},
-						"thresholdsStyle": {
-							"mode": "off"
-						}
-					},
-					"mappings": [],
-					"thresholds": {
-						"mode": "absolute",
-						"steps": [
-							{
-								"color": "green",
-								"value": null
-							},
-							{
-								"color": "red",
-								"value": 80
-							}
-						]
-					},
-					"unit": "s"
-				},
-				"overrides": []
-			},
-			"gridPos": {
-				"h": 8,
-				"w": 12,
-				"x": 0,
-				"y": 61
-			},
-			"id": 28,
-			"options": {
-				"legend": {
-					"calcs": [],
-					"displayMode": "list",
-					"placement": "bottom"
-				},
-				"tooltip": {
-					"mode": "single"
-				}
-			},
-			"pluginVersion": "8.3.3",
-			"targets": [
-				{
-					"datasource": {
-						"type": "prometheus",
-						"uid": "risedev-prometheus"
-					},
-					"exemplar": true,
-					"expr": "histogram_quantile(0.5, sum(rate(state_store_get_duration_bucket[1m])) by (le, instance))",
-					"hide": true,
-					"interval": "",
-					"legendFormat": "get p50 (cn: {{instance}})",
-					"refId": "A"
-				},
-				{
-					"datasource": {
-						"type": "prometheus",
-						"uid": "risedev-prometheus"
-					},
-					"exemplar": true,
-					"expr": "histogram_quantile(0.99, sum(rate(state_store_get_duration_bucket[1m])) by (le, instance))",
-					"hide": true,
-					"interval": "",
-					"legendFormat": "get p99 (cn: {{instance}})",
-					"refId": "B"
-				},
-				{
-					"datasource": {
-						"type": "prometheus",
-						"uid": "risedev-prometheus"
-					},
-					"exemplar": true,
-					"expr": "histogram_quantile(0.9, sum(rate(state_store_get_duration_bucket[1m])) by (le, instance))",
-					"hide": true,
-					"interval": "",
-					"legendFormat": "get p90 (cn: {{instance}})",
-					"refId": "C"
-				},
-				{
-					"datasource": {
-						"type": "prometheus",
-						"uid": "risedev-prometheus"
-					},
-					"exemplar": true,
-					"expr": "sum by(le, instance)(rate(state_store_get_duration_sum[1m])) / sum by(le, instance) (rate(state_store_get_duration_count[1m]))",
-					"hide": false,
-					"interval": "",
-					"legendFormat": "get avg (cn: {{instance}})",
-					"refId": "D"
-				},
-				{
-					"datasource": {
-						"type": "prometheus",
-						"uid": "risedev-prometheus"
-					},
-					"exemplar": true,
-					"expr": "histogram_quantile(0.5, sum(rate(state_store_range_scan_duration_bucket[1m])) by (le, instance))",
-					"hide": true,
-					"interval": "",
-					"legendFormat": "range_scan p50 (cn: {{instance}})",
-					"refId": "E"
-				},
-				{
-					"datasource": {
-						"type": "prometheus",
-						"uid": "risedev-prometheus"
-					},
-					"exemplar": true,
-					"expr": "histogram_quantile(0.99, sum(rate(state_store_range_scan_duration_bucket[1m])) by (le, instance))",
-					"hide": true,
-					"interval": "",
-					"legendFormat": "range_scan p99 (cn: {{instance}})",
-					"refId": "F"
-				},
-				{
-					"datasource": {
-						"type": "prometheus",
-						"uid": "risedev-prometheus"
-					},
-					"exemplar": true,
-					"expr": "histogram_quantile(0.9, sum(rate(state_store_range_scan_duration_bucket[1m])) by (le, instance))",
-					"hide": true,
-					"interval": "",
-					"legendFormat": "range_scan p90 (cn: {{instance}})",
-					"refId": "G"
-				},
-				{
-					"datasource": {
-						"type": "prometheus",
-						"uid": "risedev-prometheus"
-					},
-					"exemplar": true,
-					"expr": "sum by(le, instance)(rate(state_store_range_scan_duration_sum[1m])) / sum by(le, instance) (rate(state_store_range_scan_duration_count[1m]))",
-					"hide": false,
-					"interval": "",
-					"legendFormat": "range_scan avg (cn: {{instance}})",
-					"refId": "H"
-				},
-				{
-					"datasource": {
-						"type": "prometheus",
-						"uid": "risedev-prometheus"
-					},
-					"exemplar": true,
-					"expr": "histogram_quantile(0.5, sum(rate(state_store_range_reverse_scan_duration_bucket[1m])) by (le, instance))",
-					"hide": true,
-					"interval": "",
-					"legendFormat": "reverse_range_scan p50 (cn: {{instance}})",
-					"refId": "I"
-				},
-				{
-					"datasource": {
-						"type": "prometheus",
-						"uid": "risedev-prometheus"
-					},
-					"exemplar": true,
-					"expr": "histogram_quantile(0.99, sum(rate(state_store_range_reverse_scan_duration_bucket[1m])) by (le, instance))",
-					"hide": true,
-					"interval": "",
-					"legendFormat": "reverse_range_scan p99 (cn: {{instance}})",
-					"refId": "J"
-				},
-				{
-					"datasource": {
-						"type": "prometheus",
-						"uid": "risedev-prometheus"
-					},
-					"exemplar": true,
-					"expr": "sum by(le, instance)(rate(state_store_range_reverse_scan_duration_sum[1m])) / sum by(le, instance) (rate(state_store_range_reverse_scan_duration_count[1m]))",
-					"hide": false,
-					"interval": "",
-					"legendFormat": "reverse_range_scan avg (cn: {{instance}})",
-					"refId": "K"
-				}
-			],
-			"title": "read duration",
-			"type": "timeseries"
-		},
-		{
-			"aliasColors": {},
-			"bars": false,
-			"dashLength": 10,
-			"dashes": false,
-			"fill": 1,
-			"fillGradient": 0,
-			"gridPos": {
-				"h": 8,
-				"w": 12,
-				"x": 12,
-				"y": 61
-			},
-			"hiddenSeries": false,
-			"id": 196,
-			"legend": {
-				"avg": false,
-				"current": false,
-				"max": false,
-				"min": false,
-				"show": true,
-				"total": false,
-				"values": false
-			},
-			"lines": true,
-			"linewidth": 1,
-			"nullPointMode": "null",
-			"options": {
-				"alertThreshold": true
-			},
-			"percentage": false,
-			"pluginVersion": "8.3.3",
-			"pointradius": 2,
-			"points": false,
-			"renderer": "flot",
-			"seriesOverrides": [],
-			"spaceLength": 10,
-			"stack": false,
-			"steppedLine": false,
-			"targets": [
-				{
-					"datasource": {
-						"type": "prometheus",
-						"uid": "risedev-prometheus"
-					},
-					"exemplar": true,
-					"expr": "avg(state_store_meta_cache_size) by (instance)",
-					"format": "time_series",
-					"hide": false,
-					"interval": "",
-					"intervalFactor": 2,
-					"legendFormat": "meta-cache (cn: {{instance}})",
-					"refId": "A"
-				},
-				{
-					"datasource": {
-						"type": "prometheus",
-						"uid": "risedev-prometheus"
-					},
-					"exemplar": true,
-					"expr": "avg(state_store_block_cache_size) by (instance)",
-					"hide": false,
-					"interval": "",
-					"legendFormat": "meta-cache (cn: {{instance}})",
-					"refId": "B"
-				}
-			],
-			"thresholds": [],
-			"timeRegions": [],
-			"title": "Cache Size",
-			"tooltip": {
-				"shared": true,
-				"sort": 0,
-				"value_type": "individual"
-			},
-			"type": "graph",
-			"xaxis": {
-				"mode": "time",
-				"show": true,
-				"values": []
-			},
-			"yaxes": [
-				{
-					"$$hashKey": "object:37",
-					"format": "decbytes",
-					"logBase": 1,
-					"show": true
-				},
-				{
-					"$$hashKey": "object:38",
-					"format": "short",
-					"logBase": 1,
-					"show": true
-				}
-			],
-			"yaxis": {
-				"align": false
-			}
-		},
-		{
-			"fieldConfig": {
-				"defaults": {
-					"color": {
-						"mode": "palette-classic"
-					},
-					"custom": {
-						"axisLabel": "",
-						"axisPlacement": "auto",
-						"barAlignment": 0,
-						"drawStyle": "line",
-						"fillOpacity": 10,
-						"gradientMode": "none",
-						"hideFrom": {
-							"legend": false,
-							"tooltip": false,
-							"viz": false
-						},
-						"lineInterpolation": "linear",
-						"lineWidth": 1,
-						"pointSize": 5,
-						"scaleDistribution": {
-							"type": "linear"
-						},
-						"showPoints": "never",
-						"spanNulls": true,
-						"stacking": {
-							"group": "A",
-							"mode": "none"
-						},
-						"thresholdsStyle": {
-							"mode": "off"
-						}
-					},
-					"mappings": [],
-					"thresholds": {
-						"mode": "absolute",
-						"steps": [
-							{
-								"color": "green",
-								"value": null
-							},
-							{
-								"color": "red",
-								"value": 80
-							}
-						]
-					},
-					"unit": "ops"
-				},
-				"overrides": []
-			},
-			"gridPos": {
-				"h": 8,
-				"w": 12,
-				"x": 0,
-				"y": 69
-			},
-			"id": 43,
-			"options": {
-				"legend": {
-					"calcs": [],
-					"displayMode": "list",
-					"placement": "bottom"
-				},
-				"tooltip": {
-					"mode": "single"
-				}
-			},
-			"pluginVersion": "8.3.3",
-			"targets": [
-				{
-					"datasource": {
-						"type": "prometheus",
-						"uid": "risedev-prometheus"
-					},
-					"exemplar": true,
-					"expr": "sum(rate(state_store_write_batch_duration_count[1m])) by (instance)",
-					"interval": "",
-					"intervalFactor": 2,
-					"legendFormat": "write batch cn= {{instance}} ",
-					"refId": "A"
-				},
-				{
-					"datasource": {
-						"type": "prometheus",
-						"uid": "risedev-prometheus"
-					},
-					"exemplar": true,
-					"expr": "sum(rate(state_store_shared_buffer_to_l0_duration_count[1m])) by (instance)",
-					"hide": false,
-					"interval": "",
-					"legendFormat": "l0 cn = {{instance}} ",
-					"refId": "B"
-				}
-			],
-			"title": "write ops",
-			"type": "timeseries"
-		},
-		{
-			"fieldConfig": {
-				"defaults": {
-					"color": {
-						"mode": "palette-classic"
-					},
-					"custom": {
-						"axisLabel": "",
-						"axisPlacement": "auto",
-						"barAlignment": 0,
-						"drawStyle": "line",
-						"fillOpacity": 0,
-						"gradientMode": "none",
-						"hideFrom": {
-							"legend": false,
-							"tooltip": false,
-							"viz": false
-						},
-						"lineInterpolation": "linear",
-						"lineWidth": 1,
-						"pointSize": 5,
-						"scaleDistribution": {
-							"type": "linear"
-						},
-						"showPoints": "auto",
-						"spanNulls": false,
-						"stacking": {
-							"group": "A",
-							"mode": "none"
-						},
-						"thresholdsStyle": {
-							"mode": "off"
-						}
-					},
-					"mappings": [],
-					"thresholds": {
-						"mode": "absolute",
-						"steps": [
-							{
-								"color": "green",
-								"value": null
-							},
-							{
-								"color": "red",
-								"value": 80
-							}
-						]
-					},
-					"unit": "cpm"
-				},
-				"overrides": []
-			},
-			"gridPos": {
-				"h": 8,
-				"w": 12,
-				"x": 12,
-				"y": 69
-			},
-			"id": 130,
-			"options": {
-				"legend": {
-					"calcs": [],
-					"displayMode": "list",
-					"placement": "bottom"
-				},
-				"tooltip": {
-					"mode": "single"
-				}
-			},
-			"pluginVersion": "8.3.3",
-			"targets": [
-				{
-					"datasource": {
-						"type": "prometheus",
-						"uid": "risedev-prometheus"
-					},
-					"exemplar": true,
-					"expr": "sum(rate(state_store_bloom_filter_true_negative_counts[1m])) by (instance)",
-					"hide": false,
-					"interval": "",
-					"legendFormat": "bloom filter true negative (cn:{{instance}})",
-					"refId": "G"
-				},
-				{
-					"datasource": {
-						"type": "prometheus",
-						"uid": "risedev-prometheus"
-					},
-					"exemplar": true,
-					"expr": "sum(rate(state_store_bloom_filter_might_positive_counts[1m])) by (instance)",
-					"hide": false,
-					"interval": "",
-					"legendFormat": "bloom filter might positive (cn:{{instance}})",
-					"refId": "H"
-				},
-				{
-					"datasource": {
-						"type": "prometheus",
-						"uid": "risedev-prometheus"
-					},
-					"exemplar": true,
-					"expr": "histogram_quantile(0.9, sum(rate(state_store_iter_merge_sstable_counts_bucket[1m])) by (le, instance))",
-					"hide": true,
-					"interval": "",
-					"legendFormat": "# merged ssts p90 (cn:{{instance}})",
-					"refId": "A"
-				},
-				{
-					"datasource": {
-						"type": "prometheus",
-						"uid": "risedev-prometheus"
-					},
-					"exemplar": true,
-					"expr": "histogram_quantile(0.99, sum(rate(state_store_iter_merge_sstable_counts_bucket[1m])) by (le, instance))",
-					"hide": true,
-					"interval": "",
-					"legendFormat": "# merged ssts p99 (cn:{{instance}})",
-					"refId": "C"
-				},
-				{
-					"datasource": {
-						"type": "prometheus",
-						"uid": "risedev-prometheus"
-					},
-					"exemplar": true,
-					"expr": "sum by(le, instance)(rate(state_store_iter_merge_sstable_counts_sum[1m]))  / sum by(le, instance)(rate(state_store_iter_merge_sstable_counts_count[1m]))",
-					"hide": false,
-					"interval": "",
-					"legendFormat": "# merged ssts avg (cn:{{instance}})",
-					"refId": "B"
-				}
-			],
-			"title": "sst read counters",
-			"type": "timeseries"
-		},
-		{
-			"fieldConfig": {
-				"defaults": {
-					"color": {
-						"mode": "palette-classic"
-					},
-					"custom": {
-						"axisLabel": "",
-						"axisPlacement": "auto",
-						"barAlignment": 0,
-						"drawStyle": "line",
-						"fillOpacity": 10,
-						"gradientMode": "none",
-						"hideFrom": {
-							"legend": false,
-							"tooltip": false,
-							"viz": false
-						},
-						"lineInterpolation": "linear",
-						"lineWidth": 1,
-						"pointSize": 5,
-						"scaleDistribution": {
-							"type": "linear"
-						},
-						"showPoints": "never",
-						"spanNulls": true,
-						"stacking": {
-							"group": "A",
-							"mode": "none"
-						},
-						"thresholdsStyle": {
-							"mode": "off"
-						}
-					},
-					"mappings": [],
-					"thresholds": {
-						"mode": "absolute",
-						"steps": [
-							{
-								"color": "green",
-								"value": null
-							},
-							{
-								"color": "red",
-								"value": 80
-							}
-						]
-					},
-					"unit": "s"
-				},
-				"overrides": []
-			},
-			"gridPos": {
-				"h": 8,
-				"w": 12,
-				"x": 0,
-				"y": 77
-			},
-			"id": 40,
-			"options": {
-				"legend": {
-					"calcs": [],
-					"displayMode": "list",
-					"placement": "bottom"
-				},
-				"tooltip": {
-					"mode": "single"
-				}
-			},
-			"pluginVersion": "8.3.3",
-			"targets": [
-				{
-					"datasource": {
-						"type": "prometheus",
-						"uid": "risedev-prometheus"
-					},
-					"exemplar": true,
-					"expr": "histogram_quantile(0.5, sum(rate(state_store_write_batch_duration_bucket[1m])) by (le, instance))",
-					"interval": "",
-					"legendFormat": "shared_buffer p50  (cn: {{instance}})",
-					"refId": "A"
-				},
-				{
-					"datasource": {
-						"type": "prometheus",
-						"uid": "risedev-prometheus"
-					},
-					"exemplar": true,
-					"expr": "histogram_quantile(0.9, sum(rate(state_store_write_batch_duration_bucket[1m])) by (le, instance))",
-					"hide": false,
-					"interval": "",
-					"legendFormat": "shared_buffer p90  (cn: {{instance}})",
-					"refId": "B"
-				},
-				{
-					"datasource": {
-						"type": "prometheus",
-						"uid": "risedev-prometheus"
-					},
-					"exemplar": true,
-					"expr": "histogram_quantile(0.99, sum(rate(state_store_write_batch_duration_bucket[1m])) by (le, instance))",
-					"hide": false,
-					"interval": "",
-					"legendFormat": "shared_buffer p99  (cn: {{instance}})",
-					"refId": "C"
-				},
-				{
-					"datasource": {
-						"type": "prometheus",
-						"uid": "risedev-prometheus"
-					},
-					"exemplar": true,
-					"expr": "sum by(le, instance)(rate(state_store_write_batch_duration_sum[1m]))  / sum by(le, instance)(rate(state_store_write_batch_duration_count[1m]))",
-					"hide": false,
-					"interval": "",
-					"legendFormat": "shared_buffer avg (cn: {{instance}})",
-					"refId": "D"
-				},
-				{
-					"datasource": {
-						"type": "prometheus",
-						"uid": "risedev-prometheus"
-					},
-					"exemplar": true,
-					"expr": "histogram_quantile(0.5, sum(rate(state_store_write_shared_buffer_sync_time_bucket[1m])) by (le, instance))",
-					"hide": false,
-					"interval": "",
-					"legendFormat": "sync_remote p50 (cn: {{instance}})",
-					"refId": "E"
-				},
-				{
-					"datasource": {
-						"type": "prometheus",
-						"uid": "risedev-prometheus"
-					},
-					"exemplar": true,
-					"expr": "histogram_quantile(0.9, sum(rate(state_store_write_shared_buffer_sync_time_bucket[1m])) by (le, instance))",
-					"hide": false,
-					"interval": "",
-					"legendFormat": "sync_remote p90 (cn: {{instance}})",
-					"refId": "F"
-				},
-				{
-					"datasource": {
-						"type": "prometheus",
-						"uid": "risedev-prometheus"
-					},
-					"exemplar": true,
-					"expr": "histogram_quantile(0.99, sum(rate(state_store_write_shared_buffer_sync_time_bucket[1m])) by (le, instance))",
-					"hide": false,
-					"interval": "",
-					"legendFormat": "sync_remote p99 (cn: {{instance}})",
-					"refId": "G"
-				},
-				{
-					"datasource": {
-						"type": "prometheus",
-						"uid": "risedev-prometheus"
-					},
-					"exemplar": true,
-					"expr": "sum by(le, instance)(rate(state_store_write_shared_buffer_sync_time_sum[1m]))  / sum by(le, instance)(rate(state_store_write_shared_buffer_sync_time_count[1m]))",
-					"hide": false,
-					"interval": "",
-					"legendFormat": "sync_remote avg (cn: {{instance}})",
-					"refId": "H"
-				}
-			],
-			"title": "write duration",
-			"type": "timeseries"
-		},
-		{
-			"fieldConfig": {
-				"defaults": {
-					"color": {
-						"mode": "palette-classic"
-					},
-					"custom": {
-						"axisLabel": "",
-						"axisPlacement": "auto",
-						"barAlignment": 0,
-						"drawStyle": "line",
-						"fillOpacity": 10,
-						"gradientMode": "none",
-						"hideFrom": {
-							"legend": false,
-							"tooltip": false,
-							"viz": false
-						},
-						"lineInterpolation": "linear",
-						"lineWidth": 1,
-						"pointSize": 5,
-						"scaleDistribution": {
-							"type": "linear"
-						},
-						"showPoints": "never",
-						"spanNulls": true,
-						"stacking": {
-							"group": "A",
-							"mode": "none"
-						},
-						"thresholdsStyle": {
-							"mode": "off"
-						}
-					},
-					"mappings": [],
-					"thresholds": {
-						"mode": "absolute",
-						"steps": [
-							{
-								"color": "green",
-								"value": null
-							},
-							{
-								"color": "red",
-								"value": 80
-							}
-						]
-					},
-					"unit": "Bps"
-				},
-				"overrides": []
-			},
-			"gridPos": {
-				"h": 8,
-				"w": 12,
-				"x": 12,
-				"y": 77
-			},
-			"id": 32,
-			"options": {
-				"legend": {
-					"calcs": [],
-					"displayMode": "list",
-					"placement": "bottom"
-				},
-				"tooltip": {
-					"mode": "single"
-				}
-			},
-			"pluginVersion": "8.3.3",
-			"targets": [
-				{
-					"datasource": {
-						"type": "prometheus",
-						"uid": "risedev-prometheus"
-					},
-					"exemplar": true,
-					"expr": "sum by(instance)(rate(state_store_get_key_size_sum[1m])+rate(state_store_get_value_size_sum[1m]))/sum by(instance)(rate(state_store_get_key_size_count[1m]))",
-					"interval": "",
-					"legendFormat": "get (cn:{{instance}})",
-					"refId": "A"
-				},
-				{
-					"datasource": {
-						"type": "prometheus",
-						"uid": "risedev-prometheus"
-					},
-					"exemplar": true,
-					"expr": "sum by(instance)(rate(state_store_get_key_size_sum[1m]))/sum by(instance)(rate(state_store_get_key_size_count[1m]))",
-					"hide": false,
-					"interval": "",
-					"legendFormat": "get key (cn:{{instance}})",
-					"refId": "B"
-				},
-				{
-					"datasource": {
-						"type": "prometheus",
-						"uid": "risedev-prometheus"
-					},
-					"exemplar": true,
-					"expr": "sum by(instance)(rate(state_store_get_value_size_sum[1m]))/sum by(instance)(rate(state_store_get_value_size_count[1m]))",
-					"hide": false,
-					"interval": "",
-					"legendFormat": "get value (cn:{{instance}})",
-					"refId": "C"
-				},
-				{
-					"datasource": {
-						"type": "prometheus",
-						"uid": "risedev-prometheus"
-					},
-					"exemplar": true,
-					"expr": "sum by(instance)(rate(state_store_range_scan_size_sum[1m]))/sum by(instance)(rate(state_store_range_scan_size_count[1m]))",
-					"hide": false,
-					"interval": "",
-					"legendFormat": "range_scan (cn:{{instance}})",
-					"refId": "D"
-				},
-				{
-					"datasource": {
-						"type": "prometheus",
-						"uid": "risedev-prometheus"
-					},
-					"exemplar": true,
-					"expr": "sum by(instance)(rate(state_store_range_reverse_scan_size_sum[1m]))/sum by(instance)(rate(state_store_range_reverse_scan_size_count[1m]))",
-					"hide": false,
-					"interval": "",
-					"legendFormat": "reverse_range_scan (cn:{{instance}})",
-					"refId": "E"
-				}
-			],
-			"title": "read throughput",
-			"type": "timeseries"
-		},
-		{
-			"fieldConfig": {
-				"defaults": {
-					"color": {
-						"mode": "palette-classic"
-					},
-					"custom": {
-						"axisLabel": "",
-						"axisPlacement": "auto",
-						"barAlignment": 0,
-						"drawStyle": "line",
-						"fillOpacity": 10,
-						"gradientMode": "none",
-						"hideFrom": {
-							"legend": false,
-							"tooltip": false,
-							"viz": false
-						},
-						"lineInterpolation": "linear",
-						"lineWidth": 1,
-						"pointSize": 5,
-						"scaleDistribution": {
-							"type": "linear"
-						},
-						"showPoints": "never",
-						"spanNulls": true,
-						"stacking": {
-							"group": "A",
-							"mode": "none"
-						},
-						"thresholdsStyle": {
-							"mode": "off"
-						}
-					},
-					"mappings": [],
-					"thresholds": {
-						"mode": "absolute",
-						"steps": [
-							{
-								"color": "green",
-								"value": null
-							},
-							{
-								"color": "red",
-								"value": 80
-							}
-						]
-					},
-					"unit": "s"
-				},
-				"overrides": []
-			},
-			"gridPos": {
-				"h": 8,
-				"w": 12,
-				"x": 0,
-				"y": 85
-			},
-			"id": 41,
-			"options": {
-				"legend": {
-					"calcs": [],
-					"displayMode": "list",
-					"placement": "bottom"
-				},
-				"tooltip": {
-					"mode": "single"
-				}
-			},
-			"pluginVersion": "8.3.3",
-			"targets": [
-				{
-					"datasource": {
-						"type": "prometheus",
-						"uid": "risedev-prometheus"
-					},
-					"exemplar": true,
-					"expr": "histogram_quantile(0.5, sum(rate(state_store_shared_buffer_to_l0_duration_bucket[1m])) by (le, instance))",
-					"hide": true,
-					"interval": "",
-					"legendFormat": "p50 (cn: {{instance}})",
-					"refId": "A"
-				},
-				{
-					"datasource": {
-						"type": "prometheus",
-						"uid": "risedev-prometheus"
-					},
-					"exemplar": true,
-					"expr": "histogram_quantile(0.9, sum(rate(state_store_shared_buffer_to_l0_duration_bucket[1m])) by (le, instance))",
-					"hide": true,
-					"interval": "",
-					"legendFormat": "p90 (cn: {{instance}})",
-					"refId": "B"
-				},
-				{
-					"datasource": {
-						"type": "prometheus",
-						"uid": "risedev-prometheus"
-					},
-					"exemplar": true,
-					"expr": "histogram_quantile(0.99, sum(rate(state_store_shared_buffer_to_l0_duration_bucket[1m])) by (le, instance))",
-					"hide": true,
-					"interval": "",
-					"legendFormat": "p99 (cn: {{instance}})",
-					"refId": "C"
-				},
-				{
-					"datasource": {
-						"type": "prometheus",
-						"uid": "risedev-prometheus"
-					},
-					"exemplar": true,
-					"expr": "sum by(le, instance) (rate(state_store_shared_buffer_to_l0_duration_sum[1m])) / sum by(le, instance) (rate(state_store_shared_buffer_to_l0_duration_count[1m]))",
-					"hide": false,
-					"interval": "",
-					"legendFormat": "avg (cn: {{instance}})",
-					"refId": "D"
-				}
-			],
-			"title": "build sstable duration",
-			"type": "timeseries"
-		},
-		{
-			"fieldConfig": {
-				"defaults": {
-					"color": {
-						"mode": "palette-classic"
-					},
-					"custom": {
-						"axisLabel": "",
-						"axisPlacement": "auto",
-						"barAlignment": 0,
-						"drawStyle": "line",
-						"fillOpacity": 10,
-						"gradientMode": "none",
-						"hideFrom": {
-							"legend": false,
-							"tooltip": false,
-							"viz": false
-						},
-						"lineInterpolation": "linear",
-						"lineWidth": 1,
-						"pointSize": 5,
-						"scaleDistribution": {
-							"type": "linear"
-						},
-						"showPoints": "never",
-						"spanNulls": true,
-						"stacking": {
-							"group": "A",
-							"mode": "none"
-						},
-						"thresholdsStyle": {
-							"mode": "off"
-						}
-					},
-					"mappings": [],
-					"thresholds": {
-						"mode": "absolute",
-						"steps": [
-							{
-								"color": "green",
-								"value": null
-							},
-							{
-								"color": "red",
-								"value": 80
-							}
-						]
-					},
-					"unit": "ops"
-				},
-				"overrides": []
-			},
-			"gridPos": {
-				"h": 8,
-				"w": 12,
-				"x": 12,
-				"y": 85
-			},
-			"id": 132,
-			"options": {
-				"legend": {
-					"calcs": [],
-					"displayMode": "list",
-					"placement": "bottom"
-				},
-				"tooltip": {
-					"mode": "single"
-				}
-			},
-			"pluginVersion": "8.3.3",
-			"targets": [
-				{
-					"datasource": {
-						"type": "prometheus",
-						"uid": "risedev-prometheus"
-					},
-					"exemplar": true,
-					"expr": "sum(rate(state_store_iter_merge_seek_duration_count[1m])) by (instance)",
-					"hide": false,
-					"interval": "",
-					"legendFormat": "MI seek (cn:{{instance}})",
-					"refId": "G"
-				},
-				{
-					"datasource": {
-						"type": "prometheus",
-						"uid": "risedev-prometheus"
-					},
-					"exemplar": true,
-					"expr": "sum(rate(state_store_iter_merge_next_duration_count[1m])) by (instance)",
-					"hide": false,
-					"interval": "",
-					"legendFormat": "MI next (cn:{{instance}})",
-					"refId": "H"
-				}
-			],
-			"title": "merge iterators ops",
-			"type": "timeseries"
-		},
-		{
-			"fieldConfig": {
-				"defaults": {
-					"color": {
-						"mode": "palette-classic"
-					},
-					"custom": {
-						"axisLabel": "",
-						"axisPlacement": "auto",
-						"barAlignment": 0,
-						"drawStyle": "line",
-						"fillOpacity": 10,
-						"gradientMode": "none",
-						"hideFrom": {
-							"legend": false,
-							"tooltip": false,
-							"viz": false
-						},
-						"lineInterpolation": "linear",
-						"lineWidth": 1,
-						"pointSize": 5,
-						"scaleDistribution": {
-							"type": "linear"
-						},
-						"showPoints": "never",
-						"spanNulls": true,
-						"stacking": {
-							"group": "A",
-							"mode": "none"
-						},
-						"thresholdsStyle": {
-							"mode": "off"
-						}
-					},
-					"mappings": [],
-					"thresholds": {
-						"mode": "absolute",
-						"steps": [
-							{
-								"color": "green",
-								"value": null
-							},
-							{
-								"color": "red",
-								"value": 80
-							}
-						]
-					},
-					"unit": "s"
-				},
-				"overrides": []
-			},
-			"gridPos": {
-				"h": 8,
-				"w": 12,
-				"x": 0,
-				"y": 93
-			},
-			"id": 134,
-			"options": {
-				"legend": {
-					"calcs": [],
-					"displayMode": "list",
-					"placement": "bottom"
-				},
-				"tooltip": {
-					"mode": "single"
-				}
-			},
-			"pluginVersion": "8.3.3",
-			"targets": [
-				{
-					"datasource": {
-						"type": "prometheus",
-						"uid": "risedev-prometheus"
-					},
-					"exemplar": true,
-					"expr": "histogram_quantile(0.5, sum(rate(batch_row_seq_scan_next_duration_bucket[1m])) by (le, instance))",
-					"hide": true,
-					"interval": "",
-					"legendFormat": "row_seq_scan next p50 (cn: {{instance}})",
-					"refId": "A"
-				},
-				{
-					"datasource": {
-						"type": "prometheus",
-						"uid": "risedev-prometheus"
-					},
-					"exemplar": true,
-					"expr": "histogram_quantile(0.9, sum(rate(batch_row_seq_scan_next_duration_bucket[1m])) by (le, instance))",
-					"hide": true,
-					"interval": "",
-					"legendFormat": "p90 (cn: {{instance}})",
-					"refId": "B"
-				},
-				{
-					"datasource": {
-						"type": "prometheus",
-						"uid": "risedev-prometheus"
-					},
-					"exemplar": true,
-					"expr": "histogram_quantile(0.99, sum(rate(batch_row_seq_scan_next_duration_bucket[1m])) by (le, instance))",
-					"hide": true,
-					"interval": "",
-					"legendFormat": "p99 (cn: {{instance}})",
-					"refId": "C"
-				},
-				{
-					"datasource": {
-						"type": "prometheus",
-						"uid": "risedev-prometheus"
-					},
-					"exemplar": true,
-					"expr": "sum by(le, instance) (rate(batch_row_seq_scan_next_duration_sum[1m])) / sum by(le, instance) (rate(batch_row_seq_scan_next_duration_count[1m]))",
-					"hide": false,
-					"interval": "",
-					"legendFormat": "row_seq_scan next avg (cn: {{instance}})",
-					"refId": "D"
-				}
-			],
-			"title": "row seq scan next duration",
-			"type": "timeseries"
-		},
-		{
-			"fieldConfig": {
-				"defaults": {
-					"color": {
-						"mode": "palette-classic"
-					},
-					"custom": {
-						"axisLabel": "",
-						"axisPlacement": "auto",
-						"barAlignment": 0,
-						"drawStyle": "line",
-						"fillOpacity": 10,
-						"gradientMode": "none",
-						"hideFrom": {
-							"legend": false,
-							"tooltip": false,
-							"viz": false
-						},
-						"lineInterpolation": "linear",
-						"lineWidth": 1,
-						"pointSize": 5,
-						"scaleDistribution": {
-							"type": "linear"
-						},
-						"showPoints": "never",
-						"spanNulls": true,
-						"stacking": {
-							"group": "A",
-							"mode": "none"
-						},
-						"thresholdsStyle": {
-							"mode": "off"
-						}
-					},
-					"mappings": [],
-					"thresholds": {
-						"mode": "absolute",
-						"steps": [
-							{
-								"color": "green",
-								"value": null
-							},
-							{
-								"color": "red",
-								"value": 80
-							}
-						]
-					},
-					"unit": "s"
-				},
-				"overrides": []
-			},
-			"gridPos": {
-				"h": 8,
-				"w": 12,
-				"x": 12,
-				"y": 93
-			},
-			"id": 48,
-			"options": {
-				"legend": {
-					"calcs": [],
-					"displayMode": "list",
-					"placement": "bottom"
-				},
-				"tooltip": {
-					"mode": "single"
-				}
-			},
-			"pluginVersion": "8.3.3",
-			"targets": [
-				{
-					"datasource": {
-						"type": "prometheus",
-						"uid": "risedev-prometheus"
-					},
-					"exemplar": true,
-					"expr": "histogram_quantile(0.5, sum(rate(state_store_iter_merge_seek_duration_bucket[1m])) by (le, instance))",
-					"hide": true,
-					"interval": "",
-					"legendFormat": "mi_seek p50 (cn:{{instance}})",
-					"refId": "E"
-				},
-				{
-					"datasource": {
-						"type": "prometheus",
-						"uid": "risedev-prometheus"
-					},
-					"exemplar": true,
-					"expr": "histogram_quantile(0.9, sum(rate(state_store_iter_merge_seek_duration_bucket[1m])) by (le, instance))",
-					"hide": true,
-					"interval": "",
-					"legendFormat": "mi_seek p90 (cn:{{instance}})",
-					"refId": "F"
-				},
-				{
-					"datasource": {
-						"type": "prometheus",
-						"uid": "risedev-prometheus"
-					},
-					"exemplar": true,
-					"expr": "histogram_quantile(0.99, sum(rate(state_store_iter_merge_seek_duration_bucket[1m])) by (le, instance))",
-					"hide": true,
-					"interval": "",
-					"legendFormat": "mi_seek p99 (cn:{{instance}})",
-					"refId": "G"
-				},
-				{
-					"datasource": {
-						"type": "prometheus",
-						"uid": "risedev-prometheus"
-					},
-					"exemplar": true,
-					"expr": "sum by(le, instance) (rate(state_store_iter_merge_seek_duration_sum[1m])) / sum by(le, instance) (rate(state_store_iter_merge_seek_duration_count[1m]))",
-					"hide": false,
-					"interval": "",
-					"legendFormat": "mi_seek avg (cn:{{instance}})",
-					"refId": "H"
-				}
-			],
-			"title": "merge iterators duration",
-			"type": "timeseries"
-		},
-		{
-			"fieldConfig": {
-				"defaults": {
-					"color": {
-						"mode": "palette-classic"
-					},
-					"custom": {
-						"axisLabel": "",
-						"axisPlacement": "auto",
-						"barAlignment": 0,
-						"drawStyle": "line",
-						"fillOpacity": 10,
-						"gradientMode": "none",
-						"hideFrom": {
-							"legend": false,
-							"tooltip": false,
-							"viz": false
-						},
-						"lineInterpolation": "linear",
-						"lineWidth": 1,
-						"pointSize": 5,
-						"scaleDistribution": {
-							"type": "linear"
-						},
-						"showPoints": "never",
-						"spanNulls": true,
-						"stacking": {
-							"group": "A",
-							"mode": "none"
-						},
-						"thresholdsStyle": {
-							"mode": "off"
-						}
-					},
-					"mappings": [],
-					"thresholds": {
-						"mode": "absolute",
-						"steps": [
-							{
-								"color": "green",
-								"value": null
-							},
-							{
-								"color": "red",
-								"value": 80
-							}
-						]
-					},
-					"unit": "cps"
-				},
-				"overrides": []
-			},
-			"gridPos": {
-				"h": 8,
-				"w": 12,
-				"x": 12,
-				"y": 101
-			},
-			"id": 44,
-			"options": {
-				"legend": {
-					"calcs": [],
-					"displayMode": "list",
-					"placement": "bottom"
-				},
-				"tooltip": {
-					"mode": "single"
-				}
-			},
-			"pluginVersion": "8.3.3",
-			"targets": [
-				{
-					"datasource": {
-						"type": "prometheus",
-						"uid": "risedev-prometheus"
-					},
-					"exemplar": true,
-					"expr": "sum(rate(state_store_write_batch_tuple_counts[1m])) by (instance)",
-					"interval": "",
-					"intervalFactor": 2,
-					"legendFormat": "write_batch_kv_pair_count - {{instance}} ",
-					"refId": "A"
-				}
-			],
-			"title": "write kv pair counts",
-			"type": "timeseries"
-		},
-		{
-			"fieldConfig": {
-				"defaults": {
-					"color": {
-						"mode": "palette-classic"
-					},
-					"custom": {
-						"axisLabel": "",
-						"axisPlacement": "auto",
-						"barAlignment": 0,
-						"drawStyle": "line",
-						"fillOpacity": 10,
-						"gradientMode": "none",
-						"hideFrom": {
-							"legend": false,
-							"tooltip": false,
-							"viz": false
-						},
-						"lineInterpolation": "linear",
-						"lineWidth": 1,
-						"pointSize": 5,
-						"scaleDistribution": {
-							"type": "linear"
-						},
-						"showPoints": "never",
-						"spanNulls": true,
-						"stacking": {
-							"group": "A",
-							"mode": "none"
-						},
-						"thresholdsStyle": {
-							"mode": "off"
-						}
-					},
-					"mappings": [],
-					"thresholds": {
-						"mode": "absolute",
-						"steps": [
-							{
-								"color": "green",
-								"value": null
-							},
-							{
-								"color": "red",
-								"value": 80
-							}
-						]
-					},
-					"unit": "Bps"
-				},
-				"overrides": []
-			},
-			"gridPos": {
-				"h": 8,
-				"w": 12,
-				"x": 12,
-				"y": 109
-			},
-			"id": 45,
-			"options": {
-				"legend": {
-					"calcs": [],
-					"displayMode": "list",
-					"placement": "bottom"
-				},
-				"tooltip": {
-					"mode": "single"
-				}
-			},
-			"pluginVersion": "8.3.3",
-			"targets": [
-				{
-					"datasource": {
-						"type": "prometheus",
-						"uid": "risedev-prometheus"
-					},
-					"exemplar": true,
-					"expr": "sum(rate(state_store_write_batch_size_sum[1m]))by(instance) / sum(rate(state_store_write_batch_size_count[1m]))by(instance)",
-					"interval": "",
-					"legendFormat": "shared_buffer (cn: {{instance}})",
-					"refId": "A"
-				},
-				{
-					"datasource": {
-						"type": "prometheus",
-						"uid": "risedev-prometheus"
-					},
-					"exemplar": true,
-					"expr": "sum(rate(state_store_shared_buffer_to_sstable_size_sum[1m]))by(instance) / sum(rate(state_store_shared_buffer_to_sstable_size_count[1m]))by(instance)",
-					"hide": false,
-					"interval": "",
-					"legendFormat": "sync (cn: {{instance}})",
-					"refId": "B"
-				}
-			],
-			"title": "write throughput",
-			"type": "timeseries"
 		},
 		{
 			"collapsed": true,
@@ -3942,7 +4043,7 @@
 				"h": 1,
 				"w": 24,
 				"x": 0,
-				"y": 117
+				"y": 53
 			},
 			"id": 115,
 			"panels": [
@@ -4532,7 +4633,7 @@
 				"h": 1,
 				"w": 24,
 				"x": 0,
-				"y": 118
+				"y": 54
 			},
 			"id": 113,
 			"panels": [
@@ -4834,7 +4935,7 @@
 				"h": 1,
 				"w": 24,
 				"x": 0,
-				"y": 119
+				"y": 55
 			},
 			"id": 97,
 			"panels": [
@@ -5424,7 +5525,7 @@
 				"h": 1,
 				"w": 24,
 				"x": 0,
-				"y": 120
+				"y": 56
 			},
 			"id": 88,
 			"panels": [
@@ -5798,7 +5899,7 @@
 				"h": 1,
 				"w": 24,
 				"x": 0,
-				"y": 121
+				"y": 57
 			},
 			"id": 84,
 			"panels": [
@@ -6052,7 +6153,7 @@
 				"h": 1,
 				"w": 24,
 				"x": 0,
-				"y": 122
+				"y": 58
 			},
 			"id": 82,
 			"panels": [
@@ -6426,7 +6527,7 @@
 				"h": 1,
 				"w": 24,
 				"x": 0,
-				"y": 123
+				"y": 59
 			},
 			"id": 78,
 			"panels": [
@@ -7065,7 +7166,7 @@
 				"h": 1,
 				"w": 24,
 				"x": 0,
-				"y": 124
+				"y": 60
 			},
 			"id": 62,
 			"panels": [
@@ -8131,13 +8232,13 @@
 		]
 	},
 	"time": {
-		"from": "now-30m",
+		"from": "now-15m",
 		"to": "now"
 	},
 	"timepicker": {},
 	"timezone": "",
 	"title": "risingwave_dashboard",
 	"uid": "Ecy3uV1nz",
-	"version": 30,
+	"version": 31,
 	"weekStart": ""
 }

--- a/proto/hummock.proto
+++ b/proto/hummock.proto
@@ -124,7 +124,7 @@ message KeyRange {
 
 message TableSetStatistics {
   uint32 level_idx = 1;
-  double size_gb = 2;
+  uint64 size_kb = 2;
   uint64 cnt = 3;
 }
 

--- a/src/compute/src/server.rs
+++ b/src/compute/src/server.rs
@@ -30,7 +30,9 @@ use risingwave_rpc_client::MetaClient;
 use risingwave_source::MemSourceManager;
 use risingwave_storage::hummock::compactor::Compactor;
 use risingwave_storage::hummock::hummock_meta_client::MonitoredHummockMetaClient;
-use risingwave_storage::monitor::{HummockMetrics, ObjectStoreMetrics, StateStoreMetrics};
+use risingwave_storage::monitor::{
+    monitor_cache, HummockMetrics, ObjectStoreMetrics, StateStoreMetrics,
+};
 use risingwave_storage::StateStoreImpl;
 use risingwave_stream::executor::monitor::StreamingMetrics;
 use risingwave_stream::task::{LocalStreamManager, StreamEnvironment};
@@ -119,6 +121,7 @@ pub async fn compute_node_serve(
             );
             sub_tasks.push((handle, shutdown_sender));
         }
+        monitor_cache(storage.inner().sstable_store(), &registry).unwrap();
     }
 
     // Initialize the managers.

--- a/src/meta/src/hummock/compaction/mod.rs
+++ b/src/meta/src/hummock/compaction/mod.rs
@@ -198,17 +198,17 @@ impl CompactStatus {
             metrics: Some(CompactMetrics {
                 read_level_n: Some(TableSetStatistics {
                     level_idx: select_level_id,
-                    size_gb: 0f64,
+                    size_kb: 0,
                     cnt: 0,
                 }),
                 read_level_nplus1: Some(TableSetStatistics {
                     level_idx: target_level_id,
-                    size_gb: 0f64,
+                    size_kb: 0,
                     cnt: 0,
                 }),
                 write: Some(TableSetStatistics {
                     level_idx: target_level_id,
-                    size_gb: 0f64,
+                    size_kb: 0,
                     cnt: 0,
                 }),
             }),

--- a/src/meta/src/rpc/metrics.rs
+++ b/src/meta/src/rpc/metrics.rs
@@ -17,11 +17,10 @@ use std::sync::Arc;
 
 use hyper::{Body, Request, Response};
 use prometheus::{
-    exponential_buckets, histogram_opts, register_counter_vec_with_registry,
-    register_histogram_vec_with_registry, register_histogram_with_registry,
-    register_int_counter_vec_with_registry, register_int_gauge_vec_with_registry,
-    register_int_gauge_with_registry, CounterVec, Encoder, Histogram, HistogramVec, IntCounterVec,
-    IntGauge, IntGaugeVec, Registry, TextEncoder,
+    exponential_buckets, histogram_opts, register_histogram_vec_with_registry,
+    register_histogram_with_registry, register_int_counter_vec_with_registry,
+    register_int_gauge_vec_with_registry, register_int_gauge_with_registry, Encoder, Histogram,
+    HistogramVec, IntCounterVec, IntGauge, IntGaugeVec, Registry, TextEncoder,
 };
 use tower::make::Shared;
 use tower::ServiceBuilder;
@@ -44,17 +43,17 @@ pub struct MetaMetrics {
     /// num of SSTs to be merged to next level in each level
     pub level_compact_cnt: IntGaugeVec,
     /// GBs read from current level during history compactions to next level
-    pub level_compact_read_curr: CounterVec,
+    pub level_compact_read_curr: HistogramVec,
     /// GBs read from next level during history compactions to next level
-    pub level_compact_read_next: CounterVec,
+    pub level_compact_read_next: HistogramVec,
     /// GBs written into next level during history compactions to next level
-    pub level_compact_write: CounterVec,
+    pub level_compact_write: HistogramVec,
     /// num of SSTs read from current level during history compactions to next level
-    pub level_compact_read_sstn_curr: IntCounterVec,
+    pub level_compact_read_sstn_curr: HistogramVec,
     /// num of SSTs read from next level during history compactions to next level
-    pub level_compact_read_sstn_next: IntCounterVec,
+    pub level_compact_read_sstn_next: HistogramVec,
     /// num of SSTs written into next level during history compactions to next level
-    pub level_compact_write_sstn: IntCounterVec,
+    pub level_compact_write_sstn: HistogramVec,
     /// num of compactions from each level to next level
     pub level_compact_frequency: IntCounterVec,
     /// hummock version size
@@ -109,39 +108,43 @@ impl MetaMetrics {
         )
         .unwrap();
 
-        let level_compact_read_curr = register_counter_vec_with_registry!(
+        let level_compact_read_curr = register_histogram_vec_with_registry!(
             "storage_level_compact_read_curr",
             "GBs read from current level during history compactions to next level",
             &["level_index"],
+            exponential_buckets(1.0, 2.0, 24).unwrap(), // max 16GB
             registry
         )
         .unwrap();
 
-        let level_compact_read_next = register_counter_vec_with_registry!(
+        let level_compact_read_next = register_histogram_vec_with_registry!(
             "storage_level_compact_read_next",
-            "GBs read from next level during history compactions to next level",
+            "KBs read from next level during history compactions to next level",
             &["level_index"],
+            exponential_buckets(1.0, 2.0, 24).unwrap(), // max 16GB
             registry
         )
         .unwrap();
 
-        let level_compact_write = register_counter_vec_with_registry!(
+        let level_compact_write = register_histogram_vec_with_registry!(
             "storage_level_compact_write",
-            "GBs written into next level during history compactions to next level",
+            "KBs written into next level during history compactions to next level",
             &["level_index"],
+            exponential_buckets(1.0, 2.0, 24).unwrap(), // max 16GB
             registry
         )
         .unwrap();
 
-        let level_compact_read_sstn_curr = register_int_counter_vec_with_registry!(
+        let level_compact_read_sstn_curr = register_histogram_vec_with_registry!(
             "storage_level_compact_read_sstn_curr",
             "num of SSTs read from current level during history compactions to next level",
             &["level_index"],
+            exponential_buckets(1.0, 2.0, 10).unwrap(), // max 1000
             registry
         )
         .unwrap();
 
-        let level_compact_read_sstn_next = register_int_counter_vec_with_registry!(
+        let level_compact_read_sstn_next = register_histogram_vec_with_registry!(
             "storage_level_compact_read_sstn_next",
             "num of SSTs read from next level during history compactions to next level",
             &["level_index"],
@@ -149,7 +152,7 @@ impl MetaMetrics {
         )
         .unwrap();
 
-        let level_compact_write_sstn = register_int_counter_vec_with_registry!(
+        let level_compact_write_sstn = register_histogram_vec_with_registry!(
             "storage_level_compact_write_sstn",
             "num of SSTs written into next level during history compactions to next level",
             &["level_index"],

--- a/src/storage/compactor/src/server.rs
+++ b/src/storage/compactor/src/server.rs
@@ -24,7 +24,9 @@ use risingwave_pb::hummock::compactor_service_server::CompactorServiceServer;
 use risingwave_rpc_client::MetaClient;
 use risingwave_storage::hummock::hummock_meta_client::MonitoredHummockMetaClient;
 use risingwave_storage::hummock::SstableStore;
-use risingwave_storage::monitor::{HummockMetrics, ObjectStoreMetrics, StateStoreMetrics};
+use risingwave_storage::monitor::{
+    monitor_cache, HummockMetrics, ObjectStoreMetrics, StateStoreMetrics,
+};
 use risingwave_storage::object::{parse_object_store, ObjectStoreImpl};
 use tokio::sync::mpsc::UnboundedSender;
 use tokio::task::JoinHandle;
@@ -83,6 +85,7 @@ pub async fn compactor_serve(
         storage_config.block_cache_capacity_mb * (1 << 20),
         storage_config.meta_cache_capacity_mb * (1 << 20),
     ));
+    monitor_cache(sstable_store.clone(), &registry).unwrap();
 
     let sub_tasks = vec![
         MetaClient::start_heartbeat_loop(

--- a/src/storage/hummock_sdk/src/compact.rs
+++ b/src/storage/hummock_sdk/src/compact.rs
@@ -27,14 +27,20 @@ pub fn compact_task_to_string(compact_task: &CompactTask) -> String {
     )
     .unwrap();
     writeln!(s, "Compaction watermark: {:?} ", compact_task.watermark).unwrap();
+    writeln!(
+        s,
+        "Compaction vnodemap size: {:?} ",
+        compact_task.vnode_mappings.len()
+    )
+    .unwrap();
     writeln!(s, "Compaction # splits: {:?} ", compact_task.splits.len()).unwrap();
     writeln!(s, "Compaction task status: {:?} ", compact_task.task_status).unwrap();
     s.push_str("Compaction SSTables structure: \n");
     for level_entry in &compact_task.input_ssts {
-        let tables: Vec<HummockSSTableId> = level_entry
+        let tables: Vec<(HummockSSTableId, String)> = level_entry
             .table_infos
             .iter()
-            .map(|table| table.id)
+            .map(|table| (table.id, format!("{}MB", table.file_size / 1024 / 1024)))
             .collect();
         writeln!(s, "Level {:?}: {:?} ", level_entry.level_idx, tables).unwrap();
     }

--- a/src/storage/src/hummock/block_cache.rs
+++ b/src/storage/src/hummock/block_cache.rs
@@ -134,6 +134,10 @@ impl BlockCache {
         hasher.finish()
     }
 
+    pub fn size(&self) -> usize {
+        self.inner.get_memory_usage()
+    }
+
     #[cfg(test)]
     pub fn clear(&self) {
         self.inner.clear();

--- a/src/storage/src/hummock/compactor.rs
+++ b/src/storage/src/hummock/compactor.rs
@@ -223,11 +223,7 @@ impl Compactor {
     /// Handle a compaction task and report its status to hummock manager.
     /// Always return `Ok` and let hummock manager handle errors.
     pub async fn compact(context: Arc<CompactorContext>, mut compact_task: CompactTask) -> bool {
-        tracing::info!(
-            "Ready to handle compaction task: \n{}",
-            compact_task_to_string(&compact_task)
-        );
-        let start_time = Instant::now();
+        tracing::info!("Ready to handle compaction task: {}", compact_task.task_id,);
         let mut compaction_read_bytes = compact_task.input_ssts[0]
             .table_infos
             .iter()
@@ -271,7 +267,7 @@ impl Compactor {
                 left: vec![],
                 right: vec![],
                 inf: false,
-            }]
+            }];
         };
 
         // Number of splits (key ranges) is equal to number of compaction tasks
@@ -345,12 +341,12 @@ impl Compactor {
 
         // After a compaction is done, mutate the compaction task.
         compactor.compact_done(output_ssts, compact_success).await;
-        tracing::debug!(
-            "execute compaction task {} cost {:?}",
-            compact_task.task_id,
-            start_time.elapsed()
+        let cost_time = timer.stop_and_record() * 1000.0;
+        tracing::info!(
+            "Finished compaction task in {:?}ms: \n{}",
+            cost_time,
+            compact_task_to_string(&compactor.compact_task)
         );
-        timer.observe_duration();
         compact_success
     }
 

--- a/src/storage/src/hummock/compactor.rs
+++ b/src/storage/src/hummock/compactor.rs
@@ -14,6 +14,7 @@
 
 use std::collections::HashMap;
 use std::future::Future;
+use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::Arc;
 use std::time::{Duration, Instant};
 
@@ -227,12 +228,43 @@ impl Compactor {
             compact_task_to_string(&compact_task)
         );
         let start_time = Instant::now();
-        for level in &compact_task.input_ssts {
-            for f in &level.table_infos {
-                context.stats.compaction_read_bytes.inc_by(f.file_size);
+        let mut compaction_read_bytes = compact_task.input_ssts[0]
+            .table_infos
+            .iter()
+            .map(|t| t.file_size)
+            .sum();
+        if let Some(metrics) = compact_task.metrics.as_mut() {
+            if let Some(read) = metrics.read_level_n.as_mut() {
+                read.level_idx = compact_task.input_ssts[0].level_idx;
+                read.cnt = compact_task.input_ssts[0].table_infos.len() as u64;
+                read.size_kb = compaction_read_bytes / 1024;
             }
         }
-        let timer = context.stats.compact_task_duration.start_timer();
+        if compact_task.input_ssts.len() > 1 {
+            let sec_level_read_bytes: u64 = compact_task.input_ssts[1]
+                .table_infos
+                .iter()
+                .map(|t| t.file_size)
+                .sum();
+            if let Some(metrics) = compact_task.metrics.as_mut() {
+                if let Some(read) = metrics.read_level_nplus1.as_mut() {
+                    read.level_idx = compact_task.input_ssts[1].level_idx;
+                    read.cnt = compact_task.input_ssts[1].table_infos.len() as u64;
+                    read.size_kb = sec_level_read_bytes / 1024;
+                }
+            }
+            compaction_read_bytes += sec_level_read_bytes;
+        }
+        context
+            .stats
+            .compaction_read_bytes
+            .inc_by(compaction_read_bytes);
+
+        let timer = context
+            .stats
+            .compact_task_duration
+            .with_label_values(&[compact_task.input_ssts[0].level_idx.to_string().as_str()])
+            .start_timer();
 
         if !compact_task.vnode_mappings.is_empty() {
             compact_task.splits = vec![risingwave_pb::hummock::KeyRange {
@@ -328,7 +360,12 @@ impl Compactor {
         self.compact_task
             .sorted_output_ssts
             .reserve(self.compact_task.splits.len());
-
+        if let Some(metrics) = self.compact_task.metrics.as_mut() {
+            if let Some(write) = metrics.write.as_mut() {
+                write.level_idx = self.compact_task.target_level;
+                write.cnt = output_ssts.len() as u64;
+            }
+        }
         for (_, ssts) in output_ssts {
             for (sst, vnode_bitmaps) in ssts {
                 let sst_info = SstableInfo {
@@ -378,18 +415,23 @@ impl Compactor {
             inf: split.get_inf(),
         };
 
+        let get_id_time = Arc::new(AtomicU64::new(0));
+
         // NOTICE: should be user_key overlap, NOT full_key overlap!
         let mut builder = GroupedSstableBuilder::new(
             || async {
+                let timer = Instant::now();
                 let table_id = (self.context.sstable_id_generator)().await?;
+                let cost = (timer.elapsed().as_secs_f64() * 1000000.0).round() as u64;
                 let builder = SSTableBuilder::new(self.context.options.as_ref().into());
+                get_id_time.fetch_add(cost, Ordering::Relaxed);
                 Ok((table_id, builder))
             },
             VirtualNode(VirtualNodeGrouping::new(vnode2unit)),
         );
 
         // Monitor time cost building shared buffer to SSTs.
-        let timer = if self.context.is_share_buffer_compact {
+        let _timer = if self.context.is_share_buffer_compact {
             self.context.stats.write_build_l0_sst_duration.start_timer()
         } else {
             self.context.stats.compact_sst_duration.start_timer()
@@ -411,14 +453,26 @@ impl Compactor {
         // TODO: decide upload concurrency. Maybe we shall create a upload task channel for multiple
         // compaction tasks.
         let mut pending_requests = vec![];
-        for (table_id, data, meta, vnode_bitmaps) in builder.finish() {
+        let files = builder.finish();
+        let file_count = files.len();
+        for (table_id, data, meta, vnode_bitmaps) in files {
             let sst = Sstable { id: table_id, meta };
             let len = data.len();
             ssts.push((sst.clone(), vnode_bitmaps));
-            let sstable_store = self.context.sstable_store.clone();
-            let ret =
-                tokio::spawn(async move { sstable_store.put(sst, data, CachePolicy::Fill).await });
-            pending_requests.push(ret);
+            if file_count > 1 {
+                let sstable_store = self.context.sstable_store.clone();
+                let ret =
+                    tokio::spawn(
+                        async move { sstable_store.put(sst, data, CachePolicy::Fill).await },
+                    );
+                pending_requests.push(ret);
+            } else {
+                self.context
+                    .sstable_store
+                    .put(sst, data, CachePolicy::Fill)
+                    .await?;
+            }
+
             if self.context.is_share_buffer_compact {
                 self.context
                     .stats
@@ -428,13 +482,18 @@ impl Compactor {
                 self.context.stats.compaction_upload_sst_counts.inc();
             }
         }
-        timer.observe_duration();
-        for ret in try_join_all(pending_requests)
-            .await
-            .map_err(HummockError::other)?
-        {
-            ret?;
+        if !pending_requests.is_empty() {
+            for ret in try_join_all(pending_requests)
+                .await
+                .map_err(HummockError::other)?
+            {
+                ret?;
+            }
         }
+        self.context
+            .stats
+            .get_table_id_total_time_duration
+            .observe(get_id_time.load(Ordering::Relaxed) as f64 / 1000.0 / 1000.0);
         Ok((split_index, ssts))
     }
 

--- a/src/storage/src/hummock/sstable/forward_sstable_iterator.rs
+++ b/src/storage/src/hummock/sstable/forward_sstable_iterator.rs
@@ -76,7 +76,7 @@ impl SSTableIterator {
         } else {
             let block = if self.options.prefetch {
                 self.sstable_store
-                    .get_with_prefetch(self.sst.value(), idx as u64)
+                    .get_with_prefetch(self.sst.value(), idx as u64, &mut self.stats)
                     .await?
             } else {
                 self.sstable_store

--- a/src/storage/src/monitor/local_metrics.rs
+++ b/src/storage/src/monitor/local_metrics.rs
@@ -26,6 +26,7 @@ pub struct StoreLocalStatistic {
     pub processed_key_count: u64,
     pub bloom_filter_true_negative_count: u64,
     pub bloom_filter_might_positive_count: u64,
+    pub remote_io_time: f64,
 }
 
 impl StoreLocalStatistic {
@@ -40,30 +41,52 @@ impl StoreLocalStatistic {
         self.processed_key_count += other.processed_key_count;
         self.bloom_filter_true_negative_count += other.bloom_filter_true_negative_count;
         self.bloom_filter_might_positive_count += other.bloom_filter_might_positive_count;
+        self.remote_io_time += other.remote_io_time;
     }
 
     pub fn report(&self, metrics: &StateStoreMetrics) {
-        metrics
-            .sst_store_block_request_counts
-            .with_label_values(&["data_total"])
-            .inc_by(self.cache_data_block_total);
-        metrics
-            .sst_store_block_request_counts
-            .with_label_values(&["data_miss"])
-            .inc_by(self.cache_data_block_miss);
-        metrics
-            .sst_store_block_request_counts
-            .with_label_values(&["meta_total"])
-            .inc_by(self.cache_meta_block_total);
-        metrics
-            .sst_store_block_request_counts
-            .with_label_values(&["meta_miss"])
-            .inc_by(self.cache_meta_block_miss);
-        metrics
-            .bloom_filter_true_negative_counts
-            .inc_by(self.bloom_filter_true_negative_count);
-        metrics
-            .bloom_filter_might_positive_counts
-            .inc_by(self.bloom_filter_might_positive_count);
+        if self.cache_data_block_total > 0 {
+            metrics
+                .sst_store_block_request_counts
+                .with_label_values(&["data_total"])
+                .inc_by(self.cache_data_block_total);
+        }
+
+        if self.cache_data_block_miss > 0 {
+            metrics
+                .sst_store_block_request_counts
+                .with_label_values(&["data_miss"])
+                .inc_by(self.cache_data_block_miss);
+        }
+
+        if self.cache_meta_block_total > 0 {
+            metrics
+                .sst_store_block_request_counts
+                .with_label_values(&["meta_total"])
+                .inc_by(self.cache_meta_block_total);
+        }
+
+        if self.cache_data_block_miss > 0 {
+            metrics
+                .sst_store_block_request_counts
+                .with_label_values(&["meta_miss"])
+                .inc_by(self.cache_meta_block_miss);
+        }
+
+        if self.bloom_filter_true_negative_count > 0 {
+            metrics
+                .bloom_filter_true_negative_counts
+                .inc_by(self.bloom_filter_true_negative_count);
+        }
+
+        if self.bloom_filter_might_positive_count > 0 {
+            metrics
+                .bloom_filter_might_positive_counts
+                .inc_by(self.bloom_filter_might_positive_count);
+        }
+
+        if self.remote_io_time > 0.0 {
+            metrics.remote_read_time.observe(self.remote_io_time);
+        }
     }
 }

--- a/src/storage/src/monitor/mod.rs
+++ b/src/storage/src/monitor/mod.rs
@@ -25,11 +25,12 @@ mod my_stats;
 pub use my_stats::MyHistogram;
 
 mod local_metrics;
-mod object_metrics;
-mod process_linux;
 pub use local_metrics::StoreLocalStatistic;
+
+mod object_metrics;
 pub use object_metrics::ObjectStoreMetrics;
 
+mod process_linux;
 pub use self::process_linux::monitor_process;
 
 /// Define extension method `print` used in `print_statistics`.

--- a/src/storage/src/monitor/state_store_metrics.rs
+++ b/src/storage/src/monitor/state_store_metrics.rs
@@ -12,14 +12,19 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use prometheus::core::{AtomicU64, GenericCounter, GenericCounterVec};
+use std::sync::Arc;
+
+use prometheus::core::{AtomicU64, Collector, Desc, GenericCounter, GenericCounterVec};
 use prometheus::{
-    exponential_buckets, histogram_opts, register_histogram_with_registry,
-    register_int_counter_vec_with_registry, register_int_counter_with_registry, Histogram,
-    Registry,
+    exponential_buckets, histogram_opts, proto, register_histogram_vec_with_registry,
+    register_histogram_with_registry, register_int_counter_vec_with_registry,
+    register_int_counter_with_registry, Histogram, HistogramVec, IntGauge, Opts, Registry,
 };
+use risingwave_hummock_sdk::HummockSSTableId;
 
 use super::{monitor_process, Print};
+use crate::hummock::sstable_store::SstableStoreRef;
+use crate::hummock::{BlockCache, LruCache, Sstable};
 
 /// Define all metrics.
 #[macro_export]
@@ -57,7 +62,10 @@ macro_rules! for_all_metrics {
             compaction_read_bytes: GenericCounter<AtomicU64>,
             compaction_write_bytes: GenericCounter<AtomicU64>,
             compact_sst_duration: Histogram,
-            compact_task_duration: Histogram,
+            compact_task_duration: HistogramVec,
+            get_table_id_total_time_duration: Histogram,
+
+            remote_read_time: Histogram,
         }
     };
 }
@@ -257,15 +265,30 @@ impl StateStoreMetrics {
         let opts = histogram_opts!(
             "state_store_compact_sst_duration",
             "Total time of compact_key_range that have been issued to state store",
-            exponential_buckets(0.001, 2.0, 16).unwrap() // max 32s
+            exponential_buckets(0.001, 1.6, 28).unwrap() // max 520s
         );
         let compact_sst_duration = register_histogram_with_registry!(opts, registry).unwrap();
         let opts = histogram_opts!(
             "state_store_compact_task_duration",
             "Total time of compact that have been issued to state store",
-            exponential_buckets(0.001, 2.0, 16).unwrap() // max 32s
+            exponential_buckets(0.001, 1.6, 28).unwrap() // max 520s
         );
-        let compact_task_duration = register_histogram_with_registry!(opts, registry).unwrap();
+        let compact_task_duration =
+            register_histogram_vec_with_registry!(opts, &["level"], registry).unwrap();
+        let opts = histogram_opts!(
+            "state_store_get_table_id_total_time_duration",
+            "Total time of compact that have been issued to state store",
+            exponential_buckets(0.001, 1.6, 28).unwrap() // max 520s
+        );
+        let get_table_id_total_time_duration =
+            register_histogram_with_registry!(opts, registry).unwrap();
+
+        let opts = histogram_opts!(
+            "state_store_remote_read_time_per_task",
+            "Total time of operations which read from remote storage when enable prefetch",
+            exponential_buckets(0.001, 1.6, 28).unwrap() // max 520s
+        );
+        let remote_read_time = register_histogram_with_registry!(opts, registry).unwrap();
 
         monitor_process(&registry).unwrap();
         Self {
@@ -297,6 +320,9 @@ impl StateStoreMetrics {
             compaction_write_bytes,
             compact_sst_duration,
             compact_task_duration,
+            get_table_id_total_time_duration,
+
+            remote_read_time,
         }
     }
 
@@ -304,4 +330,66 @@ impl StateStoreMetrics {
     pub fn unused() -> Self {
         Self::new(Registry::new())
     }
+}
+
+struct StateStoreCollector {
+    block_cache: BlockCache,
+    meta_cache: Arc<LruCache<HummockSSTableId, Box<Sstable>>>,
+    descs: Vec<Desc>,
+    block_cache_size: IntGauge,
+    meta_cache_size: IntGauge,
+}
+
+impl StateStoreCollector {
+    pub fn new(sstable_store: SstableStoreRef) -> Self {
+        let mut descs = Vec::new();
+
+        let block_cache_size = IntGauge::with_opts(Opts::new(
+            "state_store_block_cache_size",
+            "the size of cache for data block cache",
+        ))
+        .unwrap();
+        descs.extend(block_cache_size.desc().into_iter().cloned());
+
+        let meta_cache_size = IntGauge::with_opts(Opts::new(
+            "state_store_meta_cache_size",
+            "the size of cache for meta file cache",
+        ))
+        .unwrap();
+        descs.extend(meta_cache_size.desc().into_iter().cloned());
+
+        Self {
+            block_cache: sstable_store.get_block_cache(),
+            meta_cache: sstable_store.get_meta_cache(),
+            descs,
+            block_cache_size,
+            meta_cache_size,
+        }
+    }
+}
+
+impl Collector for StateStoreCollector {
+    fn desc(&self) -> Vec<&Desc> {
+        self.descs.iter().collect()
+    }
+
+    fn collect(&self) -> Vec<proto::MetricFamily> {
+        self.block_cache_size.set(self.block_cache.size() as i64);
+        self.meta_cache_size
+            .set(self.meta_cache.get_memory_usage() as i64);
+
+        // collect MetricFamilies.
+        let mut mfs = Vec::with_capacity(2);
+        mfs.extend(self.block_cache_size.collect());
+        mfs.extend(self.meta_cache_size.collect());
+        mfs
+    }
+}
+
+use std::io::{Error, ErrorKind, Result};
+pub fn monitor_cache(sstable_store: SstableStoreRef, registry: &Registry) -> Result<()> {
+    let collector = StateStoreCollector::new(sstable_store);
+    registry
+        .register(Box::new(collector))
+        .map_err(|e| Error::new(ErrorKind::Other, e.to_string()))
 }


### PR DESCRIPTION
## What's changed and what's your intention?

I add more metrics to measure the compaction write-amplification. And I'm trying to find out the time cost component of compaction so that we can make a optimization goal in the future.  And the following is what this PR adds:

1. add flush flow and we can see that the write-amplification is about 4 times or 5times.  <img width="718" alt="image" src="https://user-images.githubusercontent.com/16376959/169969642-68b0876d-6450-4392-bc48-9a3f2790c8ff.png">
2. collect remote io cost and get-table-id rpc cost so that we can know that IO and rpc to meta-service cost most of time in compaction. <img width="727" alt="image" src="https://user-images.githubusercontent.com/16376959/169969997-8dc15ab0-d4e3-4876-a6c9-d7c1fecf7a43.png">
3. report IO size of every compaction task so that we can found that the main IO is reading from the base-level. <img width="1433" alt="image" src="https://user-images.githubusercontent.com/16376959/169970559-1847a456-3f57-4cd1-9189-e96ad49a3250.png">
4. add block cache size. 
<img width="710" alt="image" src="https://user-images.githubusercontent.com/16376959/169970671-36cce8f0-d4c7-414d-b6f5-98fdff871a59.png">






## Checklist


## Refer to a related PR or issue link (optional)
