### PR TITLE
refactor(storage): avoid passing backward flag in iter_inner of hummock storage

### DIFF
--- a/src/storage/src/hummock/iterator/mod.rs
+++ b/src/storage/src/hummock/iterator/mod.rs
@@ -19,6 +19,7 @@ pub use forward_concat::*;
 mod backward_concat;
 mod concat_inner;
 pub use backward_concat::*;
+pub use concat_inner::ConcatIteratorInner;
 mod backward_merge;
 pub use backward_merge::*;
 mod backward_user;
@@ -117,12 +118,13 @@ pub type BoxedForwardHummockIterator = Box<dyn ForwardHummockIterator>;
 pub type BoxedBackwardHummockIterator = Box<dyn BackwardHummockIterator>;
 pub type BoxedHummockIterator<D> = Box<dyn HummockIterator<Direction = D>>;
 
+#[derive(PartialEq, Eq, Debug)]
 pub enum DirectionEnum {
     Forward,
     Backward,
 }
 
-pub trait HummockIteratorDirection: Sync + Send {
+pub trait HummockIteratorDirection: Sync + Send + 'static {
     fn direction() -> DirectionEnum;
 }
 

--- a/src/storage/src/hummock/shared_buffer/shared_buffer_batch.rs
+++ b/src/storage/src/hummock/shared_buffer/shared_buffer_batch.rs
@@ -133,12 +133,16 @@ impl SharedBufferBatch {
         }
     }
 
