### PR TITLE
refactor(storage): remove backward_range flag and reverse the range order only at the topest level

### DIFF
--- a/src/storage/src/hummock/utils.rs
+++ b/src/storage/src/hummock/utils.rs
@@ -25,17 +25,12 @@ pub fn range_overlap<R, B>(
     search_key_range: &R,
     inclusive_start_key: &[u8],
     inclusive_end_key: &[u8],
-    backward: bool,
 ) -> bool
 where
     R: RangeBounds<B>,
     B: AsRef<[u8]>,
 {
-    let (start_bound, end_bound) = if backward {
-        (search_key_range.end_bound(), search_key_range.start_bound())
-    } else {
-        (search_key_range.start_bound(), search_key_range.end_bound())
-    };
+    let (start_bound, end_bound) = (search_key_range.start_bound(), search_key_range.end_bound());
 
     //        RANGE
     // TABLE
@@ -101,7 +96,6 @@ pub fn bitmap_overlap(pattern: &VNodeBitmap, sst_bitmaps: &Vec<VNodeBitmap>) -> 
 pub fn prune_ssts<'a, R, B>(
     ssts: impl Iterator<Item = &'a SstableInfo>,
     key_range: &R,
-    backward: bool,
     vnode_set: Option<&VNodeBitmap>,
 ) -> Vec<&'a SstableInfo>
 where
@@ -113,7 +107,7 @@ where
             let table_range = info.key_range.as_ref().unwrap();
             let table_start = user_key(table_range.left.as_slice());
             let table_end = user_key(table_range.right.as_slice());
-            range_overlap(key_range, table_start, table_end, backward)
+            range_overlap(key_range, table_start, table_end)
         })
         .collect();
     if let Some(vnode_set) = vnode_set {


### PR DESCRIPTION
## What's changed and what's your intention?

Currently in our code, we should pass a `backward` and `backward_range` flag everywhere only to indicate whether the range passed in is a backward or forward range. When we check such flag, what we do is only swap the start and end bound of the range when the backward flag is true. In this PR, we remove all the backward flag, and only reverse the range at the high level `backward_iter`.

## Checklist

- [x] I have written necessary docs and comments
- [x] I have added necessary unit tests and integration tests

## Refer to a related PR or issue link (optional)
