### PR TITLE
fix: docker builder and wrapper should be the same version

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -28,7 +28,7 @@ RUN cargo build -p risingwave_cmd -p risingwave_cmd_all --release && \
   mv /risingwave/target/release/{frontend,compute-node,meta-node,compactor,risingwave} /risingwave/bin/ && \
   cargo clean
 
-FROM ubuntu:20.04 as image-base
+FROM ubuntu:22.04 as image-base
 RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get -y install openssl libssl-dev && rm -rf /var/lib/{apt,dpkg,cache,log}/
 
 FROM image-base as frontend-node


### PR DESCRIPTION
## What's changed and what's your intention?
Fix the following error in meta-node docker image
```bash
error while loading shared libraries: libssl.so.3: cannot open shared object file: No such file or directory
```