+    pub fn into_directed_iter<D: HummockIteratorDirection>(self) -> SharedBufferBatchIterator<D> {
+        SharedBufferBatchIterator::<D>::new(self.inner)
+    }
+
     pub fn into_forward_iter(self) -> SharedBufferBatchIterator<Forward> {
-        SharedBufferBatchIterator::<Forward>::new(self.inner)
+        Self::into_directed_iter::<Forward>(self)
     }
 
     pub fn into_backward_iter(self) -> SharedBufferBatchIterator<Backward> {
-        SharedBufferBatchIterator::<Backward>::new(self.inner)
+        Self::into_directed_iter::<Backward>(self)
     }
 
     pub fn get_payload(&self) -> &[SharedBufferItem] {

--- a/src/storage/src/hummock/shared_buffer/shared_buffer_batch.rs
+++ b/src/storage/src/hummock/shared_buffer/shared_buffer_batch.rs
@@ -138,11 +138,11 @@ impl SharedBufferBatch {
     }
 
     pub fn into_forward_iter(self) -> SharedBufferBatchIterator<Forward> {
-        Self::into_directed_iter::<Forward>(self)
+        self.into_directed_iter()
     }
 
     pub fn into_backward_iter(self) -> SharedBufferBatchIterator<Backward> {
-        Self::into_directed_iter::<Backward>(self)
+        self.into_directed_iter()
     }
 
     pub fn get_payload(&self) -> &[SharedBufferItem] {

--- a/src/storage/src/hummock/sstable/forward_sstable_iterator.rs
+++ b/src/storage/src/hummock/sstable/forward_sstable_iterator.rs
@@ -23,7 +23,7 @@ use crate::hummock::iterator::{Forward, HummockIterator, ReadOptions};
 use crate::hummock::{BlockIterator, SstableStoreRef, TableHolder};
 use crate::monitor::StoreLocalStatistic;
 
-pub trait SSTableIteratorType: HummockIterator {
+pub trait SSTableIteratorType: HummockIterator + 'static {
     fn create(
         table: TableHolder,
         sstable_store: SstableStoreRef,

--- a/src/storage/src/hummock/state_store.rs
+++ b/src/storage/src/hummock/state_store.rs
@@ -89,8 +89,8 @@ impl HummockStorage {
             // Generate shared buffer iterators
             for shared_buffer in read_version.shared_buffer {
                 for batch in shared_buffer.get_overlap_batches(&key_range, backward) {
-                    overlapped_iters.push(Box::new(batch.into_directed_iter::<T::Direction>())
-                        as BoxedHummockIterator<T::Direction>);
+                    overlapped_iters
+                        .push(Box::new(batch.into_directed_iter()) as BoxedHummockIterator<_>);
                 }
             }
 

--- a/src/storage/src/hummock/state_store.rs
+++ b/src/storage/src/hummock/state_store.rs
@@ -23,35 +23,60 @@ use risingwave_hummock_sdk::key::key_with_epoch;
 use risingwave_pb::hummock::VNodeBitmap;
 
 use super::iterator::{
-    BackwardConcatIterator, BackwardMergeIterator, BackwardUserIterator,
-    BoxedForwardHummockIterator, ConcatIterator, DirectedUserIterator, MergeIterator, UserIterator,
+    BackwardUserIterator, ConcatIteratorInner, DirectedUserIterator, UserIterator,
 };
 use super::utils::{can_concat, search_sst_idx, validate_epoch, validate_table_key_range};
 use super::{BackwardSSTableIterator, HummockStorage, SSTableIterator, SSTableIteratorType};
 use crate::error::StorageResult;
-use crate::hummock::iterator::{BoxedBackwardHummockIterator, ReadOptions};
+use crate::hummock::iterator::{
+    Backward, BoxedHummockIterator, DirectedUserIteratorBuilder, DirectionEnum, Forward,
+    HummockIteratorDirection, ReadOptions,
+};
 use crate::hummock::utils::prune_ssts;
 use crate::monitor::StoreLocalStatistic;
 use crate::storage_value::StorageValue;
 use crate::store::*;
 use crate::{define_state_store_associated_type, StateStore, StateStoreIter};
 
+trait HummockIteratorType {
+    type Direction: HummockIteratorDirection;
+    type SstableIteratorType: SSTableIteratorType<Direction = Self::Direction>;
+    type UserIteratorBuilder: DirectedUserIteratorBuilder<Direction = Self::Direction>;
+
+    fn direction() -> DirectionEnum {
+        Self::Direction::direction()
+    }
+}
+
+struct ForwardIter;
+struct BackwardIter;
+
+impl HummockIteratorType for ForwardIter {
+    type Direction = Forward;
+    type SstableIteratorType = SSTableIterator;
+    type UserIteratorBuilder = UserIterator;
+}
+
+impl HummockIteratorType for BackwardIter {
+    type Direction = Backward;
+    type SstableIteratorType = BackwardSSTableIterator;
+    type UserIteratorBuilder = BackwardUserIterator;
+}
+
 impl HummockStorage {
-    async fn iter_inner<R, B>(
+    async fn iter_inner<R, B, T>(
         &self,
         key_range: R,
         epoch: u64,
-        backward: bool,
     ) -> StorageResult<HummockStateStoreIter>
     where
         R: RangeBounds<B> + Send,
         B: AsRef<[u8]> + Send,
+        T: HummockIteratorType,
     {
         let read_options = Arc::new(ReadOptions::default());
-        // if `backward` is true, use `overlapped_backward_sstable_iters`, otherwise use
-        // `overlapped_forward_sstable_iters`
-        let mut overlapped_forward_iters = vec![];
-        let mut overlapped_backward_iters = vec![];
+        let mut overlapped_iters = vec![];
+        let backward = T::direction() == DirectionEnum::Backward;
 
         let (uncommitted_ssts, pinned_version) = {
             let read_version = self.local_version_manager.read_version(epoch);
@@ -64,14 +89,8 @@ impl HummockStorage {
             // Generate shared buffer iterators
             for shared_buffer in read_version.shared_buffer {
                 for batch in shared_buffer.get_overlap_batches(&key_range, backward) {
-                    if backward {
-                        overlapped_backward_iters
-                            .push(Box::new(batch.into_backward_iter())
-                                as BoxedBackwardHummockIterator)
-                    } else {
-                        overlapped_forward_iters
-                        .push(Box::new(batch.into_forward_iter()) as BoxedForwardHummockIterator)
-                    }
+                    overlapped_iters.push(Box::new(batch.into_directed_iter::<T::Direction>())
+                        as BoxedHummockIterator<T::Direction>);
                 }
             }
 
@@ -87,19 +106,11 @@ impl HummockStorage {
                 .sstable_store
                 .sstable(table_info.id, &mut stats)
                 .await?;
-            if backward {
-                overlapped_backward_iters.push(Box::new(BackwardSSTableIterator::create(
-                    table,
-                    self.sstable_store(),
-                    read_options.clone(),
-                )) as BoxedBackwardHummockIterator);
-            } else {
-                overlapped_forward_iters.push(Box::new(SSTableIterator::create(
-                    table,
-                    self.sstable_store(),
-                    read_options.clone(),
-                )) as BoxedForwardHummockIterator);
-            };
+            overlapped_iters.push(Box::new(T::SstableIteratorType::create(
+                table,
+                self.sstable_store(),
+                read_options.clone(),
+            )));
         }
 
         // Generate iterators for versioned ssts by filter out ssts that do not overlap with given
@@ -122,86 +133,62 @@ impl HummockStorage {
                 assert!(start_table_idx < table_infos.len() && end_table_idx < table_infos.len());
                 let matched_table_infos = &table_infos[start_table_idx..=end_table_idx];
 
-                if backward {
-                    overlapped_backward_iters.push(Box::new(BackwardConcatIterator::new(
-                        matched_table_infos
-                            .iter()
-                            .rev()
-                            .map(|&info| info.clone())
-                            .collect(),
-                        self.sstable_store(),
-                        read_options.clone(),
-                    ))
-                        as BoxedBackwardHummockIterator);
+                let tables = if backward {
+                    matched_table_infos
+                        .iter()
+                        .rev()
+                        .map(|&info| info.clone())
+                        .collect_vec()
                 } else {
-                    overlapped_forward_iters.push(Box::new(ConcatIterator::new(
-                        matched_table_infos
-                            .iter()
-                            .map(|&info| info.clone())
-                            .collect_vec(),
-                        self.sstable_store(),
-                        read_options.clone(),
-                    ))
-                        as BoxedForwardHummockIterator);
+                    matched_table_infos
+                        .iter()
+                        .map(|&info| info.clone())
+                        .collect_vec()
                 };
+
+                overlapped_iters.push(Box::new(ConcatIteratorInner::<T::SstableIteratorType>::new(
+                    tables,
+                    self.sstable_store(),
+                    read_options.clone(),
+                )) as BoxedHummockIterator<T::Direction>);
             } else {
                 for table_info in table_infos.into_iter().rev() {
                     let table = self
                         .sstable_store
                         .sstable(table_info.id, &mut stats)
                         .await?;
-                    if backward {
-                        overlapped_backward_iters.push(Box::new(BackwardSSTableIterator::new(
-                            table,
-                            self.sstable_store(),
-                        ))
-                            as BoxedBackwardHummockIterator);
-                    } else {
-                        overlapped_forward_iters.push(Box::new(SSTableIterator::new(
-                            table,
-                            self.sstable_store(),
-                            read_options.clone(),
-                        ))
-                            as BoxedForwardHummockIterator);
-                    };
+                    overlapped_iters.push(Box::new(T::SstableIteratorType::create(
+                        table,
+                        self.sstable_store(),
+                        read_options.clone(),
+                    )));
                 }
             }
         }
 
-        assert!(
-            (backward && overlapped_forward_iters.is_empty())
-                || (!backward && overlapped_backward_iters.is_empty())
-        );
-
         self.stats
             .iter_merge_sstable_counts
-            .observe((overlapped_forward_iters.len() + overlapped_backward_iters.len()) as f64);
+            .observe(overlapped_iters.len() as f64);
 
-        let mut user_iterator = if backward {
-            let backward_merge_iterator =
-                BackwardMergeIterator::new(overlapped_backward_iters, self.stats.clone());
-            DirectedUserIterator::Backward(BackwardUserIterator::with_epoch(
-                backward_merge_iterator,
-                (
-                    key_range.end_bound().map(|b| b.as_ref().to_owned()),
-                    key_range.start_bound().map(|b| b.as_ref().to_owned()),
-                ),
-                epoch,
-                Some(pinned_version),
-            ))
+        let key_range = if backward {
+            (
+                key_range.end_bound().map(|b| b.as_ref().to_owned()),
+                key_range.start_bound().map(|b| b.as_ref().to_owned()),
+            )
         } else {
-            let merge_iterator = MergeIterator::new(overlapped_forward_iters, self.stats.clone());
-
-            DirectedUserIterator::Forward(UserIterator::new(
-                merge_iterator,
-                (
-                    key_range.start_bound().map(|b| b.as_ref().to_owned()),
-                    key_range.end_bound().map(|b| b.as_ref().to_owned()),
-                ),
-                epoch,
-                Some(pinned_version),
-            ))
+            (
+                key_range.start_bound().map(|b| b.as_ref().to_owned()),
+                key_range.end_bound().map(|b| b.as_ref().to_owned()),
+            )
         };
+
+        let mut user_iterator = T::UserIteratorBuilder::create(
+            overlapped_iters,
+            self.stats.clone(),
+            key_range,
+            epoch,
+            Some(pinned_version),
+        );
 
         user_iterator.rewind().await?;
         Ok(HummockStateStoreIter::new(user_iterator))
@@ -405,7 +392,7 @@ impl StateStore for HummockStorage {
         R: RangeBounds<B> + Send,
         B: AsRef<[u8]> + Send,
     {
-        self.iter_inner(key_range, epoch, false)
+        self.iter_inner::<R, B, ForwardIter>(key_range, epoch)
     }
 
     /// Returns a backward iterator that scans from the end key to the begin key
@@ -415,7 +402,7 @@ impl StateStore for HummockStorage {
         R: RangeBounds<B> + Send,
         B: AsRef<[u8]> + Send,
     {
-        self.iter_inner(key_range, epoch, true)
+        self.iter_inner::<R, B, BackwardIter>(key_range, epoch)
     }
 
     fn wait_epoch(&self, epoch: u64) -> Self::WaitEpochFuture<'_> {


### PR DESCRIPTION
## What's changed and what's your intention?

Currently in the `iter_inner` of `HummockStorage` method, we have to pass a `backward` flag, and in the method body, we have to write some very similar code for twice for both backward and forward. In this PR, we refactor the `iter_inner method`  and specify the direction in the generic parameter of `iter_inner` so that we can remove some duplicated code.

## Checklist

- [x] I have written necessary docs and comments
- [x] I have added necessary unit tests and integration tests

## Refer to a related PR or issue link (optional)
