### PR TITLE
refactor: (Preview) Disallow creating DataChunk with empty columns and no cardinality

### DIFF
--- a/src/batch/src/executor/delete.rs
+++ b/src/batch/src/executor/delete.rs
@@ -104,7 +104,7 @@ impl DeleteExecutor {
             array_builder.append(Some(rows_deleted as i64))?;
 
             let array = array_builder.finish()?;
-            let ret_chunk = DataChunk::builder().columns(vec![array.into()]).build();
+            let ret_chunk = DataChunk::new(vec![array.into()], None);
 
             yield ret_chunk
         }

--- a/src/batch/src/executor/delete.rs
+++ b/src/batch/src/executor/delete.rs
@@ -104,7 +104,7 @@ impl DeleteExecutor {
             array_builder.append(Some(rows_deleted as i64))?;
 
             let array = array_builder.finish()?;
-            let ret_chunk = DataChunk::new(vec![array.into()], None);
+            let ret_chunk = DataChunk::tai(vec![array.into()], 1, None);
 
             yield ret_chunk
         }

--- a/src/batch/src/executor/delete.rs
+++ b/src/batch/src/executor/delete.rs
@@ -104,7 +104,7 @@ impl DeleteExecutor {
             array_builder.append(Some(rows_deleted as i64))?;
 
             let array = array_builder.finish()?;
-            let ret_chunk = DataChunk::tai(vec![array.into()], 1, None);
+            let ret_chunk = DataChunk::new(vec![array.into()], 1, None);
 
             yield ret_chunk
         }

--- a/src/batch/src/executor/generate_series.rs
+++ b/src/batch/src/executor/generate_series.rs
@@ -105,8 +105,9 @@ where
             }
 
             let arr = builder.finish()?;
+            let xxlen = arr.len();
             let columns = vec![Column::new(Arc::new(arr.into()))];
-            let chunk: DataChunk = DataChunk::new(columns, None);
+            let chunk: DataChunk = DataChunk::tai(columns, xxlen, None);
 
             yield chunk;
         }

--- a/src/batch/src/executor/generate_series.rs
+++ b/src/batch/src/executor/generate_series.rs
@@ -107,7 +107,7 @@ where
             let arr = builder.finish()?;
             let xxlen = arr.len();
             let columns = vec![Column::new(Arc::new(arr.into()))];
-            let chunk: DataChunk = DataChunk::tai(columns, xxlen, None);
+            let chunk: DataChunk = DataChunk::new(columns, xxlen, None);
 
             yield chunk;
         }

--- a/src/batch/src/executor/generate_series.rs
+++ b/src/batch/src/executor/generate_series.rs
@@ -106,7 +106,7 @@ where
 
             let arr = builder.finish()?;
             let columns = vec![Column::new(Arc::new(arr.into()))];
-            let chunk: DataChunk = DataChunk::builder().columns(columns).build();
+            let chunk: DataChunk = DataChunk::new(columns, None);
 
             yield chunk;
         }

--- a/src/batch/src/executor/generic_exchange.rs
+++ b/src/batch/src/executor/generic_exchange.rs
@@ -212,11 +212,9 @@ mod tests {
             ) -> Result<Box<dyn ExchangeSource>> {
                 let mut rng = rand::thread_rng();
                 let i = rng.gen_range(1..=100000);
-                let chunk = DataChunk::builder()
-                    .columns(vec![Column::new(Arc::new(
-                        array_nonnull! { I32Array, [i] }.into(),
-                    ))])
-                    .build();
+                let chunk = DataChunk::zooja(vec![Column::new(Arc::new(
+                    array_nonnull! { I32Array, [i] }.into(),
+                ))]);
                 let chunks = vec![Some(chunk); 100];
 
                 Ok(Box::new(FakeExchangeSource { chunks }))

--- a/src/batch/src/executor/generic_exchange.rs
+++ b/src/batch/src/executor/generic_exchange.rs
@@ -212,7 +212,7 @@ mod tests {
             ) -> Result<Box<dyn ExchangeSource>> {
                 let mut rng = rand::thread_rng();
                 let i = rng.gen_range(1..=100000);
-                let chunk = DataChunk::zooja(vec![Column::new(Arc::new(
+                let chunk = DataChunk::cols(vec![Column::new(Arc::new(
                     array_nonnull! { I32Array, [i] }.into(),
                 ))]);
                 let chunks = vec![Some(chunk); 100];

--- a/src/batch/src/executor/hash_agg.rs
+++ b/src/batch/src/executor/hash_agg.rs
@@ -229,8 +229,10 @@ impl<K: HashKey + Send + Sync> HashAggExecutor<K> {
                 .collect::<Result<Vec<_>>>()?;
 
             let mut has_next = false;
+            let mut xxlen = 0;
             for (key, states) in result.by_ref().take(cardinality) {
                 has_next = true;
+                xxlen += 1;
                 key.deserialize_to_builders(&mut group_builders[..])?;
                 states
                     .into_iter()
@@ -247,7 +249,7 @@ impl<K: HashKey + Send + Sync> HashAggExecutor<K> {
                 .map(|b| Ok(Column::new(Arc::new(b.finish()?))))
                 .collect::<Result<Vec<_>>>()?;
 
-            let output = DataChunk::new(columns, None);
+            let output = DataChunk::tai(columns, xxlen, None);
             yield output;
         }
     }

--- a/src/batch/src/executor/hash_agg.rs
+++ b/src/batch/src/executor/hash_agg.rs
@@ -249,7 +249,7 @@ impl<K: HashKey + Send + Sync> HashAggExecutor<K> {
                 .map(|b| Ok(Column::new(Arc::new(b.finish()?))))
                 .collect::<Result<Vec<_>>>()?;
 
-            let output = DataChunk::tai(columns, xxlen, None);
+            let output = DataChunk::new(columns, xxlen, None);
             yield output;
         }
     }

--- a/src/batch/src/executor/hash_agg.rs
+++ b/src/batch/src/executor/hash_agg.rs
@@ -247,7 +247,7 @@ impl<K: HashKey + Send + Sync> HashAggExecutor<K> {
                 .map(|b| Ok(Column::new(Arc::new(b.finish()?))))
                 .collect::<Result<Vec<_>>>()?;
 
-            let output = DataChunk::builder().columns(columns).build();
+            let output = DataChunk::new(columns, None);
             yield output;
         }
     }

--- a/src/batch/src/executor/hop_window.rs
+++ b/src/batch/src/executor/hop_window.rs
@@ -213,19 +213,21 @@ impl HopWindowExecutor {
         for data_chunk in child.execute() {
             let data_chunk = data_chunk?;
             let hop_start = hop_expr.eval(&data_chunk)?;
-            let hop_start_chunk = DataChunk::new(vec![Column::new(hop_start)], None);
+            let xxlen = hop_start.len();
+            let hop_start_chunk = DataChunk::tai(vec![Column::new(hop_start)], xxlen, None);
             let (origin_cols, visibility) = data_chunk.into_parts();
             // SAFETY: Already compacted.
             assert!(visibility.is_none());
             for i in 0..units {
                 let window_start_col = window_start_exprs[i].eval(&hop_start_chunk)?;
                 let window_end_col = window_end_exprs[i].eval(&hop_start_chunk)?;
+                let xxlen = window_start_col.len();
                 let mut new_cols = origin_cols.clone();
                 new_cols.extend_from_slice(&[
                     Column::new(window_start_col),
                     Column::new(window_end_col),
                 ]);
-                let new_chunk = DataChunk::new(new_cols, None);
+                let new_chunk = DataChunk::tai(new_cols, xxlen, None);
                 yield new_chunk;
             }
         }

--- a/src/batch/src/executor/hop_window.rs
+++ b/src/batch/src/executor/hop_window.rs
@@ -214,7 +214,7 @@ impl HopWindowExecutor {
             let data_chunk = data_chunk?;
             let hop_start = hop_expr.eval(&data_chunk)?;
             let xxlen = hop_start.len();
-            let hop_start_chunk = DataChunk::tai(vec![Column::new(hop_start)], xxlen, None);
+            let hop_start_chunk = DataChunk::new(vec![Column::new(hop_start)], xxlen, None);
             let (origin_cols, visibility) = data_chunk.into_parts();
             // SAFETY: Already compacted.
             assert!(visibility.is_none());
@@ -227,7 +227,7 @@ impl HopWindowExecutor {
                     Column::new(window_start_col),
                     Column::new(window_end_col),
                 ]);
-                let new_chunk = DataChunk::tai(new_cols, xxlen, None);
+                let new_chunk = DataChunk::new(new_cols, xxlen, None);
                 yield new_chunk;
             }
         }

--- a/src/batch/src/executor/insert.rs
+++ b/src/batch/src/executor/insert.rs
@@ -120,7 +120,7 @@ impl InsertExecutor {
             array_builder.append(Some(rows_inserted as i64))?;
 
             let array = array_builder.finish()?;
-            let ret_chunk = DataChunk::tai(vec![array.into()], 1, None);
+            let ret_chunk = DataChunk::new(vec![array.into()], 1, None);
 
             yield ret_chunk
         }

--- a/src/batch/src/executor/insert.rs
+++ b/src/batch/src/executor/insert.rs
@@ -220,7 +220,7 @@ mod tests {
         .map(|x| Arc::new(x.into()))
         .unwrap();
         let col3 = Column::new(array);
-        let data_chunk: DataChunk = DataChunk::zooja(vec![col1, col2, col3]);
+        let data_chunk: DataChunk = DataChunk::cols(vec![col1, col2, col3]);
         mock_executor.add(data_chunk.clone());
 
         // Create the table.

--- a/src/batch/src/executor/insert.rs
+++ b/src/batch/src/executor/insert.rs
@@ -120,7 +120,7 @@ impl InsertExecutor {
             array_builder.append(Some(rows_inserted as i64))?;
 
             let array = array_builder.finish()?;
-            let ret_chunk = DataChunk::builder().columns(vec![array.into()]).build();
+            let ret_chunk = DataChunk::new(vec![array.into()], None);
 
             yield ret_chunk
         }

--- a/src/batch/src/executor/insert.rs
+++ b/src/batch/src/executor/insert.rs
@@ -120,7 +120,7 @@ impl InsertExecutor {
             array_builder.append(Some(rows_inserted as i64))?;
 
             let array = array_builder.finish()?;
-            let ret_chunk = DataChunk::new(vec![array.into()], None);
+            let ret_chunk = DataChunk::tai(vec![array.into()], 1, None);
 
             yield ret_chunk
         }

--- a/src/batch/src/executor/insert.rs
+++ b/src/batch/src/executor/insert.rs
@@ -220,7 +220,7 @@ mod tests {
         .map(|x| Arc::new(x.into()))
         .unwrap();
         let col3 = Column::new(array);
-        let data_chunk: DataChunk = DataChunk::builder().columns(vec![col1, col2, col3]).build();
+        let data_chunk: DataChunk = DataChunk::zooja(vec![col1, col2, col3]);
         mock_executor.add(data_chunk.clone());
 
         // Create the table.

--- a/src/batch/src/executor/join/hash_join.rs
+++ b/src/batch/src/executor/join/hash_join.rs
@@ -653,7 +653,7 @@ mod tests {
             };
 
             let ttlen = keep_columns[0].array().len();
-            DataChunk::tai(keep_columns, ttlen, vis)
+            DataChunk::new(keep_columns, ttlen, vis)
         }
 
         async fn do_test(&self, expected: DataChunk, has_non_equi_cond: bool) {

--- a/src/batch/src/executor/join/hash_join.rs
+++ b/src/batch/src/executor/join/hash_join.rs
@@ -435,7 +435,7 @@ mod tests {
                 .map(|array_builder| array_builder.finish().map(|arr| Column::new(Arc::new(arr))))
                 .collect::<Result<Vec<Column>>>()?;
 
-            Ok(DataChunk::zooja(columns))
+            Ok(DataChunk::cols(columns))
         }
     }
 

--- a/src/batch/src/executor/join/hash_join.rs
+++ b/src/batch/src/executor/join/hash_join.rs
@@ -435,7 +435,7 @@ mod tests {
                 .map(|array_builder| array_builder.finish().map(|arr| Column::new(Arc::new(arr))))
                 .collect::<Result<Vec<Column>>>()?;
 
-            Ok(DataChunk::new(columns, None))
+            Ok(DataChunk::zooja(columns))
         }
     }
 

--- a/src/batch/src/executor/join/hash_join.rs
+++ b/src/batch/src/executor/join/hash_join.rs
@@ -435,7 +435,7 @@ mod tests {
                 .map(|array_builder| array_builder.finish().map(|arr| Column::new(Arc::new(arr))))
                 .collect::<Result<Vec<Column>>>()?;
 
-            DataChunk::try_from(columns)
+            Ok(DataChunk::new(columns, None))
         }
     }
 

--- a/src/batch/src/executor/join/hash_join.rs
+++ b/src/batch/src/executor/join/hash_join.rs
@@ -652,7 +652,8 @@ mod tests {
                 unreachable!()
             };
 
-            DataChunk::new(keep_columns, vis)
+            let ttlen = keep_columns[0].array().len();
+            DataChunk::tai(keep_columns, ttlen, vis)
         }
 
         async fn do_test(&self, expected: DataChunk, has_non_equi_cond: bool) {

--- a/src/batch/src/executor/join/hash_join_state.rs
+++ b/src/batch/src/executor/join/hash_join_state.rs
@@ -307,7 +307,7 @@ impl<K: HashKey> ProbeTable<K> {
                 new_column.push(Column::new(Arc::new(array)));
             }
         }
-        DataChunk::tai(new_column, xxlen, vis)
+        DataChunk::new(new_column, xxlen, vis)
     }
 
     fn remove_duplicate_rows_for_left_outer(&mut self, filter: Bitmap) -> Result<Bitmap> {
@@ -1029,7 +1029,7 @@ impl<K: HashKey> ProbeTable<K> {
 
         // TODO(tai-zooja)
         let xxlen = new_columns[0].array().len();
-        let data_chunk = DataChunk::tai(new_columns, xxlen, None);
+        let data_chunk = DataChunk::new(new_columns, xxlen, None);
 
         Ok(data_chunk)
     }
@@ -1054,7 +1054,7 @@ impl<K: HashKey> ProbeTable<K> {
             } else {
                 unreachable!()
             };
-            DataChunk::tai(keep_columns, xxlen, vis)
+            DataChunk::new(keep_columns, xxlen, vis)
         }
     }
 

