### PR TITLE
refactor(DataChunk): use `new` rather than `DataChunkBuilder` or `try_from` in simple cases

### DIFF
--- a/src/batch/src/executor/delete.rs
+++ b/src/batch/src/executor/delete.rs
@@ -104,7 +104,7 @@ impl DeleteExecutor {
             array_builder.append(Some(rows_deleted as i64))?;
 
             let array = array_builder.finish()?;
-            let ret_chunk = DataChunk::builder().columns(vec![array.into()]).build();
+            let ret_chunk = DataChunk::new(vec![array.into()], 1);
 
             yield ret_chunk
         }

--- a/src/batch/src/executor/generic_exchange.rs
+++ b/src/batch/src/executor/generic_exchange.rs
@@ -212,11 +212,12 @@ mod tests {
             ) -> Result<Box<dyn ExchangeSource>> {
                 let mut rng = rand::thread_rng();
                 let i = rng.gen_range(1..=100000);
-                let chunk = DataChunk::builder()
-                    .columns(vec![Column::new(Arc::new(
+                let chunk = DataChunk::new(
+                    vec![Column::new(Arc::new(
                         array_nonnull! { I32Array, [i] }.into(),
-                    ))])
-                    .build();
+                    ))],
+                    1,
+                );
                 let chunks = vec![Some(chunk); 100];
 
                 Ok(Box::new(FakeExchangeSource { chunks }))

--- a/src/batch/src/executor/insert.rs
+++ b/src/batch/src/executor/insert.rs
@@ -120,7 +120,7 @@ impl InsertExecutor {
             array_builder.append(Some(rows_inserted as i64))?;
 
             let array = array_builder.finish()?;
-            let ret_chunk = DataChunk::builder().columns(vec![array.into()]).build();
+            let ret_chunk = DataChunk::new(vec![array.into()], 1);
 
             yield ret_chunk
         }
@@ -220,7 +220,7 @@ mod tests {
         .map(|x| Arc::new(x.into()))
         .unwrap();
         let col3 = Column::new(array);
-        let data_chunk: DataChunk = DataChunk::builder().columns(vec![col1, col2, col3]).build();
+        let data_chunk: DataChunk = DataChunk::new(vec![col1, col2, col3], 5);
         mock_executor.add(data_chunk.clone());
 
         // Create the table.

--- a/src/batch/src/executor/join/nested_loop_join.rs
+++ b/src/batch/src/executor/join/nested_loop_join.rs
@@ -608,12 +608,12 @@ mod tests {
             let arr = builder.finish().unwrap();
             columns.push(Column::new(Arc::new(arr.into())))
         }
-        let chunk1: DataChunk = DataChunk::builder().columns(columns.clone()).build();
+        let chunk1: DataChunk = DataChunk::new(columns.clone(), length);
         let bool_vec = vec![true, false, true, false, false];
-        let chunk2: DataChunk = DataChunk::builder()
-            .columns(columns.clone())
-            .visibility((bool_vec.clone()).try_into().unwrap())
-            .build();
+        let chunk2: DataChunk = DataChunk::new(
+            columns.clone(),
+            Vis::Bitmap((bool_vec.clone()).try_into().unwrap()),
+        );
         let chunk = NestedLoopJoinExecutor::concatenate(&chunk1, &chunk2).unwrap();
         assert_eq!(chunk.capacity(), chunk1.capacity());
         assert_eq!(chunk.capacity(), chunk2.capacity());

--- a/src/batch/src/executor/limit.rs
+++ b/src/batch/src/executor/limit.rs
@@ -169,7 +169,7 @@ mod tests {
         };
         let mut mock_executor = MockExecutor::new(schema);
 
-        let data_chunk = DataChunk::builder().columns([col].to_vec()).build();
+        let data_chunk = DataChunk::new([col].to_vec(), row_num);
 
         DataChunk::rechunk(&[data_chunk], chunk_size)
             .unwrap()
@@ -300,7 +300,7 @@ mod tests {
         };
         let mut mock_executor = MockExecutor::new(schema);
 
-        let data_chunk = DataChunk::builder().columns([col0, col1].to_vec()).build();
+        let data_chunk = DataChunk::new([col0, col1].to_vec(), row_num);
 
         DataChunk::rechunk(&[data_chunk], chunk_size)
             .unwrap()

--- a/src/batch/src/executor/order_by.rs
+++ b/src/batch/src/executor/order_by.rs
@@ -266,7 +266,7 @@ impl OrderByExecutor {
                 .into_iter()
                 .map(|b| Ok(Column::new(Arc::new(b.finish()?))))
                 .collect::<Result<Vec<_>>>()?;
-            let chunk = DataChunk::builder().columns(columns).build();
+            let chunk = DataChunk::new(columns, chunk_size);
             yield chunk
         }
     }

--- a/src/batch/src/executor/project.rs
+++ b/src/batch/src/executor/project.rs
@@ -58,11 +58,7 @@ impl ProjectExecutor {
                 .iter_mut()
                 .map(|expr| expr.eval(&data_chunk).map(Column::new))
                 .collect::<Result<Vec<_>>>()?;
-            let ret = if arrays.is_empty() {
-                DataChunk::new_dummy(data_chunk.cardinality())
-            } else {
-                DataChunk::builder().columns(arrays).build()
-            };
+            let ret = DataChunk::new(arrays, data_chunk.cardinality());
             yield ret
         }
     }

