### PR TITLE
chore(ci): rename CI name

### DIFF
--- a/ci/workflows/main-cron.yml
+++ b/ci/workflows/main-cron.yml
@@ -1,5 +1,5 @@
 steps:
-  - label: "build (dev mode)"
+  - label: "build"
     command: "ci/scripts/compute-node-build.sh -t debug -p dev"
     key: "build"
     plugins:

--- a/ci/workflows/main-cron.yml
+++ b/ci/workflows/main-cron.yml
@@ -1,5 +1,5 @@
 steps:
-  - label: "compute node build dev"
+  - label: "build (dev mode)"
     command: "ci/scripts/compute-node-build.sh -t debug -p dev"
     key: "build"
     plugins:
@@ -9,7 +9,7 @@ steps:
           mount-buildkite-agent: true
     timeout_in_minutes: 10
 
-  - label: "e2e risedev"
+  - label: "end-to-end test"
     command: "ci/scripts/e2e-risedev.sh -p dev"
     depends_on: "build"
     plugins:
@@ -19,7 +19,7 @@ steps:
           mount-buildkite-agent: true
     timeout_in_minutes: 10
 
-  - label: "e2e source"
+  - label: "end-to-end source test"
     command: "ci/scripts/e2e-source.sh"
     depends_on: "build"
     plugins:
@@ -29,7 +29,7 @@ steps:
           mount-buildkite-agent: true
     timeout_in_minutes: 5
 
-  - label: "compute node test"
+  - label: "unit test"
     command: "ci/scripts/compute-node-test.sh"
     plugins:
       - seek-oss/aws-sm#v2.3.1:
@@ -42,7 +42,7 @@ steps:
             - CODECOV_TOKEN
     timeout_in_minutes: 15
 
-  - label: "deterministic simulation test"
+  - label: "unit test (deterministic simulation)"
     command: "ci/scripts/deterministic-simulation-test.sh"
     plugins:
       - docker-compose#v3.9.0:

--- a/ci/workflows/main.yml
+++ b/ci/workflows/main.yml
@@ -1,5 +1,5 @@
 steps:
-  - label: "compute node build {{matrix.profile}}"
+  - label: "build ({{matrix.profile}} mode)"
     command: "ci/scripts/compute-node-build.sh -t {{matrix.target}} -p {{matrix.profile}}"
     key: "build"
     timeout_in_minutes: 15
@@ -26,7 +26,7 @@ steps:
             profile: "dev"
           skip: true
 
-  - label: " {{matrix.profile}}: e2e risedev"
+  - label: "end-to-end test ({{matrix.profile}} mode)"
     command: "ci/scripts/e2e-risedev.sh -p {{matrix.profile}}"
     depends_on: "build"
     timeout_in_minutes: 10
@@ -41,7 +41,7 @@ steps:
           - "dev"
           - "release"
 
-  - label: "e2e source"
+  - label: "end-to-end source test"
     command: "ci/scripts/e2e-source.sh"
     depends_on: "build"
     plugins:
@@ -51,7 +51,7 @@ steps:
           mount-buildkite-agent: true
     timeout_in_minutes: 5
 
-  - label: "compute node test"
+  - label: "unit test"
     command: "ci/scripts/compute-node-test.sh"
     plugins:
       - seek-oss/aws-sm#v2.3.1:
@@ -64,7 +64,7 @@ steps:
             - CODECOV_TOKEN
     timeout_in_minutes: 15
 
-  - label: "deterministic simulation test"
+  - label: "unit test (deterministic simulation)"
     command: "ci/scripts/deterministic-simulation-test.sh"
     plugins:
       - docker-compose#v3.9.0:

--- a/ci/workflows/pull-request.yml
+++ b/ci/workflows/pull-request.yml
@@ -1,5 +1,5 @@
 steps:
-  - label: "build ({{matrix.profile}} mode)"
+  - label: "build"
     command: "ci/scripts/compute-node-build.sh -t debug -p dev"
     key: "build"
     plugins:
@@ -9,7 +9,7 @@ steps:
           mount-buildkite-agent: true
     timeout_in_minutes: 10
 
-  - label: "end-to-end test ({{matrix.profile}} mode)"
+  - label: "end-to-end test"
     command: "ci/scripts/e2e-risedev.sh -p dev"
     depends_on: "build"
     plugins:

--- a/ci/workflows/pull-request.yml
+++ b/ci/workflows/pull-request.yml
@@ -1,5 +1,5 @@
 steps:
-  - label: "compute node build dev"
+  - label: "build ({{matrix.profile}} mode)"
     command: "ci/scripts/compute-node-build.sh -t debug -p dev"
     key: "build"
     plugins:
@@ -9,7 +9,7 @@ steps:
           mount-buildkite-agent: true
     timeout_in_minutes: 10
 
-  - label: "e2e risedev"
+  - label: "end-to-end test ({{matrix.profile}} mode)"
     command: "ci/scripts/e2e-risedev.sh -p dev"
     depends_on: "build"
     plugins:
@@ -19,7 +19,7 @@ steps:
           mount-buildkite-agent: true
     timeout_in_minutes: 10
 
-  - label: "e2e source"
+  - label: "end-to-end source test"
     command: "ci/scripts/e2e-source.sh"
     depends_on: "build"
     plugins:
@@ -29,7 +29,7 @@ steps:
           mount-buildkite-agent: true
     timeout_in_minutes: 5
 
-  - label: "compute node test"
+  - label: "unit test"
     command: "ci/scripts/compute-node-test.sh"
     plugins:
       - seek-oss/aws-sm#v2.3.1:
@@ -42,7 +42,7 @@ steps:
             - CODECOV_TOKEN
     timeout_in_minutes: 15
 
-  - label: "deterministic simulation test"
+  - label: "unit test (deterministic simulation)"
     command: "ci/scripts/deterministic-simulation-test.sh"
     plugins:
       - docker-compose#v3.9.0:


### PR DESCRIPTION
Signed-off-by: Alex Chi <iskyzh@gmail.com>

## What's changed and what's your intention?

After Java frontend gets retired, "compute-node test" is an outdated name -- now we test and build the whole RisingWave system inside those CI steps.

## Checklist

## Refer to a related PR or issue link (optional)
