### PR TITLE
refactor(batch): use iter instead of scan in CellBasedTableRowIter

### DIFF
--- a/src/batch/src/executor/delete.rs
+++ b/src/batch/src/executor/delete.rs
@@ -111,8 +111,9 @@ impl DeleteExecutor {
     }
 }
 
+#[async_trait::async_trait]
 impl BoxedExecutorBuilder for DeleteExecutor {
-    fn new_boxed_executor<C: BatchTaskContext>(
+    async fn new_boxed_executor<C: BatchTaskContext>(
         source: &ExecutorBuilder<C>,
     ) -> Result<BoxedExecutor> {
         let delete_node = try_match_expand!(
@@ -127,7 +128,7 @@ impl BoxedExecutorBuilder for DeleteExecutor {
                 "Child interpreting error",
             )))
         })?;
-        let child = source.clone_for_plan(proto_child).build()?;
+        let child = source.clone_for_plan(proto_child).build().await?;
 
         Ok(Box::new(Self::new(
             table_id,

--- a/src/batch/src/executor/filter.rs
+++ b/src/batch/src/executor/filter.rs
@@ -94,8 +94,9 @@ impl FilterExecutor {
     }
 }
 
+#[async_trait::async_trait]
 impl BoxedExecutorBuilder for FilterExecutor {
-    fn new_boxed_executor<C: BatchTaskContext>(
+    async fn new_boxed_executor<C: BatchTaskContext>(
         source: &ExecutorBuilder<C>,
     ) -> Result<BoxedExecutor> {
         ensure!(source.plan_node().get_children().len() == 1);
@@ -108,7 +109,7 @@ impl BoxedExecutorBuilder for FilterExecutor {
         let expr_node = filter_node.get_search_condition()?;
         let expr = build_from_prost(expr_node)?;
         if let Some(child_plan) = source.plan_node.get_children().get(0) {
-            let child = source.clone_for_plan(child_plan).build()?;
+            let child = source.clone_for_plan(child_plan).build().await?;
             debug!("Child schema: {:?}", child.schema());
 
             return Ok(Box::new(Self {

--- a/src/batch/src/executor/generate_series.rs
+++ b/src/batch/src/executor/generate_series.rs
@@ -115,8 +115,9 @@ where
 
 pub struct GenerateSeriesExecutorBuilder {}
 
+#[async_trait::async_trait]
 impl BoxedExecutorBuilder for GenerateSeriesExecutorBuilder {
-    fn new_boxed_executor<C: BatchTaskContext>(
+    async fn new_boxed_executor<C: BatchTaskContext>(
         source: &ExecutorBuilder<C>,
     ) -> Result<BoxedExecutor> {
         let node = try_match_expand!(

--- a/src/batch/src/executor/generic_exchange.rs
+++ b/src/batch/src/executor/generic_exchange.rs
@@ -93,8 +93,9 @@ impl CreateSource for DefaultCreateSource {
 
 pub struct GenericExchangeExecutorBuilder {}
 
+#[async_trait::async_trait]
 impl BoxedExecutorBuilder for GenericExchangeExecutorBuilder {
-    fn new_boxed_executor<C: BatchTaskContext>(
+    async fn new_boxed_executor<C: BatchTaskContext>(
         source: &ExecutorBuilder<C>,
     ) -> Result<BoxedExecutor> {
         let node = try_match_expand!(

--- a/src/batch/src/executor/hash_agg.rs
+++ b/src/batch/src/executor/hash_agg.rs
@@ -113,14 +113,15 @@ impl HashAggExecutorBuilder {
     }
 }
 
+#[async_trait::async_trait]
 impl BoxedExecutorBuilder for HashAggExecutorBuilder {
-    fn new_boxed_executor<C: BatchTaskContext>(
+    async fn new_boxed_executor<C: BatchTaskContext>(
         source: &ExecutorBuilder<C>,
     ) -> Result<BoxedExecutor> {
         ensure!(source.plan_node().get_children().len() == 1);
 
         let proto_child = &source.plan_node().get_children()[0];
-        let child = source.clone_for_plan(proto_child).build()?;
+        let child = source.clone_for_plan(proto_child).build().await?;
 
         let hash_agg_node = try_match_expand!(
             source.plan_node().get_node_body().unwrap(),

--- a/src/batch/src/executor/hop_window.rs
+++ b/src/batch/src/executor/hop_window.rs
@@ -40,8 +40,9 @@ pub struct HopWindowExecutor {
     window_size: IntervalUnit,
 }
 
+#[async_trait::async_trait]
 impl BoxedExecutorBuilder for HopWindowExecutor {
-    fn new_boxed_executor<C: BatchTaskContext>(
+    async fn new_boxed_executor<C: BatchTaskContext>(
         source: &ExecutorBuilder<C>,
     ) -> Result<BoxedExecutor> {
         ensure!(source.plan_node().get_children().len() == 1);
@@ -53,7 +54,7 @@ impl BoxedExecutorBuilder for HopWindowExecutor {
         let window_slide = hop_window_node.get_window_slide()?.into();
         let window_size = hop_window_node.get_window_size()?.into();
         if let Some(child_plan) = source.plan_node.get_children().get(0) {
-            let child = source.clone_for_plan(child_plan).build()?;
+            let child = source.clone_for_plan(child_plan).build().await?;
             let schema = child
                 .schema()
                 .clone()

--- a/src/batch/src/executor/insert.rs
+++ b/src/batch/src/executor/insert.rs
@@ -127,8 +127,9 @@ impl InsertExecutor {
     }
 }
 
+#[async_trait::async_trait]
 impl BoxedExecutorBuilder for InsertExecutor {
-    fn new_boxed_executor<C: BatchTaskContext>(
+    async fn new_boxed_executor<C: BatchTaskContext>(
         source: &ExecutorBuilder<C>,
     ) -> Result<BoxedExecutor> {
         let insert_node = try_match_expand!(
@@ -143,7 +144,7 @@ impl BoxedExecutorBuilder for InsertExecutor {
                 "Child interpreting error",
             )))
         })?;
-        let child = source.clone_for_plan(proto_child).build()?;
+        let child = source.clone_for_plan(proto_child).build().await?;
 
         Ok(Box::new(Self::new(
             table_id,

--- a/src/batch/src/executor/join/hash_join.rs
+++ b/src/batch/src/executor/join/hash_join.rs
@@ -284,18 +284,21 @@ impl HashKeyDispatcher for HashJoinExecutorBuilderDispatcher {
 }
 
 /// Hash join executor builder.
+#[async_trait::async_trait]
 impl BoxedExecutorBuilder for HashJoinExecutorBuilder {
-    fn new_boxed_executor<C: BatchTaskContext>(
+    async fn new_boxed_executor<C: BatchTaskContext>(
         context: &ExecutorBuilder<C>,
     ) -> Result<BoxedExecutor> {
         ensure!(context.plan_node().get_children().len() == 2);
 
         let left_child = context
             .clone_for_plan(&context.plan_node.get_children()[0])
-            .build()?;
+            .build()
+            .await?;
         let right_child = context
             .clone_for_plan(&context.plan_node.get_children()[1])
-            .build()?;
+            .build()
+            .await?;
 
         let hash_join_node = try_match_expand!(
             context.plan_node().get_node_body().unwrap(),

--- a/src/batch/src/executor/join/nested_loop_join.rs
+++ b/src/batch/src/executor/join/nested_loop_join.rs
@@ -188,8 +188,9 @@ impl NestedLoopJoinExecutor {
     }
 }
 
+#[async_trait::async_trait]
 impl BoxedExecutorBuilder for NestedLoopJoinExecutor {
-    fn new_boxed_executor<C: BatchTaskContext>(
+    async fn new_boxed_executor<C: BatchTaskContext>(
         source: &ExecutorBuilder<C>,
     ) -> Result<BoxedExecutor> {
         ensure!(source.plan_node().get_children().len() == 2);
@@ -207,9 +208,9 @@ impl BoxedExecutorBuilder for NestedLoopJoinExecutor {
         let right_plan_opt = source.plan_node().get_children().get(1);
         match (left_plan_opt, right_plan_opt) {
             (Some(left_plan), Some(right_plan)) => {
-                let left_child = source.clone_for_plan(left_plan).build()?;
+                let left_child = source.clone_for_plan(left_plan).build().await?;
                 let probe_side_schema = left_child.schema().data_types();
-                let right_child = source.clone_for_plan(right_plan).build()?;
+                let right_child = source.clone_for_plan(right_plan).build().await?;
 
                 // TODO(Bowen): Merge this with derive schema in Logical Join (#790).
                 let fields = match join_type {

--- a/src/batch/src/executor/join/sort_merge_join.rs
+++ b/src/batch/src/executor/join/sort_merge_join.rs
@@ -233,8 +233,9 @@ impl SortMergeJoinExecutor {
     }
 }
 
+#[async_trait::async_trait]
 impl BoxedExecutorBuilder for SortMergeJoinExecutor {
-    fn new_boxed_executor<C: BatchTaskContext>(
+    async fn new_boxed_executor<C: BatchTaskContext>(
         source: &ExecutorBuilder<C>,
     ) -> risingwave_common::error::Result<BoxedExecutor> {
         ensure!(source.plan_node().get_children().len() == 2);
@@ -254,8 +255,8 @@ impl BoxedExecutorBuilder for SortMergeJoinExecutor {
         let right_plan_opt = source.plan_node().get_children().get(1);
         match (left_plan_opt, right_plan_opt) {
             (Some(left_plan), Some(right_plan)) => {
-                let left_child = source.clone_for_plan(left_plan).build()?;
-                let right_child = source.clone_for_plan(right_plan).build()?;
+                let left_child = source.clone_for_plan(left_plan).build().await?;
+                let right_child = source.clone_for_plan(right_plan).build().await?;
 
                 let fields = left_child
                     .schema()

--- a/src/batch/src/executor/limit.rs
+++ b/src/batch/src/executor/limit.rs
@@ -38,8 +38,9 @@ pub struct LimitExecutor {
     identity: String,
 }
 
+#[async_trait::async_trait]
 impl BoxedExecutorBuilder for LimitExecutor {
-    fn new_boxed_executor<C: BatchTaskContext>(
+    async fn new_boxed_executor<C: BatchTaskContext>(
         source: &ExecutorBuilder<C>,
     ) -> Result<BoxedExecutor> {
         ensure!(source.plan_node().get_children().len() == 1);
@@ -51,7 +52,7 @@ impl BoxedExecutorBuilder for LimitExecutor {
         let offset = limit_node.get_offset() as usize;
 
         if let Some(child_plan) = source.plan_node.get_children().get(0) {
-            let child = source.clone_for_plan(child_plan).build()?;
+            let child = source.clone_for_plan(child_plan).build().await?;
             return Ok(Box::new(Self {
                 child,
                 limit,

--- a/src/batch/src/executor/merge_sort_exchange.rs
+++ b/src/batch/src/executor/merge_sort_exchange.rs
@@ -189,8 +189,9 @@ impl<CS: 'static + CreateSource, C: BatchTaskContext> MergeSortExchangeExecutorI
 
 pub struct MergeSortExchangeExecutorBuilder {}
 
+#[async_trait::async_trait]
 impl BoxedExecutorBuilder for MergeSortExchangeExecutorBuilder {
-    fn new_boxed_executor<C: BatchTaskContext>(
+    async fn new_boxed_executor<C: BatchTaskContext>(
         source: &ExecutorBuilder<C>,
     ) -> Result<BoxedExecutor> {
         let sort_merge_node = try_match_expand!(

--- a/src/batch/src/executor/order_by.rs
+++ b/src/batch/src/executor/order_by.rs
@@ -82,8 +82,10 @@ impl OrderByExecutor {
         }
     }
 }
+
+#[async_trait::async_trait]
 impl BoxedExecutorBuilder for OrderByExecutor {
-    fn new_boxed_executor<C: BatchTaskContext>(
+    async fn new_boxed_executor<C: BatchTaskContext>(
         source: &ExecutorBuilder<C>,
     ) -> Result<BoxedExecutor> {
         ensure!(source.plan_node().get_children().len() == 1);
@@ -99,7 +101,7 @@ impl BoxedExecutorBuilder for OrderByExecutor {
             .map(OrderPair::from_prost)
             .collect();
         if let Some(child_plan) = source.plan_node.get_children().get(0) {
-            let child = source.clone_for_plan(child_plan).build()?;
+            let child = source.clone_for_plan(child_plan).build().await?;
             return Ok(Box::new(OrderByExecutor::new(
                 child,
                 vec![],

--- a/src/batch/src/executor/project.rs
+++ b/src/batch/src/executor/project.rs
@@ -68,8 +68,9 @@ impl ProjectExecutor {
     }
 }
 
+#[async_trait::async_trait]
 impl BoxedExecutorBuilder for ProjectExecutor {
-    fn new_boxed_executor<C: BatchTaskContext>(
+    async fn new_boxed_executor<C: BatchTaskContext>(
         source: &ExecutorBuilder<C>,
     ) -> Result<BoxedExecutor> {
         ensure!(source.plan_node().get_children().len() == 1);
@@ -84,7 +85,7 @@ impl BoxedExecutorBuilder for ProjectExecutor {
                 "Child interpreting error",
             )))
         })?;
-        let child_node = source.clone_for_plan(proto_child).build()?;
+        let child_node = source.clone_for_plan(proto_child).build().await?;
 
         let project_exprs = project_node
             .get_select_list()

--- a/src/batch/src/executor/row_seq_scan.rs
+++ b/src/batch/src/executor/row_seq_scan.rs
@@ -19,7 +19,7 @@ use risingwave_common::array::DataChunk;
 use risingwave_common::catalog::{ColumnDesc, Schema, TableId};
 use risingwave_common::error::{Result, RwError};
 use risingwave_pb::batch_plan::plan_node::NodeBody;
-use risingwave_storage::table::cell_based_table::CellBasedTable;
+use risingwave_storage::table::cell_based_table::{CellBasedTable, CellBasedTableRowIter};
 use risingwave_storage::{dispatch_state_store, Keyspace, StateStore, StateStoreImpl};
 
 use crate::executor::monitor::BatchMetrics;
@@ -30,34 +30,30 @@ use crate::task::BatchTaskContext;
 
 /// Executor that scans data from row table
 pub struct RowSeqScanExecutor<S: StateStore> {
-    table: CellBasedTable<S>,
     primary: bool,
     chunk_size: usize,
     schema: Schema,
     identity: String,
-    epoch: u64,
     stats: Arc<BatchMetrics>,
+    row_iter: CellBasedTableRowIter<S>,
 }
 
 impl<S: StateStore> RowSeqScanExecutor<S> {
     pub fn new(
-        table: CellBasedTable<S>,
+        schema: Schema,
+        row_iter: CellBasedTableRowIter<S>,
         chunk_size: usize,
         primary: bool,
         identity: String,
-        epoch: u64,
         stats: Arc<BatchMetrics>,
     ) -> Self {
-        let schema = table.schema().clone();
-
         Self {
-            table,
             primary,
             chunk_size,
             schema,
             identity,
-            epoch,
             stats,
+            row_iter,
         }
     }
 
@@ -76,8 +72,9 @@ impl RowSeqScanExecutorBuilder {
     pub const DEFAULT_CHUNK_SIZE: usize = 1024;
 }
 
+#[async_trait::async_trait]
 impl BoxedExecutorBuilder for RowSeqScanExecutorBuilder {
-    fn new_boxed_executor<C: BatchTaskContext>(
+    async fn new_boxed_executor<C: BatchTaskContext>(
         source: &ExecutorBuilder<C>,
     ) -> Result<BoxedExecutor> {
         let seq_scan_node = try_match_expand!(
@@ -101,12 +98,13 @@ impl BoxedExecutorBuilder for RowSeqScanExecutorBuilder {
                 let storage_stats = state_store.stats();
                 let batch_stats = source.batch_task_context().stats();
                 let table = CellBasedTable::new_adhoc(keyspace, column_descs, storage_stats);
+                let iter = table.iter(source.epoch).await?;
                 Ok(Box::new(RowSeqScanExecutor::new(
-                    table,
+                    table.schema().clone(),
+                    iter,
                     RowSeqScanExecutorBuilder::DEFAULT_CHUNK_SIZE,
                     source.task_id.task_id == 0,
                     source.plan_node().get_identity().clone(),
-                    source.epoch(),
                     batch_stats,
                 )))
             }
@@ -130,15 +128,14 @@ impl<S: StateStore> Executor for RowSeqScanExecutor<S> {
 
 impl<S: StateStore> RowSeqScanExecutor<S> {
     #[try_stream(boxed, ok = DataChunk, error = RwError)]
-    async fn do_execute(self: Box<Self>) {
+    async fn do_execute(mut self: Box<Self>) {
         if !self.should_ignore() {
-            let mut iter = self.table.iter(self.epoch).await.map_err(RwError::from)?;
-
             loop {
                 let timer = self.stats.row_seq_scan_next_duration.start_timer();
 
-                let chunk = iter
-                    .collect_data_chunk(&self.table, Some(self.chunk_size))
+                let chunk = self
+                    .row_iter
+                    .collect_data_chunk(&self.schema, Some(self.chunk_size))
                     .await
                     .map_err(RwError::from)?;
                 timer.observe_duration();

--- a/src/batch/src/executor/sort_agg.rs
+++ b/src/batch/src/executor/sort_agg.rs
@@ -49,8 +49,9 @@ pub struct SortAggExecutor {
     output_size_limit: usize, // make unit test easy
 }
 
+#[async_trait::async_trait]
 impl BoxedExecutorBuilder for SortAggExecutor {
-    fn new_boxed_executor<C: BatchTaskContext>(
+    async fn new_boxed_executor<C: BatchTaskContext>(
         source: &ExecutorBuilder<C>,
     ) -> Result<BoxedExecutor> {
         ensure!(source.plan_node().get_children().len() == 1);
@@ -58,7 +59,7 @@ impl BoxedExecutorBuilder for SortAggExecutor {
             source.plan_node().get_children().get(0).ok_or_else(|| {
                 ErrorCode::InternalError("SortAgg must have child node".to_string())
             })?;
-        let child = source.clone_for_plan(proto_child).build()?;
+        let child = source.clone_for_plan(proto_child).build().await?;
 
         let sort_agg_node = try_match_expand!(
             source.plan_node().get_node_body().unwrap(),

--- a/src/batch/src/executor/top_n.rs
+++ b/src/batch/src/executor/top_n.rs
@@ -92,8 +92,9 @@ pub struct TopNExecutor {
     offset: usize,
 }
 
+#[async_trait::async_trait]
 impl BoxedExecutorBuilder for TopNExecutor {
-    fn new_boxed_executor<C: BatchTaskContext>(
+    async fn new_boxed_executor<C: BatchTaskContext>(
         source: &ExecutorBuilder<C>,
     ) -> Result<BoxedExecutor> {
         ensure!(source.plan_node().get_children().len() == 1);
@@ -107,7 +108,7 @@ impl BoxedExecutorBuilder for TopNExecutor {
             .map(OrderPair::from_prost)
             .collect();
         if let Some(child_plan) = source.plan_node.get_children().get(0) {
-            let child = source.clone_for_plan(child_plan).build()?;
+            let child = source.clone_for_plan(child_plan).build().await?;
             return Ok(Box::new(Self::new(
                 child,
                 order_pairs,

--- a/src/batch/src/executor/update.rs
+++ b/src/batch/src/executor/update.rs
@@ -162,8 +162,9 @@ impl UpdateExecutor {
     }
 }
 
+#[async_trait::async_trait]
 impl BoxedExecutorBuilder for UpdateExecutor {
-    fn new_boxed_executor<C: BatchTaskContext>(
+    async fn new_boxed_executor<C: BatchTaskContext>(
         source: &ExecutorBuilder<C>,
     ) -> Result<BoxedExecutor> {
         let update_node = try_match_expand!(
@@ -184,7 +185,7 @@ impl BoxedExecutorBuilder for UpdateExecutor {
                 "Child interpreting error",
             )))
         })?;
-        let child = source.clone_for_plan(proto_child).build()?;
+        let child = source.clone_for_plan(proto_child).build().await?;
 
         Ok(Box::new(Self::new(
             table_id,

--- a/src/batch/src/executor/values.rs
+++ b/src/batch/src/executor/values.rs
@@ -111,8 +111,10 @@ impl ValuesExecutor {
         }
     }
 }
+
+#[async_trait::async_trait]
 impl BoxedExecutorBuilder for ValuesExecutor {
-    fn new_boxed_executor<C: BatchTaskContext>(
+    async fn new_boxed_executor<C: BatchTaskContext>(
         source: &ExecutorBuilder<C>,
     ) -> Result<BoxedExecutor> {
         let value_node = try_match_expand!(

--- a/src/batch/src/rpc/service/task_service.rs
+++ b/src/batch/src/rpc/service/task_service.rs
@@ -44,12 +44,15 @@ impl TaskService for BatchServiceImpl {
     ) -> Result<Response<CreateTaskResponse>, Status> {
         let req = request.into_inner();
 
-        let res = self.mgr.fire_task(
-            req.get_task_id().expect("no task id found"),
-            req.get_plan().expect("no plan found").clone(),
-            req.epoch,
-            ComputeNodeContext::new(self.env.clone()),
-        );
+        let res = self
+            .mgr
+            .fire_task(
+                req.get_task_id().expect("no task id found"),
+                req.get_plan().expect("no plan found").clone(),
+                req.epoch,
+                ComputeNodeContext::new(self.env.clone()),
+            )
+            .await;
         match res {
             Ok(_) => Ok(Response::new(CreateTaskResponse { status: None })),
             Err(e) => {

--- a/src/batch/src/task/task_.rs
+++ b/src/batch/src/task/task_.rs
@@ -217,7 +217,7 @@ impl<C: BatchTaskContext> BatchTaskExecution<C> {
     /// hash partitioned across multiple channels.
     /// To obtain the result, one must pick one of the channels to consume via [`TaskOutputId`]. As
     /// such, parallel consumers are able to consume the result idependently.
-    pub fn async_execute(self: Arc<Self>) -> Result<()> {
+    pub async fn async_execute(self: Arc<Self>) -> Result<()> {
         trace!(
             "Prepare executing plan [{:?}]: {}",
             self.task_id,
@@ -230,7 +230,8 @@ impl<C: BatchTaskContext> BatchTaskExecution<C> {
             self.context.clone(),
             self.epoch,
         )
-        .build()?;
+        .build()
+        .await?;
 
         let (sender, receivers) = create_output_channel(self.plan.get_exchange_info()?)?;
         let (shutdown_tx, shutdown_rx) = tokio::sync::oneshot::channel::<u64>();

--- a/src/batch/src/task/task_manager.rs
+++ b/src/batch/src/task/task_manager.rs
@@ -43,7 +43,7 @@ impl BatchManager {
         }
     }
 
-    pub fn fire_task(
+    pub async fn fire_task(
         &self,
         tid: &ProstTaskId,
         plan: PlanFragment,
@@ -55,7 +55,7 @@ impl BatchManager {
         let task_id = task.get_task_id().clone();
         let task = Arc::new(task);
 
-        task.clone().async_execute()?;
+        task.clone().async_execute().await?;
         if let hash_map::Entry::Vacant(e) = self.tasks.lock().entry(task_id.clone()) {
             e.insert(task);
             Ok(())
@@ -246,8 +246,12 @@ mod tests {
         };
         manager
             .fire_task(&task_id, plan.clone(), 0, context.clone())
+            .await
             .unwrap();
-        let err = manager.fire_task(&task_id, plan, 0, context).unwrap_err();
+        let err = manager
+            .fire_task(&task_id, plan, 0, context)
+            .await
+            .unwrap_err();
         assert!(err
             .to_string()
             .contains("can not create duplicate task with the same id"));
@@ -281,6 +285,7 @@ mod tests {
         };
         manager
             .fire_task(&task_id, plan.clone(), 0, context.clone())
+            .await
             .unwrap();
         manager.abort_task(&task_id).unwrap();
         let task_id = TaskId::from(&task_id);

--- a/src/compute/tests/table_v2_materialize.rs
+++ b/src/compute/tests/table_v2_materialize.rs
@@ -202,11 +202,11 @@ async fn test_table_v2_materialize() -> Result<()> {
     );
 
     let scan = Box::new(RowSeqScanExecutor::new(
-        table.clone(),
+        table.schema().clone(),
+        table.iter(u64::MAX).await?,
         1024,
         true,
         "RowSeqExecutor2".to_string(),
-        u64::MAX,
         Arc::new(BatchMetrics::unused()),
     ));
     let mut stream = scan.execute();
@@ -261,11 +261,11 @@ async fn test_table_v2_materialize() -> Result<()> {
 
     // Scan the table again, we are able to get the data now!
     let scan = Box::new(RowSeqScanExecutor::new(
-        table.clone(),
+        table.schema().clone(),
+        table.iter(u64::MAX).await?,
         1024,
         true,
         "RowSeqScanExecutor2".to_string(),
-        u64::MAX,
         Arc::new(BatchMetrics::unused()),
     ));
 
@@ -329,11 +329,11 @@ async fn test_table_v2_materialize() -> Result<()> {
 
     // Scan the table again, we are able to see the deletion now!
     let scan = Box::new(RowSeqScanExecutor::new(
-        table.clone(),
+        table.schema().clone(),
+        table.iter(u64::MAX).await?,
         1024,
         true,
         "RowSeqScanExecutor2".to_string(),
-        u64::MAX,
         Arc::new(BatchMetrics::unused()),
     ));
 

--- a/src/frontend/src/scheduler/local.rs
+++ b/src/frontend/src/scheduler/local.rs
@@ -67,8 +67,9 @@ impl LocalQueryExecution {
         };
 
         let epoch = self.hummock_snapshot_manager.get_epoch(query_id).await?;
-        let executor =
-            ExecutorBuilder::new(&plan_fragment.root.unwrap(), &task_id, context, epoch).build()?;
+        let plan_node = plan_fragment.root.unwrap();
+        let executor = ExecutorBuilder::new(&plan_node, &task_id, context, epoch);
+        let executor = executor.build().await?;
 
         #[for_await]
         for chunk in executor.execute() {

--- a/src/storage/src/memory.rs
+++ b/src/storage/src/memory.rs
@@ -23,6 +23,8 @@ use bytes::Bytes;
 use lazy_static::lazy_static;
 use parking_lot::RwLock;
 
+use crate::error::{StorageError, StorageResult};
+use crate::hummock::HummockError;
 use crate::storage_value::StorageValue;
 use crate::store::*;
 use crate::{define_state_store_associated_type, StateStore, StateStoreIter};
@@ -39,6 +41,8 @@ type KeyWithEpoch = (Bytes, Reverse<u64>);
 pub struct MemoryStateStore {
     /// Stores (key, epoch) -> user value. We currently don't consider value meta here.
     inner: Arc<RwLock<BTreeMap<KeyWithEpoch, Option<Bytes>>>>,
+    /// current largest committed epoch,
+    epoch: Option<u64>,
 }
 
 impl Default for MemoryStateStore {
@@ -69,6 +73,7 @@ impl MemoryStateStore {
     pub fn new() -> Self {
         Self {
             inner: Arc::new(RwLock::new(BTreeMap::new())),
+            epoch: None,
         }
     }
 
@@ -77,6 +82,25 @@ impl MemoryStateStore {
             static ref STORE: MemoryStateStore = MemoryStateStore::new();
         }
         STORE.clone()
+    }
+
+    pub fn commit_epoch(&mut self, epoch: u64) -> StorageResult<()> {
+        match self.epoch {
+            None => {
+                self.epoch = Some(epoch);
+                Ok(())
+            }
+            Some(current_epoch) => {
+                if current_epoch > epoch {
+                    Err(StorageError::Hummock(HummockError::expired_epoch(
+                        current_epoch,
+                        epoch,
+                    )))
+                } else {
+                    Ok(())
+                }
+            }
+        }
     }
 }
 
@@ -223,7 +247,10 @@ impl StateStoreIter for MemoryStateStoreIter {
         impl Future<Output = crate::error::StorageResult<Option<Self::Item>>> + Send;
 
     fn next(&mut self) -> Self::NextFuture<'_> {
-        async move { Ok(self.inner.next()) }
+        async move {
+            let item = self.inner.next();
+            Ok(item)
+        }
     }
 }
 

--- a/src/storage/src/table/test_relational_table.rs
+++ b/src/storage/src/table/test_relational_table.rs
@@ -1404,7 +1404,7 @@ async fn test_cell_based_scan_empty_column_ids_cardinality() {
 
     let chunk = {
         let mut iter = table.iter(u64::MAX).await.unwrap();
-        iter.collect_data_chunk(&table, None)
+        iter.collect_data_chunk(table.schema(), None)
             .await
             .unwrap()
             .unwrap()

--- a/src/stream/src/executor/batch_query.rs
+++ b/src/stream/src/executor/batch_query.rs
@@ -69,7 +69,7 @@ where
         let mut iter = self.table.iter(epoch).await?;
 
         while let Some(data_chunk) = iter
-            .collect_data_chunk(&self.table, Some(self.batch_size))
+            .collect_data_chunk(self.schema(), Some(self.batch_size))
             .await?
         {
             // Filter out rows


### PR DESCRIPTION
## What's changed and what's your intention?
We replace `scan` with `iter` after we can finally unpin the epoch earlier, i.e. after the iterator is successfully or unsuccessfully created.

This is possible as we now #2825  unpin the epoch of a batch query after it `successfully` schedules all the tasks of leaf stages. The implicit assumption here is that the `CellBasedRowIterator` for batch query will only be used in leaf stages.

The ugly part is that I have to create the iterator during building (a non-sync func) the executors instead of during executing. Since `building` is part of scheduling while `executing` is an independent process, creating iterators during build can be effectively considered part of scheduling. 

Otherwise, we need to introduce another communication path for CN to notify the batch query manager in the frontend that all the iterators are created successfully. (Note that failure does not need this extra path as it is considered the failure of the task).

Since `table.iter(epoch)` is async and now it needs to be done during `fire_task`, so this PR changes the `new_boxed_executor` to be async. `fire_task` does not hold any locks during building of executors.

## Refer to a related PR or issue link (optional)
closes #2238 
closes #2236 
closes #407