--- a/src/batch/src/executor/join/hash_join_state.rs
+++ b/src/batch/src/executor/join/hash_join_state.rs
@@ -1027,7 +1027,7 @@ impl<K: HashKey> ProbeTable<K> {
             .map(|array| Column::new(Arc::new(array)))
             .collect_vec();
 
-        let data_chunk = DataChunk::try_from(new_columns)?;
+        let data_chunk = DataChunk::new(new_columns, None);
 
         Ok(data_chunk)
     }

--- a/src/batch/src/executor/join/nested_loop_join.rs
+++ b/src/batch/src/executor/join/nested_loop_join.rs
@@ -567,12 +567,7 @@ impl NestedLoopJoinExecutor {
                 .into())
             }
         };
-        let builder = DataChunk::builder().columns(concated_columns);
-        let data_chunk = if let Some(vis) = vis {
-            builder.visibility(vis).build()
-        } else {
-            builder.build()
-        };
+        let data_chunk = DataChunk::new(concated_columns, vis);
         Ok(data_chunk)
     }
 }
@@ -610,10 +605,10 @@ mod tests {
         }
         let chunk1: DataChunk = DataChunk::builder().columns(columns.clone()).build();
         let bool_vec = vec![true, false, true, false, false];
-        let chunk2: DataChunk = DataChunk::builder()
-            .columns(columns.clone())
-            .visibility((bool_vec.clone()).try_into().unwrap())
-            .build();
+        let chunk2 = DataChunk::new(
+            columns.clone(),
+            Some((bool_vec.clone()).try_into().unwrap()),
+        );
         let chunk = NestedLoopJoinExecutor::concatenate(&chunk1, &chunk2).unwrap();
         assert_eq!(chunk.capacity(), chunk1.capacity());
         assert_eq!(chunk.capacity(), chunk2.capacity());

--- a/src/batch/src/executor/join/nested_loop_join.rs
+++ b/src/batch/src/executor/join/nested_loop_join.rs
@@ -603,7 +603,7 @@ mod tests {
             let arr = builder.finish().unwrap();
             columns.push(Column::new(Arc::new(arr.into())))
         }
-        let chunk1: DataChunk = DataChunk::builder().columns(columns.clone()).build();
+        let chunk1: DataChunk = DataChunk::zooja(columns.clone());
         let bool_vec = vec![true, false, true, false, false];
         let chunk2 = DataChunk::new(
             columns.clone(),

--- a/src/batch/src/executor/join/nested_loop_join.rs
+++ b/src/batch/src/executor/join/nested_loop_join.rs
@@ -604,7 +604,7 @@ mod tests {
             let arr = builder.finish().unwrap();
             columns.push(Column::new(Arc::new(arr.into())))
         }
-        let chunk1: DataChunk = DataChunk::zooja(columns.clone());
+        let chunk1: DataChunk = DataChunk::cols(columns.clone());
         let bool_vec = vec![true, false, true, false, false];
         let chunk2 = DataChunk::new(
             columns.clone(),

--- a/src/batch/src/executor/join/nested_loop_join.rs
+++ b/src/batch/src/executor/join/nested_loop_join.rs
@@ -173,7 +173,7 @@ impl NestedLoopJoinExecutor {
             .map(|builder| builder.finish().map(|arr| Column::new(Arc::new(arr))))
             .collect::<Result<Vec<Column>>>()?;
 
-        Ok(DataChunk::builder().columns(result_columns).build())
+        Ok(DataChunk::new(result_columns, None))
     }
 
     /// Create constant data chunk (one tuple repeat `num_tuples` times).

--- a/src/batch/src/executor/join/nested_loop_join.rs
+++ b/src/batch/src/executor/join/nested_loop_join.rs
@@ -173,7 +173,7 @@ impl NestedLoopJoinExecutor {
             .map(|builder| builder.finish().map(|arr| Column::new(Arc::new(arr))))
             .collect::<Result<Vec<Column>>>()?;
 
-        Ok(DataChunk::tai(result_columns, num_tuples, None))
+        Ok(DataChunk::new(result_columns, num_tuples, None))
     }
 
     /// Create constant data chunk (one tuple repeat `num_tuples` times).
@@ -568,7 +568,7 @@ impl NestedLoopJoinExecutor {
                 .into())
             }
         };
-        let data_chunk = DataChunk::tai(concated_columns, xxlen, vis);
+        let data_chunk = DataChunk::new(concated_columns, xxlen, vis);
         Ok(data_chunk)
     }
 }
@@ -606,7 +606,7 @@ mod tests {
         }
         let chunk1: DataChunk = DataChunk::zooja(columns.clone());
         let bool_vec = vec![true, false, true, false, false];
