### PR TITLE
chore(proto): allow same type for rpc response

### DIFF
--- a/proto/buf.yaml
+++ b/proto/buf.yaml
@@ -11,3 +11,5 @@ lint:
     # We guarantee that every file is one package. So this check isn't necessary.
     - DIRECTORY_SAME_PACKAGE
     - PACKAGE_DIRECTORY_MATCH
+    - RPC_REQUEST_RESPONSE_UNIQUE
+    - RPC_RESPONSE_STANDARD_NAME

--- a/proto/task_service.proto
+++ b/proto/task_service.proto
@@ -82,17 +82,12 @@ message ExecuteRequest {
   uint64 epoch = 3;
 }
 
-message ExecuteResponse {
-  common.Status status = 1;
-  data.DataChunk record_batch = 2;
-}
-
 service TaskService {
   rpc CreateTask(CreateTaskRequest) returns (CreateTaskResponse);
   rpc GetTaskInfo(GetTaskInfoRequest) returns (GetTaskInfoResponse);
   rpc AbortTask(AbortTaskRequest) returns (AbortTaskResponse);
   rpc RemoveTask(RemoveTaskRequest) returns (RemoveTaskResponse);
-  rpc Execute(ExecuteRequest) returns (stream ExecuteResponse);
+  rpc Execute(ExecuteRequest) returns (stream GetDataResponse);
 }
 
 message GetDataRequest {

--- a/src/batch/src/rpc/service/exchange.rs
+++ b/src/batch/src/rpc/service/exchange.rs
@@ -13,47 +13,23 @@
 // limitations under the License.
 
 use risingwave_common::error::{Result, ToRwResult};
-use risingwave_pb::common::Status as PbStatus;
-use risingwave_pb::data::DataChunk;
-use risingwave_pb::task_service::{ExecuteResponse, GetDataResponse};
+use risingwave_pb::task_service::GetDataResponse;
 use tonic::Status;
 
-type ExchangeDataSender<T> = tokio::sync::mpsc::Sender<std::result::Result<T, Status>>;
-
-pub trait CreateDataResponse: Send {
-    fn create_data_response(status: PbStatus, data_chunk: DataChunk) -> Self;
-}
-
-impl CreateDataResponse for GetDataResponse {
-    fn create_data_response(status: PbStatus, data_chunk: DataChunk) -> Self {
-        Self {
-            status: Some(status),
-            record_batch: Some(data_chunk),
-        }
-    }
-}
-
-impl CreateDataResponse for ExecuteResponse {
-    fn create_data_response(status: PbStatus, data_chunk: DataChunk) -> Self {
-        Self {
-            status: Some(status),
-            record_batch: Some(data_chunk),
-        }
-    }
-}
+type ExchangeDataSender = tokio::sync::mpsc::Sender<std::result::Result<GetDataResponse, Status>>;
 
 #[async_trait::async_trait]
-pub trait ExchangeWriter<T: CreateDataResponse>: Send {
-    async fn write(&mut self, resp: T) -> Result<()>;
+pub trait ExchangeWriter: Send {
+    async fn write(&mut self, resp: GetDataResponse) -> Result<()>;
 }
 
-pub struct GrpcExchangeWriter<T: CreateDataResponse> {
-    sender: ExchangeDataSender<T>,
+pub struct GrpcExchangeWriter {
+    sender: ExchangeDataSender,
     written_chunks: usize,
 }
 
-impl<T: CreateDataResponse> GrpcExchangeWriter<T> {
-    pub fn new(sender: ExchangeDataSender<T>) -> Self {
+impl GrpcExchangeWriter {
+    pub fn new(sender: ExchangeDataSender) -> Self {
         Self {
             sender,
             written_chunks: 0,
@@ -66,8 +42,8 @@ impl<T: CreateDataResponse> GrpcExchangeWriter<T> {
 }
 
 #[async_trait::async_trait]
-impl<T: CreateDataResponse> ExchangeWriter<T> for GrpcExchangeWriter<T> {
-    async fn write(&mut self, data: T) -> Result<()> {
+impl ExchangeWriter for GrpcExchangeWriter {
+    async fn write(&mut self, data: GetDataResponse) -> Result<()> {
         self.written_chunks += 1;
         self.sender
             .send(Ok(data))

--- a/src/batch/src/rpc/service/task_service.rs
+++ b/src/batch/src/rpc/service/task_service.rs
@@ -19,7 +19,7 @@ use risingwave_pb::batch_plan::TaskOutputId;
 use risingwave_pb::task_service::task_service_server::TaskService;
 use risingwave_pb::task_service::{
     AbortTaskRequest, AbortTaskResponse, CreateTaskRequest, CreateTaskResponse, ExecuteRequest,
-    ExecuteResponse, GetTaskInfoRequest, GetTaskInfoResponse, RemoveTaskRequest,
+    GetDataResponse, GetTaskInfoRequest, GetTaskInfoResponse, RemoveTaskRequest,
     RemoveTaskResponse,
 };
 use tokio_stream::wrappers::ReceiverStream;
@@ -44,7 +44,7 @@ impl BatchServiceImpl {
 
 #[async_trait::async_trait]
 impl TaskService for BatchServiceImpl {
-    type ExecuteStream = ReceiverStream<std::result::Result<ExecuteResponse, Status>>;
+    type ExecuteStream = ReceiverStream<std::result::Result<GetDataResponse, Status>>;
 
     #[cfg_attr(coverage, no_coverage)]
     async fn create_task(

--- a/src/batch/src/task/task_.rs
+++ b/src/batch/src/task/task_.rs
@@ -23,11 +23,12 @@ use risingwave_pb::batch_plan::{
     PlanFragment, TaskId as ProstTaskId, TaskOutputId as ProstOutputId,
 };
 use risingwave_pb::task_service::task_info::TaskStatus;
+use risingwave_pb::task_service::GetDataResponse;
 use tokio::sync::oneshot::{Receiver, Sender};
 use tracing_futures::Instrument;
 
 use crate::executor::{BoxedExecutor, ExecutorBuilder};
-use crate::rpc::service::exchange::{CreateDataResponse, ExchangeWriter};
+use crate::rpc::service::exchange::ExchangeWriter;
 use crate::task::channel::{create_output_channel, ChanReceiverImpl, ChanSenderImpl};
 use crate::task::BatchTaskContext;
 
@@ -110,10 +111,7 @@ pub struct TaskOutput {
 
 impl TaskOutput {
     /// Writes the data in serialized format to `ExchangeWriter`.
-    pub async fn take_data<T: CreateDataResponse>(
-        &mut self,
-        writer: &mut dyn ExchangeWriter<T>,
-    ) -> Result<()> {
+    pub async fn take_data(&mut self, writer: &mut dyn ExchangeWriter) -> Result<()> {
         loop {
             match self.receiver.recv().await {
                 // Received some data
@@ -125,7 +123,10 @@ impl TaskOutput {
                         chunk.cardinality()
                     );
                     let pb = chunk.to_protobuf();
-                    let resp = T::create_data_response(Default::default(), pb);
+                    let resp = GetDataResponse {
+                        status: Default::default(),
+                        record_batch: Some(pb),
+                    };
                     writer.write(resp).await?;
                 }
                 // Reached EOF


### PR DESCRIPTION
## What's changed and what's your intention?
Remove `ExecuteResponse` as it is the same as `GetDataResponse`.

We add two configurations into `buf.yaml` to enable so.