### PR TITLE
refactor(test): use `DataChunk::from_pretty` for literals in unit tests rather than DataChunkBuilder

### DIFF
--- a/src/batch/src/executor/delete.rs
+++ b/src/batch/src/executor/delete.rs
@@ -145,9 +145,9 @@ mod tests {
     use std::sync::Arc;
 
     use futures::StreamExt;
-    use risingwave_common::array::{Array, I32Array};
+    use risingwave_common::array::Array;
     use risingwave_common::catalog::{schema_test_utils, ColumnDesc, ColumnId};
-    use risingwave_common::column_nonnull;
+    use risingwave_common::test_prelude::DataChunkTestExt;
     use risingwave_source::{MemSourceManager, SourceManager, StreamSourceReader};
 
     use super::*;
@@ -178,10 +178,14 @@ mod tests {
             })
             .collect();
 
-        let col1 = column_nonnull! { I32Array, [1, 3, 5, 7, 9] };
-        let col2 = column_nonnull! { I32Array, [2, 4, 6, 8, 10] };
-        let data_chunk: DataChunk = DataChunk::builder().columns(vec![col1, col2]).build();
-        mock_executor.add(data_chunk.clone());
+        mock_executor.add(DataChunk::from_pretty(
+            "i  i
+             1  2
+             3  4
+             5  6
+             7  8
+             9 10",
+        ));
 
         // Create the table.
         let table_id = TableId::new(0);

