### PR TITLE
fix: batch TopN sort_util handles null

### DIFF
--- a/e2e_test/batch/order_by.slt
+++ b/e2e_test/batch/order_by.slt
@@ -2,7 +2,7 @@ statement ok
 SET RW_IMPLICIT_FLUSH TO true;
 
 statement ok
-create table t (v1 int not null, v2 int not null, v3 int not null)
+create table t (v1 int, v2 int, v3 int);
 
 statement ok
 insert into t values (1,4,2), (2,3,3), (3,4,4), (4,3,5)
@@ -84,6 +84,24 @@ select * from t order by v2 desc, v1 limit 2
 ----
 1 4 2
 3 4 4
+
+statement ok
+insert into t values (null, 7, null);
+
+query III
+select * from t order by v1 limit 2;
+----
+NULL 7 NULL
+1 4 2
+
+query III
+select * from t order by v1 desc limit 7;
+----
+4 3 5
+3 4 4
+2 3 3
+1 4 2
+NULL 7 NULL
 
 statement ok
 drop table t;


### PR DESCRIPTION
## What's changed and what's your intention?

It should handle null values properly rather than unwrap and panic.

## Checklist

- [x] I have written necessary docs and comments
- [x] I have added necessary unit tests and integration tests

## Refer to a related PR or issue link (optional)

Fixes #2826