--- a/src/batch/src/executor/update.rs
+++ b/src/batch/src/executor/update.rs
@@ -155,7 +155,7 @@ impl UpdateExecutor {
             array_builder.append(Some(rows_updated as i64))?;
 
             let array = array_builder.finish()?;
-            let ret_chunk = DataChunk::builder().columns(vec![array.into()]).build();
+            let ret_chunk = DataChunk::new(vec![array.into()], 1);
 
             yield ret_chunk
         }

--- a/src/batch/src/executor/update.rs
+++ b/src/batch/src/executor/update.rs
@@ -105,7 +105,7 @@ impl UpdateExecutor {
                     .map(|expr| expr.eval(&data_chunk).map(Column::new))
                     .collect::<Result<Vec<_>>>()?;
 
-                DataChunk::builder().columns(columns).build()
+                DataChunk::new(columns, len)
             };
 
             // Merge two data chunks into (U-, U+) pairs.

--- a/src/batch/src/executor/values.rs
+++ b/src/batch/src/executor/values.rs
@@ -18,7 +18,7 @@ use std::vec;
 use futures_async_stream::try_stream;
 use itertools::Itertools;
 use risingwave_common::array::column::Column;
-use risingwave_common::array::{DataChunk, I32Array};
+use risingwave_common::array::DataChunk;
 use risingwave_common::catalog::{Field, Schema};
 use risingwave_common::error::{Result, RwError};
 use risingwave_common::util::chunk_coalesce::DEFAULT_CHUNK_BUFFER_SIZE;
@@ -81,13 +81,10 @@ impl ValuesExecutor {
                 yield DataChunk::new_dummy(cardinality);
             } else {
                 while !self.rows.is_empty() {
-                    let one_row_array = I32Array::from_slice(&[Some(1)])?;
                     // We need a one row chunk rather than an empty chunk because constant
                     // expression's eval result is same size as input chunk
                     // cardinality.
-                    let one_row_chunk = DataChunk::builder()
-                        .columns(vec![Column::new(Arc::new(one_row_array.into()))])
-                        .build();
+                    let one_row_chunk = DataChunk::new_dummy(1);
 
                     let chunk_size = self.chunk_size.min(self.rows.len());
                     let mut array_builders = self.schema.create_array_builders(chunk_size)?;

--- a/src/common/src/array/data_chunk.rs
+++ b/src/common/src/array/data_chunk.rs
@@ -622,11 +622,10 @@ mod tests {
                 for i in chunk_size * chunk_idx..chunk_size * (chunk_idx + 1) {
                     builder.append(Some(i as i32)).unwrap();
                 }
-                let chunk = DataChunk::builder()
-                    .columns(vec![Column::new(Arc::new(
-                        builder.finish().unwrap().into(),
-                    ))])
-                    .build();
+                let chunk = DataChunk::new(
+                    vec![Column::new(Arc::new(builder.finish().unwrap().into()))],
+                    chunk_size,
+                );
                 chunks.push(chunk);
             }
 
@@ -688,7 +687,7 @@ mod tests {
             let arr = builder.finish().unwrap();
             columns.push(Column::new(Arc::new(arr.into())))
         }
-        let chunk: DataChunk = DataChunk::builder().columns(columns).build();
+        let chunk: DataChunk = DataChunk::new(columns, length);
         for row in chunk.rows() {
             for i in 0..num_of_columns {
                 let val = row.value_at(i).unwrap();

--- a/src/common/src/array/data_chunk.rs
+++ b/src/common/src/array/data_chunk.rs
@@ -267,7 +267,7 @@ impl DataChunk {
                             .map(|array| Column::new(Arc::new(array)))
                     })
                     .collect::<Result<Vec<_>>>()?;
-                Ok(Self::builder().columns(columns).build())
+                Ok(Self::new(columns, cardinality))
             }
         }
     }

