### PR TITLE
refactor(frontend): unpin epoch when all leaf stages are scheduled

### DIFF
--- a/src/frontend/src/handler/query.rs
+++ b/src/frontend/src/handler/query.rs
@@ -12,8 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use std::sync::Arc;
-
 use futures_async_stream::for_await;
 use pgwire::pg_field_descriptor::PgFieldDescriptor;
 use pgwire::pg_response::{PgResponse, StatementType};
@@ -27,9 +25,7 @@ use crate::config::QueryMode;
 use crate::handler::util::{to_pg_field, to_pg_rows};
 use crate::planner::Planner;
 use crate::scheduler::plan_fragmenter::BatchPlanFragmenter;
-use crate::scheduler::{
-    ExecutionContext, ExecutionContextRef, HummockSnapshotManager, LocalQueryExecution,
-};
+use crate::scheduler::{ExecutionContext, ExecutionContextRef, LocalQueryExecution};
 use crate::session::OptimizerContext;
 
 pub static QUERY_MODE: &str = "query_mode";
@@ -146,8 +142,7 @@ async fn local_execute(
         (query, pg_descs)
     };
 
-    let hummock_snapshot_manager =
-        Arc::new(HummockSnapshotManager::new(session.env().meta_client_ref()));
+    let hummock_snapshot_manager = session.env().hummock_snapshot_manager().clone();
 
     // TODO: Passing sql here
     let execution = LocalQueryExecution::new(query, hummock_snapshot_manager, "");

--- a/src/frontend/src/scheduler/local.rs
+++ b/src/frontend/src/scheduler/local.rs
@@ -58,13 +58,15 @@ impl LocalQueryExecution {
 
         let context = FrontendBatchTaskContext::default();
 
+        let query_id = self.query.query_id().clone();
+
         let task_id = TaskId {
             query_id: self.query.query_id.id,
             stage_id: 0,
             task_id: 0,
         };
 
-        let epoch = self.hummock_snapshot_manager.get_epoch().await?;
+        let epoch = self.hummock_snapshot_manager.get_epoch(query_id).await?;
         let executor = ExecutorBuilder::new(&plan_fragment.root.unwrap(), &task_id, context, epoch)
             .build2()?;
 
@@ -72,8 +74,6 @@ impl LocalQueryExecution {
         for chunk in executor.execute() {
             yield chunk?;
         }
-
-        self.hummock_snapshot_manager.unpin_snapshot(epoch).await?
     }
 
     /// Convert query to plan fragment.

--- a/src/frontend/src/scheduler/plan_fragmenter.rs
+++ b/src/frontend/src/scheduler/plan_fragmenter.rs
@@ -133,6 +133,10 @@ impl Query {
     pub fn root_stage_id(&self) -> StageId {
         self.stage_graph.root_stage_id
     }
+
+    pub fn query_id(&self) -> &QueryId {
+        &self.query_id
+    }
 }
 
 /// Fragment part of `Query`.


### PR DESCRIPTION
## What's changed and what's your intention?

Currently, the batch query manager unpins a query only after that query has been executed successfully. There is no handling for errors.

After this PR, we unpin the epoch/snapshot when:
1. all the leaf stages are scheduled.
2. when the scheduling fails.

Then:
1. we don't need to unpin the epoch after the job fails in any way after (1).
2. As long as the iterator is created during scheduling, i.e. they should be initialized when the backend builds the executors according to the plan, we do not need to take care of their failure or success in a unique way. It's the same as scheduling success(1) or failure(2).

Other changes:
1. Put the request to meta for unpinning the epoch into another task. So all the resources related to a query can be reclaimed without being blocked.
2. Since (1) can happen before (2), the PR makes `HummockSnapshotManager` aware of `QueryId`. So that repetitive unpin_snapshot on `HummockSnapshotManager` become idempotent.
3. Use the same `HummockSnapshotManager` for local and distributed execution.

I believe this does not conflict with using a background thread to pin/unpin, as the API exposed to the pin/unpin caller should largely stay the same.

## Checklist

- [x] I have written necessary docs and comments

## Refer to a related PR or issue link (optional)
#2238 