### PR TITLE
feat(storage): zero-copy state table iterator

### DIFF
--- a/src/storage/src/table/state_table.rs
+++ b/src/storage/src/table/state_table.rs
@@ -11,12 +11,14 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
+use std::borrow::Cow;
 use std::cmp::Ordering;
 use std::collections::btree_map;
 use std::marker::PhantomData;
 use std::sync::Arc;
 
-use futures::Stream;
+use aws_smithy_http::pin_mut;
+use futures::{Stream, StreamExt};
 use futures_async_stream::try_stream;
 use risingwave_common::array::Row;
 use risingwave_common::catalog::ColumnDesc;
@@ -127,7 +129,7 @@ impl<S: StateStore> StateTable<S> {
     }
 }
 
-pub trait RowStream<'a> = Stream<Item = StorageResult<Option<Row>>> + 'a;
+pub trait RowStream<'a> = Stream<Item = StorageResult<Cow<'a, Row>>> + 'a;
 
 struct StateTableRowIter<S: StateStore> {
     _phantom: PhantomData<S>,
@@ -139,85 +141,85 @@ impl<S: StateStore> StateTableRowIter<S> {
     /// This function scans kv pairs from the `shared_storage`(`cell_based_table`) and
     /// memory(`mem_table`). If a record exist in both `cell_based_table` and `mem_table`, result
     /// `mem_table` is returned according to the operation(RowOp) on it.
-    #[try_stream(ok = Option<Row>, error = StorageError)]
+    #[try_stream(ok = Cow<'a, Row>, error = StorageError)]
     async fn into_stream<'a>(
         keyspace: &'a Keyspace<S>,
         table_descs: Vec<ColumnDesc>,
-        mut mem_table_iter: MemTableIter<'a>,
+        mem_table_iter: MemTableIter<'a>,
         order_types_vec: &'a [OrderType],
         epoch: u64,
     ) {
-        let mut cell_based_table_iter =
+        let cell_based_table_iter: CellBasedTableStreamingIter<_> =
             CellBasedTableStreamingIter::new(keyspace, table_descs, epoch).await?;
-        let pk_serializer = OrderedRowSerializer::new(order_types_vec.to_vec());
-        let mem_table_next =
-            |mem_table_iter: &mut MemTableIter<'a>| -> StorageResult<Option<(Vec<u8>, RowOp)>> {
-                mem_table_iter
-                    .next()
-                    .map::<StorageResult<(Vec<u8>, RowOp)>, _>(|(k, v)| {
-                        Ok((serialize_pk(k, &pk_serializer).map_err(err)?, v.clone()))
-                    })
-                    .transpose()
-            };
+        let cell_based_table_iter = cell_based_table_iter.into_stream().peekable();
+        pin_mut!(cell_based_table_iter);
 
-        let mut cell_based_table_item = cell_based_table_iter.next().await.map_err(err)?;
-        let mut mem_table_item = mem_table_next(&mut mem_table_iter)?;
+        let pk_serializer = OrderedRowSerializer::new(order_types_vec.to_vec());
+        let mut mem_table_iter = mem_table_iter
+            .map(|(k, v)| Ok::<_, StorageError>((serialize_pk(k, &pk_serializer).map_err(err)?, v)))
+            .peekable();
+
         loop {
-            match (cell_based_table_item.as_mut(), mem_table_item.as_mut()) {
-                (None, None) => {
-                    yield None;
+            match (
+                cell_based_table_iter.as_mut().peek().await,
+                mem_table_iter.peek(),
+            ) {
+                (None, None) => break,
+                (Some(_), None) => {
+                    let row: Row = cell_based_table_iter.next().await.unwrap()?.1;
+                    yield Cow::Owned(row);
                 }
-                (Some((_, row)), None) => {
-                    yield Some(std::mem::take(row));
-                    cell_based_table_item = cell_based_table_iter.next().await.map_err(err)?;
-                }
-                (None, Some((_, row_op))) => {
+                (None, Some(_)) => {
+                    let row_op = mem_table_iter.next().unwrap()?.1;
                     match row_op {
                         RowOp::Insert(row) | RowOp::Update((_, row)) => {
-                            yield Some(std::mem::take(row));
+                            yield Cow::Borrowed(row);
                         }
                         _ => {}
                     }
-                    mem_table_item = mem_table_next(&mut mem_table_iter)?;
                 }
-                (Some((cell_based_pk, cell_based_row)), Some((mem_table_pk, mem_table_row_op))) => {
+
+                (
+                    Some(Ok((cell_based_pk, cell_based_row))),
+                    Some(Ok((mem_table_pk, _mem_table_row_op))),
+                ) => {
                     match cell_based_pk.cmp(&mem_table_pk) {
                         Ordering::Less => {
                             // cell_based_table_item will be return
-                            yield Some(std::mem::take(cell_based_row));
-                            cell_based_table_item =
-                                cell_based_table_iter.next().await.map_err(err)?;
+                            let row: Row = cell_based_table_iter.next().await.unwrap()?.1;
+                            yield Cow::Owned(row);
                         }
                         Ordering::Equal => {
                             // mem_table_item will be return, while both cell_based_streaming_iter
                             // and mem_table_iter need to execute next()
                             // once.
-                            match mem_table_row_op {
-                                RowOp::Insert(row) => yield Some(row.clone()),
+                            let row_op = mem_table_iter.next().unwrap()?.1;
+                            match row_op {
+                                RowOp::Insert(row) => yield Cow::Borrowed(row),
                                 RowOp::Delete(_) => {}
                                 RowOp::Update((old_row, new_row)) => {
                                     debug_assert!(old_row == cell_based_row);
-                                    yield Some(std::mem::take(new_row));
+                                    yield Cow::Borrowed(new_row);
                                 }
                             }
-                            cell_based_table_item =
-                                cell_based_table_iter.next().await.map_err(err)?;
-                            mem_table_item = mem_table_next(&mut mem_table_iter)?;
+                            let _cell_based_row = cell_based_table_iter.next().await.unwrap()?.1;
                         }
                         Ordering::Greater => {
                             // mem_table_item will be return
-                            match mem_table_row_op {
-                                RowOp::Insert(row) => {
-                                    yield Some(std::mem::take(row));
-                                }
+                            let row_op = mem_table_iter.next().unwrap()?.1;
+                            match row_op {
+                                RowOp::Insert(row) => yield Cow::Borrowed(row),
                                 RowOp::Delete(_) => {}
-                                RowOp::Update(_) => {
-                                    unreachable!();
-                                }
+                                RowOp::Update(_) => unreachable!(),
                             }
-                            mem_table_item = mem_table_next(&mut mem_table_iter)?;
                         }
                     }
+                }
+                (Some(_), Some(_)) => {
+                    let _ = cell_based_table_iter.next().await.unwrap()?;
+                    let _ = mem_table_iter.next().unwrap()?;
+
+                    unreachable!()
                 }
             }
         }

--- a/src/storage/src/table/state_table.rs
+++ b/src/storage/src/table/state_table.rs
@@ -17,8 +17,7 @@ use std::collections::btree_map;
 use std::marker::PhantomData;
 use std::sync::Arc;
 
-use aws_smithy_http::pin_mut;
-use futures::{Stream, StreamExt};
+use futures::{pin_mut, Stream, StreamExt};
 use futures_async_stream::try_stream;
 use risingwave_common::array::Row;
 use risingwave_common::catalog::ColumnDesc;

--- a/src/storage/src/table/state_table.rs
+++ b/src/storage/src/table/state_table.rs
@@ -183,7 +183,7 @@ impl<S: StateStore> StateTableRowIter<S> {
                     Some(Ok((cell_based_pk, cell_based_row))),
                     Some(Ok((mem_table_pk, _mem_table_row_op))),
                 ) => {
-                    match cell_based_pk.cmp(&mem_table_pk) {
+                    match cell_based_pk.cmp(mem_table_pk) {
                         Ordering::Less => {
                             // cell_based_table_item will be return
                             let row: Row = cell_based_table_iter.next().await.unwrap()?.1;

--- a/src/storage/src/table/test_relational_table.rs
+++ b/src/storage/src/table/test_relational_table.rs
@@ -469,38 +469,34 @@ async fn test_state_table_iter() {
         let mut iter = Box::pin(state.iter(epoch).await.unwrap());
 
         let res = iter.next().await.unwrap().unwrap();
-        assert!(res.is_some());
         assert_eq!(
-            Row(vec![
+            &Row(vec![
                 Some(1_i32.into()),
                 Some(11_i32.into()),
                 Some(111_i32.into())
             ]),
-            res.unwrap()
+            res.as_ref()
         );
 
         // will not get [2, 22, 222]
         let res = iter.next().await.unwrap().unwrap();
-
-        assert!(res.is_some());
         assert_eq!(
-            Row(vec![
+            &Row(vec![
                 Some(3333_i32.into()),
                 Some(3333_i32.into()),
                 Some(3333_i32.into())
             ]),
-            res.unwrap()
+            res.as_ref()
         );
 
         let res = iter.next().await.unwrap().unwrap();
-        assert!(res.is_some());
         assert_eq!(
-            Row(vec![
+            &Row(vec![
                 Some(6_i32.into()),
                 Some(66_i32.into()),
                 Some(666_i32.into())
             ]),
-            res.unwrap()
+            res.as_ref()
         );
     }
 
@@ -582,85 +578,85 @@ async fn test_state_table_iter() {
 
     // this pk exist in both cell_based_table(shared_storage) and mem_table(buffer)
     assert_eq!(
-        Row(vec![
+        &Row(vec![
             Some(3_i32.into()),
             Some(33_i32.into()),
             Some(333_i32.into())
         ]),
-        res.unwrap()
+        res.as_ref()
     );
 
     // this row exists in mem_table
     let res = iter.next().await.unwrap().unwrap();
     assert_eq!(
-        Row(vec![
+        &Row(vec![
             Some(4_i32.into()),
             Some(44_i32.into()),
             Some(444_i32.into())
         ]),
-        res.unwrap()
+        res.as_ref()
     );
 
     let res = iter.next().await.unwrap().unwrap();
 
     // this row exists in mem_table
     assert_eq!(
-        Row(vec![
+        &Row(vec![
             Some(5_i32.into()),
             Some(55_i32.into()),
             Some(555_i32.into())
         ]),
-        res.unwrap()
+        res.as_ref()
     );
     let res = iter.next().await.unwrap().unwrap();
 
     // this row exists in cell_based_table
     assert_eq!(
-        Row(vec![
+        &Row(vec![
             Some(6_i32.into()),
             Some(66_i32.into()),
             Some(666_i32.into())
         ]),
-        res.unwrap()
+        res.as_ref()
     );
 
     let res = iter.next().await.unwrap().unwrap();
     // this row exists in mem_table
     assert_eq!(
-        Row(vec![
+        &Row(vec![
             Some(7_i32.into()),
             Some(77_i32.into()),
             Some(777.into())
         ]),
-        res.unwrap()
+        res.as_ref()
     );
 
     let res = iter.next().await.unwrap().unwrap();
 
     // this row exists in mem_table
     assert_eq!(
-        Row(vec![
+        &Row(vec![
             Some(8_i32.into()),
             Some(88_i32.into()),
             Some(888_i32.into())
         ]),
-        res.unwrap()
+        res.as_ref()
     );
 
     let res = iter.next().await.unwrap().unwrap();
 
     // this row exists in cell_based_table
     assert_eq!(
-        Row(vec![
+        &Row(vec![
             Some(9_i32.into()),
             Some(99_i32.into()),
             Some(999_i32.into())
         ]),
-        res.unwrap()
+        res.as_ref()
     );
 
     // there is no row in both cell_based_table and mem_table
-    let res = iter.next().await.unwrap().unwrap();
+    let res = iter.next().await;
     assert!(res.is_none());
 }
 
@@ -775,29 +771,27 @@ async fn test_multi_state_table_iter() {
         let mut iter_2 = Box::pin(state_2.iter(epoch).await.unwrap());
 
         let res_1_1 = iter_1.next().await.unwrap().unwrap();
-        assert!(res_1_1.is_some());
         assert_eq!(
-            Row(vec![
+            &Row(vec![
                 Some(1_i32.into()),
                 Some(11_i32.into()),
                 Some(111_i32.into()),
             ]),
-            res_1_1.unwrap()
+            res_1_1.as_ref()
         );
-        let res_1_2 = iter_1.next().await.unwrap().unwrap();
+        let res_1_2 = iter_1.next().await;
         assert!(res_1_2.is_none());
 
         let res_2_1 = iter_2.next().await.unwrap().unwrap();
-        assert!(res_2_1.is_some());
         assert_eq!(
-            Row(vec![
+            &Row(vec![
                 Some("1".to_string().into()),
                 Some("11".to_string().into()),
                 Some("111".to_string().into())
             ]),
-            res_2_1.unwrap()
+            res_2_1.as_ref()
         );
-        let res_2_2 = iter_2.next().await.unwrap().unwrap();
+        let res_2_2 = iter_2.next().await;
         assert!(res_2_2.is_none());
     }
 


### PR DESCRIPTION
## What's changed and what's your intention?

This PR refactors the state table iterator in a zero-copy manner.
- Use `Cow` as the item type of this iterator.
- Avoid cloning from the peek result.

## Checklist

- [x] I have written necessary docs and comments
- [x] I have added necessary unit tests and integration tests

## Refer to a related PR or issue link (optional)
- #2885 
- Close #2893 