-        let chunk2 = DataChunk::tai(
+        let chunk2 = DataChunk::new(
             columns.clone(),
             length,
             Some((bool_vec.clone()).try_into().unwrap()),

--- a/src/batch/src/executor/limit.rs
+++ b/src/batch/src/executor/limit.rs
@@ -169,7 +169,7 @@ mod tests {
         };
         let mut mock_executor = MockExecutor::new(schema);
 
-        let data_chunk = DataChunk::builder().columns([col].to_vec()).build();
+        let data_chunk = DataChunk::zooja([col].to_vec());
 
         DataChunk::rechunk(&[data_chunk], chunk_size)
             .unwrap()
@@ -300,7 +300,7 @@ mod tests {
         };
         let mut mock_executor = MockExecutor::new(schema);
 
-        let data_chunk = DataChunk::builder().columns([col0, col1].to_vec()).build();
+        let data_chunk = DataChunk::zooja([col0, col1].to_vec());
 
         DataChunk::rechunk(&[data_chunk], chunk_size)
             .unwrap()

--- a/src/batch/src/executor/limit.rs
+++ b/src/batch/src/executor/limit.rs
@@ -169,7 +169,7 @@ mod tests {
         };
         let mut mock_executor = MockExecutor::new(schema);
 
-        let data_chunk = DataChunk::zooja([col].to_vec());
+        let data_chunk = DataChunk::cols([col].to_vec());
 
         DataChunk::rechunk(&[data_chunk], chunk_size)
             .unwrap()
@@ -300,7 +300,7 @@ mod tests {
         };
         let mut mock_executor = MockExecutor::new(schema);
 
-        let data_chunk = DataChunk::zooja([col0, col1].to_vec());
+        let data_chunk = DataChunk::cols([col0, col1].to_vec());
 
         DataChunk::rechunk(&[data_chunk], chunk_size)
             .unwrap()

--- a/src/batch/src/executor/merge_sort_exchange.rs
+++ b/src/batch/src/executor/merge_sort_exchange.rs
@@ -149,7 +149,9 @@ impl<CS: 'static + CreateSource, C: BatchTaskContext> MergeSortExchangeExecutorI
                         .create_array_builder(K_PROCESSING_WINDOW_SIZE)
                 })
                 .collect::<Result<Vec<ArrayBuilderImpl>>>()?;
+            let mut xxlen = 0;
             while want_to_produce > 0 && !self.min_heap.is_empty() {
+                xxlen += 1;
                 let top_elem = self.min_heap.pop().unwrap();
                 let child_idx = top_elem.chunk_idx;
                 let cur_chunk = top_elem.chunk;
@@ -181,7 +183,7 @@ impl<CS: 'static + CreateSource, C: BatchTaskContext> MergeSortExchangeExecutorI
                 .into_iter()
                 .map(|builder| Ok(Column::new(Arc::new(builder.finish()?))))
                 .collect::<Result<Vec<_>>>()?;
-            let chunk = DataChunk::new(columns, None);
+            let chunk = DataChunk::tai(columns, xxlen, None);
             yield chunk
         }
     }

--- a/src/batch/src/executor/merge_sort_exchange.rs
+++ b/src/batch/src/executor/merge_sort_exchange.rs
@@ -181,7 +181,7 @@ impl<CS: 'static + CreateSource, C: BatchTaskContext> MergeSortExchangeExecutorI
                 .into_iter()
                 .map(|builder| Ok(Column::new(Arc::new(builder.finish()?))))
                 .collect::<Result<Vec<_>>>()?;
-            let chunk = DataChunk::builder().columns(columns).build();
+            let chunk = DataChunk::new(columns, None);
             yield chunk
         }
     }

--- a/src/batch/src/executor/merge_sort_exchange.rs
+++ b/src/batch/src/executor/merge_sort_exchange.rs
@@ -183,7 +183,7 @@ impl<CS: 'static + CreateSource, C: BatchTaskContext> MergeSortExchangeExecutorI
                 .into_iter()
                 .map(|builder| Ok(Column::new(Arc::new(builder.finish()?))))
                 .collect::<Result<Vec<_>>>()?;
-            let chunk = DataChunk::tai(columns, xxlen, None);
+            let chunk = DataChunk::new(columns, xxlen, None);
             yield chunk
         }
     }

--- a/src/batch/src/executor/order_by.rs
+++ b/src/batch/src/executor/order_by.rs
@@ -266,7 +266,7 @@ impl OrderByExecutor {
                 .into_iter()
                 .map(|b| Ok(Column::new(Arc::new(b.finish()?))))
                 .collect::<Result<Vec<_>>>()?;
-            let chunk = DataChunk::builder().columns(columns).build();
+            let chunk = DataChunk::new(columns, None);
             yield chunk
         }
     }

--- a/src/batch/src/executor/order_by.rs
+++ b/src/batch/src/executor/order_by.rs
@@ -266,7 +266,7 @@ impl OrderByExecutor {
                 .into_iter()
                 .map(|b| Ok(Column::new(Arc::new(b.finish()?))))
                 .collect::<Result<Vec<_>>>()?;
-            let chunk = DataChunk::tai(columns, chunk_size, None);
+            let chunk = DataChunk::new(columns, chunk_size, None);
             yield chunk
         }
     }

--- a/src/batch/src/executor/order_by.rs
+++ b/src/batch/src/executor/order_by.rs
@@ -266,7 +266,7 @@ impl OrderByExecutor {
                 .into_iter()
                 .map(|b| Ok(Column::new(Arc::new(b.finish()?))))
                 .collect::<Result<Vec<_>>>()?;
-            let chunk = DataChunk::new(columns, None);
+            let chunk = DataChunk::tai(columns, chunk_size, None);
             yield chunk
         }
     }

--- a/src/batch/src/executor/project.rs
+++ b/src/batch/src/executor/project.rs
@@ -61,7 +61,7 @@ impl ProjectExecutor {
             let ret = if arrays.is_empty() {
                 DataChunk::new_dummy(data_chunk.cardinality())
             } else {
-                DataChunk::builder().columns(arrays).build()
+                DataChunk::new(arrays, None)
             };
             yield ret
         }

--- a/src/batch/src/executor/project.rs
+++ b/src/batch/src/executor/project.rs
@@ -61,7 +61,7 @@ impl ProjectExecutor {
             let ret = if arrays.is_empty() {
                 DataChunk::new_dummy(data_chunk.cardinality())
             } else {
-                DataChunk::tai(arrays, data_chunk.cardinality(), None)
+                DataChunk::new(arrays, data_chunk.cardinality(), None)
             };
             yield ret
         }

--- a/src/batch/src/executor/project.rs
+++ b/src/batch/src/executor/project.rs
@@ -61,7 +61,7 @@ impl ProjectExecutor {
             let ret = if arrays.is_empty() {
                 DataChunk::new_dummy(data_chunk.cardinality())
             } else {
-                DataChunk::new(arrays, None)
+                DataChunk::tai(arrays, data_chunk.cardinality(), None)
             };
             yield ret
         }

