### PR TITLE
fix(build): lock madsim version

### DIFF
--- a/src/batch/Cargo.toml
+++ b/src/batch/Cargo.toml
@@ -49,7 +49,7 @@ tokio = { version = "1", features = [
     "fs",
 ] }
 tokio-stream = "0.1"
-tonic = { version = "0.2.0-alpha.1", package = "madsim-tonic" }
+tonic = { version = "=0.2.0-alpha.1", package = "madsim-tonic" }
 tracing = { version = "0.1" }
 tracing-futures = "0.2"
 twox-hash = "1"

--- a/src/common/Cargo.toml
+++ b/src/common/Cargo.toml
@@ -33,7 +33,7 @@ thiserror = "1"
 tokio = { version = "1", features = ["rt", "rt-multi-thread", "sync", "macros", "time", "signal"] }
 tokio-stream = "0.1"
 toml = "0.5"
-tonic = { version = "0.2.0-alpha.1", package = "madsim-tonic" }
+tonic = { version = "=0.2.0-alpha.1", package = "madsim-tonic" }
 tower = { version = "0.4", features = ["util", "load-shed"] }
 tower-http = { version = "0.3", features = ["add-extension", "cors"] }
 tracing = { version = "0.1" }

--- a/src/compute/Cargo.toml
+++ b/src/compute/Cargo.toml
@@ -49,7 +49,7 @@ tokio = { version = "1", features = [
     "fs",
 ] }
 tokio-stream = "0.1"
-tonic = { version = "0.2.0-alpha.1", package = "madsim-tonic" }
+tonic = { version = "=0.2.0-alpha.1", package = "madsim-tonic" }
 tower = { version = "0.4", features = ["util", "load-shed"] }
 tower-http = { version = "0.3", features = ["add-extension", "cors"] }
 tracing = { version = "0.1" }

--- a/src/connector/Cargo.toml
+++ b/src/connector/Cargo.toml
@@ -51,7 +51,7 @@ thiserror = "1"
 tokio = { version = "1", features = ["rt", "rt-multi-thread", "sync", "macros", "time", "signal", "fs"] }
 tokio-stream = "0.1"
 tokio-util = { version = "0.7", features = ["codec", "io"] }
-tonic = { version = "0.2.0-alpha.1", package = "madsim-tonic" }
+tonic = { version = "=0.2.0-alpha.1", package = "madsim-tonic" }
 twox-hash = "1"
 url = "2"
 urlencoding = "2"

--- a/src/expr/Cargo.toml
+++ b/src/expr/Cargo.toml
@@ -30,6 +30,6 @@ thiserror = "1"
 tokio = { version = "1", features = ["rt", "rt-multi-thread", "sync", "macros", "time", "signal"] }
 tokio-stream = "0.1"
 toml = "0.5"
-tonic = { version = "0.2.0-alpha.1", package = "madsim-tonic" }
+tonic = { version = "=0.2.0-alpha.1", package = "madsim-tonic" }
 value-encoding = { path = "../utils/value-encoding" }
 workspace-hack = { version = "0.1", path = "../workspace-hack" }

--- a/src/frontend/Cargo.toml
+++ b/src/frontend/Cargo.toml
@@ -49,7 +49,7 @@ tokio = { version = "1", features = [
     "signal",
     "fs",
 ] }
-tonic = { version = "0.2.0-alpha.1", package = "madsim-tonic" }
+tonic = { version = "=0.2.0-alpha.1", package = "madsim-tonic" }
 tracing = { version = "0.1" }
 uuid = "1"
 workspace-hack = { version = "0.1", path = "../workspace-hack" }

--- a/src/meta/Cargo.toml
+++ b/src/meta/Cargo.toml
@@ -52,7 +52,7 @@ tokio = { version = "1", features = [
 ] }
 tokio-retry = "0.3"
 tokio-stream = { version = "0.1", features = ["net"] }
-tonic = { version = "0.2.0-alpha.1", package = "madsim-tonic" }
+tonic = { version = "=0.2.0-alpha.1", package = "madsim-tonic" }
 tower = { version = "0.4", features = ["util", "load-shed"] }
 tower-http = { version = "0.3", features = ["add-extension", "cors", "fs"] }
 tracing = { version = "0.1" }

