### PR TITLE
refactor(DataChunk): consolidate visibility bitmap and cardinality

### DIFF
--- a/src/batch/src/executor/join/nested_loop_join.rs
+++ b/src/batch/src/executor/join/nested_loop_join.rs
@@ -556,8 +556,8 @@ impl NestedLoopJoinExecutor {
         concated_columns.extend_from_slice(right.columns());
         // Only handle one side is constant row chunk: One of visibility must be None.
         let vis = match (left.visibility(), right.visibility()) {
-            (None, _) => right.visibility().clone(),
-            (_, None) => left.visibility().clone(),
+            (None, _) => right.visibility().cloned(),
+            (_, None) => left.visibility().cloned(),
             (Some(_), Some(_)) => {
                 return Err(ErrorCode::NotImplemented(
                     "The concatenate behaviour of two chunk with visibility is undefined"
@@ -619,7 +619,7 @@ mod tests {
         assert_eq!(chunk.capacity(), chunk2.capacity());
         assert_eq!(chunk.columns().len(), chunk1.columns().len() * 2);
         assert_eq!(
-            chunk.visibility().clone().unwrap(),
+            chunk.visibility().cloned().unwrap(),
             (bool_vec).try_into().unwrap()
         );
     }

--- a/src/common/src/array/data_chunk.rs
+++ b/src/common/src/array/data_chunk.rs
@@ -71,9 +71,11 @@ pub struct DataChunk {
 #[derive(Clone, PartialEq)]
 enum Vis {
     Bitmap(Bitmap),
-    Compact(usize),
+    Compact(usize), // equivalent to all ones of this size
 }
 
+// Indirectly required by StreamChunk::default(), which is only used in tests.
+// Maybe we should impl Default for StreamChunk directly with #[cfg(test)]
 impl Default for Vis {
     fn default() -> Self {
         Vis::Compact(0)
@@ -97,7 +99,7 @@ impl DataChunk {
             Vis::Compact(card)
         } else {
             // no data (dummy)
-            Vis::Compact(0)
+            Vis::default()
         };
 
         DataChunk { columns, vis2 }

--- a/src/common/src/array/data_chunk.rs
+++ b/src/common/src/array/data_chunk.rs
@@ -62,7 +62,7 @@ impl DataChunkBuilder {
 }
 
 /// `DataChunk` is a collection of arrays with visibility mask.
-#[derive(Clone, Default, PartialEq)]
+#[derive(Clone, PartialEq)]
 pub struct DataChunk {
     columns: Vec<Column>,
     vis2: Vis,
@@ -72,14 +72,6 @@ pub struct DataChunk {
 enum Vis {
     Bitmap(Bitmap),
     Compact(usize), // equivalent to all ones of this size
-}
-
-// Indirectly required by StreamChunk::default(), which is only used in tests.
-// Maybe we should impl Default for StreamChunk directly with #[cfg(test)]
-impl Default for Vis {
-    fn default() -> Self {
-        Vis::Compact(0)
-    }
 }
 
 impl DataChunk {
@@ -99,7 +91,7 @@ impl DataChunk {
             Vis::Compact(card)
         } else {
             // no data (dummy)
-            Vis::default()
+            Vis::Compact(0)
         };
 
         DataChunk { columns, vis2 }

--- a/src/common/src/array/stream_chunk.rs
+++ b/src/common/src/array/stream_chunk.rs
@@ -203,7 +203,7 @@ impl StreamChunk {
         &self.ops
     }
 
-    pub fn visibility(&self) -> &Option<Bitmap> {
+    pub fn visibility(&self) -> Option<&Bitmap> {
         self.data.visibility()
     }
 

--- a/src/common/src/array/stream_chunk.rs
+++ b/src/common/src/array/stream_chunk.rs
@@ -79,7 +79,7 @@ pub struct StreamChunk {
 }
 
 impl Default for StreamChunk {
-    /// Create a 0-row-0-col StreamChunk. Only used in some existing tests.
+    /// Create a 0-row-0-col `StreamChunk`. Only used in some existing tests.
     /// This is NOT the same as an **empty** chunk, which has 0 rows but with
     /// columns aligned with executor schema.
     fn default() -> Self {

--- a/src/common/src/array/stream_chunk.rs
+++ b/src/common/src/array/stream_chunk.rs
@@ -70,12 +70,24 @@ impl Op {
 pub type Ops<'a> = &'a [Op];
 
 /// `StreamChunk` is used to pass data over the streaming pathway.
-#[derive(Default, Clone, PartialEq)]
+#[derive(Clone, PartialEq)]
 pub struct StreamChunk {
     // TODO: Optimize using bitmap
     ops: Vec<Op>,
 
     pub(super) data: DataChunk,
+}
+
+impl Default for StreamChunk {
+    /// Create a 0-row-0-col StreamChunk. Only used in some existing tests.
+    /// This is NOT the same as an **empty** chunk, which has 0 rows but with
+    /// columns aligned with executor schema.
+    fn default() -> Self {
+        Self {
+            ops: Default::default(),
+            data: DataChunk::new(vec![], None),
+        }
+    }
 }
 
 impl StreamChunk {

--- a/src/expr/src/expr/expr_array.rs
+++ b/src/expr/src/expr/expr_array.rs
@@ -49,7 +49,7 @@ impl Expression for ArrayExpression {
                 Ok(Column::new(array))
             })
             .collect::<Result<Vec<Column>>>()?;
-        let chunk = DataChunk::new(columns, input.visibility().clone());
+        let chunk = DataChunk::new(columns, input.visibility().cloned());
 
         let mut builder = ListArrayBuilder::with_meta(
             input.capacity(),


### PR DESCRIPTION
## What's changed and what's your intention?

As of now, `DataChunk` stores an optional visibility bitmap and a cardinality at the same time. However, when a visibility bitmap does exist, the cardinality is redundant and need to be kept consistent with visibility (e.g. `DataChunk::set_visibility`). It is even harder after `into_parts` and `new` are refactored to include cardinality (#2907).

All public interfaces are still using `Option<Bitmap>`; only the internal implementation is updated. This allows a smoother migration and smaller PR. As mentioned above, `into_parts` and `new` will use this new `Vis` as public interface in the next PR. All remaining methods can decide whether or not to change individually.

Also removed unused `DataChunk::default()`, and added warning comments of `StreamChunk::default()`, which is only used in some unit tests.

## Checklist

- [x] I have written necessary docs and comments
- [x] I have added necessary unit tests and integration tests (Refactoring does not break existing tests.)

## Refer to a related PR or issue link (optional)

#2663