### PR TITLE
chore(build): add Cargo.lock into docker image

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:20.04 as builder
+FROM ubuntu:22.04 as builder
 
 ENV LANG en_US.utf8
 
@@ -12,10 +12,7 @@ RUN mkdir -p /risingwave
 
 WORKDIR /risingwave
 
-COPY proto proto
-COPY src src
-COPY rust-toolchain rust-toolchain
-COPY Cargo.toml Cargo.toml
+COPY ./ /risingwave
 
 ENV PATH /root/.cargo/bin/:$PATH
 


### PR DESCRIPTION
Signed-off-by: Alex Chi <iskyzh@gmail.com>

## What's changed and what's your intention?

Previous, we only selectively added some components into docker build image, which will absolutely cause problems like https://github.com/singularity-data/risingwave/issues/2782. In this PR, we copy everything into the image.

## Checklist

- [x] I have written necessary docs and comments
- [x] I have added necessary unit tests and integration tests

## Refer to a related PR or issue link (optional)