--- a/src/batch/src/executor/sort_agg.rs
+++ b/src/batch/src/executor/sort_agg.rs
@@ -176,7 +176,7 @@ impl SortAggExecutor {
                         .collect::<Result<Vec<_>>>()?;
 
                     assert_eq!(columns[0].array().len(), self.output_size_limit);
-                    let output = DataChunk::tai(columns, self.output_size_limit, None);
+                    let output = DataChunk::new(columns, self.output_size_limit, None);
                     yield output;
 
                     // reset builders and capactiy to build next output chunk
@@ -216,7 +216,7 @@ impl SortAggExecutor {
             false => {
                 let xxlen = columns[0].array().len();
                 assert_eq!(xxlen, self.output_size_limit - left_capacity + 1);
-                DataChunk::tai(columns, xxlen, None)
+                DataChunk::new(columns, xxlen, None)
             }
         };
 

--- a/src/batch/src/executor/sort_agg.rs
+++ b/src/batch/src/executor/sort_agg.rs
@@ -175,7 +175,7 @@ impl SortAggExecutor {
                         .map(|b| Ok(Column::new(Arc::new(b.finish()?))))
                         .collect::<Result<Vec<_>>>()?;
 
-                    let output = DataChunk::builder().columns(columns).build();
+                    let output = DataChunk::new(columns, None);
                     yield output;
 
                     // reset builders and capactiy to build next output chunk
@@ -212,7 +212,7 @@ impl SortAggExecutor {
         let output = match columns.is_empty() {
             // Zero group column means SimpleAgg, which always returns 1 row.
             true => DataChunk::new_dummy(1),
-            false => DataChunk::builder().columns(columns).build(),
+            false => DataChunk::new(columns, None),
         };
 
         yield output;

--- a/src/batch/src/executor/update.rs
+++ b/src/batch/src/executor/update.rs
@@ -105,7 +105,7 @@ impl UpdateExecutor {
                     .map(|expr| expr.eval(&data_chunk).map(Column::new))
                     .collect::<Result<Vec<_>>>()?;
 
-                DataChunk::new(columns, None)
+                DataChunk::tai(columns, len, None)
             };
 
             // Merge two data chunks into (U-, U+) pairs.
@@ -155,7 +155,7 @@ impl UpdateExecutor {
             array_builder.append(Some(rows_updated as i64))?;
 
             let array = array_builder.finish()?;
-            let ret_chunk = DataChunk::new(vec![array.into()], None);
+            let ret_chunk = DataChunk::tai(vec![array.into()], 1, None);
 
             yield ret_chunk
         }

--- a/src/batch/src/executor/update.rs
+++ b/src/batch/src/executor/update.rs
@@ -105,7 +105,7 @@ impl UpdateExecutor {
                     .map(|expr| expr.eval(&data_chunk).map(Column::new))
                     .collect::<Result<Vec<_>>>()?;
 
-                DataChunk::tai(columns, len, None)
+                DataChunk::new(columns, len, None)
             };
 
             // Merge two data chunks into (U-, U+) pairs.
@@ -155,7 +155,7 @@ impl UpdateExecutor {
             array_builder.append(Some(rows_updated as i64))?;
 
             let array = array_builder.finish()?;
-            let ret_chunk = DataChunk::tai(vec![array.into()], 1, None);
+            let ret_chunk = DataChunk::new(vec![array.into()], 1, None);
 
             yield ret_chunk
         }

--- a/src/batch/src/executor/update.rs
+++ b/src/batch/src/executor/update.rs
@@ -105,7 +105,7 @@ impl UpdateExecutor {
                     .map(|expr| expr.eval(&data_chunk).map(Column::new))
                     .collect::<Result<Vec<_>>>()?;
 
-                DataChunk::builder().columns(columns).build()
+                DataChunk::new(columns, None)
             };
 
             // Merge two data chunks into (U-, U+) pairs.
@@ -155,7 +155,7 @@ impl UpdateExecutor {
             array_builder.append(Some(rows_updated as i64))?;
 
             let array = array_builder.finish()?;
-            let ret_chunk = DataChunk::builder().columns(vec![array.into()]).build();
+            let ret_chunk = DataChunk::new(vec![array.into()], None);
 
             yield ret_chunk
         }

--- a/src/batch/src/executor/values.rs
+++ b/src/batch/src/executor/values.rs
@@ -85,9 +85,8 @@ impl ValuesExecutor {
                     // We need a one row chunk rather than an empty chunk because constant
                     // expression's eval result is same size as input chunk
                     // cardinality.
-                    let one_row_chunk = DataChunk::builder()
-                        .columns(vec![Column::new(Arc::new(one_row_array.into()))])
-                        .build();
+                    let one_row_chunk =
+                        DataChunk::new(vec![Column::new(Arc::new(one_row_array.into()))], None);
 
                     let chunk_size = self.chunk_size.min(self.rows.len());
                     let mut array_builders = self.schema.create_array_builders(chunk_size)?;
@@ -103,7 +102,7 @@ impl ValuesExecutor {
                         .map(|builder| builder.finish().map(|arr| Column::new(Arc::new(arr))))
                         .collect::<Result<Vec<Column>>>()?;
 
-                    let chunk = DataChunk::builder().columns(columns).build();
+                    let chunk = DataChunk::new(columns, None);
 
                     yield chunk
                 }

--- a/src/batch/src/executor/values.rs
+++ b/src/batch/src/executor/values.rs
@@ -101,7 +101,7 @@ impl ValuesExecutor {
                         .collect::<Result<Vec<Column>>>()?;
 
                     let xxlen = columns[0].array().len(); // no-column handled above
-                    let chunk = DataChunk::tai(columns, xxlen, None);
+                    let chunk = DataChunk::new(columns, xxlen, None);
 
                     yield chunk
                 }

--- a/src/common/src/array/data_chunk.rs
+++ b/src/common/src/array/data_chunk.rs
@@ -47,10 +47,10 @@ impl DataChunk {
     pub fn zooja(columns: Vec<Column>) -> Self {
         assert!(!columns.is_empty());
         let xxlen = columns[0].array().len();
-        Self::tai(columns, xxlen, None)
+        Self::new(columns, xxlen, None)
     }
 
-    pub fn tai(columns: Vec<Column>, cardinality: usize, visibility: Option<Bitmap>) -> Self {
+    pub fn new(columns: Vec<Column>, cardinality: usize, visibility: Option<Bitmap>) -> Self {
         DataChunk {
             columns,
             visibility,
@@ -89,7 +89,7 @@ impl DataChunk {
             .into_iter()
             .map(|array_impl| Column::new(Arc::new(array_impl)))
             .collect::<Vec<_>>();
-        Ok(DataChunk::tai(new_columns, rows.len(), None))
+        Ok(DataChunk::new(new_columns, rows.len(), None))
     }
 
     /// Return the next visible row index on or after `row_idx`.
@@ -138,7 +138,7 @@ impl DataChunk {
 
     #[must_use]
     pub fn with_visibility(&self, visibility: Bitmap) -> Self {
-        DataChunk::tai(
+        DataChunk::new(
             self.columns.clone(),
             visibility.num_high_bits(),
             Some(visibility),
@@ -202,7 +202,7 @@ impl DataChunk {
                             .map(|array| Column::new(Arc::new(array)))
                     })
                     .collect::<Result<Vec<_>>>()?;
-                Ok(Self::tai(columns, cardinality, None))
+                Ok(Self::new(columns, cardinality, None))
             }
         }
     }
@@ -218,7 +218,7 @@ impl DataChunk {
                 columns.push(Column::from_protobuf(any_col, cardinality)?);
             }
 
-            let chunk = DataChunk::tai(columns, proto.cardinality as usize, None);
+            let chunk = DataChunk::new(columns, proto.cardinality as usize, None);
             Ok(chunk)
         }
     }
@@ -305,7 +305,7 @@ impl DataChunk {
                     .map(|col_type| col_type.array_ref().create_builder(new_chunk_require))
                     .try_collect()?;
 
-                let data_chunk = DataChunk::tai(new_columns, xxlen, None);
+                let data_chunk = DataChunk::new(new_columns, xxlen, None);
                 new_chunks.push(data_chunk);
 
                 new_chunk_require = std::cmp::min(total_capacity, each_size_limit);
@@ -524,7 +524,7 @@ impl DataChunkTestExt for DataChunk {
         } else {
             Some(Bitmap::try_from(visibility).unwrap())
         };
-        DataChunk::tai(columns, xxlen, visibility)
+        DataChunk::new(columns, xxlen, visibility)
     }
 }
 
@@ -618,7 +618,7 @@ mod tests {
 
     #[test]
     fn test_to_pretty_string() {
-        let chunk = DataChunk::tai(
+        let chunk = DataChunk::new(
             vec![
                 column_nonnull!(I64Array, [1, 2, 3, 4]),
                 column!(I64Array, [Some(6), None, Some(7), None]),

--- a/src/common/src/array/data_chunk.rs
+++ b/src/common/src/array/data_chunk.rs
@@ -49,13 +49,6 @@ impl DataChunkBuilder {
         }
     }
 
-    pub fn visibility(self, visibility: Bitmap) -> DataChunkBuilder {
-        DataChunkBuilder {
-            columns: self.columns,
-            visibility: Some(visibility),
-        }
-    }
-
     pub fn build(self) -> DataChunk {
         DataChunk::new(self.columns, self.visibility)
     }

--- a/src/common/src/array/data_chunk.rs
+++ b/src/common/src/array/data_chunk.rs
@@ -34,26 +34,6 @@ pub struct DataChunkBuilder {
     visibility: Option<Bitmap>,
 }
 
-impl DataChunkBuilder {
-    fn new() -> Self {
-        DataChunkBuilder {
-            columns: vec![],
-            visibility: None,
-        }
-    }
-
-    pub fn columns(self, columns: Vec<Column>) -> DataChunkBuilder {
-        DataChunkBuilder {
-            columns,
-            visibility: self.visibility,
-        }
-    }
-
-    pub fn build(self) -> DataChunk {
-        DataChunk::new(self.columns, self.visibility)
-    }
-}
-
 /// `DataChunk` is a collection of arrays with visibility mask.
 #[derive(Clone, Default, PartialEq)]
 pub struct DataChunk {
@@ -144,10 +124,6 @@ impl DataChunk {
         }
     }
 
-    pub fn builder() -> DataChunkBuilder {
-        DataChunkBuilder::new()
-    }
-
     pub fn into_parts(self) -> (Vec<Column>, Option<Bitmap>) {
         (self.columns, self.visibility)
     }
@@ -236,7 +212,7 @@ impl DataChunk {
                             .map(|array| Column::new(Arc::new(array)))
                     })
                     .collect::<Result<Vec<_>>>()?;
-                Ok(Self::builder().columns(columns).build())
+                Ok(Self::new(columns, None))
             }
         }
     }
@@ -337,7 +313,7 @@ impl DataChunk {
                     .map(|col_type| col_type.array_ref().create_builder(new_chunk_require))
                     .try_collect()?;
 
-                let data_chunk = DataChunk::builder().columns(new_columns).build();
+                let data_chunk = DataChunk::new(new_columns, None);
                 new_chunks.push(data_chunk);
 
                 new_chunk_require = std::cmp::min(total_capacity, each_size_limit);

--- a/src/common/src/array/data_chunk.rs
+++ b/src/common/src/array/data_chunk.rs
@@ -63,6 +63,12 @@ pub struct DataChunk {
 }
 
 impl DataChunk {
+    // #[cfg(test)]
+    pub fn zooja(columns: Vec<Column>) -> Self {
+        assert!(!columns.is_empty());
+        Self::new(columns, None)
+    }
+
     pub fn new(columns: Vec<Column>, visibility: Option<Bitmap>) -> Self {
         let cardinality = if let Some(bitmap) = &visibility {
             // with visibility bitmap
@@ -566,11 +572,9 @@ mod tests {
                 for i in chunk_size * chunk_idx..chunk_size * (chunk_idx + 1) {
                     builder.append(Some(i as i32)).unwrap();
                 }
-                let chunk = DataChunk::builder()
-                    .columns(vec![Column::new(Arc::new(
-                        builder.finish().unwrap().into(),
-                    ))])
-                    .build();
+                let chunk = DataChunk::zooja(vec![Column::new(Arc::new(
+                    builder.finish().unwrap().into(),
+                ))]);
                 chunks.push(chunk);
             }
 
@@ -632,7 +636,7 @@ mod tests {
             let arr = builder.finish().unwrap();
             columns.push(Column::new(Arc::new(arr.into())))
         }
-        let chunk: DataChunk = DataChunk::builder().columns(columns).build();
+        let chunk: DataChunk = DataChunk::zooja(columns);
         for row in chunk.rows() {
             for i in 0..num_of_columns {
                 let val = row.value_at(i).unwrap();

--- a/src/common/src/array/data_chunk.rs
+++ b/src/common/src/array/data_chunk.rs
@@ -44,7 +44,7 @@ pub struct DataChunk {
 
 impl DataChunk {
     // #[cfg(test)]
-    pub fn zooja(columns: Vec<Column>) -> Self {
+    pub fn cols(columns: Vec<Column>) -> Self {
         assert!(!columns.is_empty());
         let xxlen = columns[0].array().len();
         Self::new(columns, xxlen, None)
@@ -543,7 +543,7 @@ mod tests {
                 for i in chunk_size * chunk_idx..chunk_size * (chunk_idx + 1) {
                     builder.append(Some(i as i32)).unwrap();
                 }
-                let chunk = DataChunk::zooja(vec![Column::new(Arc::new(
+                let chunk = DataChunk::cols(vec![Column::new(Arc::new(
                     builder.finish().unwrap().into(),
                 ))]);
                 chunks.push(chunk);
@@ -607,7 +607,7 @@ mod tests {
             let arr = builder.finish().unwrap();
             columns.push(Column::new(Arc::new(arr.into())))
         }
-        let chunk: DataChunk = DataChunk::zooja(columns);
+        let chunk: DataChunk = DataChunk::cols(columns);
         for row in chunk.rows() {
             for i in 0..num_of_columns {
                 let val = row.value_at(i).unwrap();

--- a/src/common/src/array/data_chunk.rs
+++ b/src/common/src/array/data_chunk.rs
@@ -22,7 +22,7 @@ use risingwave_pb::data::DataChunk as ProstDataChunk;
 
 use crate::array::column::Column;
 use crate::array::data_chunk_iter::{Row, RowRef};
-use crate::array::{ArrayBuilderImpl, ArrayImpl};
+use crate::array::ArrayBuilderImpl;
 use crate::buffer::Bitmap;
 use crate::error::{Result, RwError};
 use crate::hash::HashCode;
@@ -431,24 +431,6 @@ impl fmt::Debug for DataChunk {
             self.capacity(),
             self.to_pretty_string()
         )
-    }
-}
-
-impl TryFrom<Vec<Column>> for DataChunk {
-    type Error = RwError;
-
-    fn try_from(columns: Vec<Column>) -> Result<Self> {
-        ensure!(!columns.is_empty(), "Columns can't be empty!");
-        ensure!(
-            columns
-                .iter()
-                .map(Column::array_ref)
-                .map(ArrayImpl::len)
-                .all_equal(),
-            "Not all columns length same!"
-        );
-
-        Ok(DataChunk::new(columns, None))
     }
 }
 

--- a/src/common/src/array/stream_chunk.rs
+++ b/src/common/src/array/stream_chunk.rs
@@ -84,7 +84,7 @@ impl StreamChunk {
             assert_eq!(col.array_ref().len(), ops.len());
         }
 
-        let data = DataChunk::tai(columns, ops.len(), visibility);
+        let data = DataChunk::new(columns, ops.len(), visibility);
         StreamChunk { ops, data }
     }
 

--- a/src/common/src/array/stream_chunk.rs
+++ b/src/common/src/array/stream_chunk.rs
@@ -84,7 +84,7 @@ impl StreamChunk {
             assert_eq!(col.array_ref().len(), ops.len());
         }
 
-        let data = DataChunk::new(columns, visibility);
+        let data = DataChunk::tai(columns, ops.len(), visibility);
         StreamChunk { ops, data }
     }
 

--- a/src/common/src/hash/key.rs
+++ b/src/common/src/hash/key.rs
@@ -698,7 +698,7 @@ mod tests {
             )),
         ];
 
-        DataChunk::new(columns, None)
+        DataChunk::zooja(columns)
     }
 
     fn do_test_serialize<K: HashKey, F>(column_indexes: Vec<usize>, data_gen: F)
@@ -846,7 +846,7 @@ mod tests {
             .into(),
         ) as ArrayRef)];
 
-        DataChunk::new(columns, None)
+        DataChunk::zooja(columns)
     }
 
     #[test]

--- a/src/common/src/hash/key.rs
+++ b/src/common/src/hash/key.rs
@@ -698,7 +698,7 @@ mod tests {
             )),
         ];
 
-        DataChunk::zooja(columns)
+        DataChunk::cols(columns)
     }
 
     fn do_test_serialize<K: HashKey, F>(column_indexes: Vec<usize>, data_gen: F)
@@ -846,7 +846,7 @@ mod tests {
             .into(),
         ) as ArrayRef)];
 
-        DataChunk::zooja(columns)
+        DataChunk::cols(columns)
     }
 
     #[test]

--- a/src/common/src/hash/key.rs
+++ b/src/common/src/hash/key.rs
@@ -658,7 +658,6 @@ impl HashKey for SerializedKey {
 #[cfg(test)]
 mod tests {
     use std::collections::HashMap;
-    use std::convert::TryFrom;
     use std::str::FromStr;
     use std::sync::Arc;
 
@@ -699,7 +698,7 @@ mod tests {
             )),
         ];
 
-        DataChunk::try_from(columns).expect("Failed to create data chunk")
+        DataChunk::new(columns, None)
     }
 
     fn do_test_serialize<K: HashKey, F>(column_indexes: Vec<usize>, data_gen: F)
@@ -847,7 +846,7 @@ mod tests {
             .into(),
         ) as ArrayRef)];
 
-        DataChunk::try_from(columns).expect("Failed to create data chunk")
+        DataChunk::new(columns, None)
     }
 
     #[test]

--- a/src/common/src/util/chunk_coalesce.rs
+++ b/src/common/src/util/chunk_coalesce.rs
@@ -230,7 +230,10 @@ impl DataChunkBuilder {
         )?;
         match columns.is_empty() {
             true => Ok(DataChunk::new_dummy(cardinality)),
-            false => Ok(DataChunk::new(columns, None)),
+            false => {
+                let xxlen = columns[0].array().len();
+                Ok(DataChunk::tai(columns, xxlen, None))
+            }
         }
     }
 

--- a/src/common/src/util/chunk_coalesce.rs
+++ b/src/common/src/util/chunk_coalesce.rs
@@ -232,7 +232,7 @@ impl DataChunkBuilder {
             true => Ok(DataChunk::new_dummy(cardinality)),
             false => {
                 let xxlen = columns[0].array().len();
-                Ok(DataChunk::tai(columns, xxlen, None))
+                Ok(DataChunk::new(columns, xxlen, None))
             }
         }
     }

