### PR TITLE
ci: add deterministic simulation test

### DIFF
--- a/Makefile.toml
+++ b/Makefile.toml
@@ -403,6 +403,29 @@ cargo nextest run "$@"
 """
 description = "Run unit tests"
 
+[tasks.sbuild]
+category = "RiseDev - Build in simulation mode"
+description = "Build in simulation mode"
+dependencies = ["warn-on-missing-tools"]
+env = { RUSTFLAGS = "--cfg madsim", CARGO_TARGET_DIR = "target/sim" }
+script = """
+#!/bin/bash
+set -e
+
+cargo build "$@"
+"""
+
+[tasks.stest]
+category = "RiseDev - Deterministic Simulation Test"
+description = "Run unit tests in deterministic simulation mode"
+dependencies = ["warn-on-missing-tools"]
+env = { RUSTFLAGS = "--cfg madsim", CARGO_TARGET_DIR = "target/sim" }
+script = """
+#!/bin/bash
+set -e
+
+cargo nextest run "$@"
+"""
 
 [tasks.check-hakari]
 category = "RiseDev - Check"

--- a/ci/scripts/deterministic-simulation-test.sh
+++ b/ci/scripts/deterministic-simulation-test.sh
@@ -1,0 +1,24 @@
+#!/bin/bash
+
+# Exits as soon as any line fails.
+set -euo pipefail
+
+echo "--- Install required tools"
+rustup default "$(cat ./rust-toolchain)"
+
+echo "--- Generate RiseDev CI config"
+cp risedev-components.ci.env risedev-components.user.env
+
+echo "--- Run unit tests in deterministic simulation mode"
+~/cargo-make/makers stest \
+    --no-fail-fast \
+    -p risingwave_batch \
+    -p risingwave_common \
+    -p risingwave_compute \
+    -p risingwave_connector \
+    -p risingwave_ctl \
+    -p risingwave_expr \
+    -p risingwave_meta \
+    -p risingwave_source \
+    -p risingwave_storage \
+    -p risingwave_stream

--- a/ci/workflows/main-cron.yml
+++ b/ci/workflows/main-cron.yml
@@ -33,14 +33,24 @@ steps:
     command: "ci/scripts/compute-node-test.sh"
     plugins:
       - seek-oss/aws-sm#v2.3.1:
-            env:
-              CODECOV_TOKEN: my-codecov-token
+          env:
+            CODECOV_TOKEN: my-codecov-token
       - docker-compose#v3.9.0:
           run: rw-build-env
           config: ci/docker-compose.yml
           environment:
             - CODECOV_TOKEN
     timeout_in_minutes: 15
+
+  - label: "deterministic simulation test"
+    command: "ci/scripts/deterministic-simulation-test.sh"
+    plugins:
+      - docker-compose#v3.9.0:
+          run: rw-build-env
+          config: ci/docker-compose.yml
+          mount-buildkite-agent: true
+    timeout_in_minutes: 5
+    soft_fail: true
 
   - label: "misc check"
     command: "ci/scripts/misc-check.sh"

--- a/ci/workflows/main.yml
+++ b/ci/workflows/main.yml
@@ -64,6 +64,16 @@ steps:
             - CODECOV_TOKEN
     timeout_in_minutes: 15
 
+  - label: "deterministic simulation test"
+    command: "ci/scripts/deterministic-simulation-test.sh"
+    plugins:
+      - docker-compose#v3.9.0:
+          run: rw-build-env
+          config: ci/docker-compose.yml
+          mount-buildkite-agent: true
+    timeout_in_minutes: 5
+    soft_fail: true
+
   - label: "misc check"
     command: "ci/scripts/misc-check.sh"
     plugins:
@@ -71,6 +81,5 @@ steps:
           run: rw-build-env
           config: ci/docker-compose.yml
       - shellcheck#v1.2.0:
-            files: ./**/*.sh
+          files: ./**/*.sh
     timeout_in_minutes: 10
-

--- a/ci/workflows/pull-request.yml
+++ b/ci/workflows/pull-request.yml
@@ -42,6 +42,16 @@ steps:
             - CODECOV_TOKEN
     timeout_in_minutes: 15
 
+  - label: "deterministic simulation test"
+    command: "ci/scripts/deterministic-simulation-test.sh"
+    plugins:
+      - docker-compose#v3.9.0:
+          run: rw-build-env
+          config: ci/docker-compose.yml
+          mount-buildkite-agent: true
+    timeout_in_minutes: 5
+    soft_fail: true
+
   - label: "misc check"
     command: "ci/scripts/misc-check.sh"
     plugins:
@@ -51,4 +61,3 @@ steps:
       - shellcheck#v1.2.0:
           files: ./**/*.sh
     timeout_in_minutes: 5
-

--- a/src/meta/Cargo.toml
+++ b/src/meta/Cargo.toml
@@ -63,8 +63,10 @@ workspace-hack = { version = "0.1", path = "../workspace-hack" }
 [dev-dependencies]
 assert_matches = "1"
 rand = "0.8"
-risingwave_frontend = { path = "../frontend" }
 tempfile = "3"
+
+[target.'cfg(not(madsim))'.dev-dependencies]
+risingwave_frontend = { path = "../frontend" }
 
 [features]
 test = []

--- a/src/meta/src/stream/test_fragmenter.rs
+++ b/src/meta/src/stream/test_fragmenter.rs
@@ -17,7 +17,6 @@ use std::sync::Arc;
 
 use risingwave_common::catalog::TableId;
 use risingwave_common::error::Result;
-use risingwave_frontend::stream_fragmenter::StreamFragmenter;
 use risingwave_pb::data::data_type::TypeName;
 use risingwave_pb::data::DataType;
 use risingwave_pb::expr::agg_call::{Arg, Type};
@@ -254,8 +253,13 @@ fn make_stream_node() -> StreamNode {
     }
 }
 
+// TODO: enable this test with madsim
+// NOTE: frontend is not yet available with madsim
+#[cfg(not(madsim))]
 #[tokio::test]
 async fn test_fragmenter() -> Result<()> {
+    use risingwave_frontend::stream_fragmenter::StreamFragmenter;
+
     let env = MetaSrvEnv::for_test().await;
     let stream_node = make_stream_node();
     let fragment_manager = Arc::new(FragmentManager::new(env.clone()).await?);

--- a/src/source/src/connector_source.rs
+++ b/src/source/src/connector_source.rs
@@ -13,12 +13,12 @@
 // limitations under the License.
 
 use std::borrow::BorrowMut;
-use std::collections::HashMap;
 use std::sync::Arc;
 
 use async_trait::async_trait;
 use futures::future::{try_join_all, Either};
 use itertools::Itertools;
+use madsim::collections::HashMap;
 use risingwave_common::array::StreamChunk;
 use risingwave_common::catalog::ColumnId;
 use risingwave_common::error::{internal_error, Result, RwError, ToRwResult};

--- a/src/source/src/lib.rs
+++ b/src/source/src/lib.rs
@@ -30,11 +30,11 @@
 #![feature(binary_heap_drain_sorted)]
 #![feature(mutex_unlock)]
 
-use std::collections::HashMap;
 use std::fmt::Debug;
 
 use async_trait::async_trait;
 use enum_as_inner::EnumAsInner;
+use madsim::collections::HashMap;
 pub use manager::*;
 pub use parser::*;
 use risingwave_common::array::StreamChunk;

--- a/src/stream/src/executor/barrier_align.rs
+++ b/src/stream/src/executor/barrier_align.rs
@@ -28,11 +28,9 @@ pub enum AlignedMessage {
 
 #[try_stream(ok = AlignedMessage, error = StreamExecutorError)]
 pub async fn barrier_align(mut left: BoxedMessageStream, mut right: BoxedMessageStream) {
-    // TODO: handle stream end
-    use madsim::rand::{Rng, SeedableRng};
-    let mut rng = madsim::rand::rngs::StdRng::from_entropy();
+    use madsim::rand::Rng;
     loop {
-        let prefer_left: bool = rng.gen();
+        let prefer_left: bool = madsim::rand::thread_rng().gen();
         let select_result = if prefer_left {
             select(left.next(), right.next()).await
         } else {


### PR DESCRIPTION
## What's changed and what's your intention?

This PR fixes build with madsim and adds the command to risedev and CI scripts.

Now we can run simulation unit tests with a shorter command:
```sh
./risedev stest
```

Note that some tests still fail at this moment, so I mark the step as `soft_fail` to allow failures.

The following results from CI are as expected:
```
Summary [   5.929s] 557 tests run: 544 passed, 13 failed, 13 skipped
error: test run failed
```

## Checklist

- [x] I have written necessary docs and comments
- [x] I have added necessary unit tests and integration tests

## Refer to a related PR or issue link (optional)