--- a/src/batch/src/executor/filter.rs
+++ b/src/batch/src/executor/filter.rs
@@ -123,14 +123,11 @@ impl BoxedExecutorBuilder for FilterExecutor {
 
 #[cfg(test)]
 mod tests {
-    use std::sync::Arc;
-
     use assert_matches::assert_matches;
     use futures::stream::StreamExt;
-    use risingwave_common::array::column::Column;
-    use risingwave_common::array::{Array, DataChunk, PrimitiveArray};
+    use risingwave_common::array::{Array, DataChunk};
     use risingwave_common::catalog::{Field, Schema};
-    use risingwave_common::error::Result;
+    use risingwave_common::test_prelude::DataChunkTestExt;
     use risingwave_common::types::DataType;
     use risingwave_expr::expr::build_from_prost;
     use risingwave_pb::data::data_type::TypeName;
@@ -143,9 +140,6 @@ mod tests {
 
     #[tokio::test]
     async fn test_filter_executor() {
-        let col1 = create_column(&[Some(2), Some(2), Some(4), Some(3)]).unwrap();
-        let col2 = create_column(&[Some(1), Some(2), Some(1), Some(3)]).unwrap();
-        let data_chunk = DataChunk::builder().columns([col1, col2].to_vec()).build();
         let schema = Schema {
             fields: vec![
                 Field::unnamed(DataType::Int32),
@@ -153,7 +147,13 @@ mod tests {
             ],
         };
         let mut mock_executor = MockExecutor::new(schema);
-        mock_executor.add(data_chunk);
+        mock_executor.add(DataChunk::from_pretty(
+            "i i
+             2 1
+             2 2
+             4 1
+             3 3",
+        ));
         let expr = make_expression(Type::Equal);
         let filter_executor = Box::new(FilterExecutor {
             expr: build_from_prost(&expr).unwrap(),
@@ -204,10 +204,5 @@ mod tests {
             }),
             rex_node: Some(RexNode::InputRef(InputRefExpr { column_idx: idx })),
         }
-    }
-
-    fn create_column(vec: &[Option<i32>]) -> Result<Column> {
-        let array = PrimitiveArray::from_slice(vec).map(|x| Arc::new(x.into()))?;
-        Ok(Column::new(array))
     }
 }

--- a/src/batch/src/executor/merge_sort_exchange.rs
+++ b/src/batch/src/executor/merge_sort_exchange.rs
@@ -237,9 +237,8 @@ mod tests {
     use std::sync::Arc;
 
     use futures::StreamExt;
-    use risingwave_common::array::column::Column;
-    use risingwave_common::array::{Array, DataChunk, I32Array};
-    use risingwave_common::array_nonnull;
+    use risingwave_common::array::{Array, DataChunk};
+    use risingwave_common::test_prelude::DataChunkTestExt;
     use risingwave_common::types::DataType;
     use risingwave_common::util::sort_util::OrderType;
 
@@ -271,11 +270,12 @@ mod tests {
                 _: &ProstExchangeSource,
                 _: TaskId,
             ) -> Result<Box<dyn ExchangeSource>> {
-                let chunk = DataChunk::builder()
-                    .columns(vec![Column::new(Arc::new(
-                        array_nonnull! { I32Array, [1, 2, 3] }.into(),
-                    ))])
-                    .build();
+                let chunk = DataChunk::from_pretty(
+                    "i
+                     1
+                     2
+                     3",
+                );
                 Ok(Box::new(FakeExchangeSource { chunk: Some(chunk) }))
             }
         }

--- a/src/batch/src/executor/order_by.rs
+++ b/src/batch/src/executor/order_by.rs
@@ -274,52 +274,14 @@ impl OrderByExecutor {
 mod tests {
     use std::sync::Arc;
 
-    use itertools::Itertools;
-    use risingwave_common::array::column::Column;
-    use risingwave_common::array::{BoolArray, DataChunk, PrimitiveArray, Utf8Array};
+    use risingwave_common::array::DataChunk;
     use risingwave_common::catalog::{Field, Schema};
     use risingwave_common::test_prelude::DataChunkTestExt;
-    use risingwave_common::types::{DataType, OrderedF32, OrderedF64};
+    use risingwave_common::types::DataType;
     use risingwave_common::util::sort_util::OrderType;
 
     use super::*;
     use crate::executor::test_utils::MockExecutor;
-
-    fn create_column_i32(vec: &[Option<i32>]) -> Result<Column> {
-        let array = PrimitiveArray::from_slice(vec).map(|x| Arc::new(x.into()))?;
-        Ok(Column::new(array))
-    }
-
-    fn create_column_i16(vec: &[Option<i16>]) -> Result<Column> {
-        let array = PrimitiveArray::from_slice(vec).map(|x| Arc::new(x.into()))?;
-        Ok(Column::new(array))
-    }
-
-    fn create_column_bool(vec: &[Option<bool>]) -> Result<Column> {
-        let array = BoolArray::from_slice(vec).map(|x| Arc::new(x.into()))?;
-        Ok(Column::new(array))
-    }
-
-    fn create_column_f32(vec: &[Option<f32>]) -> Result<Column> {
-        let vec = vec.iter().map(|o| o.map(OrderedF32::from)).collect_vec();
-        let array = PrimitiveArray::from_slice(&vec).map(|x| Arc::new(x.into()))?;
-        Ok(Column::new(array))
-    }
-
-    fn create_column_f64(vec: &[Option<f64>]) -> Result<Column> {
-        let vec = vec.iter().map(|o| o.map(OrderedF64::from)).collect_vec();
-        let array = PrimitiveArray::from_slice(&vec).map(|x| Arc::new(x.into()))?;
-        Ok(Column::new(array))
-    }
-
-    fn create_column_string(vec: &[Option<String>]) -> Result<Column> {
-        let str_vec = vec
-            .iter()
-            .map(|s| s.as_ref().map(|s| s.as_str()))
-            .collect_vec();
-        let array = Utf8Array::from_slice(&str_vec).map(|x| Arc::new(x.into()))?;
-        Ok(Column::new(array))
-    }
 
     #[tokio::test]
     async fn test_simple_order_by_executor() {

--- a/src/batch/src/executor/order_by.rs
+++ b/src/batch/src/executor/order_by.rs
@@ -278,6 +278,7 @@ mod tests {
     use risingwave_common::array::column::Column;
     use risingwave_common::array::{BoolArray, DataChunk, PrimitiveArray, Utf8Array};
     use risingwave_common::catalog::{Field, Schema};
+    use risingwave_common::test_prelude::DataChunkTestExt;
     use risingwave_common::types::{DataType, OrderedF32, OrderedF64};
     use risingwave_common::util::sort_util::OrderType;
 
@@ -322,9 +323,6 @@ mod tests {
 
     #[tokio::test]
     async fn test_simple_order_by_executor() {
-        let col0 = create_column_i32(&[Some(1), Some(2), Some(3)]).unwrap();
-        let col1 = create_column_i32(&[Some(3), Some(2), Some(1)]).unwrap();
-        let data_chunk = DataChunk::builder().columns([col0, col1].to_vec()).build();
         let schema = Schema {
             fields: vec![
                 Field::unnamed(DataType::Int32),
@@ -332,7 +330,12 @@ mod tests {
             ],
         };
         let mut mock_executor = MockExecutor::new(schema);
-        mock_executor.add(data_chunk);
+        mock_executor.add(DataChunk::from_pretty(
+            "i i
+             1 3
+             2 2
+             3 1",
+        ));
         let order_pairs = vec![
             OrderPair {
                 column_idx: 1,
@@ -375,11 +378,6 @@ mod tests {
 
     #[tokio::test]
     async fn test_encoding_for_float() {
-        let col0 =
-            create_column_f32(&[Some(-2.2), Some(-1.1), Some(1.1), Some(2.2), Some(3.3)]).unwrap();
-        let col1 =
-            create_column_f64(&[Some(3.3), Some(2.2), Some(1.1), Some(-1.1), Some(-2.2)]).unwrap();
-        let data_chunk = DataChunk::builder().columns([col0, col1].to_vec()).build();
         let schema = Schema {
             fields: vec![
                 Field::unnamed(DataType::Float32),
@@ -387,7 +385,14 @@ mod tests {
             ],
         };
         let mut mock_executor = MockExecutor::new(schema);
-        mock_executor.add(data_chunk);
+        mock_executor.add(DataChunk::from_pretty(
+            " f    F
+             -2.2  3.3
+             -1.1  2.2
+              1.1  1.1
+              2.2 -1.1
+              3.3 -2.2",
+        ));
         let order_pairs = vec![
             OrderPair {
                 column_idx: 1,
@@ -431,19 +436,6 @@ mod tests {
 
     #[tokio::test]
     async fn test_bsc_for_string() {
-        let col0 = create_column_string(&[
-            Some("1.1".to_string()),
-            Some("2.2".to_string()),
-            Some("3.3".to_string()),
-        ])
-        .unwrap();
-        let col1 = create_column_string(&[
-            Some("3.3".to_string()),
-            Some("2.2".to_string()),
-            Some("1.1".to_string()),
-        ])
-        .unwrap();
-        let data_chunk = DataChunk::builder().columns([col0, col1].to_vec()).build();
         let schema = Schema {
             fields: vec![
                 Field::unnamed(DataType::Varchar),
@@ -451,7 +443,12 @@ mod tests {
             ],
         };
         let mut mock_executor = MockExecutor::new(schema);
-        mock_executor.add(data_chunk);
+        mock_executor.add(DataChunk::from_pretty(
+            "T   T
+             1.1 3.3
+             2.2 2.2
+             3.3 1.1",
+        ));
         let order_pairs = vec![
             OrderPair {
                 column_idx: 1,

--- a/src/batch/src/executor/sort_agg.rs
+++ b/src/batch/src/executor/sort_agg.rs
@@ -271,6 +271,7 @@ mod tests {
     use risingwave_common::array::{Array as _, I32Array, I64Array};
     use risingwave_common::array_nonnull;
     use risingwave_common::catalog::{Field, Schema};
+    use risingwave_common::test_prelude::DataChunkTestExt;
     use risingwave_common::types::DataType;
     use risingwave_expr::expr::build_from_prost;
     use risingwave_pb::data::data_type::TypeName;
@@ -286,17 +287,6 @@ mod tests {
     #[tokio::test]
     #[allow(clippy::many_single_char_names)]
     async fn execute_count_star_int32() -> Result<()> {
-        use risingwave_common::array::ArrayImpl;
-        let anchor: Arc<ArrayImpl> = Arc::new(array_nonnull! { I32Array, [1, 2, 3, 4] }.into());
-
-        let chunk = DataChunk::builder()
-            .columns(vec![
-                Column::new(anchor.clone()),
-                Column::new(Arc::new(array_nonnull! { I32Array, [1, 1, 3, 3] }.into())),
-                Column::new(Arc::new(array_nonnull! { I32Array, [7, 8, 8, 9] }.into())),
-            ])
-            .build();
-
         // mock a child executor
         let schema = Schema {
             fields: vec![
@@ -306,25 +296,27 @@ mod tests {
             ],
         };
         let mut child = MockExecutor::new(schema);
-        child.add(chunk);
-
-        let chunk = DataChunk::builder()
-            .columns(vec![
-                Column::new(anchor.clone()),
-                Column::new(Arc::new(array_nonnull! { I32Array, [3, 4, 4, 5] }.into())),
-                Column::new(Arc::new(array_nonnull! { I32Array, [9, 9, 9, 9] }.into())),
-            ])
-            .build();
-        child.add(chunk);
-
-        let chunk = DataChunk::builder()
-            .columns(vec![
-                Column::new(anchor.clone()),
-                Column::new(Arc::new(array_nonnull! { I32Array, [5, 5, 5, 5] }.into())),
-                Column::new(Arc::new(array_nonnull! { I32Array, [9, 9, 9, 9] }.into())),
-            ])
-            .build();
-        child.add(chunk);
+        child.add(DataChunk::from_pretty(
+            "i i i
+             1 1 7
+             2 1 8
+             3 3 8
+             4 3 9",
+        ));
+        child.add(DataChunk::from_pretty(
+            "i i i
+             1 3 9
+             2 4 9
+             3 4 9
+             4 5 9",
+        ));
+        child.add(DataChunk::from_pretty(
+            "i i i
+             1 5 9
+             2 5 9
+             3 5 9
+             4 5 9",
+        ));
 
         let prost = AggCall {
             r#type: Type::Count as i32,
@@ -382,21 +374,6 @@ mod tests {
     #[tokio::test]
     #[allow(clippy::many_single_char_names)]
     async fn execute_count_star_int32_grouped() -> Result<()> {
-        use risingwave_common::array::ArrayImpl;
-        let anchor: Arc<ArrayImpl> = Arc::new(array_nonnull! { I32Array, [1, 2, 3, 4, 5] }.into());
-
-        let chunk = DataChunk::builder()
-            .columns(vec![
-                Column::new(anchor.clone()),
-                Column::new(Arc::new(
-                    array_nonnull! { I32Array, [1, 1, 3, 3, 4] }.into(),
-                )),
-                Column::new(Arc::new(
-                    array_nonnull! { I32Array, [7, 8, 8, 9, 9] }.into(),
-                )),
-            ])
-            .build();
-
         // mock a child executor
         let schema = Schema {
             fields: vec![
@@ -406,35 +383,33 @@ mod tests {
             ],
         };
         let mut child = MockExecutor::new(schema);
-        child.add(chunk);
-
-        let chunk = DataChunk::builder()
-            .columns(vec![
-                Column::new(Arc::new(
-                    array_nonnull! { I32Array, [1, 2, 3, 4, 5, 6, 7, 8] }.into(),
-                )),
-                Column::new(Arc::new(
-                    array_nonnull! { I32Array, [4, 4, 4, 5, 6, 7, 7, 8] }.into(),
-                )),
-                Column::new(Arc::new(
-                    array_nonnull! { I32Array, [9, 9, 9, 9, 9, 9, 9, 9] }.into(),
-                )),
-            ])
-            .build();
-        child.add(chunk);
-
-        let chunk = DataChunk::builder()
-            .columns(vec![
-                Column::new(anchor.clone()),
-                Column::new(Arc::new(
-                    array_nonnull! { I32Array, [8, 8, 8, 8, 8] }.into(),
-                )),
-                Column::new(Arc::new(
-                    array_nonnull! { I32Array, [9, 9, 9, 9, 9] }.into(),
-                )),
-            ])
-            .build();
-        child.add(chunk);
+        child.add(DataChunk::from_pretty(
+            "i i i
+             1 1 7
+             2 1 8
+             3 3 8
+             4 3 9
+             5 4 9",
+        ));
+        child.add(DataChunk::from_pretty(
+            "i i i
+             1 4 9
+             2 4 9
+             3 4 9
+             4 5 9
+             5 6 9
+             6 7 9
+             7 7 9
+             8 8 9",
+        ));
+        child.add(DataChunk::from_pretty(
+            "i i i
+             1 8 9
+             2 8 9
+             3 8 9
+             4 8 9
+             5 8 9",
+        ));
 
         let prost = AggCall {
             r#type: Type::Count as i32,
@@ -601,17 +576,6 @@ mod tests {
     #[tokio::test]
     #[allow(clippy::many_single_char_names)]
     async fn execute_sum_int32_grouped() -> Result<()> {
-        use risingwave_common::array::ArrayImpl;
-        let anchor: Arc<ArrayImpl> = Arc::new(array_nonnull! { I32Array, [1, 2, 3, 4] }.into());
-
-        let chunk = DataChunk::builder()
-            .columns(vec![
-                Column::new(anchor.clone()),
-                Column::new(Arc::new(array_nonnull! { I32Array, [1, 1, 3, 3] }.into())),
-                Column::new(Arc::new(array_nonnull! { I32Array, [7, 8, 8, 9] }.into())),
-            ])
-            .build();
-
         // mock a child executor
         let schema = Schema {
             fields: vec![
@@ -621,25 +585,27 @@ mod tests {
             ],
         };
         let mut child = MockExecutor::new(schema);
-        child.add(chunk);
-
-        let chunk = DataChunk::builder()
-            .columns(vec![
-                Column::new(anchor.clone()),
-                Column::new(Arc::new(array_nonnull! { I32Array, [3, 4, 4, 5] }.into())),
-                Column::new(Arc::new(array_nonnull! { I32Array, [9, 9, 9, 9] }.into())),
-            ])
-            .build();
-        child.add(chunk);
-
-        let chunk = DataChunk::builder()
-            .columns(vec![
-                Column::new(anchor.clone()),
-                Column::new(Arc::new(array_nonnull! { I32Array, [5, 5, 5, 5] }.into())),
-                Column::new(Arc::new(array_nonnull! { I32Array, [9, 9, 9, 9] }.into())),
-            ])
-            .build();
-        child.add(chunk);
+        child.add(DataChunk::from_pretty(
+            "i i i
+             1 1 7
+             2 1 8
+             3 3 8
+             4 3 9",
+        ));
+        child.add(DataChunk::from_pretty(
+            "i i i
+             1 3 9
+             2 4 9
+             3 4 9
+             4 5 9",
+        ));
+        child.add(DataChunk::from_pretty(
+            "i i i
+             1 5 9
+             2 5 9
+             3 5 9
+             4 5 9",
+        ));
 
         let prost = AggCall {
             r#type: Type::Sum as i32,
@@ -686,7 +652,7 @@ mod tests {
             .map(Field::unnamed)
             .collect::<Vec<Field>>();
 
-        let output_size_limit = anchor.len();
+        let output_size_limit = 4;
         let executor = Box::new(SortAggExecutor {
             agg_states,
             group_keys: group_exprs,
@@ -736,20 +702,6 @@ mod tests {
     #[tokio::test]
     #[allow(clippy::many_single_char_names)]
     async fn execute_sum_int32_grouped_execeed_limit() -> Result<()> {
-        let chunk = DataChunk::builder()
-            .columns(vec![
-                Column::new(Arc::new(
-                    array_nonnull! { I32Array, [1, 2, 3, 4, 5, 6, 7, 8, 9, 10] }.into(),
-                )),
-                Column::new(Arc::new(
-                    array_nonnull! { I32Array, [1, 1, 3, 3, 4, 4, 5, 5, 6, 6] }.into(),
-                )),
-                Column::new(Arc::new(
-                    array_nonnull! { I32Array, [7, 8, 8, 8, 9, 9, 9, 9, 10, 10] }.into(),
-                )),
-            ])
-            .build();
-
         // mock a child executor
         let schema = Schema {
             fields: vec![
@@ -759,16 +711,24 @@ mod tests {
             ],
         };
         let mut child = MockExecutor::new(schema);
-        child.add(chunk);
-
-        let chunk = DataChunk::builder()
-            .columns(vec![
-                Column::new(Arc::new(array_nonnull! { I32Array, [1, 2] }.into())),
-                Column::new(Arc::new(array_nonnull! { I32Array, [6, 7] }.into())),
-                Column::new(Arc::new(array_nonnull! { I32Array, [10, 12] }.into())),
-            ])
-            .build();
-        child.add(chunk);
+        child.add(DataChunk::from_pretty(
+            " i  i  i
+              1  1  7
+              2  1  8
+              3  3  8
+              4  3  8
+              5  4  9
+              6  4  9
+              7  5  9
+              8  5  9
+              9  6 10
+             10  6 10",
+        ));
+        child.add(DataChunk::from_pretty(
+            " i  i  i
+              1  6 10
+              2  7 12",
+        ));
 
         let prost = AggCall {
             r#type: Type::Sum as i32,

--- a/src/batch/src/executor/sort_agg.rs
+++ b/src/batch/src/executor/sort_agg.rs
@@ -268,8 +268,7 @@ impl SortAggExecutor {
 mod tests {
     use assert_matches::assert_matches;
     use futures::StreamExt;
-    use risingwave_common::array::{Array as _, I32Array, I64Array};
-    use risingwave_common::array_nonnull;
+    use risingwave_common::array::{Array as _, I64Array};
     use risingwave_common::catalog::{Field, Schema};
     use risingwave_common::test_prelude::DataChunkTestExt;
     use risingwave_common::types::DataType;
@@ -515,13 +514,23 @@ mod tests {
     #[tokio::test]
     #[allow(clippy::many_single_char_names)]
     async fn execute_sum_int32() -> Result<()> {
-        let a = Arc::new(array_nonnull! { I32Array, [1,2,3,4,5,6,7,8,9,10] }.into());
-        let chunk = DataChunk::builder().columns(vec![Column::new(a)]).build();
         let schema = Schema {
             fields: vec![Field::unnamed(DataType::Int32)],
         };
         let mut child = MockExecutor::new(schema);
-        child.add(chunk);
+        child.add(DataChunk::from_pretty(
+            " i
+              1
+              2
+              3
+              4
+              5
+              6
+              7
+              8
+              9
+             10",
+        ));
 
         let prost = AggCall {
             r#type: Type::Sum as i32,

--- a/src/batch/src/executor/top_n.rs
+++ b/src/batch/src/executor/top_n.rs
@@ -180,8 +180,9 @@ impl TopNExecutor {
 mod tests {
     use futures::stream::StreamExt;
     use itertools::Itertools;
-    use risingwave_common::array::{Array, DataChunk, I32Array};
+    use risingwave_common::array::{Array, DataChunk};
     use risingwave_common::catalog::{Field, Schema};
+    use risingwave_common::test_prelude::DataChunkTestExt;
     use risingwave_common::types::DataType;
     use risingwave_common::util::sort_util::OrderType;
 
@@ -190,9 +191,6 @@ mod tests {
 
     #[tokio::test]
     async fn test_simple_top_n_executor() {
-        let col0 = column_nonnull! { I32Array, [1, 2, 3, 4, 5] };
-        let col1 = column_nonnull! { I32Array, [5, 4, 3, 2, 1] };
-        let data_chunk = DataChunk::builder().columns(vec![col0, col1]).build();
         let schema = Schema {
             fields: vec![
                 Field::unnamed(DataType::Int32),
@@ -200,7 +198,14 @@ mod tests {
             ],
         };
         let mut mock_executor = MockExecutor::new(schema);
-        mock_executor.add(data_chunk);
+        mock_executor.add(DataChunk::from_pretty(
+            "i i
+             1 5
+             2 4
+             3 3
+             4 2
+             5 1",
+        ));
         let order_pairs = vec![
             OrderPair {
                 column_idx: 1,

--- a/src/batch/src/executor/update.rs
+++ b/src/batch/src/executor/update.rs
@@ -200,9 +200,9 @@ mod tests {
     use std::sync::Arc;
 
     use futures::StreamExt;
-    use risingwave_common::array::{Array, I32Array};
+    use risingwave_common::array::Array;
     use risingwave_common::catalog::{schema_test_utils, ColumnDesc, ColumnId};
-    use risingwave_common::column_nonnull;
+    use risingwave_common::test_prelude::DataChunkTestExt;
     use risingwave_expr::expr::InputRefExpression;
     use risingwave_source::{MemSourceManager, SourceManager, StreamSourceReader};
 
@@ -234,10 +234,14 @@ mod tests {
             })
             .collect();
 
-        let col1 = column_nonnull! { I32Array, [1, 3, 5, 7, 9] };
-        let col2 = column_nonnull! { I32Array, [2, 4, 6, 8, 10] };
-        let data_chunk: DataChunk = DataChunk::builder().columns(vec![col1, col2]).build();
-        mock_executor.add(data_chunk.clone());
+        mock_executor.add(DataChunk::from_pretty(
+            "i  i
+             1  2
+             3  4
+             5  6
+             7  8
+             9 10",
+        ));
 
         // Update expressions, will swap two columns.
         let exprs = vec![

--- a/src/common/src/array/data_chunk.rs
+++ b/src/common/src/array/data_chunk.rs
@@ -526,6 +526,13 @@ impl DataChunkTestExt for DataChunk {
                             .map_err(|_| panic!("invalid int64: {s:?}"))
                             .unwrap(),
                     )),
+                    s if matches!(builder, ArrayBuilderImpl::Float32(_)) => {
+                        Some(ScalarImpl::Float32(
+                            s.parse()
+                                .map_err(|_| panic!("invalid float32: {s:?}"))
+                                .unwrap(),
+                        ))
+                    }
                     s if matches!(builder, ArrayBuilderImpl::Float64(_)) => {
                         Some(ScalarImpl::Float64(
                             s.parse()

--- a/src/common/src/hash/key.rs
+++ b/src/common/src/hash/key.rs
@@ -666,8 +666,9 @@ mod tests {
     use crate::array;
     use crate::array::column::Column;
     use crate::array::{
-        ArrayRef, BoolArray, DataChunk, DecimalArray, F32Array, F64Array, I16Array, I32Array,
-        I32ArrayBuilder, I64Array, NaiveDateArray, NaiveDateTimeArray, NaiveTimeArray, Utf8Array,
+        ArrayRef, BoolArray, DataChunk, DataChunkTestExt, DecimalArray, F32Array, F64Array,
+        I16Array, I32Array, I32ArrayBuilder, I64Array, NaiveDateArray, NaiveDateTimeArray,
+        NaiveTimeArray, Utf8Array,
     };
     use crate::hash::{
         HashKey, Key128, Key16, Key256, Key32, Key64, KeySerialized, PrecomputedBuildHasher,
@@ -860,12 +861,11 @@ mod tests {
     fn test_simple_hash_key_nullable_serde() {
         let keys = Key64::build(
             &[0, 1],
-            &DataChunk::builder()
-                .columns(vec![
-                    Column::new(Arc::new(array! { I32Array, [Some(1), None] }.into())),
-                    Column::new(Arc::new(array! { I32Array, [None, Some(2)] }.into())),
-                ])
-                .build(),
+            &DataChunk::from_pretty(
+                "i i
+                 1 .
+                 . 2",
+            ),
         )
         .unwrap();
 

--- a/src/compute/tests/table_v2_materialize.rs
+++ b/src/compute/tests/table_v2_materialize.rs
@@ -28,6 +28,7 @@ use risingwave_common::array::{Array, DataChunk, F64Array, I64Array};
 use risingwave_common::catalog::{ColumnDesc, ColumnId, Field, Schema, TableId};
 use risingwave_common::column_nonnull;
 use risingwave_common::error::{Result, RwError};
+use risingwave_common::test_prelude::DataChunkTestExt;
 use risingwave_common::types::IntoOrdered;
 use risingwave_common::util::sort_util::{OrderPair, OrderType};
 use risingwave_pb::data::data_type::TypeName;
@@ -166,8 +167,11 @@ async fn test_table_v2_materialize() -> Result<()> {
     //
 
     // Add some data using `InsertExecutor`, assuming we are inserting into the "mv"
-    let columns = vec![column_nonnull! { F64Array, [1.14, 5.14] }];
-    let chunk = DataChunk::builder().columns(columns.clone()).build();
+    let chunk = DataChunk::from_pretty(
+        "F
+         1.14
+         5.14",
+    );
     let insert_inner: BoxedExecutor = Box::new(SingleChunkExecutor::new(chunk, all_schema.clone()));
     let insert = Box::new(InsertExecutor::new(
         source_table_id,

--- a/src/expr/src/expr/expr_case.rs
+++ b/src/expr/src/expr/expr_case.rs
@@ -98,20 +98,12 @@ impl Expression for CaseExpression {
 
 #[cfg(test)]
 mod tests {
-    use std::sync::Arc;
-
-    use risingwave_common::array::column::Column;
-    use risingwave_common::array::PrimitiveArray;
+    use risingwave_common::test_prelude::DataChunkTestExt;
     use risingwave_pb::expr::expr_node::Type;
 
     use super::*;
     use crate::expr::expr_binary_nonnull::new_binary_expr;
     use crate::expr::{InputRefExpression, LiteralExpression};
-
-    fn create_column_i32(vec: &[Option<i32>]) -> Result<Column> {
-        let array = PrimitiveArray::from_slice(vec).map(|x| Arc::new(x.into()))?;
-        Ok(Column::new(array))
-    }
 
     #[test]
     fn test_searched_case() {
@@ -135,8 +127,14 @@ mod tests {
             Some(4.1f32.into()),
         ));
         let searched_case_expr = CaseExpression::new(ret_type, when_clauses, Some(els));
-        let col = create_column_i32(&[Some(1), Some(2), Some(3), Some(4), Some(5)]).unwrap();
-        let input = DataChunk::builder().columns([col].to_vec()).build();
+        let input = DataChunk::from_pretty(
+            "i
+             1
+             2
+             3
+             4
+             5",
+        );
         let output = searched_case_expr.eval(&input).unwrap();
         assert_eq!(output.datum_at(0), Some(3.1f32.into()));
         assert_eq!(output.datum_at(1), Some(3.1f32.into()));
@@ -162,8 +160,13 @@ mod tests {
             )),
         )];
         let searched_case_expr = CaseExpression::new(ret_type, when_clauses, None);
-        let col = create_column_i32(&[Some(3), Some(4), Some(3), Some(4)]).unwrap();
-        let input = DataChunk::builder().columns([col].to_vec()).build();
+        let input = DataChunk::from_pretty(
+            "i
+             3
+             4
+             3
+             4",
+        );
         let output = searched_case_expr.eval(&input).unwrap();
         assert_eq!(output.datum_at(0), Some(3.1f32.into()));
         assert_eq!(output.datum_at(1), None);

--- a/src/expr/src/expr/expr_coalesce.rs
+++ b/src/expr/src/expr/expr_coalesce.rs
@@ -89,10 +89,8 @@ impl<'a> TryFrom<&'a ExprNode> for CoalesceExpression {
 
 #[cfg(test)]
 mod tests {
-    use std::sync::Arc;
-
-    use risingwave_common::array::column::Column;
-    use risingwave_common::array::{DataChunk, PrimitiveArray};
+    use risingwave_common::array::DataChunk;
+    use risingwave_common::test_prelude::DataChunkTestExt;
     use risingwave_common::types::ScalarImpl;
     use risingwave_pb::data::data_type::TypeName;
     use risingwave_pb::data::DataType as ProstDataType;
@@ -121,20 +119,13 @@ mod tests {
         let input_node2 = make_input_ref(1, TypeName::Int32);
         let input_node3 = make_input_ref(2, TypeName::Int32);
 
-        let array = PrimitiveArray::<i32>::from_slice(&[Some(1), None, None, None])
-            .map(|x| Arc::new(x.into()))
-            .unwrap();
-        let col1 = Column::new(array);
-        let array = PrimitiveArray::<i32>::from_slice(&[None, Some(2), None, None])
-            .map(|x| Arc::new(x.into()))
-            .unwrap();
-        let col2 = Column::new(array);
-        let array = PrimitiveArray::<i32>::from_slice(&[None, None, Some(3), None])
-            .map(|x| Arc::new(x.into()))
-            .unwrap();
-        let col3 = Column::new(array);
-
-        let data_chunk = DataChunk::builder().columns(vec![col1, col2, col3]).build();
+        let data_chunk = DataChunk::from_pretty(
+            "i i i
+             1 . .
+             . 2 .
+             . . 3
+             . . .",
+        );
 
         let nullif_expr = CoalesceExpression::try_from(&make_coalesce_function(
             vec![input_node1, input_node2, input_node3],

--- a/src/expr/src/expr/expr_in.rs
+++ b/src/expr/src/expr/expr_in.rs
@@ -83,8 +83,8 @@ impl Expression for InExpression {
 
 #[cfg(test)]
 mod tests {
-    use risingwave_common::array::{DataChunk, Utf8Array};
-    use risingwave_common::column;
+    use risingwave_common::array::DataChunk;
+    use risingwave_common::test_prelude::DataChunkTestExt;
     use risingwave_common::types::{DataType, ScalarImpl};
 
     use crate::expr::expr_in::InExpression;
@@ -98,8 +98,13 @@ mod tests {
             Some(ScalarImpl::Utf8("def".to_string())),
         ];
         let search_expr = InExpression::new(input_ref, data.into_iter(), DataType::Boolean);
-        let column = column! {Utf8Array, [Some("abc"), Some("a"), Some("def"), Some("abc")]};
-        let data_chunk = DataChunk::builder().columns(vec![column]).build();
+        let data_chunk = DataChunk::from_pretty(
+            "T
+             abc
+             a
+             def
+             abc",
+        );
         let res = search_expr.eval(&data_chunk).unwrap();
         assert_eq!(res.datum_at(0), Some(ScalarImpl::Bool(true)));
         assert_eq!(res.datum_at(1), Some(ScalarImpl::Bool(false)));

--- a/src/stream/src/executor/managed_state/join/join_entry_state.rs
+++ b/src/stream/src/executor/managed_state/join/join_entry_state.rs
@@ -215,7 +215,6 @@ impl<S: StateStore> JoinEntryState<S> {
 #[cfg(test)]
 mod tests {
     use risingwave_common::array::*;
-    use risingwave_common::column_nonnull;
     use risingwave_common::types::ScalarImpl;
     use risingwave_storage::memory::MemoryStateStore;
 
@@ -231,15 +230,15 @@ mod tests {
             vec![DataType::Int64].into(),
         );
         assert!(!managed_state.is_dirty());
-        let columns = vec![
-            column_nonnull! { I64Array, [3, 2, 1] },
-            column_nonnull! { I64Array, [4, 5, 6] },
-        ];
         let pk_indices = [0];
         let col1 = [1, 2, 3];
         let col2 = [6, 5, 4];
-        let data_chunk_builder = DataChunk::builder().columns(columns);
-        let data_chunk = data_chunk_builder.build();
+        let data_chunk = DataChunk::from_pretty(
+            "I I
+             3 4
+             2 5
+             1 6",
+        );
 
         for row_ref in data_chunk.rows() {
             let row: Row = row_ref.into();


### PR DESCRIPTION
## What's changed and what's your intention?

To reduce the PR size of `DataChunk` refactor (#2663), we remove usage of `DataChunkBuilder` for literals in unit tests.

## Checklist

~~- [ ] I have written necessary docs and comments~~
- [x] I have added necessary unit tests and integration tests

## Refer to a related PR or issue link (optional)

#2663