### PR TITLE
fix(docs/frontend): remove some out-of-date docs

### DIFF
--- a/src/frontend/test_runner/README.md
+++ b/src/frontend/test_runner/README.md
@@ -4,9 +4,6 @@ This module contains a testing tool for binder, planner and optimizer.
 Given a sequence of SQL queries as the input, the test runner will check
 the logical operator tree if any, and the physical operator tree if any.
 
-Just the same as a normal Rust unit test, you can independently run the test runner
-via function `run_all_test_files()` in `plan_test_runner.rs`.
-
 The test data in YAML format is organized under `tests/testdata` folder.
 
 ```yaml


### PR DESCRIPTION
## What's changed and what's your intention?

The function `run_all_test_files` has been removed since commit [68d0aef](https://github.com/singularity-data/risingwave/commit/68d0aef555cc4c198d8f25fab25bc7f6edddb696).

## Checklist

- [x] I have written necessary docs and comments
- [x] I have added necessary unit tests and integration tests

## Refer to a related PR or issue link (optional)

#915
#1091
