### PR TITLE
feat(expr): Add eval_row_ref to Expression trait

### DIFF
--- a/src/expr/src/expr/expr_field.rs
+++ b/src/expr/src/expr/expr_field.rs
@@ -14,9 +14,9 @@
 
 use std::convert::TryFrom;
 
-use risingwave_common::array::{ArrayImpl, ArrayRef, DataChunk};
+use risingwave_common::array::{ArrayImpl, ArrayRef, DataChunk, Row};
 use risingwave_common::error::{internal_error, ErrorCode, Result, RwError};
-use risingwave_common::types::DataType;
+use risingwave_common::types::{DataType, Datum};
 use risingwave_common::{ensure, ensure_eq, try_match_expand};
 use risingwave_pb::expr::expr_node::{RexNode, Type};
 use risingwave_pb::expr::ExprNode;
@@ -43,6 +43,10 @@ impl Expression for FieldExpression {
         } else {
             Err(internal_error("expects a struct array ref"))
         }
+    }
+
+    fn eval_row_ref(&self, _input: &Row) -> Result<Datum> {
+        Err(internal_error("expects a struct array ref"))
     }
 }
 

--- a/src/expr/src/expr/expr_in.rs
+++ b/src/expr/src/expr/expr_in.rs
@@ -17,8 +17,8 @@ use std::fmt::Debug;
 use std::sync::Arc;
 
 use itertools::Itertools;
-use risingwave_common::array::{ArrayBuilder, ArrayRef, BoolArrayBuilder, DataChunk};
-use risingwave_common::types::{DataType, Datum, ToOwnedDatum};
+use risingwave_common::array::{ArrayBuilder, ArrayRef, BoolArrayBuilder, DataChunk, Row};
+use risingwave_common::types::{DataType, Datum, Scalar, ToOwnedDatum};
 
 use crate::expr::{BoxedExpression, Expression};
 
@@ -78,6 +78,12 @@ impl Expression for InExpression {
             }
         };
         Ok(Arc::new(output_array.finish()?.into()))
+    }
+
+    fn eval_row_ref(&self, input: &Row) -> risingwave_common::error::Result<Datum> {
+        let data = self.left.eval_row_ref(input)?;
+        let ret = self.exists(&data);
+        Ok(Some(ret.to_scalar_value()))
     }
 }
 

--- a/src/expr/src/expr/expr_input_ref.rs
+++ b/src/expr/src/expr/expr_input_ref.rs
@@ -13,12 +13,13 @@
 // limitations under the License.
 
 use std::convert::TryFrom;
+use std::ops::Index;
 use std::sync::Arc;
 
-use risingwave_common::array::{ArrayRef, DataChunk};
+use risingwave_common::array::{ArrayRef, DataChunk, Row};
 use risingwave_common::ensure;
 use risingwave_common::error::{ErrorCode, Result, RwError};
-use risingwave_common::types::DataType;
+use risingwave_common::types::{DataType, Datum};
 use risingwave_pb::expr::expr_node::{RexNode, Type};
 use risingwave_pb::expr::ExprNode;
 
@@ -52,6 +53,11 @@ impl Expression for InputRefExpression {
             }
             None => Ok(array),
         }
+    }
+
+    fn eval_row_ref(&self, input: &Row) -> Result<Datum> {
+        let cell = input.index(self.idx).as_ref().cloned();
+        Ok(cell)
     }
 }
 

--- a/src/expr/src/expr/expr_literal.rs
+++ b/src/expr/src/expr/expr_literal.rs
@@ -19,7 +19,7 @@ use std::sync::Arc;
 
 use prost::DecodeError;
 use risingwave_common::array::{
-    read_interval_unit, Array, ArrayBuilder, ArrayBuilderImpl, ArrayRef, DataChunk,
+    read_interval_unit, Array, ArrayBuilder, ArrayBuilderImpl, ArrayRef, DataChunk, Row,
 };
 use risingwave_common::error::ErrorCode::InternalError;
 use risingwave_common::error::{ErrorCode, Result, RwError};
@@ -68,6 +68,10 @@ impl Expression for LiteralExpression {
         let literal = &self.literal;
         for_all_variants! {array_impl_literal_append, builder, literal, cardinality}
         array_builder.finish().map(Arc::new)
+    }
+
+    fn eval_row_ref(&self, _input: &Row) -> Result<Datum> {
+        Ok(self.literal.as_ref().cloned())
     }
 }
 

--- a/src/expr/src/expr/mod.rs
+++ b/src/expr/src/expr/mod.rs
@@ -41,7 +41,7 @@ pub use expr_literal::*;
 use risingwave_common::array::{ArrayRef, DataChunk, Row};
 use risingwave_common::error::ErrorCode::InternalError;
 use risingwave_common::error::Result;
-use risingwave_common::types::DataType;
+use risingwave_common::types::{DataType, Datum};
 use risingwave_pb::expr::ExprNode;
 
 use crate::expr::build_expr_from_prost::*;
