### PR TITLE
fix(bitmap): make vnode bits same as upstream

### DIFF
--- a/src/storage/src/hummock/sstable/builder.rs
+++ b/src/storage/src/hummock/sstable/builder.rs
@@ -69,7 +69,7 @@ impl Default for SSTableBuilderOptions {
     }
 }
 
-pub const VNODE_BITS: usize = 8;
+pub const VNODE_BITS: usize = 11;
 pub const VNODE_BITMAP_LEN: usize = 1 << (VNODE_BITS - 3);
 pub struct SSTableBuilder {
     /// Options.


### PR DESCRIPTION
## What's changed and what's your intention?

make vnode bits same as upstream

## Checklist

## Refer to a related PR or issue link (optional)
