### PR TITLE
feat(steaming): use table_id as topN prefix for keyspace

### DIFF
--- a/proto/stream_plan.proto
+++ b/proto/stream_plan.proto
@@ -82,6 +82,8 @@ message TopNNode {
   uint64 limit = 2;
   uint64 offset = 3;
   repeated uint32 distribution_keys = 4;
+  // Used for internal table states
+  uint32 table_id = 5;
 }
 
 message HashJoinNode {

--- a/src/frontend/src/optimizer/plan_node/stream_topn.rs
+++ b/src/frontend/src/optimizer/plan_node/stream_topn.rs
@@ -92,6 +92,7 @@ impl ToStreamProst for StreamTopN {
             limit: self.logical.limit() as u64,
             offset: self.logical.offset() as u64,
             distribution_keys: vec![], // TODO: seems unnecessary
+            ..Default::default()
         })
     }
 }

--- a/src/meta/src/stream/stream_graph.rs
+++ b/src/meta/src/stream/stream_graph.rs
@@ -571,6 +571,10 @@ impl StreamGraphBuilder {
                     }
                 }
 
+                if let NodeBody::TopN(node) = new_stream_node.node_body.as_mut().unwrap() {
+                    node.table_id += table_id_offset;
+                }
+
                 match new_stream_node.node_body.as_mut().unwrap() {
                     NodeBody::GlobalSimpleAgg(node) | NodeBody::LocalSimpleAgg(node) => {
                         assert_eq!(node.table_ids.len(), node.agg_calls.len());

--- a/src/stream/src/from_proto/top_n.rs
+++ b/src/stream/src/from_proto/top_n.rs
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use risingwave_common::catalog::TableId;
 use risingwave_common::util::sort_util::OrderPair;
 
 use super::*;
@@ -39,7 +40,8 @@ impl ExecutorBuilder for TopNExecutorBuilder {
         };
         let cache_size = Some(1024);
         let total_count = (0, 0, 0);
-        let keyspace = Keyspace::executor_root(store, params.executor_id);
+        let table_id = TableId::new(node.get_table_id());
+        let keyspace = Keyspace::table_root(store, &table_id);
         let key_indices = node
             .get_distribution_keys()
             .iter()


### PR DESCRIPTION
## What's changed and what's your intention?

***PLEASE DO NOT LEAVE THIS EMPTY !!!***
Replace operator_id to table_id for `TopN`.

- Add a fields table_id in `TopNode` proto. This is designed to use indenpendent table_id to replace operator_id
- `gen_table_id` when build the `stream_fragemnet` and recaluc truely table_id when `generate_steam_graph` 
- use `keyspace::table_root` to replace `keyspace::executor_root` for table_id prefix
- refactor some code logic for pattern match

## Checklist

- [x] I have written necessary docs and comments
- [x] I have added necessary unit tests and integration tests

## Refer to a related PR or issue link (optional)
- close https://github.com/singularity-data/risingwave/issues/2925
- https://github.com/singularity-data/risingwave/pull/1987