### PR TITLE
refactor(batch): Simplify task context by removing `get_task_error`.

### DIFF
--- a/src/batch/src/execution/local_exchange.rs
+++ b/src/batch/src/execution/local_exchange.rs
@@ -21,15 +21,19 @@ use risingwave_rpc_client::ExchangeSource;
 use crate::task::{BatchTaskContext, TaskId, TaskOutput, TaskOutputId};
 
 /// Exchange data from a local task execution.
-pub struct LocalExchangeSource<C> {
-    task_output: TaskOutput<C>,
+pub struct LocalExchangeSource {
+    task_output: TaskOutput,
 
     /// Id of task which contains the `ExchangeExecutor` of this source.
     task_id: TaskId,
 }
 
-impl<C: BatchTaskContext> LocalExchangeSource<C> {
-    pub fn create(output_id: TaskOutputId, context: C, task_id: TaskId) -> Result<Self> {
+impl LocalExchangeSource {
+    pub fn create<C: BatchTaskContext>(
+        output_id: TaskOutputId,
+        context: C,
+        task_id: TaskId,
+    ) -> Result<Self> {
         let task_output = context.get_task_output(output_id)?;
         Ok(Self {
             task_output,
@@ -38,7 +42,7 @@ impl<C: BatchTaskContext> LocalExchangeSource<C> {
     }
 }
 
-impl<C> Debug for LocalExchangeSource<C> {
+impl Debug for LocalExchangeSource {
     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
         f.debug_struct("LocalExchangeSource")
             .field("task_output_id", self.task_output.id())
@@ -47,7 +51,7 @@ impl<C> Debug for LocalExchangeSource<C> {
 }
 
 #[async_trait::async_trait]
-impl<C: BatchTaskContext> ExchangeSource for LocalExchangeSource<C> {
+impl ExchangeSource for LocalExchangeSource {
     async fn take_data(&mut self) -> Result<Option<DataChunk>> {
         let ret = self.task_output.direct_take_data().await?;
         if let Some(data) = ret {

--- a/src/batch/src/task/task_manager.rs
+++ b/src/batch/src/task/task_manager.rs
@@ -94,10 +94,7 @@ impl BatchManager {
         Ok(())
     }
 
-    pub fn take_output(
-        &self,
-        output_id: &ProstTaskOutputId,
-    ) -> Result<TaskOutput<ComputeNodeContext>> {
+    pub fn take_output(&self, output_id: &ProstTaskOutputId) -> Result<TaskOutput> {
         let task_id = TaskId::from(output_id.get_task_id()?);
         debug!("Trying to take output of: {:?}", output_id);
         self.tasks

--- a/src/frontend/src/scheduler/task_context.rs
+++ b/src/frontend/src/scheduler/task_context.rs
@@ -25,18 +25,11 @@ use risingwave_source::SourceManagerRef;
 pub struct FrontendBatchTaskContext {}
 
 impl BatchTaskContext for FrontendBatchTaskContext {
-    fn get_task_output(
-        &self,
-        task_output_id: TaskOutputId,
-    ) -> risingwave_common::error::Result<TaskOutput<Self>> {
+    fn get_task_output(&self, _task_output_id: TaskOutputId) -> Result<TaskOutput> {
         todo!()
     }
 
     fn is_local_addr(&self, peer_addr: &HostAddr) -> bool {
-        todo!()
-    }
-
-    fn get_task_error(&self, task_id: TaskId) -> Result<Option<RwError>> {
         todo!()
     }
 
@@ -49,10 +42,6 @@ impl BatchTaskContext for FrontendBatchTaskContext {
     }
 
     fn stats(&self) -> Arc<BatchMetrics> {
-        todo!()
-    }
-
-    fn try_get_error(&self, task_id: &TaskId) -> risingwave_common::error::Result<Option<RwError>> {
         todo!()
     }
 }


### PR DESCRIPTION
## What's changed and what's your intention?

The first step in simplifying task context trait: remoing `get_task_error`.

## Checklist

- [x] I have written necessary docs and comments
- [x] I have added necessary unit tests and integration tests

## Refer to a related PR or issue link (optional)
