### PR TITLE
fix(storage): ensure at least one split in compaction task

### DIFF
--- a/src/meta/src/hummock/compaction/mod.rs
+++ b/src/meta/src/hummock/compaction/mod.rs
@@ -181,13 +181,17 @@ impl CompactStatus {
         let select_level_id = ret.select_level.level_idx;
         let target_level_id = ret.target_level.level_idx;
 
-        let compact_task = CompactTask {
-            input_ssts: vec![ret.select_level, ret.target_level],
-            splits: ret
-                .split_ranges
+        let splits = if ret.split_ranges.is_empty() {
+            vec![KeyRange::inf().into()]
+        } else {
+            ret.split_ranges
                 .iter()
                 .map(|v| v.clone().into())
-                .collect_vec(),
+                .collect_vec()
+        };
+        let compact_task = CompactTask {
+            input_ssts: vec![ret.select_level, ret.target_level],
+            splits,
             watermark: HummockEpoch::MAX,
             sorted_output_ssts: vec![],
             task_id: self.next_compact_task_id,

--- a/src/meta/src/hummock/compaction/tier_compaction_picker.rs
+++ b/src/meta/src/hummock/compaction/tier_compaction_picker.rs
@@ -236,7 +236,7 @@ impl TierCompactionPicker {
                     level_type: LevelType::Overlapping as i32,
                     table_infos: vec![],
                 },
-                split_ranges: vec![KeyRange::inf()],
+                split_ranges: vec![],
             });
         }
         None

--- a/src/storage/src/hummock/compactor.rs
+++ b/src/storage/src/hummock/compactor.rs
@@ -299,6 +299,7 @@ impl Compactor {
 
         // Number of splits (key ranges) is equal to number of compaction tasks
         let parallelism = compact_task.splits.len();
+        assert_ne!(parallelism, 0, "splits cannot be empty");
         let mut compact_success = true;
         let mut output_ssts = Vec::with_capacity(parallelism);
         let mut compaction_futures = vec![];


### PR DESCRIPTION
## What's changed and what's your intention?

Compaction task should not contain empty splits. Same as https://github.com/singularity-data/risingwave/pull/2251

## Checklist

## Refer to a related PR or issue link (optional)
