### PR TITLE
refactor: use oneshot channel for shutdown

### DIFF
--- a/src/batch/src/execution/local_exchange.rs
+++ b/src/batch/src/execution/local_exchange.rs
@@ -126,7 +126,7 @@ mod tests {
         let addr: SocketAddr = "127.0.0.1:12345".parse().unwrap();
 
         // Start a server.
-        let (shutdown_send, mut shutdown_recv) = tokio::sync::mpsc::unbounded_channel();
+        let (shutdown_send, shutdown_recv) = tokio::sync::oneshot::channel();
         let exchange_svc = ExchangeServiceServer::new(FakeExchangeService {
             rpc_called: rpc_called.clone(),
         });
@@ -136,7 +136,7 @@ mod tests {
             tonic::transport::Server::builder()
                 .add_service(exchange_svc)
                 .serve_with_shutdown(addr, async move {
-                    shutdown_recv.recv().await;
+                    shutdown_recv.await.unwrap();
                 })
                 .await
                 .unwrap();

--- a/src/compute/src/server.rs
+++ b/src/compute/src/server.rs
@@ -37,7 +37,7 @@ use risingwave_storage::monitor::{
 use risingwave_storage::StateStoreImpl;
 use risingwave_stream::executor::monitor::StreamingMetrics;
 use risingwave_stream::task::{LocalStreamManager, StreamEnvironment};
-use tokio::sync::mpsc::UnboundedSender;
+use tokio::sync::oneshot::Sender;
 use tokio::task::JoinHandle;
 
 use crate::rpc::service::exchange_service::ExchangeServiceImpl;
@@ -61,7 +61,7 @@ pub async fn compute_node_serve(
     listen_addr: SocketAddr,
     client_addr: HostAddr,
     opts: ComputeNodeOpts,
-) -> (JoinHandle<()>, UnboundedSender<()>) {
+) -> (JoinHandle<()>, Sender<()>) {
     // Load the configuration.
     let config = load_config(&opts);
     info!(
@@ -79,11 +79,10 @@ pub async fn compute_node_serve(
         .unwrap();
     info!("Assigned worker node id {}", worker_id);
 
-    let mut sub_tasks: Vec<(JoinHandle<()>, UnboundedSender<()>)> =
-        vec![MetaClient::start_heartbeat_loop(
-            meta_client.clone(),
-            Duration::from_millis(config.server.heartbeat_interval_ms as u64),
-        )];
+    let mut sub_tasks: Vec<(JoinHandle<()>, Sender<()>)> = vec![MetaClient::start_heartbeat_loop(
+        meta_client.clone(),
+        Duration::from_millis(config.server.heartbeat_interval_ms as u64),
+    )];
     // Initialize the metrics subsystem.
     let registry = prometheus::Registry::new();
     let hummock_metrics = Arc::new(HummockMetrics::new(registry.clone()));
@@ -163,7 +162,7 @@ pub async fn compute_node_serve(
     let exchange_srv = ExchangeServiceImpl::new(batch_mgr, stream_mgr.clone());
     let stream_srv = StreamServiceImpl::new(stream_mgr, stream_env.clone());
 
-    let (shutdown_send, mut shutdown_recv) = tokio::sync::mpsc::unbounded_channel();
+    let (shutdown_send, mut shutdown_recv) = tokio::sync::oneshot::channel::<()>();
     let join_handle = tokio::spawn(async move {
         tonic::transport::Server::builder()
             .add_service(TaskServiceServer::new(batch_srv))
@@ -172,7 +171,7 @@ pub async fn compute_node_serve(
             .serve_with_shutdown(listen_addr, async move {
                 tokio::select! {
                     _ = tokio::signal::ctrl_c() => {},
-                    _ = shutdown_recv.recv() => {
+                    _ = &mut shutdown_recv => {
                         for (join_handle, shutdown_sender) in sub_tasks {
                             if let Err(err) = shutdown_sender.send(()) {
                                 tracing::warn!("Failed to send shutdown: {:?}", err);

--- a/src/frontend/src/session.rs
+++ b/src/frontend/src/session.rs
@@ -29,7 +29,7 @@ use risingwave_common::util::addr::HostAddr;
 use risingwave_pb::common::WorkerType;
 use risingwave_rpc_client::{ComputeClientPool, MetaClient};
 use risingwave_sqlparser::parser::Parser;
-use tokio::sync::mpsc::UnboundedSender;
+use tokio::sync::oneshot::Sender;
 use tokio::sync::watch;
 use tokio::task::JoinHandle;
 
@@ -131,7 +131,7 @@ pub struct FrontendEnv {
 impl FrontendEnv {
     pub async fn init(
         opts: &FrontendOpts,
-    ) -> Result<(Self, JoinHandle<()>, JoinHandle<()>, UnboundedSender<()>)> {
+    ) -> Result<(Self, JoinHandle<()>, JoinHandle<()>, Sender<()>)> {
         let meta_client = MetaClient::new(opts.meta_addr.clone().as_str()).await?;
         Self::with_meta_client(meta_client, opts).await
     }
@@ -163,7 +163,7 @@ impl FrontendEnv {
     pub async fn with_meta_client(
         mut meta_client: MetaClient,
         opts: &FrontendOpts,
-    ) -> Result<(Self, JoinHandle<()>, JoinHandle<()>, UnboundedSender<()>)> {
+    ) -> Result<(Self, JoinHandle<()>, JoinHandle<()>, Sender<()>)> {
         let config = load_config(opts);
         tracing::info!("Starting frontend node with config {:?}", config);
 
@@ -346,7 +346,7 @@ pub struct SessionManagerImpl {
     env: FrontendEnv,
     observer_join_handle: JoinHandle<()>,
     heartbeat_join_handle: JoinHandle<()>,
-    _heartbeat_shutdown_sender: UnboundedSender<()>,
+    _heartbeat_shutdown_sender: Sender<()>,
 }
 
 impl SessionManager for SessionManagerImpl {

--- a/src/meta/src/barrier/mod.rs
+++ b/src/meta/src/barrier/mod.rs
@@ -28,7 +28,7 @@ use risingwave_pb::common::WorkerType;
 use risingwave_pb::data::Barrier;
 use risingwave_pb::stream_service::{InjectBarrierRequest, InjectBarrierResponse};
 use smallvec::SmallVec;
-use tokio::sync::mpsc::{UnboundedReceiver, UnboundedSender};
+use tokio::sync::oneshot::{Receiver, Sender};
 use tokio::sync::{oneshot, watch, RwLock};
 use tokio::task::JoinHandle;
 use uuid::Uuid;
@@ -196,10 +196,8 @@ where
         }
     }
 
-    pub async fn start(
-        barrier_manager: BarrierManagerRef<S>,
-    ) -> (JoinHandle<()>, UnboundedSender<()>) {
-        let (shutdown_tx, shutdown_rx) = tokio::sync::mpsc::unbounded_channel();
+    pub async fn start(barrier_manager: BarrierManagerRef<S>) -> (JoinHandle<()>, Sender<()>) {
+        let (shutdown_tx, shutdown_rx) = tokio::sync::oneshot::channel();
         let join_handle = tokio::spawn(async move {
             barrier_manager.run(shutdown_rx).await;
         });
@@ -208,7 +206,7 @@ where
     }
 
     /// Start an infinite loop to take scheduled barriers and send them.
-    async fn run(&self, mut shutdown_rx: UnboundedReceiver<()>) {
+    async fn run(&self, mut shutdown_rx: Receiver<()>) {
         let mut tracker = CreateMviewProgressTracker::default();
         let mut state = BarrierManagerState::create(self.env.meta_store()).await;
 
@@ -239,7 +237,7 @@ where
             tokio::select! {
                 biased;
                 // Shutdown
-                _ = shutdown_rx.recv() => {
+                _ = &mut shutdown_rx => {
                     tracing::info!("Barrier manager is shutting down");
                     return;
                 }

--- a/src/meta/src/cluster/mod.rs
+++ b/src/meta/src/cluster/mod.rs
@@ -26,7 +26,7 @@ use risingwave_common::try_match_expand;
 use risingwave_pb::common::worker_node::State;
 use risingwave_pb::common::{HostAddress, ParallelUnit, ParallelUnitType, WorkerNode, WorkerType};
 use risingwave_pb::meta::subscribe_response::{Info, Operation};
-use tokio::sync::mpsc::UnboundedSender;
+use tokio::sync::oneshot::Sender;
 use tokio::sync::{RwLock, RwLockReadGuard};
 use tokio::task::JoinHandle;
 
@@ -208,8 +208,8 @@ where
     pub async fn start_heartbeat_checker(
         cluster_manager: ClusterManagerRef<S>,
         check_interval: Duration,
-    ) -> (JoinHandle<()>, UnboundedSender<()>) {
-        let (shutdown_tx, mut shutdown_rx) = tokio::sync::mpsc::unbounded_channel();
+    ) -> (JoinHandle<()>, Sender<()>) {
+        let (shutdown_tx, mut shutdown_rx) = tokio::sync::oneshot::channel();
         let join_handle = tokio::spawn(async move {
             let mut min_interval = tokio::time::interval(check_interval);
             loop {
@@ -217,7 +217,7 @@ where
                     // Wait for interval
                     _ = min_interval.tick() => {},
                     // Shutdown
-                    _ = shutdown_rx.recv() => {
+                    _ = &mut shutdown_rx => {
                         tracing::info!("Heartbeat checker is shutting down");
                         return;
                     }

--- a/src/meta/src/test_utils.rs
+++ b/src/meta/src/test_utils.rs
@@ -14,7 +14,7 @@
 
 use std::time::Duration;
 
-use tokio::sync::mpsc::UnboundedSender;
+use tokio::sync::oneshot::Sender;
 use tokio::task::JoinHandle;
 
 use crate::manager::MetaOpts;
@@ -23,7 +23,7 @@ use crate::rpc::server::MetaStoreBackend;
 pub struct LocalMeta {
     port: u16,
     join_handle: JoinHandle<()>,
-    shutdown_sender: UnboundedSender<()>,
+    shutdown_sender: Sender<()>,
 }
 
 impl LocalMeta {

--- a/src/stream/src/executor/merge.rs
+++ b/src/stream/src/executor/merge.rs
@@ -352,7 +352,7 @@ mod tests {
         let addr = "127.0.0.1:12348".parse().unwrap();
 
         // Start a server.
-        let (shutdown_send, mut shutdown_recv) = tokio::sync::mpsc::unbounded_channel();
+        let (shutdown_send, shutdown_recv) = tokio::sync::oneshot::channel();
         let exchange_svc = ExchangeServiceServer::new(FakeExchangeService {
             rpc_called: rpc_called.clone(),
         });
@@ -362,7 +362,7 @@ mod tests {
             tonic::transport::Server::builder()
                 .add_service(exchange_svc)
                 .serve_with_shutdown(addr, async move {
-                    shutdown_recv.recv().await;
+                    shutdown_recv.await.unwrap();
                 })
                 .await
                 .unwrap();


### PR DESCRIPTION
## What's changed and what's your intention?

As said in https://github.com/crossbeam-rs/crossbeam-channel/issues/25, a one-shot channel helps exposing bugs earlier and debugging. And it is optimized for sending a single value.