### PR TITLE
fix(batch): join remaining panic when build table is empty

### DIFF
--- a/src/batch/src/executor2/join/hash_join_state.rs
+++ b/src/batch/src/executor2/join/hash_join_state.rs
@@ -221,6 +221,10 @@ impl<K: HashKey> TryFrom<BuildTable> for ProbeTable<K> {
 }
 
 impl<K: HashKey> ProbeTable<K> {
+    pub(super) fn build_data_empty(&self) -> bool {
+        self.build_data.is_empty()
+    }
+
     pub(super) fn has_non_equi_cond(&self) -> bool {
         self.params.has_non_equi_cond()
     }


### PR DESCRIPTION
## What's changed and what's your intention?
- do not join remaining when build table is empty.

## Checklist

- [x] I have written necessary docs and comments
- [x] I have added necessary unit tests and integration tests

## Refer to a related PR or issue link (optional)
#2749 