### PR TITLE
closes #2494 Implementation for bitwise operation

### DIFF
--- a/e2e_test/batch/types/bitwise.slt
+++ b/e2e_test/batch/types/bitwise.slt
@@ -1,0 +1,29 @@
+query T
+select 3&5;
+----
+1
+
+query T
+select 3|5;
+----
+7
+
+query T
+select 3#5;
+----
+6
+
+query T
+select 1<<2;
+----
+4
+
+query T
+select 4>>2;
+----
+1
+
+query T
+select ~1;
+----
+-2

--- a/proto/expr.proto
+++ b/proto/expr.proto
@@ -33,7 +33,7 @@ message ExprNode {
     BitwiseAnd = 31;
     BitwiseOr = 32;
     BitwiseXor = 33;
-    PGBitwiseXor = 34;
+    BitwiseNot = 34;
     PGBitwiseShiftLeft = 35;
     PGBitwiseShiftRight = 36;
     // date functions

--- a/proto/expr.proto
+++ b/proto/expr.proto
@@ -29,6 +29,13 @@ message ExprNode {
     OR = 22;
     NOT = 23;
     IN = 24;
+    // bitwise operators
+    BitwiseAnd = 31;
+    BitwiseOr = 32;
+    BitwiseXor = 33;
+    PGBitwiseXor = 34;
+    PGBitwiseShiftLeft = 35;
+    PGBitwiseShiftRight = 36;
     // date functions
     EXTRACT = 101;
     TUMBLE_START = 103;

--- a/src/expr/src/expr/expr_binary_nonnull.rs
+++ b/src/expr/src/expr/expr_binary_nonnull.rs
@@ -197,39 +197,73 @@ macro_rules! gen_binary_expr_atm {
             { int16, int16, int16, $general_f },
             { int16, int32, int32, $general_f },
             { int16, int64, int64, $general_f },
-            //{ int16, float32, float64, $general_f },
-            //{ int16, float64, float64, $general_f },
+            { int16, float32, float64, $general_f },
+            { int16, float64, float64, $general_f },
             { int32, int16, int32, $general_f },
             { int32, int32, int32, $general_f },
             { int32, int64, int64, $general_f },
-            //{ int32, float32, float64, $general_f },
-            //{ int32, float64, float64, $general_f },
+            { int32, float32, float64, $general_f },
+            { int32, float64, float64, $general_f },
             { int64, int16,int64, $general_f },
             { int64, int32,int64, $general_f },
             { int64, int64, int64, $general_f },
-            //{ int64, float32, float64 , $general_f},
-            //{ int64, float64, float64, $general_f },
-            //{ float32, int16, float64, $general_f },
-            //{ float32, int32, float64, $general_f },
-            //{ float32, int64, float64 , $general_f},
-            //{ float32, float32, float32, $general_f },
-            //{ float32, float64, float64, $general_f },
-            //{ float64, int16, float64, $general_f },
-            //{ float64, int32, float64, $general_f },
-            //{ float64, int64, float64, $general_f },
-            //{ float64, float32, float64, $general_f },
-            //{ float64, float64, float64, $general_f },
-            // { decimal, int16, decimal, $general_f },
-            // { decimal, int32, decimal, $general_f },
-            // { decimal, int64, decimal, $general_f },
-            //{ decimal, float32, decimal, $general_f },
-            //{ decimal, float64, decimal, $general_f },
-            // { int16, decimal, decimal, $general_f },
-            // { int32, decimal, decimal, $general_f },
-            // { int64, decimal, decimal, $general_f },
-            // { decimal, decimal, decimal, $general_f },
-            //{ float32, decimal, float64, $general_f },
-            //{ float64, decimal, float64, $general_f },
+            { int64, float32, float64 , $general_f},
+            { int64, float64, float64, $general_f },
+            { float32, int16, float64, $general_f },
+            { float32, int32, float64, $general_f },
+            { float32, int64, float64 , $general_f},
+            { float32, float32, float32, $general_f },
+            { float32, float64, float64, $general_f },
+            { float64, int16, float64, $general_f },
+            { float64, int32, float64, $general_f },
+            { float64, int64, float64, $general_f },
+            { float64, float32, float64, $general_f },
+            { float64, float64, float64, $general_f },
+            { decimal, int16, decimal, $general_f },
+            { decimal, int32, decimal, $general_f },
+            { decimal, int64, decimal, $general_f },
+            { decimal, float32, decimal, $general_f },
+            { decimal, float64, decimal, $general_f },
+            { int16, decimal, decimal, $general_f },
+            { int32, decimal, decimal, $general_f },
+            { int64, decimal, decimal, $general_f },
+            { decimal, decimal, decimal, $general_f },
+            { float32, decimal, float64, $general_f },
+            { float64, decimal, float64, $general_f },
+            $(
+                { $i1, $i2, $rt, $func },
+            )*
+        }
+    };
+}
+
+/// `gen_binary_expr_shift` is similar to `gen_binary_expr_atm`.
+///  `shift` means arithmetic shift here.
+/// They are differentiate cuz shift operation does not support for float datatype.
+/// * `$general_f`: generic atm function (require a common ``TryInto`` type for two input)
+/// * `$i1`, `$i2`, `$rt`, `$func`: extra list passed to `$macro` directly
+macro_rules! gen_binary_expr_shift {
+    (
+        $macro:ident,
+        $l:expr,
+        $r:expr,
+        $ret:expr,
+        $general_f:ident,
+        {
+            $( { $i1:ident, $i2:ident, $rt:ident, $func:ident }, )*
+        } $(,)?
+    ) => {
+        $macro! {
+            [$l, $r, $ret],
+            { int16, int16, int16, $general_f },
+            { int16, int32, int32, $general_f },
+            { int16, int64, int64, $general_f },
+            { int32, int16, int32, $general_f },
+            { int32, int32, int32, $general_f },
+            { int32, int64, int64, $general_f },
+            { int64, int16,int64, $general_f },
+            { int64, int32,int64, $general_f },
+            { int64, int64, int64, $general_f },
             $(
                 { $i1, $i2, $rt, $func },
             )*
@@ -347,8 +381,9 @@ pub fn new_binary_expr(
                 },
             }
         }
+        // BitWise Operation
         Type::PgBitwiseShiftLeft => {
-            gen_binary_expr_atm! {
+            gen_binary_expr_shift! {
                 gen_atm_impl,
                 l, r, ret,
                 general_shl,
@@ -358,7 +393,7 @@ pub fn new_binary_expr(
             }
         }
         Type::PgBitwiseShiftRight =>{
-            gen_binary_expr_atm! {
+            gen_binary_expr_shift! {
                 gen_atm_impl,
                 l, r, ret,
                 general_shr,
@@ -367,6 +402,15 @@ pub fn new_binary_expr(
                 },
             }
         }
+        Type::BitwiseAnd => {
+            gen_binary_expr_shift! {
+                gen_atm_impl,
+                l, r, ret,
+                general_bitand,
+                {
+                },
+            }
+        },
         Type::Extract => build_extract_expr(ret, l, r),
         Type::RoundDigit => Box::new(
             BinaryExpression::<DecimalArray, I32Array, DecimalArray, _>::new(

--- a/src/expr/src/expr/expr_binary_nonnull.rs
+++ b/src/expr/src/expr/expr_binary_nonnull.rs
@@ -24,6 +24,7 @@ use risingwave_pb::expr::expr_node::Type;
 use crate::expr::template::BinaryExpression;
 use crate::expr::BoxedExpression;
 use crate::vector_op::arithmetic_op::*;
+use crate::vector_op::bitwise_op::*;
 use crate::vector_op::cmp::*;
 use crate::vector_op::extract::{extract_from_date, extract_from_timestamp};
 use crate::vector_op::like::like_default;
@@ -196,39 +197,39 @@ macro_rules! gen_binary_expr_atm {
             { int16, int16, int16, $general_f },
             { int16, int32, int32, $general_f },
             { int16, int64, int64, $general_f },
-            { int16, float32, float64, $general_f },
-            { int16, float64, float64, $general_f },
+            //{ int16, float32, float64, $general_f },
+            //{ int16, float64, float64, $general_f },
             { int32, int16, int32, $general_f },
             { int32, int32, int32, $general_f },
             { int32, int64, int64, $general_f },
-            { int32, float32, float64, $general_f },
-            { int32, float64, float64, $general_f },
+            //{ int32, float32, float64, $general_f },
+            //{ int32, float64, float64, $general_f },
             { int64, int16,int64, $general_f },
             { int64, int32,int64, $general_f },
             { int64, int64, int64, $general_f },
-            { int64, float32, float64 , $general_f},
-            { int64, float64, float64, $general_f },
-            { float32, int16, float64, $general_f },
-            { float32, int32, float64, $general_f },
-            { float32, int64, float64 , $general_f},
-            { float32, float32, float32, $general_f },
-            { float32, float64, float64, $general_f },
-            { float64, int16, float64, $general_f },
-            { float64, int32, float64, $general_f },
-            { float64, int64, float64, $general_f },
-            { float64, float32, float64, $general_f },
-            { float64, float64, float64, $general_f },
-            { decimal, int16, decimal, $general_f },
-            { decimal, int32, decimal, $general_f },
-            { decimal, int64, decimal, $general_f },
-            { decimal, float32, decimal, $general_f },
-            { decimal, float64, decimal, $general_f },
-            { int16, decimal, decimal, $general_f },
-            { int32, decimal, decimal, $general_f },
-            { int64, decimal, decimal, $general_f },
-            { decimal, decimal, decimal, $general_f },
-            { float32, decimal, float64, $general_f },
-            { float64, decimal, float64, $general_f },
+            //{ int64, float32, float64 , $general_f},
+            //{ int64, float64, float64, $general_f },
+            //{ float32, int16, float64, $general_f },
+            //{ float32, int32, float64, $general_f },
+            //{ float32, int64, float64 , $general_f},
+            //{ float32, float32, float32, $general_f },
+            //{ float32, float64, float64, $general_f },
+            //{ float64, int16, float64, $general_f },
+            //{ float64, int32, float64, $general_f },
+            //{ float64, int64, float64, $general_f },
+            //{ float64, float32, float64, $general_f },
+            //{ float64, float64, float64, $general_f },
+            // { decimal, int16, decimal, $general_f },
+            // { decimal, int32, decimal, $general_f },
+            // { decimal, int64, decimal, $general_f },
+            //{ decimal, float32, decimal, $general_f },
+            //{ decimal, float64, decimal, $general_f },
+            // { int16, decimal, decimal, $general_f },
+            // { int32, decimal, decimal, $general_f },
+            // { int64, decimal, decimal, $general_f },
+            // { decimal, decimal, decimal, $general_f },
+            //{ float32, decimal, float64, $general_f },
+            //{ float64, decimal, float64, $general_f },
             $(
                 { $i1, $i2, $rt, $func },
             )*
@@ -346,6 +347,26 @@ pub fn new_binary_expr(
                 },
             }
         }
+        Type::PgBitwiseShiftLeft => {
+            gen_binary_expr_atm! {
+                gen_atm_impl,
+                l, r, ret,
+                general_shl,
+                {
+
+                },
+            }
+        }
+        Type::PgBitwiseShiftRight =>{
+            gen_binary_expr_atm! {
+                gen_atm_impl,
+                l, r, ret,
+                general_shr,
+                {
+
+                },
+            }
+        }
         Type::Extract => build_extract_expr(ret, l, r),
         Type::RoundDigit => Box::new(
             BinaryExpression::<DecimalArray, I32Array, DecimalArray, _>::new(
@@ -359,6 +380,7 @@ pub fn new_binary_expr(
             l, r, ret, position,
         )),
         Type::TumbleStart => new_tumble_start(l, r, ret),
+        
         tp => {
             unimplemented!(
                 "The expression {:?} using vectorized expression framework is not supported yet!",

--- a/src/expr/src/expr/expr_binary_nonnull.rs
+++ b/src/expr/src/expr/expr_binary_nonnull.rs
@@ -411,6 +411,33 @@ pub fn new_binary_expr(
                 },
             }
         },
+        Type::BitwiseOr => {
+            gen_binary_expr_shift! {
+                gen_atm_impl,
+                l, r, ret,
+                general_bitor,
+                {
+                },
+            }
+        },
+        Type::BitwiseXor => {
+            gen_binary_expr_shift! {
+                gen_atm_impl,
+                l, r, ret,
+                general_bitxor,
+                {
+                },
+            }
+        },
+        // Type::Bitwisenot => {
+        //     gen_binary_expr_shift! {
+        //         gen_atm_impl,
+        //         l, ret,
+        //         general_bitnot,
+        //         {
+        //         },
+        //     }
+        // },
         Type::Extract => build_extract_expr(ret, l, r),
         Type::RoundDigit => Box::new(
             BinaryExpression::<DecimalArray, I32Array, DecimalArray, _>::new(

--- a/src/expr/src/expr/expr_binary_nonnull.rs
+++ b/src/expr/src/expr/expr_binary_nonnull.rs
@@ -429,15 +429,6 @@ pub fn new_binary_expr(
                 },
             }
         },
-        // Type::Bitwisenot => {
-        //     gen_binary_expr_shift! {
-        //         gen_atm_impl,
-        //         l, ret,
-        //         general_bitnot,
-        //         {
-        //         },
-        //     }
-        // },
         Type::Extract => build_extract_expr(ret, l, r),
         Type::RoundDigit => Box::new(
             BinaryExpression::<DecimalArray, I32Array, DecimalArray, _>::new(

--- a/src/expr/src/expr/expr_unary.rs
+++ b/src/expr/src/expr/expr_unary.rs
@@ -196,8 +196,8 @@ macro_rules! gen_unary_atm_expr  {
             { int16, int16, $general_func },
             { int32, int32, $general_func },
             { int64, int64, $general_func },
-            // { float32, float32, $general_func },
-            // { float64, float64, $general_func },
+            { float32, float32, $general_func },
+            { float64, float64, $general_func },
             $(
                 { $input, $rt, $func },
             )*
@@ -281,10 +281,12 @@ pub fn new_unary_expr(
             }
         }
         (ProstType::BitwiseNot, _, _) => {
-            gen_unary_atm_expr! { "Bitwisenot", child_expr, return_type, general_bitnot,
-                {
+            gen_unary_impl!{ 
+                [ "Bitwisenot", child_expr, return_type],
+                { int16, int16, general_bitnot },
+                { int32, int32, general_bitnot },
+                { int64, int64, general_bitnot },
 
-                }
             }
         }
         (expr, ret, child) => {

--- a/src/expr/src/expr/expr_unary.rs
+++ b/src/expr/src/expr/expr_unary.rs
@@ -34,6 +34,7 @@ use crate::vector_op::ltrim::ltrim;
 use crate::vector_op::rtrim::rtrim;
 use crate::vector_op::trim::trim;
 use crate::vector_op::upper::upper;
+use crate::vector_op::bitwise_op::general_bitnot;
 
 /// This macro helps to create cast expression.
 /// It receives all the combinations of `gen_cast` and generates corresponding match cases
@@ -195,8 +196,8 @@ macro_rules! gen_unary_atm_expr  {
             { int16, int16, $general_func },
             { int32, int32, $general_func },
             { int64, int64, $general_func },
-            { float32, float32, $general_func },
-            { float64, float64, $general_func },
+            // { float32, float32, $general_func },
+            // { float64, float64, $general_func },
             $(
                 { $input, $rt, $func },
             )*
@@ -276,6 +277,13 @@ pub fn new_unary_expr(
             gen_unary_atm_expr! { "Abs", child_expr, return_type, general_abs,
                 {
                     {decimal, decimal, decimal_abs},
+                }
+            }
+        }
+        (ProstType::BitwiseNot, _, _) => {
+            gen_unary_atm_expr! { "Bitwisenot", child_expr, return_type, general_bitnot,
+                {
+
                 }
             }
         }

--- a/src/expr/src/expr/mod.rs
+++ b/src/expr/src/expr/mod.rs
@@ -79,7 +79,7 @@ pub fn build_from_prost(prost: &ExprNode) -> Result<BoxedExpression> {
         | IsNotNull | Neg | Ascii | Abs => build_unary_expr_prost(prost),
         Equal | NotEqual | LessThan | LessThanOrEqual | GreaterThan | GreaterThanOrEqual | Add
         | Subtract | Multiply | Divide | Modulus | Extract | RoundDigit | TumbleStart
-        | Position | PgBitwiseShiftLeft | PgBitwiseShiftRight => build_binary_expr_prost(prost),
+        | Position | PgBitwiseShiftLeft | PgBitwiseShiftRight | BitwiseAnd => build_binary_expr_prost(prost),
         And | Or => build_nullable_binary_expr_prost(prost),
         Coalesce => CoalesceExpression::try_from(prost).map(|d| Box::new(d) as BoxedExpression),
         Substr => build_substr_expr(prost),

--- a/src/expr/src/expr/mod.rs
+++ b/src/expr/src/expr/mod.rs
@@ -79,7 +79,7 @@ pub fn build_from_prost(prost: &ExprNode) -> Result<BoxedExpression> {
         | IsNotNull | Neg | Ascii | Abs => build_unary_expr_prost(prost),
         Equal | NotEqual | LessThan | LessThanOrEqual | GreaterThan | GreaterThanOrEqual | Add
         | Subtract | Multiply | Divide | Modulus | Extract | RoundDigit | TumbleStart
-        | Position => build_binary_expr_prost(prost),
+        | Position | PgBitwiseShiftLeft | PgBitwiseShiftRight => build_binary_expr_prost(prost),
         And | Or => build_nullable_binary_expr_prost(prost),
         Coalesce => CoalesceExpression::try_from(prost).map(|d| Box::new(d) as BoxedExpression),
         Substr => build_substr_expr(prost),

--- a/src/expr/src/expr/mod.rs
+++ b/src/expr/src/expr/mod.rs
@@ -79,7 +79,7 @@ pub fn build_from_prost(prost: &ExprNode) -> Result<BoxedExpression> {
         | IsNotNull | Neg | Ascii | Abs => build_unary_expr_prost(prost),
         Equal | NotEqual | LessThan | LessThanOrEqual | GreaterThan | GreaterThanOrEqual | Add
         | Subtract | Multiply | Divide | Modulus | Extract | RoundDigit | TumbleStart
-        | Position | PgBitwiseShiftLeft | PgBitwiseShiftRight | BitwiseAnd => build_binary_expr_prost(prost),
+        | Position | PgBitwiseShiftLeft | PgBitwiseShiftRight | BitwiseAnd | BitwiseOr | BitwiseXor => build_binary_expr_prost(prost),
         And | Or => build_nullable_binary_expr_prost(prost),
         Coalesce => CoalesceExpression::try_from(prost).map(|d| Box::new(d) as BoxedExpression),
         Substr => build_substr_expr(prost),

--- a/src/expr/src/expr/mod.rs
+++ b/src/expr/src/expr/mod.rs
@@ -76,7 +76,7 @@ pub fn build_from_prost(prost: &ExprNode) -> Result<BoxedExpression> {
 
     match prost.get_expr_type()? {
         Cast | Upper | Lower | Not | IsTrue | IsNotTrue | IsFalse | IsNotFalse | IsNull
-        | IsNotNull | Neg | Ascii | Abs => build_unary_expr_prost(prost),
+        | IsNotNull | Neg | Ascii | Abs | BitwiseNot => build_unary_expr_prost(prost),
         Equal | NotEqual | LessThan | LessThanOrEqual | GreaterThan | GreaterThanOrEqual | Add
         | Subtract | Multiply | Divide | Modulus | Extract | RoundDigit | TumbleStart
         | Position | PgBitwiseShiftLeft | PgBitwiseShiftRight | BitwiseAnd | BitwiseOr | BitwiseXor => build_binary_expr_prost(prost),

--- a/src/expr/src/vector_op/bitwise_op.rs
+++ b/src/expr/src/vector_op/bitwise_op.rs
@@ -19,7 +19,8 @@ use risingwave_common::error::ErrorCode::{InternalError, NumericValueOutOfRange}
 use risingwave_common::error::{Result, RwError};
 use risingwave_common::types::{IntervalUnit, NaiveDateTimeWrapper, NaiveDateWrapper};
 
-
+mod arithmetic_op;
+use arithmetic_op::general_atm;
 
 #[inline(always)]
 pub fn general_shl<T1, T2, T3>(l: T1, r: T2) -> Result<T3>

--- a/src/expr/src/vector_op/bitwise_op.rs
+++ b/src/expr/src/vector_op/bitwise_op.rs
@@ -14,12 +14,11 @@
 use std::any::type_name;
 use std::convert::TryInto;
 use std::fmt::Debug;
-use std::ops::{BitAnd, BitOr, BitXor};
+use std::ops::{BitAnd, BitOr, BitXor, Not};
 
 use num_traits::{CheckedShl,CheckedShr};
 use risingwave_common::error::ErrorCode::{InternalError, NumericValueOutOfRange};
 use risingwave_common::error::{Result, RwError};
-use risingwave_common::types::{IntervalUnit, NaiveDateTimeWrapper, NaiveDateWrapper};
 
 
 use crate::vector_op::arithmetic_op::general_atm;
@@ -105,3 +104,10 @@ where
 {
     general_atm(l, r,  |a, b| Ok( a.bitxor(b)) )
 }
+
+
+#[inline(always)]
+pub fn general_bitnot<T1: Not<Output = T1>>(expr: T1) -> Result<T1> {
+    Ok(expr.not())
+}
+

--- a/src/expr/src/vector_op/bitwise_op.rs
+++ b/src/expr/src/vector_op/bitwise_op.rs
@@ -14,6 +14,8 @@
 use std::any::type_name;
 use std::convert::TryInto;
 use std::fmt::Debug;
+use std::ops::{BitAnd};
+
 use num_traits::{CheckedShl,CheckedShr};
 use risingwave_common::error::ErrorCode::{InternalError, NumericValueOutOfRange};
 use risingwave_common::error::{Result, RwError};
@@ -72,3 +74,59 @@ where
     })?;
     atm(l, r)
 }
+
+// TODO Select an error message for bitand
+#[inline(always)]
+pub fn general_bitand<T1, T2, T3>(l: T1, r: T2) -> Result<T3>
+where
+    T1: TryInto<T3> + Debug,
+    T2: TryInto<T3> + Debug,
+    T3: BitAnd,
+{
+    general_atm(l, r,  |a, b|  a.bitand(b)
+        //Some(c) => Ok(c),
+        //None => Err(RwError::from(InternalError(String::from("Unknown Error")))),
+    )
+}
+
+
+// #[inline(always)]
+// pub fn general_bitor<T1, T2, T3>(l: T1, r: T2) -> Result<T3>
+// where
+//     T1: TryInto<T3> + Debug,
+//     T2: TryInto<T3> + Debug,
+//     T3: CheckedShr,
+// {
+//     general_atm(l, r, |a, b| match a.checked_shr(b) {
+//         Some(c) => Ok(c),
+//         None => Err(RwError::from(NumericValueOutOfRange)),
+//     })
+// }
+
+
+// #[inline(always)]
+// pub fn general_bitxor<T1, T2, T3>(l: T1, r: T2) -> Result<T3>
+// where
+//     T1: TryInto<T3> + Debug,
+//     T2: TryInto<T3> + Debug,
+// {
+//     general_shift(l, r, |a, b| match a.checked_shr(b) {
+//         Some(c) => Ok(c),
+//         None => Err(RwError::from(NumericValueOutOfRange)),
+//     })
+// }
+
+
+
+// #[inline(always)]
+// pub fn general_bitnot<T1, T2, T3>(l: T1, r: T2) -> Result<T3>
+// where
+//     T1: TryInto<T3> + Debug,
+//     T2: TryInto<u32> + Debug,
+//     T3: CheckedShr,
+// {
+//     general_shift(l, r, |a, b| match a.checked_shr(b) {
+//         Some(c) => Ok(c),
+//         None => Err(RwError::from(NumericValueOutOfRange)),
+//     })
+// }

--- a/src/expr/src/vector_op/bitwise_op.rs
+++ b/src/expr/src/vector_op/bitwise_op.rs
@@ -74,7 +74,7 @@ where
     atm(l, r)
 }
 
-// TODO Select an error message for bitand
+
 #[inline(always)]
 pub fn general_bitand<T1, T2, T3>(l: T1, r: T2) -> Result<T3>
 where

--- a/src/expr/src/vector_op/bitwise_op.rs
+++ b/src/expr/src/vector_op/bitwise_op.rs
@@ -11,7 +11,7 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
-
+use std::any::type_name;
 use std::convert::TryInto;
 use std::fmt::Debug;
 use num_traits::{CheckedShl,CheckedShr};
@@ -19,17 +19,17 @@ use risingwave_common::error::ErrorCode::{InternalError, NumericValueOutOfRange}
 use risingwave_common::error::{Result, RwError};
 use risingwave_common::types::{IntervalUnit, NaiveDateTimeWrapper, NaiveDateWrapper};
 
-mod arithmetic_op;
-use arithmetic_op::general_atm;
+
+use crate::vector_op::arithmetic_op::general_atm;
 
 #[inline(always)]
 pub fn general_shl<T1, T2, T3>(l: T1, r: T2) -> Result<T3>
 where
     T1: TryInto<T3> + Debug,
-    T2: TryInto<T3> + Debug,
+    T2: TryInto<u32> + Debug,
     T3: CheckedShl,
 {
-    general_atm(l, r, |a, b| match a.checked_shl(&b) {
+    general_shift(l, r, |a, b| match a.checked_shl(b) {
         Some(c) => Ok(c),
         None => Err(RwError::from(NumericValueOutOfRange)),
     })
@@ -39,11 +39,36 @@ where
 pub fn general_shr<T1, T2, T3>(l: T1, r: T2) -> Result<T3>
 where
     T1: TryInto<T3> + Debug,
-    T2: TryInto<T3> + Debug,
+    T2: TryInto<u32> + Debug,
     T3: CheckedShr,
 {
-    general_atm(l, r, |a, b| match a.checked_shr(&b) {
+    general_shift(l, r, |a, b| match a.checked_shr(b) {
         Some(c) => Ok(c),
         None => Err(RwError::from(NumericValueOutOfRange)),
     })
+}
+
+#[inline(always)]
+pub fn general_shift<T1, T2, T3, F>(l: T1, r: T2, atm: F) -> Result<T3>
+where
+    T1: TryInto<T3> + Debug,
+    T2: TryInto<u32> + Debug,
+    F: FnOnce(T3, u32) -> Result<T3>,
+{
+    // TODO: We need to improve the error message
+    let l: T3 = l.try_into().map_err(|_| {
+        RwError::from(InternalError(format!(
+            "Can't convert {} to {}",
+            type_name::<T1>(),
+            type_name::<T3>()
+        )))
+    })?;
+    let r: u32 = r.try_into().map_err(|_| {
+        RwError::from(InternalError(format!(
+            "Can't convert {} to {}",
+            type_name::<T2>(),
+            type_name::<u32>()
+        )))
+    })?;
+    atm(l, r)
 }

--- a/src/expr/src/vector_op/bitwise_op.rs
+++ b/src/expr/src/vector_op/bitwise_op.rs
@@ -14,7 +14,7 @@
 use std::any::type_name;
 use std::convert::TryInto;
 use std::fmt::Debug;
-use std::ops::{BitAnd};
+use std::ops::{BitAnd, BitOr, BitXor};
 
 use num_traits::{CheckedShl,CheckedShr};
 use risingwave_common::error::ErrorCode::{InternalError, NumericValueOutOfRange};
@@ -81,52 +81,27 @@ pub fn general_bitand<T1, T2, T3>(l: T1, r: T2) -> Result<T3>
 where
     T1: TryInto<T3> + Debug,
     T2: TryInto<T3> + Debug,
-    T3: BitAnd,
+    T3: BitAnd<Output = T3>,
 {
-    general_atm(l, r,  |a, b|  a.bitand(b)
-        //Some(c) => Ok(c),
-        //None => Err(RwError::from(InternalError(String::from("Unknown Error")))),
-    )
+    general_atm(l, r,  |a, b| Ok( a.bitand(b)) )
 }
 
+#[inline(always)]
+pub fn general_bitor<T1, T2, T3>(l: T1, r: T2) -> Result<T3>
+where
+    T1: TryInto<T3> + Debug,
+    T2: TryInto<T3> + Debug,
+    T3: BitOr<Output = T3>,
+{
+    general_atm(l, r,  |a, b| Ok( a.bitor(b)) )
+}
 
-// #[inline(always)]
-// pub fn general_bitor<T1, T2, T3>(l: T1, r: T2) -> Result<T3>
-// where
-//     T1: TryInto<T3> + Debug,
-//     T2: TryInto<T3> + Debug,
-//     T3: CheckedShr,
-// {
-//     general_atm(l, r, |a, b| match a.checked_shr(b) {
-//         Some(c) => Ok(c),
-//         None => Err(RwError::from(NumericValueOutOfRange)),
-//     })
-// }
-
-
-// #[inline(always)]
-// pub fn general_bitxor<T1, T2, T3>(l: T1, r: T2) -> Result<T3>
-// where
-//     T1: TryInto<T3> + Debug,
-//     T2: TryInto<T3> + Debug,
-// {
-//     general_shift(l, r, |a, b| match a.checked_shr(b) {
-//         Some(c) => Ok(c),
-//         None => Err(RwError::from(NumericValueOutOfRange)),
-//     })
-// }
-
-
-
-// #[inline(always)]
-// pub fn general_bitnot<T1, T2, T3>(l: T1, r: T2) -> Result<T3>
-// where
-//     T1: TryInto<T3> + Debug,
-//     T2: TryInto<u32> + Debug,
-//     T3: CheckedShr,
-// {
-//     general_shift(l, r, |a, b| match a.checked_shr(b) {
-//         Some(c) => Ok(c),
-//         None => Err(RwError::from(NumericValueOutOfRange)),
-//     })
-// }
+#[inline(always)]
+pub fn general_bitxor<T1, T2, T3>(l: T1, r: T2) -> Result<T3>
+where
+    T1: TryInto<T3> + Debug,
+    T2: TryInto<T3> + Debug,
+    T3: BitXor<Output = T3>,
+{
+    general_atm(l, r,  |a, b| Ok( a.bitxor(b)) )
+}

--- a/src/expr/src/vector_op/bitwise_op.rs
+++ b/src/expr/src/vector_op/bitwise_op.rs
@@ -1,0 +1,48 @@
+// Copyright 2022 Singularity Data
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::convert::TryInto;
+use std::fmt::Debug;
+use num_traits::{CheckedShl,CheckedShr};
+use risingwave_common::error::ErrorCode::{InternalError, NumericValueOutOfRange};
+use risingwave_common::error::{Result, RwError};
+use risingwave_common::types::{IntervalUnit, NaiveDateTimeWrapper, NaiveDateWrapper};
+
+
+
+#[inline(always)]
+pub fn general_shl<T1, T2, T3>(l: T1, r: T2) -> Result<T3>
+where
+    T1: TryInto<T3> + Debug,
+    T2: TryInto<T3> + Debug,
+    T3: CheckedShl,
+{
+    general_atm(l, r, |a, b| match a.checked_shl(&b) {
+        Some(c) => Ok(c),
+        None => Err(RwError::from(NumericValueOutOfRange)),
+    })
+}
+
+#[inline(always)]
+pub fn general_shr<T1, T2, T3>(l: T1, r: T2) -> Result<T3>
+where
+    T1: TryInto<T3> + Debug,
+    T2: TryInto<T3> + Debug,
+    T3: CheckedShr,
+{
+    general_atm(l, r, |a, b| match a.checked_shr(&b) {
+        Some(c) => Ok(c),
+        None => Err(RwError::from(NumericValueOutOfRange)),
+    })
+}

--- a/src/expr/src/vector_op/mod.rs
+++ b/src/expr/src/vector_op/mod.rs
@@ -15,6 +15,7 @@
 pub mod agg;
 pub mod arithmetic_op;
 pub mod ascii;
+pub mod bitwise_op;
 pub mod cast;
 pub mod cmp;
 pub mod conjunction;

--- a/src/expr/src/vector_op/tests.rs
+++ b/src/expr/src/vector_op/tests.rs
@@ -20,6 +20,7 @@ use risingwave_common::types::{
 };
 
 use crate::vector_op::arithmetic_op::*;
+use crate::vector_op::bitwise_op::*;
 use crate::vector_op::cast::date_to_timestamp;
 use crate::vector_op::cmp::*;
 use crate::vector_op::conjunction::*;
@@ -138,27 +139,33 @@ fn test_arithmetic() {
 
 #[test]
 fn test_bitwise() {
-    assert!(
-        general_shl::<i32, i32, i64>(1, 0).unwrap(),
-        1);
+    // check the boundary
     
-    assert!(
-        general_shl::<i32, i32, i64>(1, 1).unwrap(),
-        2);
-    assert!(
-        general_shl::<i32, i32, i64>(1, 31).unwrap(),
-        -2147483648);
-
-    assert!(
-        general_shl::<i32, i32, i64>(1, 0).unwrap(),
-        1);
-    assert!(
-        general_shl::<i32, i32, i64>(1, 1).unwrap(),
-        2);
-    assert!(
-        general_shr::<i32, i32, i64>(-2147483648, 31).unwrap(),
-        1);
-
+    assert_eq!(
+        general_shl::<i32, i32, i64>(1i32, 0i32).unwrap(),
+        1i64);
+    assert_eq!(
+        general_shl::<i32, i32, i64>(1i32, 31i32).unwrap(),
+        2147483648i64);
+    assert_eq!(
+        general_shr::<i32, i32, i64>(-2147483648i32, 31i32).unwrap(),
+        -1i64);
+    assert_eq!(
+        general_shr::<i32,i32,i64>(1i32,0i32),
+        Ok(1i64));
+    // truth table
+    assert_eq!(
+        general_bitand::<u32,u32,u64>(0b0011u32,0b0101u32),
+        Ok(0b1u64));
+    assert_eq!(
+        general_bitor::<u32,u32,u64>(0b0011u32,0b0101u32),
+        Ok(0b0111u64));
+    assert_eq!(
+        general_bitxor::<u32,u32,u64>(0b0011u32,0b0101u32),
+        Ok(0b0110u64));
+    assert_eq!(
+        general_bitnot::<i32>(0b01i32),
+        Ok(-2i32));   
 
 }
 

--- a/src/expr/src/vector_op/tests.rs
+++ b/src/expr/src/vector_op/tests.rs
@@ -137,6 +137,18 @@ fn test_arithmetic() {
 }
 
 #[test]
+fn test_bitwise() {
+    assert!(
+        general_shl::<i32, i32, i64>(1, 0).unwrap(),
+        1);
+    
+    assert!(
+        general_shl::<i32, i32, i64>(1, 0).unwrap(),
+        1);
+
+}
+
+#[test]
 fn test_comparison() {
     assert!(general_eq::<Decimal, i32, Decimal>(Decimal::from_str("1.0").unwrap(), 1).unwrap());
     assert!(general_eq::<Decimal, f32, Decimal>(Decimal::from_str("1.0").unwrap(), 1.0).unwrap());

--- a/src/expr/src/vector_op/tests.rs
+++ b/src/expr/src/vector_op/tests.rs
@@ -143,8 +143,22 @@ fn test_bitwise() {
         1);
     
     assert!(
+        general_shl::<i32, i32, i64>(1, 1).unwrap(),
+        2);
+    assert!(
+        general_shl::<i32, i32, i64>(1, 31).unwrap(),
+        -2147483648);
+
+    assert!(
         general_shl::<i32, i32, i64>(1, 0).unwrap(),
         1);
+    assert!(
+        general_shl::<i32, i32, i64>(1, 1).unwrap(),
+        2);
+    assert!(
+        general_shr::<i32, i32, i64>(-2147483648, 31).unwrap(),
+        1);
+
 
 }
 

--- a/src/frontend/src/binder/expr/binary_op.rs
+++ b/src/frontend/src/binder/expr/binary_op.rs
@@ -43,6 +43,12 @@ impl Binder {
             BinaryOperator::Or => ExprType::Or,
             BinaryOperator::Like => ExprType::Like,
             BinaryOperator::NotLike => return self.bind_not_like(bound_left, bound_right),
+            BinaryOperator::BitwiseOr => ExprType::BitwiseOr
+            BinaryOperator::BitwiseAnd => ExprType::BitwiseAnd
+            BinaryOperator::BitwiseXor => ExprType::BitwiseXor
+            BinaryOperator::PGBitwiseXor => ExprType::PGBitwiseXor,
+            BinaryOperator::PGBitwiseShiftLeft => ExprType::PGBitwiseShiftLeft,
+            BinaryOperator::PGBitwiseShiftRight => ExprType::PGBitwiseShiftRight,
             _ => return Err(ErrorCode::NotImplemented(format!("{:?}", op), 112.into()).into()),
         };
         Ok(FunctionCall::new(func_type, vec![bound_left, bound_right])?.into())

--- a/src/frontend/src/binder/expr/binary_op.rs
+++ b/src/frontend/src/binder/expr/binary_op.rs
@@ -45,7 +45,6 @@ impl Binder {
             BinaryOperator::NotLike => return self.bind_not_like(bound_left, bound_right),
             BinaryOperator::BitwiseOr => ExprType::BitwiseOr,
             BinaryOperator::BitwiseAnd => ExprType::BitwiseAnd,
-            BinaryOperator::PGRegexMatch => ExprType::BitwiseNot,
             BinaryOperator::PGBitwiseXor => ExprType::BitwiseXor,
             BinaryOperator::PGBitwiseShiftLeft => ExprType::PgBitwiseShiftLeft,
             BinaryOperator::PGBitwiseShiftRight => ExprType::PgBitwiseShiftRight,

--- a/src/frontend/src/binder/expr/binary_op.rs
+++ b/src/frontend/src/binder/expr/binary_op.rs
@@ -45,10 +45,11 @@ impl Binder {
             BinaryOperator::NotLike => return self.bind_not_like(bound_left, bound_right),
             BinaryOperator::BitwiseOr => ExprType::BitwiseOr,
             BinaryOperator::BitwiseAnd => ExprType::BitwiseAnd,
-            BinaryOperator::BitwiseXor => ExprType::BitwiseXor,
-            BinaryOperator::PGBitwiseXor => ExprType::PgBitwiseXor,
+            BinaryOperator::PGRegexMatch => ExprType::BitwiseNot,
+            BinaryOperator::PGBitwiseXor => ExprType::BitwiseXor,
             BinaryOperator::PGBitwiseShiftLeft => ExprType::PgBitwiseShiftLeft,
             BinaryOperator::PGBitwiseShiftRight => ExprType::PgBitwiseShiftRight,
+            
             _ => return Err(ErrorCode::NotImplemented(format!("{:?}", op), 112.into()).into()),
         };
         Ok(FunctionCall::new(func_type, vec![bound_left, bound_right])?.into())

--- a/src/frontend/src/binder/expr/binary_op.rs
+++ b/src/frontend/src/binder/expr/binary_op.rs
@@ -43,12 +43,12 @@ impl Binder {
             BinaryOperator::Or => ExprType::Or,
             BinaryOperator::Like => ExprType::Like,
             BinaryOperator::NotLike => return self.bind_not_like(bound_left, bound_right),
-            BinaryOperator::BitwiseOr => ExprType::BitwiseOr
-            BinaryOperator::BitwiseAnd => ExprType::BitwiseAnd
-            BinaryOperator::BitwiseXor => ExprType::BitwiseXor
-            BinaryOperator::PGBitwiseXor => ExprType::PGBitwiseXor,
-            BinaryOperator::PGBitwiseShiftLeft => ExprType::PGBitwiseShiftLeft,
-            BinaryOperator::PGBitwiseShiftRight => ExprType::PGBitwiseShiftRight,
+            BinaryOperator::BitwiseOr => ExprType::BitwiseOr,
+            BinaryOperator::BitwiseAnd => ExprType::BitwiseAnd,
+            BinaryOperator::BitwiseXor => ExprType::BitwiseXor,
+            BinaryOperator::PGBitwiseXor => ExprType::PgBitwiseXor,
+            BinaryOperator::PGBitwiseShiftLeft => ExprType::PgBitwiseShiftLeft,
+            BinaryOperator::PGBitwiseShiftRight => ExprType::PgBitwiseShiftRight,
             _ => return Err(ErrorCode::NotImplemented(format!("{:?}", op), 112.into()).into()),
         };
         Ok(FunctionCall::new(func_type, vec![bound_left, bound_right])?.into())

--- a/src/frontend/src/binder/expr/mod.rs
+++ b/src/frontend/src/binder/expr/mod.rs
@@ -179,9 +179,10 @@ impl Binder {
         let func_type = match op {
             UnaryOperator::Not => ExprType::Not,
             UnaryOperator::Minus => ExprType::Neg,
+            UnaryOperator::PGBitwiseNot => ExprType::BitwiseNot,
             UnaryOperator::Plus => {
                 return self.rewrite_positive(expr);
-            }
+            },
             _ => {
                 return Err(ErrorCode::NotImplemented(
                     format!("unsupported unary expression: {:?}", op),

--- a/src/frontend/src/expr/function_call.rs
+++ b/src/frontend/src/expr/function_call.rs
@@ -72,7 +72,8 @@ impl std::fmt::Debug for FunctionCall {
                 ExprType::GreaterThanOrEqual => debug_binary_op(f, ">=", &self.inputs),
                 ExprType::And => debug_binary_op(f, "AND", &self.inputs),
                 ExprType::Or => debug_binary_op(f, "OR", &self.inputs),
-                
+                ExprType::PgBitwiseShiftLeft => debug_binary_op(f, "<<", &self.inputs),
+                ExprType::PgBitwiseShiftRight => debug_binary_op(f,">>", &self.inputs),
                 _ => {
                     let func_name = format!("{:?}", self.func_type);
                     let mut builder = f.debug_tuple(&func_name);

--- a/src/frontend/src/expr/function_call.rs
+++ b/src/frontend/src/expr/function_call.rs
@@ -77,7 +77,6 @@ impl std::fmt::Debug for FunctionCall {
                 ExprType::BitwiseAnd => debug_binary_op(f,"&", &self.inputs),
                 ExprType::BitwiseOr => debug_binary_op(f,"|", &self.inputs),
                 ExprType::BitwiseXor => debug_binary_op(f,"#", &self.inputs),
-                ExprType::BitwiseNot => debug_binary_op(f,"~",&self.inputs),
                 _ => {
                     let func_name = format!("{:?}", self.func_type);
                     let mut builder = f.debug_tuple(&func_name);

--- a/src/frontend/src/expr/function_call.rs
+++ b/src/frontend/src/expr/function_call.rs
@@ -72,6 +72,7 @@ impl std::fmt::Debug for FunctionCall {
                 ExprType::GreaterThanOrEqual => debug_binary_op(f, ">=", &self.inputs),
                 ExprType::And => debug_binary_op(f, "AND", &self.inputs),
                 ExprType::Or => debug_binary_op(f, "OR", &self.inputs),
+                
                 _ => {
                     let func_name = format!("{:?}", self.func_type);
                     let mut builder = f.debug_tuple(&func_name);

--- a/src/frontend/src/expr/function_call.rs
+++ b/src/frontend/src/expr/function_call.rs
@@ -74,6 +74,10 @@ impl std::fmt::Debug for FunctionCall {
                 ExprType::Or => debug_binary_op(f, "OR", &self.inputs),
                 ExprType::PgBitwiseShiftLeft => debug_binary_op(f, "<<", &self.inputs),
                 ExprType::PgBitwiseShiftRight => debug_binary_op(f,">>", &self.inputs),
+                ExprType::BitwiseAnd => debug_binary_op(f,"&", &self.inputs),
+                ExprType::BitwiseOr => debug_binary_op(f,"|", &self.inputs),
+                ExprType::BitwiseXor => debug_binary_op(f,"#", &self.inputs),
+                ExprType::BitwiseNot => debug_binary_op(f,"~",&self.inputs),
                 _ => {
                     let func_name = format!("{:?}", self.func_type);
                     let mut builder = f.debug_tuple(&func_name);

--- a/src/frontend/src/expr/type_inference.rs
+++ b/src/frontend/src/expr/type_inference.rs
@@ -242,10 +242,10 @@ fn build_type_derive_map() -> HashMap<FuncSign, DataTypeName> {
         FuncSign::new(E::RoundDigit, vec![T::Decimal, T::Int32]),
         T::Decimal,
     );
-    // build bitwise operator
+    // bitwise operator
     build_binary_atm_funcs(
         &mut map,
-        &[E::PgBitwiseShiftLeft, E::PgBitwiseShiftRight],
+        &[E::PgBitwiseShiftLeft, E::PgBitwiseShiftRight, E::BitwiseAnd, E::BitwiseOr, E::BitwiseNot, E::BitwiseXor],
         &[T::Int16, T::Int32, T::Int64],
     );
     // temporal expressions

--- a/src/frontend/src/expr/type_inference.rs
+++ b/src/frontend/src/expr/type_inference.rs
@@ -242,7 +242,12 @@ fn build_type_derive_map() -> HashMap<FuncSign, DataTypeName> {
         FuncSign::new(E::RoundDigit, vec![T::Decimal, T::Int32]),
         T::Decimal,
     );
-
+    // build bitwise operator
+    build_binary_atm_funcs(
+        &mut map,
+        &[E::PgBitwiseShiftLeft, E::PgBitwiseShiftRight],
+        &[T::Int16, T::Int32, T::Int64],
+    );
     // temporal expressions
     for (base, delta) in [
         (T::Date, T::Int32),

--- a/src/frontend/src/expr/type_inference.rs
+++ b/src/frontend/src/expr/type_inference.rs
@@ -248,6 +248,11 @@ fn build_type_derive_map() -> HashMap<FuncSign, DataTypeName> {
         &[E::PgBitwiseShiftLeft, E::PgBitwiseShiftRight, E::BitwiseAnd, E::BitwiseOr, E::BitwiseNot, E::BitwiseXor],
         &[T::Int16, T::Int32, T::Int64],
     );
+    build_unary_atm_funcs(
+        &mut map,
+        &[E::BitwiseNot],
+        &[T::Int16, T::Int32, T::Int64],
+    );
     // temporal expressions
     for (base, delta) in [
         (T::Date, T::Int32),

--- a/src/frontend/src/expr/type_inference.rs
+++ b/src/frontend/src/expr/type_inference.rs
@@ -552,6 +552,34 @@ mod tests {
     }
 
     #[test]
+    fn test_bitwise(){
+        use DataType::*;
+        let bitwise_exprs = vec![
+            ExprType::BitwiseAnd,
+            ExprType::BitwiseNot,
+            ExprType::BitwiseXor,
+            ExprType::PgBitwiseShiftLeft,
+            ExprType::PgBitwiseShiftRight,
+        ];
+        let num_promote_table = vec![
+            (Int16, Int16, Int16),
+            (Int16, Int32, Int32),
+            (Int16, Int64, Int64),
+            (Int32, Int16, Int32),
+            (Int32, Int32, Int32),
+            (Int32, Int64, Int64),
+            (Int64, Int16, Int64),
+            (Int64, Int32, Int64),
+            (Int64, Int64, Int64),
+           
+            
+            
+        ];
+        for (expr, (t1, t2, tr)) in iproduct!(bitwise_exprs, num_promote_table) {
+            test_simple_infer_type(expr, vec![t1, t2], tr);
+        }
+    }
+    #[test]
     fn test_bool_num_not_exist() {
         let exprs = vec![
             ExprType::Add,


### PR DESCRIPTION
## What's changed and what's your intention?

Implement bitwise operation (& , | , # (XOR), ~, >> , << ) supports integer number.
Add unit testing for the expr
Add e2e testing

## Refer to a related PR or issue link (optional)
https://github.com/singularity-data/risingwave/issues/2494