--- a/src/common/src/hash/key.rs
+++ b/src/common/src/hash/key.rs
@@ -658,7 +658,6 @@ impl HashKey for SerializedKey {
 #[cfg(test)]
 mod tests {
     use std::collections::HashMap;
-    use std::convert::TryFrom;
     use std::str::FromStr;
     use std::sync::Arc;
 
@@ -699,7 +698,7 @@ mod tests {
             )),
         ];
 
-        DataChunk::try_from(columns).expect("Failed to create data chunk")
+        DataChunk::new(columns, capacity)
     }
 
     fn do_test_serialize<K: HashKey, F>(column_indexes: Vec<usize>, data_gen: F)
@@ -847,7 +846,7 @@ mod tests {
             .into(),
         ) as ArrayRef)];
 
-        DataChunk::try_from(columns).expect("Failed to create data chunk")
+        DataChunk::new(columns, 5)
     }
 
     #[test]

--- a/src/common/src/util/chunk_coalesce.rs
+++ b/src/common/src/util/chunk_coalesce.rs
@@ -228,10 +228,7 @@ impl DataChunkBuilder {
                 Ok(vec)
             },
         )?;
-        match columns.is_empty() {
-            true => Ok(DataChunk::new_dummy(cardinality)),
-            false => DataChunk::try_from(columns),
-        }
+        Ok(DataChunk::new(columns, cardinality))
     }
 
     pub fn buffered_count(&self) -> usize {

--- a/src/compute/tests/table_v2_materialize.rs
+++ b/src/compute/tests/table_v2_materialize.rs
@@ -290,7 +290,7 @@ async fn test_table_v2_materialize() -> Result<()> {
         column_nonnull! { I64Array, [ col_row_ids[0]] }, // row id column
         column_nonnull! { F64Array, [1.14] },
     ];
-    let chunk = DataChunk::builder().columns(columns.clone()).build();
+    let chunk = DataChunk::new(columns.clone(), 1);
     let delete_inner: BoxedExecutor = Box::new(SingleChunkExecutor::new(chunk, all_schema.clone()));
     let delete = Box::new(DeleteExecutor::new(
         source_table_id,

--- a/src/expr/src/expr/expr_binary_nonnull.rs
+++ b/src/expr/src/expr/expr_binary_nonnull.rs
@@ -473,7 +473,7 @@ mod tests {
                 .map(|x| Arc::new(x.into()))
                 .unwrap(),
         );
-        let data_chunk = DataChunk::builder().columns(vec![col1, col2]).build();
+        let data_chunk = DataChunk::new(vec![col1, col2], 100);
         let expr = make_expression(kind, &[TypeName::Int32, TypeName::Int32], &[0, 1]);
         let vec_executor = build_from_prost(&expr).unwrap();
         let res = vec_executor.eval(&data_chunk).unwrap();
@@ -531,7 +531,7 @@ mod tests {
                 .map(|x| Arc::new(x.into()))
                 .unwrap(),
         );
-        let data_chunk = DataChunk::builder().columns(vec![col1, col2]).build();
+        let data_chunk = DataChunk::new(vec![col1, col2], 100);
         let expr = make_expression(kind, &[TypeName::Date, TypeName::Interval], &[0, 1]);
         let vec_executor = build_from_prost(&expr).unwrap();
         let res = vec_executor.eval(&data_chunk).unwrap();
@@ -592,7 +592,7 @@ mod tests {
                 .map(|x| Arc::new(x.into()))
                 .unwrap(),
         );
-        let data_chunk = DataChunk::builder().columns(vec![col1, col2]).build();
+        let data_chunk = DataChunk::new(vec![col1, col2], 100);
         let expr = make_expression(kind, &[TypeName::Decimal, TypeName::Decimal], &[0, 1]);
         let vec_executor = build_from_prost(&expr).unwrap();
         let res = vec_executor.eval(&data_chunk).unwrap();

--- a/src/expr/src/expr/expr_field.rs
+++ b/src/expr/src/expr/expr_field.rs
@@ -117,7 +117,7 @@ mod tests {
         .unwrap();
 
         let column = Column::new(array);
-        let data_chunk = DataChunk::builder().columns(vec![column]).build();
+        let data_chunk = DataChunk::new(vec![column], 1);
         let res = field_expr.eval(&data_chunk).unwrap();
         assert_eq!(res.datum_at(0), Some(ScalarImpl::Int32(1)));
         assert_eq!(res.datum_at(1), Some(ScalarImpl::Int32(2)));
@@ -159,7 +159,7 @@ mod tests {
         .unwrap();
 
         let column = Column::new(array);
-        let data_chunk = DataChunk::builder().columns(vec![column]).build();
+        let data_chunk = DataChunk::new(vec![column], 1);
         let res = field_expr.eval(&data_chunk).unwrap();
         assert_eq!(res.datum_at(0), Some(ScalarImpl::Float32(1.0.into())));
         assert_eq!(res.datum_at(1), Some(ScalarImpl::Float32(2.0.into())));

--- a/src/expr/src/expr/expr_is_null.rs
+++ b/src/expr/src/expr/expr_is_null.rs
@@ -124,9 +124,10 @@ mod tests {
             builder.finish()?
         };
 
-        let input_chunk = DataChunk::builder()
-            .columns(vec![Column::new(Arc::new(ArrayImpl::Decimal(input_array)))])
-            .build();
+        let input_chunk = DataChunk::new(
+            vec![Column::new(Arc::new(ArrayImpl::Decimal(input_array)))],
+            3,
+        );
         let result_array = expr.eval(&input_chunk).unwrap();
         assert_eq!(3, result_array.len());
         for (i, v) in expected_eval_result.iter().enumerate() {

--- a/src/expr/src/expr/expr_unary.rs
+++ b/src/expr/src/expr/expr_unary.rs
@@ -400,7 +400,7 @@ mod tests {
                 .map(|x| Arc::new(x.into()))
                 .unwrap(),
         );
-        let data_chunk = DataChunk::builder().columns(vec![col1]).build();
+        let data_chunk = DataChunk::new(vec![col1], 100);
         let return_type = DataType {
             type_name: TypeName::Int32 as i32,
             is_nullable: false,
@@ -447,7 +447,7 @@ mod tests {
                 .map(|x| Arc::new(x.into()))
                 .unwrap(),
         );
-        let data_chunk = DataChunk::builder().columns(vec![col1]).build();
+        let data_chunk = DataChunk::new(vec![col1], 3);
         let return_type = DataType {
             type_name: TypeName::Int32 as i32,
             is_nullable: false,
@@ -500,7 +500,7 @@ mod tests {
                 .map(|x| Arc::new(x.into()))
                 .unwrap(),
         );
-        let data_chunk = DataChunk::builder().columns(vec![col1]).build();
+        let data_chunk = DataChunk::new(vec![col1], 1);
         let return_type = DataType {
             type_name: TypeName::Int16 as i32,
             is_nullable: false,
@@ -559,7 +559,7 @@ mod tests {
                 .map(|x| Arc::new(x.into()))
                 .unwrap(),
         );
-        let data_chunk = DataChunk::builder().columns(vec![col1]).build();
+        let data_chunk = DataChunk::new(vec![col1], 100);
         let expr = make_expression(kind, &[TypeName::Boolean], &[0]);
         let vec_executor = build_from_prost(&expr).unwrap();
         let res = vec_executor.eval(&data_chunk).unwrap();
@@ -602,7 +602,7 @@ mod tests {
                 .map(|x| Arc::new(x.into()))
                 .unwrap(),
         );
-        let data_chunk = DataChunk::builder().columns(vec![col1]).build();
+        let data_chunk = DataChunk::new(vec![col1], 100);
         let expr = make_expression(kind, &[TypeName::Date], &[0]);
         let vec_executor = build_from_prost(&expr).unwrap();
         let res = vec_executor.eval(&data_chunk).unwrap();

--- a/src/expr/src/vector_op/agg/general_agg.rs
+++ b/src/expr/src/vector_op/agg/general_agg.rs
@@ -220,9 +220,8 @@ mod tests {
         return_type: DataType,
         mut builder: ArrayBuilderImpl,
     ) -> Result<ArrayImpl> {
-        let input_chunk = DataChunk::builder()
-            .columns(vec![Column::new(input)])
-            .build();
+        let len = input.len();
+        let input_chunk = DataChunk::new(vec![Column::new(input)], len);
         let mut agg_state = create_agg_state_unary(input_type, 0, agg_type, return_type, false)?;
         agg_state.update(&input_chunk)?;
         agg_state.output(&mut builder)?;

--- a/src/expr/src/vector_op/agg/general_distinct_agg.rs
+++ b/src/expr/src/vector_op/agg/general_distinct_agg.rs
@@ -236,9 +236,8 @@ mod tests {
         return_type: DataType,
         mut builder: ArrayBuilderImpl,
     ) -> Result<ArrayImpl> {
-        let input_chunk = DataChunk::builder()
-            .columns(vec![Column::new(input)])
-            .build();
+        let len = input.len();
+        let input_chunk = DataChunk::new(vec![Column::new(input)], len);
         let mut agg_state = create_agg_state_unary(input_type, 0, agg_type, return_type, true)?;
         agg_state.update(&input_chunk)?;
         agg_state.output(&mut builder)?;

--- a/src/expr/src/vector_op/agg/general_sorted_grouper.rs
+++ b/src/expr/src/vector_op/agg/general_sorted_grouper.rs
@@ -420,9 +420,7 @@ mod tests {
         g0.update_and_output_with_sorted_groups_concrete(&input, &mut g0_builder, &eq)
             .unwrap();
         agg.update_and_output_with_sorted_groups(
-            &DataChunk::builder()
-                .columns(vec![Column::new(Arc::new(input.into()))])
-                .build(),
+            &DataChunk::new(vec![Column::new(Arc::new(input.into()))], 3),
             &mut a_builder,
             &eq,
         )
@@ -433,9 +431,7 @@ mod tests {
         g0.update_and_output_with_sorted_groups_concrete(&input, &mut g0_builder, &eq)
             .unwrap();
         agg.update_and_output_with_sorted_groups(
-            &DataChunk::builder()
-                .columns(vec![Column::new(Arc::new(input.into()))])
-                .build(),
+            &DataChunk::new(vec![Column::new(Arc::new(input.into()))], 3),
             &mut a_builder,
             &eq,
         )
@@ -446,9 +442,7 @@ mod tests {
         g0.update_and_output_with_sorted_groups_concrete(&input, &mut g0_builder, &eq)
             .unwrap();
         agg.update_and_output_with_sorted_groups(
-            &DataChunk::builder()
-                .columns(vec![Column::new(Arc::new(input.into()))])
-                .build(),
+            &DataChunk::new(vec![Column::new(Arc::new(input.into()))], 3),
             &mut a_builder,
             &eq,
         )

--- a/src/source/src/common.rs
+++ b/src/source/src/common.rs
@@ -47,6 +47,6 @@ pub(crate) trait SourceChunkBuilder {
 
     fn build_datachunk(column_desc: &[SourceColumnDesc], rows: &[Vec<Datum>]) -> Result<DataChunk> {
         let columns = Self::build_columns(column_desc, rows)?;
-        Ok(DataChunk::builder().columns(columns).build())
+        Ok(DataChunk::new(columns, rows.len()))
     }
 }

--- a/src/storage/src/table/cell_based_table.rs
+++ b/src/storage/src/table/cell_based_table.rs
@@ -374,17 +374,13 @@ impl<S: StateStore> CellBasedTableRowIter<S> {
             }
         }
 
-        let chunk = if schema.is_empty() {
-            // Generate some dummy data to ensure a correct cardinality, which might be used by
-            // count(*).
-            DataChunk::new_dummy(row_count)
-        } else {
+        let chunk = {
             let columns: Vec<Column> = builders
                 .into_iter()
                 .map(|builder| builder.finish().map(|a| Column::new(Arc::new(a))))
                 .try_collect()
                 .map_err(err)?;
-            DataChunk::builder().columns(columns).build()
+            DataChunk::new(columns, row_count)
         };
 
         if chunk.cardinality() == 0 {

--- a/src/stream/src/executor/filter.rs
+++ b/src/stream/src/executor/filter.rs
@@ -15,7 +15,7 @@
 use std::fmt::{Debug, Formatter};
 
 use itertools::Itertools;
-use risingwave_common::array::{Array, ArrayImpl, DataChunk, Op, StreamChunk, Vis};
+use risingwave_common::array::{Array, ArrayImpl, Op, StreamChunk, Vis};
 use risingwave_common::buffer::BitmapBuilder;
 use risingwave_common::catalog::Schema;
 use risingwave_expr::expr::BoxedExpression;
@@ -79,8 +79,7 @@ impl SimpleExecutor for SimpleFilterExecutor {
     ) -> StreamExecutorResult<Option<StreamChunk>> {
         let chunk = chunk.compact().map_err(StreamExecutorError::eval_error)?;
 
-        let (ops, columns, _visibility) = chunk.into_inner();
-        let data_chunk = DataChunk::new(columns, ops.len());
+        let (data_chunk, ops) = chunk.into_parts();
 
         let pred_output = self
             .expr

--- a/src/stream/src/executor/filter.rs
+++ b/src/stream/src/executor/filter.rs
@@ -80,7 +80,7 @@ impl SimpleExecutor for SimpleFilterExecutor {
         let chunk = chunk.compact().map_err(StreamExecutorError::eval_error)?;
 
         let (ops, columns, _visibility) = chunk.into_inner();
-        let data_chunk = DataChunk::builder().columns(columns).build();
+        let data_chunk = DataChunk::new(columns, ops.len());
 
         let pred_output = self
             .expr

--- a/src/stream/src/executor/project.rs
+++ b/src/stream/src/executor/project.rs
@@ -16,7 +16,7 @@ use std::fmt::{Debug, Formatter};
 
 use itertools::Itertools;
 use risingwave_common::array::column::Column;
-use risingwave_common::array::{DataChunk, StreamChunk};
+use risingwave_common::array::StreamChunk;
 use risingwave_common::catalog::{Field, Schema};
 use risingwave_expr::expr::BoxedExpression;
 
@@ -91,15 +91,7 @@ impl SimpleExecutor for SimpleProjectExecutor {
     ) -> StreamExecutorResult<Option<StreamChunk>> {
         let chunk = chunk.compact().map_err(StreamExecutorError::eval_error)?;
 
-        let (ops, columns, visibility) = chunk.into_inner();
-        let data_chunk = {
-            let data_chunk_builder = DataChunk::builder().columns(columns);
-            if let Some(visibility) = visibility {
-                data_chunk_builder.visibility(visibility).build()
-            } else {
-                data_chunk_builder.build()
-            }
-        };
+        let (data_chunk, ops) = chunk.into_parts();
 
         let projected_columns = self
             .exprs


### PR DESCRIPTION
## What's changed and what's your intention?

Part 2/3 of actual refactor #2663

With the introduction of a safer `DataChunk::new` in #2934, this PR migrate some callers of `DataChunkBuilder` or `TryFrom<Vec<Column>>` to `new`. **We need to find the proper `cardinality` as extra argument to pass into `new`.**

The original plan in #2934 was to migrate `TryFrom<Vec<Column>>` as part 2 and `DataChunkBuilder` as part 3. But here I am making simple callers as part 2 and complicated callers as part3.

Simple callers include:
* The ones in unit tests (`@@ mod tests`). `cardinality` for test cases are usually static and easy to find.
* The return of DML. Before #2678 is fixed, we are returning number of affected rows, which is always a 1-row-1-col int64 chunk.
* Other callers where `cardinality` is already available in a local variable.
  * batch order by
  * batch project
  * batch update
  * compact
  * chunk_coalesce
  * SourceChunkBuilder
  * CellBasedTableRowIter

Complicated callers do not have `cardinality` available and requires more code change to calculate it, especially when `columns` can be empty:
* batch hash join
* nested loop join
* batch hash agg
* batch sort agg
* batch merge sort exchange
* batch generate series
* batch values
* rechunk

## Checklist

~~- [ ] I have written necessary docs and comments~~
- [x] I have added necessary unit tests and integration tests
- [x] All checks passed in `./risedev check` (or alias, `./risedev c`)

## Refer to a related PR or issue link (optional)