@@ -62,6 +62,8 @@ pub trait Expression: std::fmt::Debug + Sync + Send {
     ///
     /// * `input` - input data of the Project Executor
     fn eval(&self, input: &DataChunk) -> Result<ArrayRef>;
+
+    fn eval_row_ref(&self, input: &Row) -> Result<Datum>;
 
     fn boxed(self) -> BoxedExpression
     where

--- a/src/expr/src/expr/template.rs
+++ b/src/expr/src/expr/template.rs
@@ -20,12 +20,32 @@ use std::sync::Arc;
 use itertools::{multizip, Itertools};
 use paste::paste;
 use risingwave_common::array::{
-    Array, ArrayBuilder, ArrayImpl, ArrayRef, BytesGuard, BytesWriter, DataChunk, Utf8Array,
+    Array, ArrayBuilder, ArrayBuilderImpl, ArrayImpl, ArrayRef, BytesGuard, BytesWriter, DataChunk,
+    Row, Utf8Array,
 };
-use risingwave_common::error::Result;
-use risingwave_common::types::{option_as_scalar_ref, DataType, Scalar};
+use risingwave_common::error::{ErrorCode, Result};
+use risingwave_common::for_all_variants;
+use risingwave_common::types::{option_as_scalar_ref, DataType, Datum, Scalar, ScalarImpl};
 
 use crate::expr::{BoxedExpression, Expression};
+
+macro_rules! array_impl_add_datum {
+    ([$arr_builder: ident, $datum: ident], $( { $variant_name:ident, $suffix_name:ident, $array:ty, $builder:ty } ),*) => {
+        match ($arr_builder, $datum) {
+            $(
+                (ArrayBuilderImpl::$variant_name(inner), Some(ScalarImpl::$variant_name(v))) => {
+                    inner.append(Some(v.as_scalar_ref()))?;
+                }
+                (ArrayBuilderImpl::$variant_name(inner), None) => {
+                    inner.append(None)?;
+                }
+            )*
+            (_, _) => return Err(ErrorCode::NotImplemented(
+                "Do not support values in insert values executor".to_string(), None.into(),
+            ).into()),
+        }
+    };
+}
 
 macro_rules! gen_eval {
     { $macro:ident, $ty_name:ident, $OA:ty, $($arg:ident,)* } => {
@@ -55,6 +75,34 @@ macro_rules! gen_eval {
                         output_array.finish()?.into()
                     }
                 }))
+            }
+        }
+
+        // Currently, eval_row_ref() first calls eval_row_ref() on the inner expressions. The
+        // resulting datums are placed in their own arrays. The arrays are then handled in the same
+        // way as in eval(). This could be optimized to work on the datums directly
+        // instead of placing them in arrays.
+        fn eval_row_ref(&self, row: &Row) -> Result<Datum> {
+            paste! {
+                $(
+                    let [<datum_ $arg:lower>] = self.[<expr_ $arg:lower>].eval_row_ref(row)?;
+
+                    let mut [<builder_ $arg:lower>] = self.[<expr_ $arg:lower>].return_type().create_array_builder(1)?;
+                    let [<ref_ $arg:lower>] = &mut [<builder_ $arg:lower>];
+
+                    for_all_variants! {array_impl_add_datum, [<ref_ $arg:lower>], [<datum_ $arg:lower>]}
+
+                    let [<arr_ $arg:lower>] = [<builder_ $arg:lower>].finish().map(Arc::new)?;
+                    let [<arr_ $arg:lower>]: &$arg = [<arr_ $arg:lower>].as_ref().into();
+                )*
+
+                let mut output_array = <$OA as Array>::Builder::new(1)?;
+                for ($([<v_ $arg:lower>], )*) in multizip(($([<arr_ $arg:lower>].iter(), )*)) {
+                    $macro!(self, output_array, $([<v_ $arg:lower>],)*)
+                }
+                let output_arrayimpl: ArrayImpl = output_array.finish()?.into();
+
+                Ok(output_arrayimpl.to_datum())
             }
         }
     }


### PR DESCRIPTION
## What's changed and what's your intention?

- Add the `eval_row_ref()` function to the `Expression` trait (and by extension all structs that implement `Expression`
- `eval_row_ref` takes in itself and `&Row` as arguments and returns `Result<Datum>`

Limitations:
- The implementation of `eval_row_ref` for Unary/Binary/TernaryExpressions in `template.rs` is unoptimized as it inserts the `Datums` in an array first instead of just working with them directly.
- TODO: Unit tests still need to be written for each implementation of `eval_row_ref`. However, I believe the code that was committed can already be reviewed.
- TODO: More code documentation?

## Checklist

- [x] I have written necessary docs and comments
- [ ] I have added necessary unit tests and integration tests

## Refer to a related PR or issue link (optional)

#2706