### PR TITLE
refactor(test): use `DataChunk::from_pretty` for literals in unit tests rather than try_from or new

### DIFF
--- a/src/batch/src/executor/join/hash_join.rs
+++ b/src/batch/src/executor/join/hash_join.rs
@@ -386,12 +386,12 @@ mod tests {
 
     use futures::StreamExt;
     use itertools::Itertools;
-    use risingwave_common::array;
     use risingwave_common::array::column::Column;
-    use risingwave_common::array::{ArrayBuilderImpl, DataChunk, F32Array, F64Array, I32Array};
+    use risingwave_common::array::{ArrayBuilderImpl, DataChunk};
     use risingwave_common::catalog::{Field, Schema};
     use risingwave_common::error::Result;
     use risingwave_common::hash::Key32;
+    use risingwave_common::test_prelude::DataChunkTestExt;
     use risingwave_common::types::DataType;
     use risingwave_expr::expr::expr_binary_nonnull::new_binary_expr;
     use risingwave_expr::expr::{BoxedExpression, InputRefExpression};
@@ -492,33 +492,23 @@ mod tests {
             };
             let mut executor = MockExecutor::new(schema);
 
-            {
-                let column1 = Column::new(Arc::new(
-                    array! {I32Array, [Some(1), Some(2), None, Some(3), None]}.into(),
-                ));
-                let column2 = Column::new(Arc::new(
-                    array! {F32Array, [Some(6.1f32), None, Some(8.4f32), Some(3.9f32), None]}
-                        .into(),
-                ));
+            executor.add(DataChunk::from_pretty(
+                "i f
+                 1 6.1
+                 2 .
+                 . 8.4
+                 3 3.9
+                 . .  ",
+            ));
 
-                let chunk =
-                    DataChunk::try_from(vec![column1, column2]).expect("Failed to create chunk!");
-                executor.add(chunk);
-            }
-
-            {
-                let column1 = Column::new(Arc::new(
-                    array! {I32Array, [Some(4), Some(3), None, Some(5), None]}.into(),
-                ));
-                let column2 = Column::new(Arc::new(
-                    array! {F32Array, [Some(6.6f32), None, Some(0.7f32), None, Some(5.5f32)]}
-                        .into(),
-                ));
-
-                let chunk =
-                    DataChunk::try_from(vec![column1, column2]).expect("Failed to create chunk!");
-                executor.add(chunk);
-            }
+            executor.add(DataChunk::from_pretty(
+                "i f
+                 4 6.6
+                 3 .
+                 . 0.7
+                 5 .
+                 . 5.5",
+            ));
 
             Box::new(executor)
         }
@@ -532,49 +522,35 @@ mod tests {
             };
             let mut executor = MockExecutor::new(schema);
 
-            {
-                let column1 = Column::new(Arc::new(
-                    array! {I32Array, [Some(8), Some(2), None, Some(3), None, Some(6)]}.into(),
-                ));
+            executor.add(DataChunk::from_pretty(
+                "i F
+                 8 6.1
+                 2 .
+                 . 8.9
+                 3 .
+                 . 3.5
+                 6 .  ",
+            ));
 
-                let column2 = Column::new(Arc::new(
-                    array! {F64Array, [Some(6.1f64), None, Some(8.9f64), None, Some(3.5f64), None]}
-                        .into(),
-                ));
+            executor.add(DataChunk::from_pretty(
+                "i F
+                 4 7.5
+                 6 .
+                 . 8
+                 7 .
+                 . 9.1
+                 9 .  ",
+            ));
 
-                let chunk =
-                    DataChunk::try_from(vec![column1, column2]).expect("Failed to create chunk!");
-                executor.add(chunk);
-            }
-
-            {
-                let column1 = Column::new(Arc::new(
-                    array! {I32Array, [Some(4), Some(6), None, Some(7), None, Some(9)]}.into(),
-                ));
-
-                let column2 = Column::new(Arc::new(
-                    array! {F64Array, [Some(7.5f64), None, Some(8f64), None, Some(9.1f64), None]}
-                        .into(),
-                ));
-
-                let chunk =
-                    DataChunk::try_from(vec![column1, column2]).expect("Failed to create chunk!");
-                executor.add(chunk);
-            }
-
-            {
-                let column1 = Column::new(Arc::new(
-                    array! {I32Array, [Some(3), Some(9), None, Some(100), None, Some(200)]}.into(),
-                ));
-
-                let column2 = Column::new(Arc::new(
-                array! {F64Array, [Some(3.7f64), None, Some(9.6f64), None, Some(8.18f64), None]}.into(),
-                ));
-
-                let chunk =
-                    DataChunk::try_from(vec![column1, column2]).expect("Failed to create chunk!");
-                executor.add(chunk);
-            }
+            executor.add(DataChunk::from_pretty(
+                "  i F
+                   3 3.7
+                   9 .
+                   . 9.6
+                 100 .
+                   . 8.18
+                 200 .   ",
+            ));
 
             Box::new(executor)
         }