--- a/src/common/src/util/chunk_coalesce.rs
+++ b/src/common/src/util/chunk_coalesce.rs
@@ -230,7 +230,7 @@ impl DataChunkBuilder {
         )?;
         match columns.is_empty() {
             true => Ok(DataChunk::new_dummy(cardinality)),
-            false => DataChunk::try_from(columns),
+            false => Ok(DataChunk::new(columns, None)),
         }
     }
 

--- a/src/compute/tests/table_v2_materialize.rs
+++ b/src/compute/tests/table_v2_materialize.rs
@@ -290,7 +290,7 @@ async fn test_table_v2_materialize() -> Result<()> {
         column_nonnull! { I64Array, [ col_row_ids[0]] }, // row id column
         column_nonnull! { F64Array, [1.14] },
     ];
-    let chunk = DataChunk::builder().columns(columns.clone()).build();
+    let chunk = DataChunk::zooja(columns.clone());
     let delete_inner: BoxedExecutor = Box::new(SingleChunkExecutor::new(chunk, all_schema.clone()));
     let delete = Box::new(DeleteExecutor::new(
         source_table_id,

--- a/src/compute/tests/table_v2_materialize.rs
+++ b/src/compute/tests/table_v2_materialize.rs
@@ -290,7 +290,7 @@ async fn test_table_v2_materialize() -> Result<()> {
         column_nonnull! { I64Array, [ col_row_ids[0]] }, // row id column
         column_nonnull! { F64Array, [1.14] },
     ];
-    let chunk = DataChunk::zooja(columns.clone());
+    let chunk = DataChunk::cols(columns.clone());
     let delete_inner: BoxedExecutor = Box::new(SingleChunkExecutor::new(chunk, all_schema.clone()));
     let delete = Box::new(DeleteExecutor::new(
         source_table_id,

--- a/src/expr/src/expr/expr_array.rs
+++ b/src/expr/src/expr/expr_array.rs
@@ -49,7 +49,7 @@ impl Expression for ArrayExpression {
                 Ok(Column::new(array))
             })
             .collect::<Result<Vec<Column>>>()?;
-        let chunk = DataChunk::new(columns, input.visibility().clone());
+        let chunk = DataChunk::tai(columns, input.cardinality(), input.visibility().clone());
 
         let mut builder = ListArrayBuilder::with_meta(
             input.capacity(),

--- a/src/expr/src/expr/expr_array.rs
+++ b/src/expr/src/expr/expr_array.rs
@@ -49,7 +49,7 @@ impl Expression for ArrayExpression {
                 Ok(Column::new(array))
             })
             .collect::<Result<Vec<Column>>>()?;
-        let chunk = DataChunk::tai(columns, input.cardinality(), input.visibility().clone());
+        let chunk = DataChunk::new(columns, input.cardinality(), input.visibility().clone());
 
         let mut builder = ListArrayBuilder::with_meta(
             input.capacity(),

--- a/src/expr/src/expr/expr_binary_nonnull.rs
+++ b/src/expr/src/expr/expr_binary_nonnull.rs
@@ -473,7 +473,7 @@ mod tests {
                 .map(|x| Arc::new(x.into()))
                 .unwrap(),
         );
-        let data_chunk = DataChunk::builder().columns(vec![col1, col2]).build();
+        let data_chunk = DataChunk::zooja(vec![col1, col2]);
         let expr = make_expression(kind, &[TypeName::Int32, TypeName::Int32], &[0, 1]);
         let vec_executor = build_from_prost(&expr).unwrap();
         let res = vec_executor.eval(&data_chunk).unwrap();
@@ -531,7 +531,7 @@ mod tests {
                 .map(|x| Arc::new(x.into()))
                 .unwrap(),
         );
-        let data_chunk = DataChunk::builder().columns(vec![col1, col2]).build();
+        let data_chunk = DataChunk::zooja(vec![col1, col2]);
         let expr = make_expression(kind, &[TypeName::Date, TypeName::Interval], &[0, 1]);
         let vec_executor = build_from_prost(&expr).unwrap();
         let res = vec_executor.eval(&data_chunk).unwrap();
@@ -592,7 +592,7 @@ mod tests {
                 .map(|x| Arc::new(x.into()))
                 .unwrap(),
         );
-        let data_chunk = DataChunk::builder().columns(vec![col1, col2]).build();
+        let data_chunk = DataChunk::zooja(vec![col1, col2]);
         let expr = make_expression(kind, &[TypeName::Decimal, TypeName::Decimal], &[0, 1]);
         let vec_executor = build_from_prost(&expr).unwrap();
         let res = vec_executor.eval(&data_chunk).unwrap();

--- a/src/expr/src/expr/expr_binary_nonnull.rs
+++ b/src/expr/src/expr/expr_binary_nonnull.rs
@@ -473,7 +473,7 @@ mod tests {
                 .map(|x| Arc::new(x.into()))
                 .unwrap(),
         );
-        let data_chunk = DataChunk::zooja(vec![col1, col2]);
+        let data_chunk = DataChunk::cols(vec![col1, col2]);
         let expr = make_expression(kind, &[TypeName::Int32, TypeName::Int32], &[0, 1]);
         let vec_executor = build_from_prost(&expr).unwrap();
         let res = vec_executor.eval(&data_chunk).unwrap();
@@ -531,7 +531,7 @@ mod tests {
                 .map(|x| Arc::new(x.into()))
                 .unwrap(),
         );
-        let data_chunk = DataChunk::zooja(vec![col1, col2]);
+        let data_chunk = DataChunk::cols(vec![col1, col2]);
         let expr = make_expression(kind, &[TypeName::Date, TypeName::Interval], &[0, 1]);
         let vec_executor = build_from_prost(&expr).unwrap();
         let res = vec_executor.eval(&data_chunk).unwrap();
@@ -592,7 +592,7 @@ mod tests {
                 .map(|x| Arc::new(x.into()))
                 .unwrap(),
         );
-        let data_chunk = DataChunk::zooja(vec![col1, col2]);
+        let data_chunk = DataChunk::cols(vec![col1, col2]);
         let expr = make_expression(kind, &[TypeName::Decimal, TypeName::Decimal], &[0, 1]);
         let vec_executor = build_from_prost(&expr).unwrap();
         let res = vec_executor.eval(&data_chunk).unwrap();

--- a/src/expr/src/expr/expr_field.rs
+++ b/src/expr/src/expr/expr_field.rs
@@ -117,7 +117,7 @@ mod tests {
         .unwrap();
 
         let column = Column::new(array);
-        let data_chunk = DataChunk::zooja(vec![column]);
+        let data_chunk = DataChunk::cols(vec![column]);
         let res = field_expr.eval(&data_chunk).unwrap();
         assert_eq!(res.datum_at(0), Some(ScalarImpl::Int32(1)));
         assert_eq!(res.datum_at(1), Some(ScalarImpl::Int32(2)));
@@ -159,7 +159,7 @@ mod tests {
         .unwrap();
 
         let column = Column::new(array);
-        let data_chunk = DataChunk::zooja(vec![column]);
+        let data_chunk = DataChunk::cols(vec![column]);
         let res = field_expr.eval(&data_chunk).unwrap();
         assert_eq!(res.datum_at(0), Some(ScalarImpl::Float32(1.0.into())));
         assert_eq!(res.datum_at(1), Some(ScalarImpl::Float32(2.0.into())));

--- a/src/expr/src/expr/expr_field.rs
+++ b/src/expr/src/expr/expr_field.rs
@@ -117,7 +117,7 @@ mod tests {
         .unwrap();
 
         let column = Column::new(array);
-        let data_chunk = DataChunk::builder().columns(vec![column]).build();
+        let data_chunk = DataChunk::zooja(vec![column]);
         let res = field_expr.eval(&data_chunk).unwrap();
         assert_eq!(res.datum_at(0), Some(ScalarImpl::Int32(1)));
         assert_eq!(res.datum_at(1), Some(ScalarImpl::Int32(2)));
@@ -159,7 +159,7 @@ mod tests {
         .unwrap();
 
         let column = Column::new(array);
-        let data_chunk = DataChunk::builder().columns(vec![column]).build();
+        let data_chunk = DataChunk::zooja(vec![column]);
         let res = field_expr.eval(&data_chunk).unwrap();
         assert_eq!(res.datum_at(0), Some(ScalarImpl::Float32(1.0.into())));
         assert_eq!(res.datum_at(1), Some(ScalarImpl::Float32(2.0.into())));

--- a/src/expr/src/expr/expr_is_null.rs
+++ b/src/expr/src/expr/expr_is_null.rs
@@ -125,7 +125,7 @@ mod tests {
         };
 
         let input_chunk =
-            DataChunk::zooja(vec![Column::new(Arc::new(ArrayImpl::Decimal(input_array)))]);
+            DataChunk::cols(vec![Column::new(Arc::new(ArrayImpl::Decimal(input_array)))]);
         let result_array = expr.eval(&input_chunk).unwrap();
         assert_eq!(3, result_array.len());
         for (i, v) in expected_eval_result.iter().enumerate() {

--- a/src/expr/src/expr/expr_is_null.rs
+++ b/src/expr/src/expr/expr_is_null.rs
@@ -124,9 +124,8 @@ mod tests {
             builder.finish()?
         };
 
-        let input_chunk = DataChunk::builder()
-            .columns(vec![Column::new(Arc::new(ArrayImpl::Decimal(input_array)))])
-            .build();
+        let input_chunk =
+            DataChunk::zooja(vec![Column::new(Arc::new(ArrayImpl::Decimal(input_array)))]);
         let result_array = expr.eval(&input_chunk).unwrap();
         assert_eq!(3, result_array.len());
         for (i, v) in expected_eval_result.iter().enumerate() {

--- a/src/expr/src/expr/expr_unary.rs
+++ b/src/expr/src/expr/expr_unary.rs
@@ -394,7 +394,7 @@ mod tests {
                 .map(|x| Arc::new(x.into()))
                 .unwrap(),
         );
-        let data_chunk = DataChunk::zooja(vec![col1]);
+        let data_chunk = DataChunk::cols(vec![col1]);
         let return_type = DataType {
             type_name: TypeName::Int32 as i32,
             is_nullable: false,
@@ -441,7 +441,7 @@ mod tests {
                 .map(|x| Arc::new(x.into()))
                 .unwrap(),
         );
-        let data_chunk = DataChunk::zooja(vec![col1]);
+        let data_chunk = DataChunk::cols(vec![col1]);
         let return_type = DataType {
             type_name: TypeName::Int32 as i32,
             is_nullable: false,
@@ -494,7 +494,7 @@ mod tests {
                 .map(|x| Arc::new(x.into()))
                 .unwrap(),
         );
-        let data_chunk = DataChunk::zooja(vec![col1]);
+        let data_chunk = DataChunk::cols(vec![col1]);
         let return_type = DataType {
             type_name: TypeName::Int16 as i32,
             is_nullable: false,
@@ -553,7 +553,7 @@ mod tests {
                 .map(|x| Arc::new(x.into()))
                 .unwrap(),
         );
-        let data_chunk = DataChunk::zooja(vec![col1]);
+        let data_chunk = DataChunk::cols(vec![col1]);
         let expr = make_expression(kind, &[TypeName::Boolean], &[0]);
         let vec_executor = build_from_prost(&expr).unwrap();
         let res = vec_executor.eval(&data_chunk).unwrap();
@@ -596,7 +596,7 @@ mod tests {
                 .map(|x| Arc::new(x.into()))
                 .unwrap(),
         );
-        let data_chunk = DataChunk::zooja(vec![col1]);
+        let data_chunk = DataChunk::cols(vec![col1]);
         let expr = make_expression(kind, &[TypeName::Date], &[0]);
         let vec_executor = build_from_prost(&expr).unwrap();
         let res = vec_executor.eval(&data_chunk).unwrap();

--- a/src/expr/src/expr/expr_unary.rs
+++ b/src/expr/src/expr/expr_unary.rs
@@ -394,7 +394,7 @@ mod tests {
                 .map(|x| Arc::new(x.into()))
                 .unwrap(),
         );
-        let data_chunk = DataChunk::builder().columns(vec![col1]).build();
+        let data_chunk = DataChunk::zooja(vec![col1]);
         let return_type = DataType {
             type_name: TypeName::Int32 as i32,
             is_nullable: false,
@@ -441,7 +441,7 @@ mod tests {
                 .map(|x| Arc::new(x.into()))
                 .unwrap(),
         );
-        let data_chunk = DataChunk::builder().columns(vec![col1]).build();
+        let data_chunk = DataChunk::zooja(vec![col1]);
         let return_type = DataType {
             type_name: TypeName::Int32 as i32,
             is_nullable: false,
@@ -494,7 +494,7 @@ mod tests {
                 .map(|x| Arc::new(x.into()))
                 .unwrap(),
         );
-        let data_chunk = DataChunk::builder().columns(vec![col1]).build();
+        let data_chunk = DataChunk::zooja(vec![col1]);
         let return_type = DataType {
             type_name: TypeName::Int16 as i32,
             is_nullable: false,
@@ -553,7 +553,7 @@ mod tests {
                 .map(|x| Arc::new(x.into()))
                 .unwrap(),
         );
-        let data_chunk = DataChunk::builder().columns(vec![col1]).build();
+        let data_chunk = DataChunk::zooja(vec![col1]);
         let expr = make_expression(kind, &[TypeName::Boolean], &[0]);
         let vec_executor = build_from_prost(&expr).unwrap();
         let res = vec_executor.eval(&data_chunk).unwrap();
@@ -596,7 +596,7 @@ mod tests {
                 .map(|x| Arc::new(x.into()))
                 .unwrap(),
         );
-        let data_chunk = DataChunk::builder().columns(vec![col1]).build();
+        let data_chunk = DataChunk::zooja(vec![col1]);
         let expr = make_expression(kind, &[TypeName::Date], &[0]);
         let vec_executor = build_from_prost(&expr).unwrap();
         let res = vec_executor.eval(&data_chunk).unwrap();

--- a/src/expr/src/vector_op/agg/general_agg.rs
+++ b/src/expr/src/vector_op/agg/general_agg.rs
@@ -220,7 +220,7 @@ mod tests {
         return_type: DataType,
         mut builder: ArrayBuilderImpl,
     ) -> Result<ArrayImpl> {
-        let input_chunk = DataChunk::zooja(vec![Column::new(input)]);
+        let input_chunk = DataChunk::cols(vec![Column::new(input)]);
         let mut agg_state = create_agg_state_unary(input_type, 0, agg_type, return_type, false)?;
         agg_state.update(&input_chunk)?;
         agg_state.output(&mut builder)?;

--- a/src/expr/src/vector_op/agg/general_agg.rs
+++ b/src/expr/src/vector_op/agg/general_agg.rs
@@ -220,9 +220,7 @@ mod tests {
         return_type: DataType,
         mut builder: ArrayBuilderImpl,
     ) -> Result<ArrayImpl> {
-        let input_chunk = DataChunk::builder()
-            .columns(vec![Column::new(input)])
-            .build();
+        let input_chunk = DataChunk::zooja(vec![Column::new(input)]);
         let mut agg_state = create_agg_state_unary(input_type, 0, agg_type, return_type, false)?;
         agg_state.update(&input_chunk)?;
         agg_state.output(&mut builder)?;

--- a/src/expr/src/vector_op/agg/general_distinct_agg.rs
+++ b/src/expr/src/vector_op/agg/general_distinct_agg.rs
@@ -236,7 +236,7 @@ mod tests {
         return_type: DataType,
         mut builder: ArrayBuilderImpl,
     ) -> Result<ArrayImpl> {
-        let input_chunk = DataChunk::zooja(vec![Column::new(input)]);
+        let input_chunk = DataChunk::cols(vec![Column::new(input)]);
         let mut agg_state = create_agg_state_unary(input_type, 0, agg_type, return_type, true)?;
         agg_state.update(&input_chunk)?;
         agg_state.output(&mut builder)?;

--- a/src/expr/src/vector_op/agg/general_distinct_agg.rs
+++ b/src/expr/src/vector_op/agg/general_distinct_agg.rs
@@ -236,9 +236,7 @@ mod tests {
         return_type: DataType,
         mut builder: ArrayBuilderImpl,
     ) -> Result<ArrayImpl> {
-        let input_chunk = DataChunk::builder()
-            .columns(vec![Column::new(input)])
-            .build();
+        let input_chunk = DataChunk::zooja(vec![Column::new(input)]);
         let mut agg_state = create_agg_state_unary(input_type, 0, agg_type, return_type, true)?;
         agg_state.update(&input_chunk)?;
         agg_state.output(&mut builder)?;

--- a/src/expr/src/vector_op/agg/general_sorted_grouper.rs
+++ b/src/expr/src/vector_op/agg/general_sorted_grouper.rs
@@ -420,7 +420,7 @@ mod tests {
         g0.update_and_output_with_sorted_groups_concrete(&input, &mut g0_builder, &eq)
             .unwrap();
         agg.update_and_output_with_sorted_groups(
-            &DataChunk::zooja(vec![Column::new(Arc::new(input.into()))]),
+            &DataChunk::cols(vec![Column::new(Arc::new(input.into()))]),
             &mut a_builder,
             &eq,
         )
@@ -431,7 +431,7 @@ mod tests {
         g0.update_and_output_with_sorted_groups_concrete(&input, &mut g0_builder, &eq)
             .unwrap();
         agg.update_and_output_with_sorted_groups(
-            &DataChunk::zooja(vec![Column::new(Arc::new(input.into()))]),
+            &DataChunk::cols(vec![Column::new(Arc::new(input.into()))]),
             &mut a_builder,
             &eq,
         )
@@ -442,7 +442,7 @@ mod tests {
         g0.update_and_output_with_sorted_groups_concrete(&input, &mut g0_builder, &eq)
             .unwrap();
         agg.update_and_output_with_sorted_groups(
-            &DataChunk::zooja(vec![Column::new(Arc::new(input.into()))]),
+            &DataChunk::cols(vec![Column::new(Arc::new(input.into()))]),
             &mut a_builder,
             &eq,
         )

--- a/src/expr/src/vector_op/agg/general_sorted_grouper.rs
+++ b/src/expr/src/vector_op/agg/general_sorted_grouper.rs
@@ -420,9 +420,7 @@ mod tests {
         g0.update_and_output_with_sorted_groups_concrete(&input, &mut g0_builder, &eq)
             .unwrap();
         agg.update_and_output_with_sorted_groups(
-            &DataChunk::builder()
-                .columns(vec![Column::new(Arc::new(input.into()))])
-                .build(),
+            &DataChunk::zooja(vec![Column::new(Arc::new(input.into()))]),
             &mut a_builder,
             &eq,
         )
@@ -433,9 +431,7 @@ mod tests {
         g0.update_and_output_with_sorted_groups_concrete(&input, &mut g0_builder, &eq)
             .unwrap();
         agg.update_and_output_with_sorted_groups(
-            &DataChunk::builder()
-                .columns(vec![Column::new(Arc::new(input.into()))])
-                .build(),
+            &DataChunk::zooja(vec![Column::new(Arc::new(input.into()))]),
             &mut a_builder,
             &eq,
         )
@@ -446,9 +442,7 @@ mod tests {
         g0.update_and_output_with_sorted_groups_concrete(&input, &mut g0_builder, &eq)
             .unwrap();
         agg.update_and_output_with_sorted_groups(
-            &DataChunk::builder()
-                .columns(vec![Column::new(Arc::new(input.into()))])
-                .build(),
+            &DataChunk::zooja(vec![Column::new(Arc::new(input.into()))]),
             &mut a_builder,
             &eq,
         )

--- a/src/source/src/common.rs
+++ b/src/source/src/common.rs
@@ -47,6 +47,6 @@ pub(crate) trait SourceChunkBuilder {
 
     fn build_datachunk(column_desc: &[SourceColumnDesc], rows: &[Vec<Datum>]) -> Result<DataChunk> {
         let columns = Self::build_columns(column_desc, rows)?;
-        Ok(DataChunk::tai(columns, rows.len(), None))
+        Ok(DataChunk::new(columns, rows.len(), None))
     }
 }

--- a/src/source/src/common.rs
+++ b/src/source/src/common.rs
@@ -47,6 +47,6 @@ pub(crate) trait SourceChunkBuilder {
 
     fn build_datachunk(column_desc: &[SourceColumnDesc], rows: &[Vec<Datum>]) -> Result<DataChunk> {
         let columns = Self::build_columns(column_desc, rows)?;
-        Ok(DataChunk::new(columns, None))
+        Ok(DataChunk::tai(columns, rows.len(), None))
     }
 }

--- a/src/source/src/common.rs
+++ b/src/source/src/common.rs
@@ -47,6 +47,6 @@ pub(crate) trait SourceChunkBuilder {
 
     fn build_datachunk(column_desc: &[SourceColumnDesc], rows: &[Vec<Datum>]) -> Result<DataChunk> {
         let columns = Self::build_columns(column_desc, rows)?;
-        Ok(DataChunk::builder().columns(columns).build())
+        Ok(DataChunk::new(columns, None))
     }
 }

--- a/src/storage/src/table/cell_based_table.rs
+++ b/src/storage/src/table/cell_based_table.rs
@@ -383,7 +383,8 @@ impl<S: StateStore> CellBasedTableRowIter<S> {
                 .map(|builder| builder.finish().map(|a| Column::new(Arc::new(a))))
                 .try_collect()
                 .map_err(err)?;
-            DataChunk::new(columns, None)
+            let xxlen = columns[0].array().len();
+            DataChunk::tai(columns, xxlen, None)
         };
 
         if chunk.cardinality() == 0 {

--- a/src/storage/src/table/cell_based_table.rs
+++ b/src/storage/src/table/cell_based_table.rs
@@ -384,7 +384,7 @@ impl<S: StateStore> CellBasedTableRowIter<S> {
                 .try_collect()
                 .map_err(err)?;
             let xxlen = columns[0].array().len();
-            DataChunk::tai(columns, xxlen, None)
+            DataChunk::new(columns, xxlen, None)
         };
 
         if chunk.cardinality() == 0 {

--- a/src/storage/src/table/cell_based_table.rs
+++ b/src/storage/src/table/cell_based_table.rs
@@ -383,7 +383,7 @@ impl<S: StateStore> CellBasedTableRowIter<S> {
                 .map(|builder| builder.finish().map(|a| Column::new(Arc::new(a))))
                 .try_collect()
                 .map_err(err)?;
-            DataChunk::builder().columns(columns).build()
+            DataChunk::new(columns, None)
         };
 
         if chunk.cardinality() == 0 {

--- a/src/stream/src/executor/batch_query.rs
+++ b/src/stream/src/executor/batch_query.rs
@@ -106,7 +106,7 @@ where
         }
         let new_visibility = new_visibility.finish();
         if new_visibility.num_high_bits() > 0 {
-            Some(DataChunk::tai(
+            Some(DataChunk::new(
                 columns,
                 new_visibility.num_high_bits(),
                 Some(new_visibility),

--- a/src/stream/src/executor/batch_query.rs
+++ b/src/stream/src/executor/batch_query.rs
@@ -106,7 +106,11 @@ where
         }
         let new_visibility = new_visibility.finish();
         if new_visibility.num_high_bits() > 0 {
-            Some(DataChunk::new(columns, Some(new_visibility)))
+            Some(DataChunk::tai(
+                columns,
+                new_visibility.num_high_bits(),
+                Some(new_visibility),
+            ))
         } else {
             None
         }

--- a/src/stream/src/executor/filter.rs
+++ b/src/stream/src/executor/filter.rs
@@ -80,7 +80,7 @@ impl SimpleExecutor for SimpleFilterExecutor {
         let chunk = chunk.compact().map_err(StreamExecutorError::eval_error)?;
 
         let (ops, columns, _visibility) = chunk.into_inner();
-        let data_chunk = DataChunk::builder().columns(columns).build();
+        let data_chunk = DataChunk::new(columns, None);
 
         let pred_output = self
             .expr

--- a/src/stream/src/executor/filter.rs
+++ b/src/stream/src/executor/filter.rs
@@ -80,7 +80,7 @@ impl SimpleExecutor for SimpleFilterExecutor {
         let chunk = chunk.compact().map_err(StreamExecutorError::eval_error)?;
 
         let (ops, columns, _visibility) = chunk.into_inner();
-        let data_chunk = DataChunk::new(columns, None);
+        let data_chunk = DataChunk::tai(columns, ops.len(), None);
 
         let pred_output = self
             .expr

--- a/src/stream/src/executor/filter.rs
+++ b/src/stream/src/executor/filter.rs
@@ -80,7 +80,7 @@ impl SimpleExecutor for SimpleFilterExecutor {
         let chunk = chunk.compact().map_err(StreamExecutorError::eval_error)?;
 
         let (ops, columns, _visibility) = chunk.into_inner();
-        let data_chunk = DataChunk::tai(columns, ops.len(), None);
+        let data_chunk = DataChunk::new(columns, ops.len(), None);
 
         let pred_output = self
             .expr

--- a/src/stream/src/executor/hash_join.rs
+++ b/src/stream/src/executor/hash_join.rs
@@ -582,7 +582,7 @@ impl<K: HashKey, S: StateStore, const T: JoinTypePrimitive> HashJoinExecutor<K, 
         let chunk = chunk.compact()?;
         let (ops, columns, visibility) = chunk.into_inner();
 
-        let data_chunk = DataChunk::new(columns, visibility);
+        let data_chunk = DataChunk::tai(columns, ops.len(), visibility);
 
         let (side_update, side_match) = if SIDE == SideType::Left {
             (&mut side_l, &mut side_r)

--- a/src/stream/src/executor/hash_join.rs
+++ b/src/stream/src/executor/hash_join.rs
@@ -582,14 +582,7 @@ impl<K: HashKey, S: StateStore, const T: JoinTypePrimitive> HashJoinExecutor<K, 
         let chunk = chunk.compact()?;
         let (ops, columns, visibility) = chunk.into_inner();
 
-        let data_chunk = {
-            let data_chunk_builder = DataChunk::builder().columns(columns);
-            if let Some(visibility) = visibility {
-                data_chunk_builder.visibility(visibility).build()
-            } else {
-                data_chunk_builder.build()
-            }
-        };
+        let data_chunk = DataChunk::new(columns, visibility);
 
         let (side_update, side_match) = if SIDE == SideType::Left {
             (&mut side_l, &mut side_r)

--- a/src/stream/src/executor/hash_join.rs
+++ b/src/stream/src/executor/hash_join.rs
@@ -582,7 +582,7 @@ impl<K: HashKey, S: StateStore, const T: JoinTypePrimitive> HashJoinExecutor<K, 
         let chunk = chunk.compact()?;
         let (ops, columns, visibility) = chunk.into_inner();
 
-        let data_chunk = DataChunk::tai(columns, ops.len(), visibility);
+        let data_chunk = DataChunk::new(columns, ops.len(), visibility);
 
         let (side_update, side_match) = if SIDE == SideType::Left {
             (&mut side_l, &mut side_r)

--- a/src/stream/src/executor/hop_window.rs
+++ b/src/stream/src/executor/hop_window.rs
@@ -182,7 +182,8 @@ impl HopWindowExecutor {
             let hop_start = hop_start
                 .eval(&data_chunk)
                 .map_err(StreamExecutorError::eval_error)?;
-            let hop_start_chunk = DataChunk::new(vec![Column::new(hop_start)], None);
+            let xxlen = hop_start.len();
+            let hop_start_chunk = DataChunk::tai(vec![Column::new(hop_start)], xxlen, None);
             let (origin_cols, visibility) = data_chunk.into_parts();
             // SAFETY: Already compacted.
             assert!(visibility.is_none());

--- a/src/stream/src/executor/hop_window.rs
+++ b/src/stream/src/executor/hop_window.rs
@@ -183,7 +183,7 @@ impl HopWindowExecutor {
                 .eval(&data_chunk)
                 .map_err(StreamExecutorError::eval_error)?;
             let xxlen = hop_start.len();
-            let hop_start_chunk = DataChunk::tai(vec![Column::new(hop_start)], xxlen, None);
+            let hop_start_chunk = DataChunk::new(vec![Column::new(hop_start)], xxlen, None);
             let (origin_cols, visibility) = data_chunk.into_parts();
             // SAFETY: Already compacted.
             assert!(visibility.is_none());

--- a/src/stream/src/executor/project.rs
+++ b/src/stream/src/executor/project.rs
@@ -92,7 +92,7 @@ impl SimpleExecutor for SimpleProjectExecutor {
         let chunk = chunk.compact().map_err(StreamExecutorError::eval_error)?;
 
         let (ops, columns, visibility) = chunk.into_inner();
-        let data_chunk = DataChunk::new(columns, visibility);
+        let data_chunk = DataChunk::tai(columns, ops.len(), visibility);
 
         let projected_columns = self
             .exprs

--- a/src/stream/src/executor/project.rs
+++ b/src/stream/src/executor/project.rs
@@ -92,14 +92,7 @@ impl SimpleExecutor for SimpleProjectExecutor {
         let chunk = chunk.compact().map_err(StreamExecutorError::eval_error)?;
 
         let (ops, columns, visibility) = chunk.into_inner();
-        let data_chunk = {
-            let data_chunk_builder = DataChunk::builder().columns(columns);
-            if let Some(visibility) = visibility {
-                data_chunk_builder.visibility(visibility).build()
-            } else {
-                data_chunk_builder.build()
-            }
-        };
+        let data_chunk = DataChunk::new(columns, visibility);
 
         let projected_columns = self
             .exprs

--- a/src/stream/src/executor/project.rs
+++ b/src/stream/src/executor/project.rs
@@ -92,7 +92,7 @@ impl SimpleExecutor for SimpleProjectExecutor {
         let chunk = chunk.compact().map_err(StreamExecutorError::eval_error)?;
 
         let (ops, columns, visibility) = chunk.into_inner();
-        let data_chunk = DataChunk::tai(columns, ops.len(), visibility);
+        let data_chunk = DataChunk::new(columns, ops.len(), visibility);
 
         let projected_columns = self
             .exprs


### PR DESCRIPTION
## What's changed and what's your intention?

This PR is not intended to be merged directly. It is just a preview / attempt of the following DataChunk API change:
* Remove `DataChunkBuilder`.
* Remove `TryFrom<Vec<Columns>> for DataChunk`.
* `DataChunk::new` requires `cardinality` as a parameter.

Limitations:
* Nested loop join is still not handling zero column correctly (https://github.com/singularity-data/risingwave/issues/2663#issuecomment-1140827168) - likely this PR is faulty
* `DataChunk::new` should verify consistency among `cardinality`, `visibility` and `columns`
* The `cardinality` passed into `new` may be incorrect - need to split PR and review each caller carefully.

Also thinking the following:
```
enum Visibility {
  Bitmap(Bitmap),
  Capacity(usize),
}
struct DataChunk {
  columns: Vec<Column>,
  visibility: Visibility,
  // visibility: Option<Bitmap>,
  // cardinality: usize,
}
```

## Checklist

- [ ] I have written necessary docs and comments
- [ ] I have added necessary unit tests and integration tests

## Refer to a related PR or issue link (optional)
