### PR TITLE
feat(batch): add rpc for local execution mode

### DIFF
--- a/proto/task_service.proto
+++ b/proto/task_service.proto
@@ -76,11 +76,23 @@ message GetStreamRequest {
   uint32 down_fragment_id = 2;
 }
 
+message ExecuteRequest {
+  batch_plan.TaskId task_id = 1;
+  batch_plan.PlanFragment plan = 2;
+  uint64 epoch = 3;
+}
+
+message ExecuteResponse {
+  common.Status status = 1;
+  data.DataChunk record_batch = 2;
+}
+
 service TaskService {
   rpc CreateTask(CreateTaskRequest) returns (CreateTaskResponse);
   rpc GetTaskInfo(GetTaskInfoRequest) returns (GetTaskInfoResponse);
   rpc AbortTask(AbortTaskRequest) returns (AbortTaskResponse);
   rpc RemoveTask(RemoveTaskRequest) returns (RemoveTaskResponse);
+  rpc Execute(ExecuteRequest) returns (stream ExecuteResponse);
 }
 
 message GetDataRequest {


### PR DESCRIPTION
## What's changed and what's your intention?
As title.

~Reuse the `GetDataResponse` as the return value of `rpc execute(ExecuteRequest)`.~ Actually forbidden by `buf lint`...

## Checklist

- [x] I have written necessary docs and comments

## Refer to a related PR or issue link (optional)
#2809 