--- a/src/prost/Cargo.toml
+++ b/src/prost/Cargo.toml
@@ -10,7 +10,7 @@ prost = "0.10"
 prost-helpers = { path = "helpers" }
 prost-types = "0.10"
 serde = { version = "1", features = ["derive"] }
-tonic = { version = "0.2.0-alpha.1", package = "madsim-tonic" }
+tonic = { version = "=0.2.0-alpha.1", package = "madsim-tonic" }
 workspace-hack = { version = "0.1", path = "../workspace-hack" }
 
 [build-dependencies]
@@ -18,4 +18,4 @@ pbjson-build = "0.3"
 prost = "0.10"
 prost-types = "0.10"
 quote = "1"
-tonic-build = { version = "0.2.0-alpha.1", package = "madsim-tonic-build" }
+tonic-build = { version = "=0.2.0-alpha.1", package = "madsim-tonic-build" }

--- a/src/rpc_client/Cargo.toml
+++ b/src/rpc_client/Cargo.toml
@@ -20,6 +20,6 @@ tokio = { version = "1", features = [
     "time",
     "signal",
 ] }
-tonic = { version = "0.2.0-alpha.1", package = "madsim-tonic" }
+tonic = { version = "=0.2.0-alpha.1", package = "madsim-tonic" }
 tracing = { version = "0.1" }
 workspace-hack = { version = "0.1", path = "../workspace-hack" }

--- a/src/source/Cargo.toml
+++ b/src/source/Cargo.toml
@@ -46,7 +46,7 @@ tempfile = "3"
 thiserror = "1"
 tokio = { version = "1", features = ["rt", "rt-multi-thread", "sync", "macros", "time", "signal", "fs"] }
 tokio-stream = "0.1"
-tonic = { version = "0.2.0-alpha.1", package = "madsim-tonic" }
+tonic = { version = "=0.2.0-alpha.1", package = "madsim-tonic" }
 tracing = { version = "0.1", features = ["release_max_level_info"] }
 twox-hash = "1"
 url = "2"

--- a/src/storage/Cargo.toml
+++ b/src/storage/Cargo.toml
@@ -64,7 +64,7 @@ tokio = { version = "1", features = [
 ] }
 tokio-retry = "0.3"
 tokio-stream = "0.1"
-tonic = { version = "0.2.0-alpha.1", package = "madsim-tonic" }
+tonic = { version = "=0.2.0-alpha.1", package = "madsim-tonic" }
 tracing = { version = "0.1" }
 twox-hash = "1"
 value-encoding = { path = "../utils/value-encoding" }

--- a/src/storage/compactor/Cargo.toml
+++ b/src/storage/compactor/Cargo.toml
@@ -24,5 +24,5 @@ tokio = { version = "1", features = [
 tokio-retry = "0.3"
 tokio-stream = "0.1"
 toml = "0.5"
-tonic = { version = "0.2.0-alpha.1", package = "madsim-tonic" }
+tonic = { version = "=0.2.0-alpha.1", package = "madsim-tonic" }
 tracing = { version = "0.1" }

--- a/src/stream/Cargo.toml
+++ b/src/stream/Cargo.toml
@@ -23,7 +23,7 @@ iter-chunks = "0.1"
 itertools = "0.10"
 lazy_static = "1"
 log = "0.4"
-madsim = "0.2.0-alpha.1"
+madsim = "=0.2.0-alpha.1"
 memcomparable = { path = "../utils/memcomparable" }
 num-traits = "0.2"
 parking_lot = "0.12"
@@ -54,7 +54,7 @@ tokio = { version = "1", features = [
     "fs",
 ] }
 tokio-stream = "0.1"
-tonic = { version = "0.2.0-alpha.1", package = "madsim-tonic" }
+tonic = { version = "=0.2.0-alpha.1", package = "madsim-tonic" }
 tower = { version = "0.4", features = ["util", "load-shed"] }
 tracing = { version = "0.1" }
 tracing-futures = "0.2"


### PR DESCRIPTION
Signed-off-by: Runji Wang <wangrunji0408@163.com>

## What's changed and what's your intention?

Lock madsim version to `0.2.0-alpha.1` to fix the build.

## Checklist

- [x] I have written necessary docs and comments
- [x] I have added necessary unit tests and integration tests

## Refer to a related PR or issue link (optional)
fix #2782