@@ -725,17 +701,15 @@ mod tests {
     async fn test_inner_join() {
         let test_fixture = TestFixture::with_join_type(JoinType::Inner);
 
-        let column1 = Column::new(Arc::new(
-            array! {F32Array, [None, Some(3.9f32), Some(3.9f32), Some(6.6f32), None, None]}.into(),
-        ));
-
-        let column2 = Column::new(Arc::new(
-            array! {F64Array, [None, Some(3.7f64), None,  Some(7.5f64), Some(3.7f64),  None]}
-                .into(),
-        ));
-
-        let expected_chunk =
-            DataChunk::try_from(vec![column1, column2]).expect("Failed to create chunk!");
+        let expected_chunk = DataChunk::from_pretty(
+            "f   F
+             .   .
+             3.9 3.7
+             3.9 .
+             6.6 7.5
+             .   3.7
+             .   .  ",
+        );
 
         test_fixture.do_test(expected_chunk, false).await;
     }
@@ -748,16 +722,10 @@ mod tests {
     async fn test_inner_join_with_non_equi_condition() {
         let test_fixture = TestFixture::with_join_type(JoinType::Inner);
 
-        let column1 = Column::new(Arc::new(
-            array! {F32Array, [
-            Some(6.6f32)]}
-            .into(),
-        ));
-
-        let column2 = Column::new(Arc::new(array! {F64Array, [Some(7.5f64)]}.into()));
-
-        let expected_chunk =
-            DataChunk::try_from(vec![column1, column2]).expect("Failed to create chunk!");
+        let expected_chunk = DataChunk::from_pretty(
+            "f   F
+             6.6 7.5",
+        );
 
         test_fixture.do_test(expected_chunk, true).await;
     }
@@ -770,19 +738,21 @@ mod tests {
     async fn test_left_outer_join() {
         let test_fixture = TestFixture::with_join_type(JoinType::LeftOuter);
 
-        let column1 = Column::new(Arc::new(
-            array! {F32Array, [Some(6.1f32), None, Some(8.4f32), Some(3.9f32), Some(3.9f32), None,
-            Some(6.6f32), None, None, Some(0.7f32), None, Some(5.5f32)]}
-            .into(),
-        ));
-
-        let column2 = Column::new(Arc::new(
-            array! {F64Array, [None, None, None, Some(3.7f64), None, None, Some(7.5f64), Some(3.7f64),
-                None, None, None, None]}.into(),
-    ));
-
-        let expected_chunk =
-            DataChunk::try_from(vec![column1, column2]).expect("Failed to create chunk!");
+        let expected_chunk = DataChunk::from_pretty(
+            "f   F
+             6.1 .
+             .   .
+             8.4 .
+             3.9 3.7
+             3.9 .
+             .   .
+             6.6 7.5
+             .   3.7
+             .   .
+             0.7 .
+             .   .
+             5.5 .  ",
+        );
 
         test_fixture.do_test(expected_chunk, false).await;
     }
@@ -795,19 +765,19 @@ mod tests {
     async fn test_left_outer_join_with_non_equi_condition() {
         let test_fixture = TestFixture::with_join_type(JoinType::LeftOuter);
 
-        let column1 = Column::new(Arc::new(
-            array! {F32Array, [Some(6.1f32), None, Some(8.4f32), Some(3.9f32), None,
-            Some(6.6f32), None, Some(0.7f32), None, Some(5.5f32)]}
-            .into(),
-        ));
-
-        let column2 = Column::new(Arc::new(
-            array! {F64Array, [None, None, None, None, None, Some(7.5f64), None, None, None, None]}
-                .into(),
-        ));
-
-        let expected_chunk =
-            DataChunk::try_from(vec![column1, column2]).expect("Failed to create chunk!");
+        let expected_chunk = DataChunk::from_pretty(
+            "f   F
+             6.1 .
+             .   .
+             8.4 .
+             3.9 .
+             .   .
+             6.6 7.5
+             .   .
+             0.7 .
+             .   .
+             5.5 .",
+        );
 
         test_fixture.do_test(expected_chunk, true).await;
     }
@@ -820,27 +790,29 @@ mod tests {
     async fn test_right_outer_join() {
         let test_fixture = TestFixture::with_join_type(JoinType::RightOuter);
 
-        let column1 = Column::new(Arc::new(
-            array! {F32Array, [
-                None, Some(3.9f32), Some(3.9f32), Some(6.6), None,
-                None, None, None, None, None,
-                None, None, None, None, None,
-                None, None, None, None, None
-            ]}
-            .into(),
-        ));
-
-        let column2 = Column::new(Arc::new(
-            array! {F64Array, [
-            None, Some(3.7f64), None, Some(7.5f64), Some(3.7f64),
-            None, Some(6.1f64), Some(8.9f64), Some(3.5f64), None,
-            None, Some(8.0f64), None, Some(9.1f64), None,
-            None, Some(9.6f64),None, Some(8.18f64), None]}
-            .into(),
-        ));
-
-        let expected_chunk =
-            DataChunk::try_from(vec![column1, column2]).expect("Failed to create chunk!");
+        let expected_chunk = DataChunk::from_pretty(
+            "f   F
+             .   .
+             3.9 3.7
+             3.9 .
+             6.6 7.5
+             .   3.7
+             .   .
+             .   6.1
+             .   8.9
+             .   3.5
+             .   .
+             .   .
+             .   8.0
+             .   .
+             .   9.1
+             .   .
+             .   .
+             .   9.6
+             .   .
+             .   8.18
+             .   .",
+        );
 
         test_fixture.do_test(expected_chunk, false).await;
     }
@@ -853,25 +825,27 @@ mod tests {
     async fn test_right_outer_join_with_non_equi_condition() {
         let test_fixture = TestFixture::with_join_type(JoinType::RightOuter);
 
-        let column1 = Column::new(Arc::new(
-            array! {F32Array, [
-                Some(6.6), None, None, None, None, None, None,
-                None, None, None, None, None,
-                None, None, None, None, None, None
-            ]}
-            .into(),
-        ));
-
-        let column2 = Column::new(Arc::new(
-            array! {F64Array, [
-            Some(7.5f64), Some(6.1f64), None, Some(8.9f64), None, Some(3.5f64), None,
-            None, Some(8.0f64), None, Some(9.1f64), None, Some(3.7),
-            None, Some(9.6f64),None, Some(8.18f64), None]}
-            .into(),
-        ));
-
-        let expected_chunk =
-            DataChunk::try_from(vec![column1, column2]).expect("Failed to create chunk!");
+        let expected_chunk = DataChunk::from_pretty(
+            "f   F
+             6.6 7.5
+             .   6.1
+             .   .
+             .   8.9
+             .   .
+             .   3.5
+             .   .
+             .   .
+             .   8.0
+             .   .
+             .   9.1
+             .   .
+             .   3.7
+             .   .
+             .   9.6
+             .   .
+             .   8.18
+             .   .",
+        );
 
         test_fixture.do_test(expected_chunk, true).await;
     }
@@ -883,32 +857,35 @@ mod tests {
     async fn test_full_outer_join() {
         let test_fixture = TestFixture::with_join_type(JoinType::FullOuter);
 
-        let column1 = Column::new(Arc::new(
-            array! {F32Array, [
-                Some(6.1f32), None, Some(8.4f32), Some(3.9f32), Some(3.9f32),
-                None, Some(6.6f32), None, None, Some(0.7f32),
-                None, Some(5.5f32), None, None, None,
-                None, None, None, None, None,
-                None, None, None, None, None,
-                None
-            ]}
-            .into(),
-        ));
-
-        let column2 = Column::new(Arc::new(
-            array! {F64Array, [
-                None, None, None, Some(3.7f64), None,
-                None, Some(7.5f64), Some(3.7f64), None, None,
-                None, None, Some(6.1f64), Some(8.9f64), Some(3.5f64),
-                None, None, Some(8.0f64), None, Some(9.1f64),
-                None, None, Some(9.6f64), None, Some(8.18f64),
-                None
-            ]}
-            .into(),
-        ));
-
-        let expected_chunk =
-            DataChunk::try_from(vec![column1, column2]).expect("Failed to create chunk!");
+        let expected_chunk = DataChunk::from_pretty(
+            "f   F
+             6.1 .
+             .   .
+             8.4 .
+             3.9 3.7
+             3.9 .
+             .   .
+             6.6 7.5
+             .   3.7
+             .   .
+             0.7 .
+             .   .
+             5.5 .
+             .   6.1
+             .   8.9
+             .   3.5
+             .   .
+             .   .
+             .   8.0
+             .   .
+             .   9.1
+             .   .
+             .   .
+             .   9.6
+             .   .
+             .   8.18
+             .   .   ",
+        );
 
         test_fixture.do_test(expected_chunk, false).await;
     }
@@ -917,14 +894,15 @@ mod tests {
     async fn test_left_anti_join() {
         let test_fixture = TestFixture::with_join_type(JoinType::LeftAnti);
 
-        let column1 = Column::new(Arc::new(
-            array! {F32Array, [
-                Some(6.1f32), Some(8.4f32), None, Some(0.7f32), None, Some(5.5f32)
-            ]}
-            .into(),
-        ));
-
-        let expected_chunk = DataChunk::try_from(vec![column1]).expect("Failed to create chunk!");
+        let expected_chunk = DataChunk::from_pretty(
+            "f
+             6.1
+             8.4
+             .
+             0.7
+             .
+             5.5",
+        );
 
         test_fixture.do_test(expected_chunk, false).await;
     }
@@ -933,14 +911,18 @@ mod tests {
     async fn test_left_anti_join_with_non_equi_condition() {
         let test_fixture = TestFixture::with_join_type(JoinType::LeftAnti);
 
-        let column1 = Column::new(Arc::new(
-            array! {F32Array, [
-                Some(6.1f32), None, Some(8.4f32), Some(3.9), None, None, Some(0.7f32), None, Some(5.5f32)
-            ]}
-            .into(),
-        ));
-
-        let expected_chunk = DataChunk::try_from(vec![column1]).expect("Failed to create chunk!");
+        let expected_chunk = DataChunk::from_pretty(
+            "f
+             6.1
+             .
+             8.4
+             3.9
+             .
+             .
+             0.7
+             .
+             5.5",
+        );
 
         test_fixture.do_test(expected_chunk, true).await;
     }
@@ -949,14 +931,13 @@ mod tests {
     async fn test_left_semi_join() {
         let test_fixture = TestFixture::with_join_type(JoinType::LeftSemi);
 
-        let column1 = Column::new(Arc::new(
-            array! {F32Array, [
-                None, Some(3.9f32), Some(6.6f32), None
-            ]}
-            .into(),
-        ));
-
-        let expected_chunk = DataChunk::try_from(vec![column1]).expect("Failed to create chunk!");
+        let expected_chunk = DataChunk::from_pretty(
+            "f
+             .
+             3.9
+             6.6
+             .",
+        );
 
         test_fixture.do_test(expected_chunk, false).await;
     }
@@ -965,14 +946,10 @@ mod tests {
     async fn test_left_semi_join_with_non_equi_condition() {
         let test_fixture = TestFixture::with_join_type(JoinType::LeftSemi);
 
-        let column1 = Column::new(Arc::new(
-            array! {F32Array, [
-                Some(6.6f32)
-            ]}
-            .into(),
-        ));
-
-        let expected_chunk = DataChunk::try_from(vec![column1]).expect("Failed to create chunk!");
+        let expected_chunk = DataChunk::from_pretty(
+            "f
+             6.6",
+        );
 
         test_fixture.do_test(expected_chunk, true).await;
     }
@@ -981,16 +958,23 @@ mod tests {
     async fn test_right_anti_join() {
         let test_fixture = TestFixture::with_join_type(JoinType::RightAnti);
 
-        let column1 = Column::new(Arc::new(
-            array! {F64Array, [
-                Some(6.1f64), Some(8.9f64), Some(3.5f64), None, None,
-                Some(8.0f64), None, Some(9.1f64), None, None,
-                Some(9.6f64), None, Some(8.18f64), None
-            ]}
-            .into(),
-        ));
-
-        let expected_chunk = DataChunk::try_from(vec![column1]).expect("Failed to create chunk!");
+        let expected_chunk = DataChunk::from_pretty(
+            "F
+             6.1
+             8.9
+             3.5
+             .
+             .
+             8.0
+             .
+             9.1
+             .
+             .
+             9.6
+             .
+             8.18
+             .",
+        );
 
         test_fixture.do_test(expected_chunk, false).await;
     }
@@ -999,16 +983,26 @@ mod tests {
     async fn test_right_anti_join_with_non_equi_condition() {
         let test_fixture = TestFixture::with_join_type(JoinType::RightAnti);
 
-        let column1 = Column::new(Arc::new(
-            array! {F64Array, [
-                Some(6.1f64), None, Some(8.9f64), None, Some(3.5f64), None, None,
-                Some(8.0f64), None, Some(9.1f64), None, Some(3.7f64), None,
-                Some(9.6f64), None, Some(8.18f64), None
-            ]}
-            .into(),
-        ));
-
-        let expected_chunk = DataChunk::try_from(vec![column1]).expect("Failed to create chunk!");
+        let expected_chunk = DataChunk::from_pretty(
+            "F
+             6.1
+             .
+             8.9
+             .
+             3.5
+             .
+             .
+             8.0
+             .
+             9.1
+             .
+             3.7
+             .
+             9.6
+             .
+             8.18
+             .",
+        );
 
         test_fixture.do_test(expected_chunk, true).await;
     }
@@ -1017,14 +1011,13 @@ mod tests {
     async fn test_right_semi_join() {
         let test_fixture = TestFixture::with_join_type(JoinType::RightSemi);
 
-        let column1 = Column::new(Arc::new(
-            array! {F64Array, [
-                None, Some(3.7f64), None, Some(7.5f64)
-            ]}
-            .into(),
-        ));
-
-        let expected_chunk = DataChunk::try_from(vec![column1]).expect("Failed to create chunk!");
+        let expected_chunk = DataChunk::from_pretty(
+            "F
+             .
+             3.7
+             .
+             7.5",
+        );
 
         test_fixture.do_test(expected_chunk, false).await;
     }
@@ -1033,14 +1026,10 @@ mod tests {
     async fn test_right_semi_join_with_non_equi_condition() {
         let test_fixture = TestFixture::with_join_type(JoinType::RightSemi);
 
-        let column1 = Column::new(Arc::new(
-            array! {F64Array, [
-                Some(7.5f64)
-            ]}
-            .into(),
-        ));
-
-        let expected_chunk = DataChunk::try_from(vec![column1]).expect("Failed to create chunk!");
+        let expected_chunk = DataChunk::from_pretty(
+            "F
+             7.5",
+        );
 
         test_fixture.do_test(expected_chunk, true).await;
     }

--- a/src/batch/src/executor/join/nested_loop_join.rs
+++ b/src/batch/src/executor/join/nested_loop_join.rs
@@ -578,7 +578,6 @@ impl NestedLoopJoinExecutor {
 }
 #[cfg(test)]
 mod tests {
-    use std::convert::TryFrom;
     use std::sync::Arc;
 
     use risingwave_common::array::column::Column;
@@ -698,31 +697,21 @@ mod tests {
             };
             let mut executor = MockExecutor::new(schema);
 
-            {
-                let column1 = Column::new(Arc::new(
-                    array! {I32Array, [Some(1), Some(2), Some(3)]}.into(),
-                ));
-                let column2 = Column::new(Arc::new(
-                    array! {F32Array, [Some(6.1f32), Some(8.4f32), Some(3.9f32)]}.into(),
-                ));
+            executor.add(DataChunk::from_pretty(
+                "i f
+                 1 6.1
+                 2 8.4
+                 3 3.9",
+            ));
 
-                let chunk =
-                    DataChunk::try_from(vec![column1, column2]).expect("Failed to create chunk!");
-                executor.add(chunk);
-            }
-
-            {
-                let column1 = Column::new(Arc::new(
-                    array! {I32Array, [Some(3), Some(4), Some(6), Some(6), Some(8)]}.into(),
-                ));
-                let column2 = Column::new(Arc::new(
-                    array! {F32Array, [Some(6.6f32), Some(0.7f32), Some(5.5f32), Some(5.6f32), Some(7.0f32)]}.into(),
-                ));
-
-                let chunk =
-                    DataChunk::try_from(vec![column1, column2]).expect("Failed to create chunk!");
-                executor.add(chunk);
-            }
+            executor.add(DataChunk::from_pretty(
+                "i f
+                 3 6.6
+                 4 0.7
+                 6 5.5
+                 6 5.6
+                 8 7.0",
+            ));
 
             Box::new(executor)
         }
@@ -736,48 +725,29 @@ mod tests {
             };
             let mut executor = MockExecutor::new(schema);
 
-            {
-                let column1 = Column::new(Arc::new(
-                    array! {I32Array, [Some(2), Some(3), Some(6), Some(8)]}.into(),
-                ));
+            executor.add(DataChunk::from_pretty(
+                "i F
+                 2 6.1
+                 3 8.9
+                 6 3.4
+                 8 3.5",
+            ));
 
-                let column2 = Column::new(Arc::new(
-                    array! {F64Array, [Some(6.1f64), Some(8.9f64), Some(3.4f64), Some(3.5f64)]}
-                        .into(),
-                ));
+            executor.add(DataChunk::from_pretty(
+                " i F
+                  9 7.5
+                 10 .
+                 11 8
+                 12 .",
+            ));
 
-                let chunk =
-                    DataChunk::try_from(vec![column1, column2]).expect("Failed to create chunk!");
-                executor.add(chunk);
-            }
-
-            {
-                let column1 = Column::new(Arc::new(
-                    array! {I32Array, [Some(9), Some(10), Some(11), Some(12)]}.into(),
-                ));
-
-                let column2 = Column::new(Arc::new(
-                    array! {F64Array, [Some(7.5f64), None, Some(8f64), None]}.into(),
-                ));
-
-                let chunk =
-                    DataChunk::try_from(vec![column1, column2]).expect("Failed to create chunk!");
-                executor.add(chunk);
-            }
-
-            {
-                let column1 = Column::new(Arc::new(
-                    array! {I32Array, [Some(20), Some(30), Some(100), Some(200)]}.into(),
-                ));
-
-                let column2 = Column::new(Arc::new(
-                    array! {F64Array, [Some(5.7f64),  Some(9.6f64), None, Some(8.18f64)]}.into(),
-                ));
-
-                let chunk =
-                    DataChunk::try_from(vec![column1, column2]).expect("Failed to create chunk!");
-                executor.add(chunk);
-            }
+            executor.add(DataChunk::from_pretty(
+                "  i F
+                  20 5.7
+                  30 9.6
+                 100 .
+                 200 8.18",
+            ));
 
             Box::new(executor)
         }
@@ -839,20 +809,15 @@ mod tests {
     async fn test_inner_join() {
         let test_fixture = TestFixture::with_join_type(JoinType::Inner);
 
-        let column1 = Column::new(Arc::new(
-            array! {I32Array, [Some(2), Some(3), Some(3), Some(6), Some(6), Some(8)]}.into(),
-        ));
-
-        let column2 = Column::new(Arc::new(array! {F32Array, [Some(8.4f32), Some(3.9f32), Some(6.6f32), Some(5.5f32), Some(5.6f32), Some(7.0f32)]}.into()));
-
-        let column3 = Column::new(Arc::new(
-            array! {I32Array, [Some(2), Some(3), Some(3), Some(6), Some(6), Some(8)]}.into(),
-        ));
-
-        let column4 = Column::new(Arc::new(array! {F64Array, [Some(6.1f64), Some(8.9f64), Some(8.9f64), Some(3.4f64), Some(3.4f64), Some(3.5f64)]}.into()));
-
-        let expected_chunk = DataChunk::try_from(vec![column1, column2, column3, column4])
-            .expect("Failed to create chunk!");
+        let expected_chunk = DataChunk::from_pretty(
+            "i f   i F
+             2 8.4 2 6.1
+             3 3.9 3 8.9
+             3 6.6 3 8.9
+             6 5.5 6 3.4
+             6 5.6 6 3.4
+             8 7.0 8 3.5",
+        );
 
         test_fixture.do_test(expected_chunk).await;
     }
@@ -862,21 +827,17 @@ mod tests {
     async fn test_left_outer_join() {
         let test_fixture = TestFixture::with_join_type(JoinType::LeftOuter);
 
-        let column1 = Column::new(Arc::new(
-            array! {I32Array, [Some(1), Some(2), Some(3), Some(3), Some(4), Some(6), Some(6), Some(8)]}.into(),
-        ));
-
-        let column2 = Column::new(Arc::new(array! {F32Array, [Some(6.1f32), Some(8.4f32), Some(3.9f32), Some(6.6f32), Some(0.7f32), Some(5.5f32), Some(5.6f32), Some(7.0f32)]}.into()));
-
-        let column3 = Column::new(Arc::new(
-            array! {I32Array, [None, Some(2), Some(3), Some(3), None, Some(6), Some(6), Some(8)]}
-                .into(),
-        ));
-
-        let column4 = Column::new(Arc::new(array! {F64Array, [None, Some(6.1f64), Some(8.9f64), Some(8.9f64), None, Some(3.4f64), Some(3.4f64), Some(3.5f64)]}.into()));
-
-        let expected_chunk = DataChunk::try_from(vec![column1, column2, column3, column4])
-            .expect("Failed to create chunk!");
+        let expected_chunk = DataChunk::from_pretty(
+            "i f   i F
+             1 6.1 . .
+             2 8.4 2 6.1
+             3 3.9 3 8.9
+             3 6.6 3 8.9
+             4 0.7 . .
+             6 5.5 6 3.4
+             6 5.6 6 3.4
+             8 7.0 8 3.5",
+        );
 
         test_fixture.do_test(expected_chunk).await;
     }
@@ -885,14 +846,15 @@ mod tests {
     async fn test_left_semi_join() {
         let test_fixture = TestFixture::with_join_type(JoinType::LeftSemi);
 
-        let column1 = Column::new(Arc::new(
-            array! {I32Array, [Some(2), Some(3), Some(3), Some(6), Some(6), Some(8)]}.into(),
-        ));
-
-        let column2 = Column::new(Arc::new(array! {F32Array, [Some(8.4f32), Some(3.9f32), Some(6.6f32), Some(5.5f32), Some(5.6f32), Some(7.0f32)]}.into()));
-
-        let expected_chunk =
-            DataChunk::try_from(vec![column1, column2]).expect("Failed to create chunk!");
+        let expected_chunk = DataChunk::from_pretty(
+            "i f
+             2 8.4
+             3 3.9
+             3 6.6
+             6 5.5
+             6 5.6
+             8 7.0",
+        );
 
         test_fixture.do_test(expected_chunk).await;
     }
@@ -901,14 +863,11 @@ mod tests {
     async fn test_left_anti_join() {
         let test_fixture = TestFixture::with_join_type(JoinType::LeftAnti);
 
-        let column1 = Column::new(Arc::new(array! {I32Array, [Some(1), Some(4)]}.into()));
-
-        let column2 = Column::new(Arc::new(
-            array! {F32Array, [Some(6.1f32), Some(0.7f32)]}.into(),
-        ));
-
-        let expected_chunk =
-            DataChunk::try_from(vec![column1, column2]).expect("Failed to create chunk!");
+        let expected_chunk = DataChunk::from_pretty(
+            "i f
+             1 6.1
+             4 0.7",
+        );
 
         test_fixture.do_test(expected_chunk).await;
     }
@@ -917,16 +876,13 @@ mod tests {
     async fn test_right_semi_join() {
         let test_fixture = TestFixture::with_join_type(JoinType::RightSemi);
 
-        let column1 = Column::new(Arc::new(
-            array! {I32Array, [Some(2), Some(3), Some(6), Some(8)]}.into(),
-        ));
-
-        let column2 = Column::new(Arc::new(
-            array! {F64Array, [Some(6.1f64), Some(8.9f64), Some(3.4f64), Some(3.5f64)]}.into(),
-        ));
-
-        let expected_chunk =
-            DataChunk::try_from(vec![column1, column2]).expect("Failed to create chunk!");
+        let expected_chunk = DataChunk::from_pretty(
+            "i F
+             2 6.1
+             3 8.9
+             6 3.4
+             8 3.5",
+        );
 
         test_fixture.do_test(expected_chunk).await;
     }
@@ -935,14 +891,17 @@ mod tests {
     async fn test_right_anti_join() {
         let test_fixture = TestFixture::with_join_type(JoinType::RightAnti);
 
-        let column1 = Column::new(Arc::new(
-            array! {I32Array, [Some(9), Some(10), Some(11), Some(12), Some(20), Some(30), Some(100), Some(200)]}.into(),
-        ));
-
-        let column2 = Column::new(Arc::new(array! {F64Array, [Some(7.5f64), None, Some(8f64), None, Some(5.7f64), Some(9.6f64), None, Some(8.18f64)]}.into()));
-
-        let expected_chunk =
-            DataChunk::try_from(vec![column1, column2]).expect("Failed to create chunk!");
+        let expected_chunk = DataChunk::from_pretty(
+            "  i F
+               9 7.5
+              10 .
+              11 8
+              12 .
+              20 5.7
+              30 9.6
+             100 .
+             200 8.18",
+        );
 
         test_fixture.do_test(expected_chunk).await;
     }

--- a/src/batch/src/executor/join/sort_merge_join.rs
+++ b/src/batch/src/executor/join/sort_merge_join.rs
@@ -307,12 +307,9 @@ impl BoxedExecutorBuilder for SortMergeJoinExecutor {
 
 #[cfg(test)]
 mod tests {
-    use std::convert::TryFrom;
-    use std::sync::Arc;
-
-    use risingwave_common::array::column::Column;
-    use risingwave_common::array::{DataChunk, F32Array, F64Array, I32Array};
+    use risingwave_common::array::DataChunk;
     use risingwave_common::catalog::{Field, Schema};
+    use risingwave_common::test_prelude::DataChunkTestExt;
     use risingwave_common::types::DataType;
 
     use crate::executor::join::sort_merge_join::{RowLevelIter, SortMergeJoinExecutor};
@@ -359,34 +356,21 @@ mod tests {
             };
             let mut executor = MockExecutor::new(schema);
 
-            {
-                let column1 = Column::new(Arc::new(
-                    array! {I32Array, [Some(1), Some(2), Some(3)]}.into(),
-                ));
-                let column2 = Column::new(Arc::new(
-                    array! {F32Array, [Some(6.1f32), Some(8.4f32), Some(3.9f32)]}.into(),
-                ));
+            executor.add(DataChunk::from_pretty(
+                "i f
+                 1 6.1
+                 2 8.4
+                 3 3.9",
+            ));
 
-                let chunk =
-                    DataChunk::try_from(vec![column1, column2]).expect("Failed to create chunk!");
-                executor.add(chunk);
-            }
-
-            {
-                let column1 = Column::new(Arc::new(
-                    array! {I32Array, [Some(3), Some(4), Some(6), Some(6), Some(8)]}.into(),
-                ));
-                let column2 = Column::new(Arc::new(
-                    array! {F32Array, [
-                        Some(6.6f32), Some(0.7f32), Some(5.5f32), Some(5.6f32), Some(7.0f32)
-                    ]}
-                    .into(),
-                ));
-
-                let chunk =
-                    DataChunk::try_from(vec![column1, column2]).expect("Failed to create chunk!");
-                executor.add(chunk);
-            }
+            executor.add(DataChunk::from_pretty(
+                "i f
+                 3 6.6
+                 4 0.7
+                 6 5.5
+                 6 5.6
+                 8 7.0",
+            ));
 
             Box::new(executor)
         }
@@ -400,48 +384,29 @@ mod tests {
             };
             let mut executor = MockExecutor::new(schema);
 
-            {
-                let column1 = Column::new(Arc::new(
-                    array! {I32Array, [Some(2), Some(3), Some(6), Some(8)]}.into(),
-                ));
+            executor.add(DataChunk::from_pretty(
+                "i F
+                 2 6.1
+                 3 8.9
+                 6 3.4
+                 8 3.5",
+            ));
 
-                let column2 = Column::new(Arc::new(
-                    array! {F64Array, [Some(6.1f64), Some(8.9f64), Some(3.4f64), Some(3.5f64)]}
-                        .into(),
-                ));
+            executor.add(DataChunk::from_pretty(
+                " i F
+                  9 7.5
+                 10 .
+                 11 8
+                 12 .",
+            ));
 
-                let chunk =
-                    DataChunk::try_from(vec![column1, column2]).expect("Failed to create chunk!");
-                executor.add(chunk);
-            }
-
-            {
-                let column1 = Column::new(Arc::new(
-                    array! {I32Array, [Some(9), Some(10), Some(11), Some(12)]}.into(),
-                ));
-
-                let column2 = Column::new(Arc::new(
-                    array! {F64Array, [Some(7.5f64), None, Some(8f64), None]}.into(),
-                ));
-
-                let chunk =
-                    DataChunk::try_from(vec![column1, column2]).expect("Failed to create chunk!");
-                executor.add(chunk);
-            }
-
-            {
-                let column1 = Column::new(Arc::new(
-                    array! {I32Array, [Some(20), Some(30), Some(100), Some(200)]}.into(),
-                ));
-
-                let column2 = Column::new(Arc::new(
-                    array! {F64Array, [Some(5.7f64),  Some(9.6f64), None, Some(8.18f64)]}.into(),
-                ));
-
-                let chunk =
-                    DataChunk::try_from(vec![column1, column2]).expect("Failed to create chunk!");
-                executor.add(chunk);
-            }
+            executor.add(DataChunk::from_pretty(
+                "  i F
+                  20 5.7
+                  30 9.6
+                 100 .
+                 200 8.18",
+            ));
 
             Box::new(executor)
         }
@@ -486,20 +451,15 @@ mod tests {
     async fn test_inner_join() {
         let test_fixture = TestFixture::with_join_type(JoinType::Inner);
 
-        let column1 = Column::new(Arc::new(
-            array! {I32Array, [Some(2), Some(3), Some(3), Some(6), Some(6), Some(8)]}.into(),
-        ));
-
-        let column2 = Column::new(Arc::new(array! {F32Array, [Some(8.4f32), Some(3.9f32), Some(6.6f32), Some(5.5f32), Some(5.6f32), Some(7.0f32)]}.into()));
-
-        let column3 = Column::new(Arc::new(
-            array! {I32Array, [Some(2), Some(3), Some(3), Some(6), Some(6), Some(8)]}.into(),
-        ));
-
-        let column4 = Column::new(Arc::new(array! {F64Array, [Some(6.1f64), Some(8.9f64), Some(8.9f64), Some(3.4f64), Some(3.4f64), Some(3.5f64)]}.into()));
-
-        let expected_chunk = DataChunk::try_from(vec![column1, column2, column3, column4])
-            .expect("Failed to create chunk!");
+        let expected_chunk = DataChunk::from_pretty(
+            "i f   i F
+             2 8.4 2 6.1
+             3 3.9 3 8.9
+             3 6.6 3 8.9
+             6 5.5 6 3.4
+             6 5.6 6 3.4
+             8 7.0 8 3.5",
+        );
 
         test_fixture.do_test(expected_chunk).await;
     }

--- a/src/common/src/util/chunk_coalesce.rs
+++ b/src/common/src/util/chunk_coalesce.rs
@@ -260,9 +260,8 @@ impl SlicedDataChunk {
 
 #[cfg(test)]
 mod tests {
-    use crate::array::{DataChunk, I32Array, I64Array};
-    use crate::buffer::Bitmap;
-    use crate::column;
+    use crate::array::DataChunk;
+    use crate::test_prelude::DataChunkTestExt;
     use crate::types::DataType;
     use crate::util::chunk_coalesce::{DataChunkBuilder, SlicedDataChunk};
 
@@ -271,19 +270,12 @@ mod tests {
         let mut builder = DataChunkBuilder::new(vec![DataType::Int32, DataType::Int64], 3);
 
         // Append a chunk with 2 rows
-        let input = {
-            let column1 = column! {
-                I32Array, [Some(3), None]
-            };
-
-            let column2 = column! {
-                I64Array, [None, Some(7i64)]
-            };
-
-            let chunk =
-                DataChunk::try_from(vec![column1, column2]).expect("Failed to create chunk!");
-            SlicedDataChunk::new_checked(chunk).expect("Failed to create sliced data chunk")
-        };
+        let input = SlicedDataChunk::new_checked(DataChunk::from_pretty(
+            "i I
+             3 .
+             . 7",
+        ))
+        .expect("Failed to create sliced data chunk");
 
         let (returned_input, output) = builder
             .append_chunk(input)
@@ -292,15 +284,14 @@ mod tests {
         assert!(output.is_none());
 
         // Append a chunk with 4 rows
-        let input = {
-            let column1 = column! {I32Array, [Some(3), None, Some(4), None]};
-
-            let column2 = column! {I64Array, [None, Some(7i64), Some(8i64), Some(9i64)]};
-
-            let chunk =
-                DataChunk::try_from(vec![column1, column2]).expect("Failed to create chunk!");
-            SlicedDataChunk::new_checked(chunk).expect("Failed to create sliced data chunk")
-        };
+        let input = SlicedDataChunk::new_checked(DataChunk::from_pretty(
+            "i I
+             3 .
+             . 7
+             4 8
+             . 9",
+        ))
+        .expect("Failed to create sliced data chunk");
         let (returned_input, output) = builder
             .append_chunk(input)
             .expect("Failed to append chunk!");
@@ -324,16 +315,12 @@ mod tests {
         let mut builder = DataChunkBuilder::new(vec![DataType::Int32, DataType::Int64], 3);
 
         // Append a chunk with 2 rows
-        let input = {
-            let column1 = column! {I32Array, [Some(3), None]};
-            let column2 = column! {I64Array, [None, Some(7i64)]};
-
-            let chunk =
-                DataChunk::try_from(vec![column1, column2]).expect("Failed to create chunk!");
-            let bitmap = Bitmap::try_from(vec![true, false]).expect("Failed to create bitmap");
-            SlicedDataChunk::new_checked(chunk.with_visibility(bitmap))
-                .expect("Failed to create sliced data chunk")
-        };
+        let input = SlicedDataChunk::new_checked(DataChunk::from_pretty(
+            "i I
+             3 .
+             . 7 D",
+        ))
+        .expect("Failed to create sliced data chunk");
 
         let (returned_input, output) = builder
             .append_chunk(input)
@@ -343,18 +330,14 @@ mod tests {
         assert_eq!(1, builder.buffered_count());
 
         // Append a chunk with 4 rows
-        let input = {
-            let column1 = column! { I32Array, [Some(3), None, Some(4), None] };
-
-            let column2 = column! { I64Array, [None, Some(7i64), Some(8i64), Some(9i64)]};
-
-            let chunk =
-                DataChunk::try_from(vec![column1, column2]).expect("Failed to create chunk!");
-            let bitmap =
-                Bitmap::try_from(vec![false, true, true, false]).expect("Failed to create bitmap!");
-            SlicedDataChunk::new_checked(chunk.with_visibility(bitmap))
-                .expect("Failed to create sliced data chunk")
-        };
+        let input = SlicedDataChunk::new_checked(DataChunk::from_pretty(
+            "i I
+             3 . D
+             . 7
+             4 8
+             . 9 D",
+        ))
+        .expect("Failed to create sliced data chunk");
         let (returned_input, output) = builder
             .append_chunk(input)
             .expect("Failed to append chunk!");
@@ -381,13 +364,12 @@ mod tests {
         assert!(builder.consume_all().unwrap().is_none());
 
         // Append a chunk with 2 rows
-        let input = {
-            let column1 = column! {I32Array, [Some(3), None]};
-            let column2 = column! {I64Array, [None, Some(7i64)] };
-            let chunk =
-                DataChunk::try_from(vec![column1, column2]).expect("Failed to create chunk!");
-            SlicedDataChunk::new_checked(chunk).expect("Failed to create sliced data chunk")
-        };
+        let input = SlicedDataChunk::new_checked(DataChunk::from_pretty(
+            "i I
+             3 .
+             . 7",
+        ))
+        .expect("Failed to create sliced data chunk");
 
         let (returned_input, output) = builder
             .append_chunk(input)

--- a/src/frontend/src/handler/util.rs
+++ b/src/frontend/src/handler/util.rs
@@ -106,7 +106,6 @@ pub fn data_type_to_type_oid(data_type: DataType) -> TypeOid {
 #[cfg(test)]
 mod tests {
     use risingwave_common::array::*;
-    use risingwave_common::{column, column_nonnull};
 
     use super::*;
 
@@ -123,14 +122,12 @@ mod tests {
 
     #[test]
     fn test_to_pg_rows() {
-        let chunk = DataChunk::new(
-            vec![
-                column_nonnull!(I32Array, [1, 2, 3, 4]),
-                column!(I64Array, [Some(6), None, Some(7), None]),
-                column!(F32Array, [Some(6.01), None, Some(7.01), None]),
-                column!(Utf8Array, [Some("aaa"), None, Some("vvv"), None]),
-            ],
-            None,
+        let chunk = DataChunk::from_pretty(
+            "i I f    T
+             1 6 6.01 aaa
+             2 . .    .
+             3 7 7.01 vvv
+             4 . .    .  ",
         );
         let rows = to_pg_rows(chunk);
         let expected = vec![


### PR DESCRIPTION
## What's changed and what's your intention?

To reduce the PR size of `DataChunk` refactor (#2663), we remove usage of `DataChunk::try_from` and `DataChunk::new` for literals in unit tests.

Also noticed that test fixtures for hash join, nested loop join, sort merge join are duplicated. It is not a concern of this PR to DRY them.

## Checklist

~~- [ ] I have written necessary docs and comments~~
- [x] I have added necessary unit tests and integration tests

## Refer to a related PR or issue link (optional)

1st part: #2874 removal of `DataChunkBuilder` for test literals