### PR TITLE
chore(stream): change default local channel size to 16

### DIFF
--- a/src/stream/src/task/mod.rs
+++ b/src/stream/src/task/mod.rs
@@ -31,7 +31,7 @@ pub use env::*;
 pub use stream_manager::*;
 
 /// Default capacity of channel if two actors are on the same node
-pub const LOCAL_OUTPUT_CHANNEL_SIZE: usize = 4;
+pub const LOCAL_OUTPUT_CHANNEL_SIZE: usize = 16;
 
 pub type ConsumableChannelPair = (Option<Sender<Message>>, Option<Receiver<Message>>);
 pub type ConsumableChannelVecPair = (Vec<Sender<Message>>, Vec<Receiver<Message>>);


### PR DESCRIPTION
## What's changed and what's your intention?

Per discussion at #wg-perf, local channel size has some effects on throughput but little effect on barrier latency. So we make it larger to improve throughput.

## Checklist

- [x] I have written necessary docs and comments
- [x] I have added necessary unit tests and integration tests

## Refer to a related PR or issue link (optional)
