### PR TITLE
refactor(meta): use IdGenerator for compaction task id

### DIFF
--- a/proto/hummock.proto
+++ b/proto/hummock.proto
@@ -158,7 +158,6 @@ message LevelHandler {
 
 message CompactStatus {
   repeated LevelHandler level_handlers = 1;
-  uint64 next_compact_task_id = 2;
 }
 
 message CompactTaskAssignment {

--- a/src/meta/src/hummock/compaction/level_selector.rs
+++ b/src/meta/src/hummock/compaction/level_selector.rs
@@ -19,6 +19,7 @@
 
 use std::sync::Arc;
 
+use risingwave_hummock_sdk::HummockCompactionTaskId;
 use risingwave_pb::hummock::Level;
 
 use crate::hummock::compaction::compaction_picker::{CompactionPicker, MinOverlappingPicker};
@@ -39,7 +40,7 @@ pub trait LevelSelector: Sync + Send {
 
     fn pick_compaction(
         &self,
-        task_id: u64,
+        task_id: HummockCompactionTaskId,
         levels: &[Level],
         level_handlers: &mut [LevelHandler],
     ) -> Option<SearchResult>;
@@ -88,7 +89,7 @@ impl DynamicLevelSelector {
         &self,
         select_level: usize,
         target_level: usize,
-        task_id: u64,
+        task_id: HummockCompactionTaskId,
     ) -> Box<dyn CompactionPicker> {
         if select_level == 0 {
             if target_level == 0 {
@@ -235,7 +236,7 @@ impl LevelSelector for DynamicLevelSelector {
 
     fn pick_compaction(
         &self,
-        task_id: u64,
+        task_id: HummockCompactionTaskId,
         levels: &[Level],
         level_handlers: &mut [LevelHandler],
     ) -> Option<SearchResult> {

--- a/src/meta/src/hummock/compaction/mod.rs
+++ b/src/meta/src/hummock/compaction/mod.rs
@@ -26,7 +26,7 @@ use itertools::Itertools;
 use prost::Message;
 use risingwave_common::error::Result;
 use risingwave_hummock_sdk::key_range::KeyRange;
-use risingwave_hummock_sdk::HummockEpoch;
+use risingwave_hummock_sdk::{HummockCompactionTaskId, HummockEpoch};
 use risingwave_pb::hummock::{
     CompactMetrics, CompactTask, HummockVersion, Level, TableSetStatistics,
 };
@@ -56,7 +56,6 @@ const MAX_LEVEL: usize = 6;
 
 pub struct CompactStatus {
     pub(crate) level_handlers: Vec<LevelHandler>,
-    pub(crate) next_compact_task_id: u64,
     compaction_selector: Arc<dyn LevelSelector>,
 }
 
@@ -64,7 +63,6 @@ impl Debug for CompactStatus {
     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
         f.debug_struct("CompactStatus")
             .field("level_handlers", &self.level_handlers)
-            .field("next_compact_task_id", &self.next_compact_task_id)
             .field("compaction_selector", &self.compaction_selector.name())
             .finish()
     }
@@ -73,7 +71,6 @@ impl Debug for CompactStatus {
 impl PartialEq for CompactStatus {
     fn eq(&self, other: &Self) -> bool {
         self.level_handlers.eq(&other.level_handlers)
-            && self.next_compact_task_id == other.next_compact_task_id
             && self.compaction_selector.name() == other.compaction_selector.name()
     }
 }
@@ -83,7 +80,6 @@ impl Clone for CompactStatus {
         Self {
             level_handlers: self.level_handlers.clone(),
             compaction_selector: self.compaction_selector.clone(),
-            next_compact_task_id: self.next_compact_task_id,
         }
     }
 }
@@ -139,7 +135,6 @@ impl CompactStatus {
         };
         CompactStatus {
             level_handlers,
-            next_compact_task_id: 1,
             // TODO: create selector and overlap strategy by configure.
             compaction_selector: Arc::new(DynamicLevelSelector::new(config, overlap_strategy)),
         }
@@ -161,7 +156,6 @@ impl CompactStatus {
         {
             Ok(compact_status) => {
                 self.level_handlers = compact_status.level_handlers.iter().map_into().collect();
-                self.next_compact_task_id = compact_status.next_compact_task_id;
                 Ok(())
             }
             Err(err) => {
@@ -173,12 +167,16 @@ impl CompactStatus {
         }
     }
 
-    pub fn get_compact_task(&mut self, levels: &[Level]) -> Option<CompactTask> {
+    pub fn get_compact_task(
+        &mut self,
+        levels: &[Level],
+        task_id: HummockCompactionTaskId,
+    ) -> Option<CompactTask> {
         // When we compact the files, we must make the result of compaction meet the following
         // conditions, for any user key, the epoch of it in the file existing in the lower
         // layer must be larger.
 
-        let ret = match self.pick_compaction(levels) {
+        let ret = match self.pick_compaction(levels, task_id) {
             Some(ret) => ret,
             None => return None,
         };
@@ -199,7 +197,7 @@ impl CompactStatus {
             splits,
             watermark: HummockEpoch::MAX,
             sorted_output_ssts: vec![],
-            task_id: self.next_compact_task_id,
+            task_id,
             target_level: target_level_id,
             is_target_ultimate_and_leveling: target_level_id as usize
                 == self.level_handlers.len() - 1
@@ -226,16 +224,16 @@ impl CompactStatus {
             prefix_pairs: vec![],
             vnode_mappings: vec![],
         };
-        self.next_compact_task_id += 1;
         Some(compact_task)
     }
 
-    fn pick_compaction(&mut self, levels: &[Level]) -> Option<SearchResult> {
-        self.compaction_selector.pick_compaction(
-            self.next_compact_task_id,
-            levels,
-            &mut self.level_handlers,
-        )
+    fn pick_compaction(
+        &mut self,
+        levels: &[Level],
+        task_id: HummockCompactionTaskId,
+    ) -> Option<SearchResult> {
+        self.compaction_selector
+            .pick_compaction(task_id, levels, &mut self.level_handlers)
     }
 
     /// Declares a task is either finished or canceled.
@@ -334,7 +332,6 @@ impl From<&CompactStatus> for risingwave_pb::hummock::CompactStatus {
     fn from(status: &CompactStatus) -> Self {
         risingwave_pb::hummock::CompactStatus {
             level_handlers: status.level_handlers.iter().map_into().collect(),
-            next_compact_task_id: status.next_compact_task_id,
         }
     }
 }
@@ -343,7 +340,6 @@ impl From<&risingwave_pb::hummock::CompactStatus> for CompactStatus {
     fn from(status: &risingwave_pb::hummock::CompactStatus) -> Self {
         CompactStatus {
             level_handlers: status.level_handlers.iter().map_into().collect(),
-            next_compact_task_id: status.next_compact_task_id,
             compaction_selector: Arc::new(DynamicLevelSelector::default()),
         }
     }
@@ -356,7 +352,6 @@ mod tests {
     #[tokio::test]
     async fn test_serde() -> Result<()> {
         let origin = CompactStatus {
-            next_compact_task_id: 4,
             ..Default::default()
         };
         let ser = risingwave_pb::hummock::CompactStatus::from(&origin).encode_to_vec();

--- a/src/meta/src/hummock/hummock_manager.rs
+++ b/src/meta/src/hummock/hummock_manager.rs
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use std::collections::{BTreeMap, HashSet};
+use std::collections::{BTreeMap, HashSet, VecDeque};
 use std::future::Future;
 use std::ops::DerefMut;
 use std::sync::Arc;
@@ -25,8 +25,8 @@ use risingwave_common::util::epoch::INVALID_EPOCH;
 use risingwave_hummock_sdk::compact::compact_task_to_string;
 use risingwave_hummock_sdk::compaction_group::CompactionGroupId;
 use risingwave_hummock_sdk::{
-    get_remote_sst_id, HummockContextId, HummockEpoch, HummockRefCount, HummockSSTableId,
-    HummockVersionId,
+    get_remote_sst_id, HummockCompactionTaskId, HummockContextId, HummockEpoch, HummockRefCount,
+    HummockSSTableId, HummockVersionId,
 };
 use risingwave_pb::common::ParallelUnitMapping;
 use risingwave_pb::hummock::{
@@ -75,8 +75,28 @@ pub struct HummockManager<S: MetaStore> {
 pub type HummockManagerRef<S> = Arc<HummockManager<S>>;
 
 struct Compaction {
+    // TODO: `compact_status` will be managed per `compaction_groups` soon
     compact_status: CompactStatus,
     compact_task_assignment: BTreeMap<u64, CompactTaskAssignment>,
+    /// Available compaction task ids for use
+    next_task_ids: VecDeque<HummockCompactionTaskId>,
+}
+
+impl Compaction {
+    /// Gets a new compaction task id locally. If no id is available locally, fetch some ids via
+    /// `get_more_ids` first.
+    async fn get_next_task_id<F>(&mut self, get_more_ids: F) -> Result<HummockCompactionTaskId>
+    where
+        F: Future<Output = Result<Vec<HummockCompactionTaskId>>>,
+    {
+        if self.next_task_ids.is_empty() {
+            let new_ids = get_more_ids.await?;
+            self.next_task_ids.extend(new_ids);
+        }
+        self.next_task_ids
+            .pop_front()
+            .ok_or_else(|| Error::InternalError("cannot get compaction task id".to_string()))
+    }
 }
 
 /// Commit multiple `ValTransaction`s to state store and upon success update the local in-mem state
@@ -159,6 +179,7 @@ where
             compaction: RwLock::new(Compaction {
                 compact_status: CompactStatus::new(config.clone()),
                 compact_task_assignment: Default::default(),
+                next_task_ids: Default::default(),
             }),
             metrics,
             cluster_manager,
@@ -467,11 +488,26 @@ where
     pub async fn get_compact_task(&self) -> Result<Option<CompactTask>> {
         let start_time = Instant::now();
         let mut compaction_guard = self.compaction.write().await;
-
         let compaction = compaction_guard.deref_mut();
+        let task_id = compaction
+            .get_next_task_id(async {
+                let batch_size = 10;
+                self.env
+                    .id_gen_manager()
+                    .generate_interval::<{ IdCategory::HummockCompactionTask }>(batch_size)
+                    .await
+                    .map(|id| {
+                        (id as HummockCompactionTaskId
+                            ..(id + batch_size) as HummockCompactionTaskId)
+                            .collect_vec()
+                    })
+                    .map_err(Error::from)
+            })
+            .await?;
         let mut compact_status = VarTransaction::new(&mut compaction.compact_status);
         let current_version = self.versioning.read().await.current_version();
-        let compact_task = compact_status.get_compact_task(&current_version.levels);
+        let compact_task = compact_status
+            .get_compact_task(&current_version.levels, task_id as HummockCompactionTaskId);
         let ret = match compact_task {
             None => Ok(None),
             Some(mut compact_task) => {

--- a/src/meta/src/hummock/hummock_manager_tests.rs
+++ b/src/meta/src/hummock/hummock_manager_tests.rs
@@ -170,7 +170,7 @@ async fn test_hummock_compaction_task() {
             .get_level_idx(),
         0
     );
-    assert_eq!(compact_task.get_task_id(), 1);
+    assert_eq!(compact_task.get_task_id(), 2);
     // In the test case, we assume that each SST contains data of 2 relational tables, and
     // one of them overlaps with the previous SST. So there will be one more relational tables
     // (for vnode mapping) than SSTs.
@@ -213,7 +213,7 @@ async fn test_hummock_compaction_task() {
         .assign_compaction_task(&compact_task, context_id, async { true })
         .await
         .unwrap();
-    assert_eq!(compact_task.get_task_id(), 2);
+    assert_eq!(compact_task.get_task_id(), 3);
     // Finish the task and succeed.
     compact_task.task_status = true;
 

--- a/src/meta/src/manager/id.rs
+++ b/src/meta/src/manager/id.rs
@@ -132,6 +132,7 @@ pub mod IdCategory {
     pub const HummockSSTableId: IdCategoryType = 8;
     pub const ParallelUnit: IdCategoryType = 9;
     pub const Source: IdCategoryType = 10;
+    pub const HummockCompactionTask: IdCategoryType = 11;
 }
 
 pub type IdGeneratorManagerRef<S> = Arc<IdGeneratorManager<S>>;
@@ -149,6 +150,7 @@ pub struct IdGeneratorManager<S> {
     actor: Arc<StoredIdGenerator<S>>,
     hummock_snapshot: Arc<StoredIdGenerator<S>>,
     hummock_ss_table_id: Arc<StoredIdGenerator<S>>,
+    hummock_compaction_task: Arc<StoredIdGenerator<S>>,
     parallel_unit: Arc<StoredIdGenerator<S>>,
 }
 
@@ -177,6 +179,10 @@ where
             hummock_ss_table_id: Arc::new(
                 StoredIdGenerator::new(meta_store.clone(), "hummock_ss_table_id", Some(1)).await,
             ),
+            hummock_compaction_task: Arc::new(
+                StoredIdGenerator::new(meta_store.clone(), "hummock_compaction_task", Some(1))
+                    .await,
+            ),
             parallel_unit: Arc::new(
                 StoredIdGenerator::new(meta_store.clone(), "parallel_unit", None).await,
             ),
@@ -196,6 +202,7 @@ where
             IdCategory::Worker => &self.worker,
             IdCategory::HummockSSTableId => &self.hummock_ss_table_id,
             IdCategory::ParallelUnit => &self.parallel_unit,
+            IdCategory::HummockCompactionTask => &self.hummock_compaction_task,
             _ => unreachable!(),
         }
     }

--- a/src/storage/hummock_sdk/src/lib.rs
+++ b/src/storage/hummock_sdk/src/lib.rs
@@ -24,6 +24,7 @@ pub type HummockRefCount = u64;
 pub type HummockVersionId = u64;
 pub type HummockContextId = u32;
 pub type HummockEpoch = u64;
+pub type HummockCompactionTaskId = u64;
 pub const INVALID_VERSION_ID: HummockVersionId = 0;
 pub const FIRST_VERSION_ID: HummockVersionId = 1;
 


### PR DESCRIPTION
## What's changed and what's your intention?

Use `IdGenerator` for compaction task id, in order to make later compaction group easier (each compaction group owns a `CompactStatus` and share the same compaction task id). 
This also fixes a bug that originally `next_compact_task_id` was not correctly stored to meta store.


## Checklist

- [x] I have written necessary docs and comments
- [x] I have added necessary unit tests and integration tests
- [x] All checks passed in `./risedev check` (or alias, `./risedev c`)

## Refer to a related PR or issue link (optional)
