### PR TITLE
feat(vnode mapping): add sequence number for vnode mapping

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3921,6 +3921,7 @@ dependencies = [
  "tower",
  "tower-http",
  "tracing",
+ "twox-hash",
  "uuid 1.0.0",
  "workspace-hack",
 ]

--- a/proto/common.proto
+++ b/proto/common.proto
@@ -64,7 +64,7 @@ message Cluster {
 // Vnode mapping for stream fragments / relational state tables. Stores mapping from virtual node to parallel unit id.
 message ParallelUnitMapping {
   uint32 table_id = 1;
-  uint64 map_seq = 2;
+  uint64 map_hsh = 2;
   repeated uint64 original_indices = 3;
   repeated uint32 data = 4;
 }

--- a/proto/common.proto
+++ b/proto/common.proto
@@ -64,6 +64,7 @@ message Cluster {
 // Vnode mapping for stream fragments / relational state tables. Stores mapping from virtual node to parallel unit id.
 message ParallelUnitMapping {
   uint32 table_id = 1;
-  repeated uint64 original_indices = 2;
-  repeated uint32 data = 3;
+  uint64 map_seq = 2;
+  repeated uint64 original_indices = 3;
+  repeated uint32 data = 4;
 }

--- a/proto/hummock.proto
+++ b/proto/hummock.proto
@@ -23,7 +23,7 @@ message SstableIdInfo {
 message VNodeBitmap {
   uint32 table_id = 1;
   uint32 maplen = 2;
-  uint64 map_seq = 3;
+  uint64 map_hsh = 3;
   bytes bitmap = 4;
 }
 

--- a/proto/hummock.proto
+++ b/proto/hummock.proto
@@ -23,7 +23,8 @@ message SstableIdInfo {
 message VNodeBitmap {
   uint32 table_id = 1;
   uint32 maplen = 2;
-  bytes bitmap = 3;
+  uint64 map_seq = 3;
+  bytes bitmap = 4;
 }
 
 message SstableInfo {

--- a/src/meta/Cargo.toml
+++ b/src/meta/Cargo.toml
@@ -56,6 +56,7 @@ tonic = { version = "0.2.0-alpha.1", package = "madsim-tonic" }
 tower = { version = "0.4", features = ["util", "load-shed"] }
 tower-http = { version = "0.3", features = ["add-extension", "cors", "fs"] }
 tracing = { version = "0.1" }
+twox-hash = "1"
 uuid = { version = "1", features = ["v4"] }
 workspace-hack = { version = "0.1", path = "../workspace-hack" }
 

--- a/src/meta/src/hummock/compaction/level_selector.rs
+++ b/src/meta/src/hummock/compaction/level_selector.rs
@@ -29,17 +29,24 @@ use crate::hummock::compaction::tier_compaction_picker::TierCompactionPicker;
 use crate::hummock::compaction::CompactionMode::{ConsistentHashMode, RangeMode};
 use crate::hummock::compaction::{CompactionConfig, SearchResult};
 use crate::hummock::level_handler::LevelHandler;
+use crate::manager::HashMappingManager;
 
 const SCORE_BASE: u64 = 100;
 
 pub trait LevelSelector: Sync + Send {
-    fn need_compaction(&self, levels: &[Level], level_handlers: &mut [LevelHandler]) -> bool;
+    fn need_compaction(
+        &self,
+        levels: &[Level],
+        level_handlers: &mut [LevelHandler],
+        hash_mapping_manager: Option<&HashMappingManager>,
+    ) -> bool;
 
     fn pick_compaction(
         &self,
         task_id: u64,
         levels: &[Level],
         level_handlers: &mut [LevelHandler],
+        hash_mapping_manager: Option<&HashMappingManager>,
     ) -> Option<SearchResult>;
 
     fn name(&self) -> &'static str;
@@ -226,12 +233,21 @@ impl DynamicLevelSelector {
 }
 
 impl LevelSelector for DynamicLevelSelector {
-    fn need_compaction(&self, levels: &[Level], level_handlers: &mut [LevelHandler]) -> bool {
-        let ctx = self.get_priority_levels(levels, level_handlers);
-        ctx.score_levels
-            .first()
-            .map(|(score, _)| *score > SCORE_BASE)
-            .unwrap_or(false)
+    fn need_compaction(
+        &self,
+        levels: &[Level],
+        level_handlers: &mut [LevelHandler],
+        hash_mapping_manager: Option<&HashMappingManager>,
+    ) -> bool {
+        if hash_mapping_manager.is_some() {
+            true
+        } else {
+            let ctx = self.get_priority_levels(levels, level_handlers);
+            ctx.score_levels
+                .first()
+                .map(|(score, _)| *score > SCORE_BASE)
+                .unwrap_or(false)
+        }
     }
 
     fn pick_compaction(
@@ -239,10 +255,39 @@ impl LevelSelector for DynamicLevelSelector {
         task_id: u64,
         levels: &[Level],
         level_handlers: &mut [LevelHandler],
+        hash_mapping_manager: Option<&HashMappingManager>,
     ) -> Option<SearchResult> {
         let ctx = self.get_priority_levels(levels, level_handlers);
         for (score, level_idx) in ctx.score_levels {
             if score <= SCORE_BASE {
+                if let Some(hash_mapping_manager) = hash_mapping_manager {
+                    for level in levels.iter().rev() {
+                        let level_idx = level.level_idx as usize;
+                        for table in &level.table_infos {
+                            if !level_handlers[level_idx].is_pending_compact(&table.id)
+                                && hash_mapping_manager
+                                    .check_sst_deprecated(table.get_vnode_bitmaps())
+                            {
+                                let select_input_ssts = vec![table.clone()];
+                                level_handlers[level_idx]
+                                    .add_pending_task(task_id, &select_input_ssts);
+                                return Some(SearchResult {
+                                    select_level: Level {
+                                        level_idx: level_idx as u32,
+                                        level_type: levels[level_idx].level_type,
+                                        table_infos: select_input_ssts,
+                                    },
+                                    target_level: Level {
+                                        level_idx: level_idx as u32,
+                                        level_type: levels[level_idx].level_type,
+                                        table_infos: vec![],
+                                    },
+                                    split_ranges: vec![],
+                                });
+                            }
+                        }
+                    }
+                }
                 return None;
             }
             let picker = self.create_compaction_picker(level_idx, ctx.base_level, task_id);
@@ -407,7 +452,7 @@ pub mod tests {
         ];
         let mut levels_handlers = (0..5).into_iter().map(LevelHandler::new).collect_vec();
         let compaction = selector
-            .pick_compaction(1, &levels, &mut levels_handlers)
+            .pick_compaction(1, &levels, &mut levels_handlers, None)
             .unwrap();
         assert_eq!(compaction.select_level.level_idx, 0);
         assert_eq!(compaction.target_level.level_idx, 2);
@@ -418,7 +463,7 @@ pub mod tests {
         levels[0].table_infos.clear();
         levels[2].table_infos = generate_tables(20..30, 0..1000, 3, 10);
         let compaction = selector
-            .pick_compaction(2, &levels, &mut levels_handlers)
+            .pick_compaction(2, &levels, &mut levels_handlers, None)
             .unwrap();
         assert_eq!(compaction.select_level.level_idx, 3);
         assert_eq!(compaction.target_level.level_idx, 4);
@@ -427,7 +472,7 @@ pub mod tests {
 
         // no compaction need to be scheduled because we do not calculate the size of pending files
         // to score.
-        let compaction = selector.pick_compaction(2, &levels, &mut levels_handlers);
+        let compaction = selector.pick_compaction(2, &levels, &mut levels_handlers, None);
         assert!(compaction.is_none());
     }
 }

--- a/src/meta/src/hummock/compaction/mod.rs
+++ b/src/meta/src/hummock/compaction/mod.rs
@@ -192,9 +192,7 @@ impl CompactStatus {
             sorted_output_ssts: vec![],
             task_id: self.next_compact_task_id,
             target_level: target_level_id,
-            is_target_ultimate_and_leveling: target_level_id as usize
-                == self.level_handlers.len() - 1
-                && select_level_id > 0,
+            is_target_ultimate_and_leveling: false,
             metrics: Some(CompactMetrics {
                 read_level_n: Some(TableSetStatistics {
                     level_idx: select_level_id,

--- a/src/meta/src/hummock/hummock_manager.rs
+++ b/src/meta/src/hummock/hummock_manager.rs
@@ -594,7 +594,7 @@ where
                     .collect::<HashSet<u32>>();
                 compact_task.vnode_mappings.reserve_exact(table_ids.len());
                 for table_id in table_ids {
-                    if let Some((map_seq, vnode_mapping)) = self
+                    if let Some((map_hsh, vnode_mapping)) = self
                         .env
                         .hash_mapping_manager()
                         .get_table_hash_mapping(&table_id)
@@ -602,7 +602,7 @@ where
                         let (original_indices, compressed_data) = compress_data(&vnode_mapping);
                         let compressed_mapping = ParallelUnitMapping {
                             table_id,
-                            map_seq,
+                            map_hsh,
                             original_indices,
                             data: compressed_data,
                         };

--- a/src/meta/src/hummock/hummock_manager.rs
+++ b/src/meta/src/hummock/hummock_manager.rs
@@ -558,7 +558,10 @@ where
         let compaction = compaction_guard.deref_mut();
         let mut compact_status = VarTransaction::new(&mut compaction.compact_status);
         let current_version = self.versioning.read().await.current_version();
-        let compact_task = compact_status.get_compact_task(&current_version.levels);
+        let compact_task = compact_status.get_compact_task(
+            &current_version.levels,
+            Some(self.env.hash_mapping_manager()),
+        );
         let ret = match compact_task {
             None => Ok(None),
             Some(mut compact_task) => {

--- a/src/meta/src/hummock/hummock_manager.rs
+++ b/src/meta/src/hummock/hummock_manager.rs
@@ -591,7 +591,7 @@ where
                     .collect::<HashSet<u32>>();
                 compact_task.vnode_mappings.reserve_exact(table_ids.len());
                 for table_id in table_ids {
-                    if let Some(vnode_mapping) = self
+                    if let Some((map_seq, vnode_mapping)) = self
                         .env
                         .hash_mapping_manager()
                         .get_table_hash_mapping(&table_id)
@@ -599,6 +599,7 @@ where
                         let (original_indices, compressed_data) = compress_data(&vnode_mapping);
                         let compressed_mapping = ParallelUnitMapping {
                             table_id,
+                            map_seq,
                             original_indices,
                             data: compressed_data,
                         };

--- a/src/meta/src/hummock/test_utils.rs
+++ b/src/meta/src/hummock/test_utils.rs
@@ -97,11 +97,13 @@ pub fn generate_test_tables(epoch: u64, sst_ids: Vec<HummockSSTableId>) -> Vec<S
             vnode_bitmaps: vec![
                 VNodeBitmap {
                     table_id: (i + 1) as u32,
+                    map_seq: 0,
                     maplen: 0,
                     bitmap: vec![],
                 },
                 VNodeBitmap {
                     table_id: (i + 2) as u32,
+                    map_seq: 0,
                     maplen: 0,
                     bitmap: vec![],
                 },

--- a/src/meta/src/hummock/test_utils.rs
+++ b/src/meta/src/hummock/test_utils.rs
@@ -97,13 +97,13 @@ pub fn generate_test_tables(epoch: u64, sst_ids: Vec<HummockSSTableId>) -> Vec<S
             vnode_bitmaps: vec![
                 VNodeBitmap {
                     table_id: (i + 1) as u32,
-                    map_seq: 0,
+                    map_hsh: 0,
                     maplen: 0,
                     bitmap: vec![],
                 },
                 VNodeBitmap {
                     table_id: (i + 2) as u32,
-                    map_seq: 0,
+                    map_hsh: 0,
                     maplen: 0,
                     bitmap: vec![],
                 },

--- a/src/meta/src/stream/stream_manager.rs
+++ b/src/meta/src/stream/stream_manager.rs
@@ -151,7 +151,8 @@ where
                     .get_table_hash_mapping(&table_id.table_id)
                     .unwrap_or_else(|| {
                         panic!("table {} should have a vnode mapping", table_id.table_id)
-                    });
+                    })
+                    .1;
 
                 let (upstream_actor_id, parallel_unit_id) = {
                     // 1. use table id to get upstream parallel_unit -> actor_id mapping
@@ -222,6 +223,7 @@ where
                     let (original_indices, data) = compress_data(&hash_mapping);
                     batch_query.hash_mapping = Some(ParallelUnitMapping {
                         table_id: Default::default(),
+                        map_seq: 0,
                         original_indices,
                         data,
                     });

--- a/src/meta/src/stream/stream_manager.rs
+++ b/src/meta/src/stream/stream_manager.rs
@@ -223,7 +223,7 @@ where
                     let (original_indices, data) = compress_data(&hash_mapping);
                     batch_query.hash_mapping = Some(ParallelUnitMapping {
                         table_id: Default::default(),
-                        map_seq: 0,
+                        map_hsh: 0,
                         original_indices,
                         data,
                     });

--- a/src/storage/src/hummock/compactor.rs
+++ b/src/storage/src/hummock/compactor.rs
@@ -342,8 +342,8 @@ impl Compactor {
                             tar.get_table_id()
                         })
                     {
-                        vnode_bitmap.map_seq =
-                            self.compact_task.get_vnode_mappings()[pos].get_map_seq();
+                        vnode_bitmap.map_hsh =
+                            self.compact_task.get_vnode_mappings()[pos].get_map_hsh();
                     }
                 }
                 let sst_info = SstableInfo {

--- a/src/storage/src/hummock/sstable/builder.rs
+++ b/src/storage/src/hummock/sstable/builder.rs
@@ -194,7 +194,7 @@ impl SSTableBuilder {
                 .iter()
                 .map(|(table_id, vnode_bitmaps)| VNodeBitmap {
                     table_id: *table_id,
-                    map_seq: 0,
+                    map_hsh: 0,
                     maplen: VNODE_BITMAP_LEN as u32,
                     bitmap: ::prost::alloc::vec::Vec::from(*vnode_bitmaps),
                 })

--- a/src/storage/src/hummock/sstable/builder.rs
+++ b/src/storage/src/hummock/sstable/builder.rs
@@ -194,6 +194,7 @@ impl SSTableBuilder {
                 .iter()
                 .map(|(table_id, vnode_bitmaps)| VNodeBitmap {
                     table_id: *table_id,
+                    map_seq: 0,
                     maplen: VNODE_BITMAP_LEN as u32,
                     bitmap: ::prost::alloc::vec::Vec::from(*vnode_bitmaps),
                 })

--- a/src/storage/src/hummock/state_store_tests.rs
+++ b/src/storage/src/hummock/state_store_tests.rs
@@ -208,6 +208,7 @@ async fn test_vnode_filter() {
             epoch,
             Some(VNodeBitmap {
                 table_id: 0,
+                map_seq: 0,
                 maplen: VNODE_BITMAP_LEN as u32,
                 bitmap: [1; VNODE_BITMAP_LEN].to_vec(),
             }),
@@ -222,6 +223,7 @@ async fn test_vnode_filter() {
             epoch,
             Some(VNodeBitmap {
                 table_id: 0,
+                map_seq: 0,
                 maplen: VNODE_BITMAP_LEN as u32,
                 bitmap: [0; VNODE_BITMAP_LEN].to_vec(),
             }),
@@ -236,6 +238,7 @@ async fn test_vnode_filter() {
             epoch,
             Some(VNodeBitmap {
                 table_id: 5,
+                map_seq: 0,
                 maplen: VNODE_BITMAP_LEN as u32,
                 bitmap: [1; VNODE_BITMAP_LEN].to_vec(),
             }),

--- a/src/storage/src/hummock/state_store_tests.rs
+++ b/src/storage/src/hummock/state_store_tests.rs
@@ -208,7 +208,7 @@ async fn test_vnode_filter() {
             epoch,
             Some(VNodeBitmap {
                 table_id: 0,
-                map_seq: 0,
+                map_hsh: 0,
                 maplen: VNODE_BITMAP_LEN as u32,
                 bitmap: [1; VNODE_BITMAP_LEN].to_vec(),
             }),
@@ -223,7 +223,7 @@ async fn test_vnode_filter() {
             epoch,
             Some(VNodeBitmap {
                 table_id: 0,
-                map_seq: 0,
+                map_hsh: 0,
                 maplen: VNODE_BITMAP_LEN as u32,
                 bitmap: [0; VNODE_BITMAP_LEN].to_vec(),
             }),
@@ -238,7 +238,7 @@ async fn test_vnode_filter() {
             epoch,
             Some(VNodeBitmap {
                 table_id: 5,
-                map_seq: 0,
+                map_hsh: 0,
                 maplen: VNODE_BITMAP_LEN as u32,
                 bitmap: [1; VNODE_BITMAP_LEN].to_vec(),
             }),


### PR DESCRIPTION
## What's changed and what's your intention?

add sequence number for vnode mapping
sequence number is used for find out SSTs with deprecated mapping in order to consolidate them
after parallel unit reschedule, all existing SSTs will become deprecated

## Checklist

- [x] I have written necessary docs and comments

## Refer to a related PR or issue link (optional)
