### PR TITLE
refactor(batch): Executor builder should not create their children

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3559,6 +3559,7 @@ version = "0.1.7"
 dependencies = [
  "anyhow",
  "assert_matches",
+ "async-recursion",
  "async-stream",
  "async-trait",
  "byteorder",

--- a/src/batch/Cargo.toml
+++ b/src/batch/Cargo.toml
@@ -5,6 +5,7 @@ version = "0.1.7"
 
 [dependencies]
 anyhow = "1"
+async-recursion = "1"
 async-stream = "0.3"
 async-trait = "0.1"
 byteorder = "1"

--- a/src/batch/src/executor/delete.rs
+++ b/src/batch/src/executor/delete.rs
@@ -115,7 +115,9 @@ impl DeleteExecutor {
 impl BoxedExecutorBuilder for DeleteExecutor {
     async fn new_boxed_executor<C: BatchTaskContext>(
         source: &ExecutorBuilder<C>,
+        mut inputs: Vec<BoxedExecutor>,
     ) -> Result<BoxedExecutor> {
+        ensure!(inputs.len() == 1, "Delete executor should have 1 child!");
         let delete_node = try_match_expand!(
             source.plan_node().get_node_body().unwrap(),
             NodeBody::Delete
@@ -123,20 +125,13 @@ impl BoxedExecutorBuilder for DeleteExecutor {
 
         let table_id = TableId::from(&delete_node.table_source_ref_id);
 
-        let proto_child = source.plan_node.get_children().get(0).ok_or_else(|| {
-            RwError::from(ErrorCode::InternalError(String::from(
-                "Child interpreting error",
-            )))
-        })?;
-        let child = source.clone_for_plan(proto_child).build().await?;
-
         Ok(Box::new(Self::new(
             table_id,
             source
                 .context()
                 .source_manager_ref()
                 .ok_or_else(|| InternalError("Source manager not found".to_string()))?,
-            child,
+            inputs.remove(0),
         )))
     }
 }

--- a/src/batch/src/executor/generate_series.rs
+++ b/src/batch/src/executor/generate_series.rs
@@ -119,7 +119,12 @@ pub struct GenerateSeriesExecutorBuilder {}
 impl BoxedExecutorBuilder for GenerateSeriesExecutorBuilder {
     async fn new_boxed_executor<C: BatchTaskContext>(
         source: &ExecutorBuilder<C>,
+        inputs: Vec<BoxedExecutor>,
     ) -> Result<BoxedExecutor> {
+        ensure!(
+            inputs.is_empty(),
+            "GenerateSeriesExecutor should not have child!"
+        );
         let node = try_match_expand!(
             source.plan_node().get_node_body().unwrap(),
             NodeBody::GenerateSeries

--- a/src/batch/src/executor/generic_exchange.rs
+++ b/src/batch/src/executor/generic_exchange.rs
@@ -97,7 +97,12 @@ pub struct GenericExchangeExecutorBuilder {}
 impl BoxedExecutorBuilder for GenericExchangeExecutorBuilder {
     async fn new_boxed_executor<C: BatchTaskContext>(
         source: &ExecutorBuilder<C>,
+        inputs: Vec<BoxedExecutor>,
     ) -> Result<BoxedExecutor> {
+        ensure!(
+            inputs.is_empty(),
+            "Exchange executor should not have children!"
+        );
         let node = try_match_expand!(
             source.plan_node().get_node_body().unwrap(),
             NodeBody::Exchange

--- a/src/batch/src/executor/insert.rs
+++ b/src/batch/src/executor/insert.rs
@@ -131,7 +131,9 @@ impl InsertExecutor {
 impl BoxedExecutorBuilder for InsertExecutor {
     async fn new_boxed_executor<C: BatchTaskContext>(
         source: &ExecutorBuilder<C>,
+        mut inputs: Vec<BoxedExecutor>,
     ) -> Result<BoxedExecutor> {
+        ensure!(inputs.len() == 1, "Insert executor should 1 child!");
         let insert_node = try_match_expand!(
             source.plan_node().get_node_body().unwrap(),
             NodeBody::Insert
@@ -139,20 +141,13 @@ impl BoxedExecutorBuilder for InsertExecutor {
 
         let table_id = TableId::from(&insert_node.table_source_ref_id);
 
-        let proto_child = source.plan_node.get_children().get(0).ok_or_else(|| {
-            RwError::from(ErrorCode::InternalError(String::from(
-                "Child interpreting error",
-            )))
-        })?;
-        let child = source.clone_for_plan(proto_child).build().await?;
-
         Ok(Box::new(Self::new(
             table_id,
             source
                 .context()
                 .source_manager_ref()
                 .ok_or_else(|| InternalError("Source manager not found".to_string()))?,
-            child,
+            inputs.remove(0),
         )))
     }
 }

--- a/src/batch/src/executor/join/hash_join.rs
+++ b/src/batch/src/executor/join/hash_join.rs
@@ -288,17 +288,15 @@ impl HashKeyDispatcher for HashJoinExecutorBuilderDispatcher {
 impl BoxedExecutorBuilder for HashJoinExecutorBuilder {
     async fn new_boxed_executor<C: BatchTaskContext>(
         context: &ExecutorBuilder<C>,
+        mut inputs: Vec<BoxedExecutor>,
     ) -> Result<BoxedExecutor> {
-        ensure!(context.plan_node().get_children().len() == 2);
+        ensure!(
+            inputs.len() == 2,
+            "HashJoinExecutorBuilder should have 2 children!"
+        );
 
-        let left_child = context
-            .clone_for_plan(&context.plan_node.get_children()[0])
-            .build()
-            .await?;
-        let right_child = context
-            .clone_for_plan(&context.plan_node.get_children()[1])
-            .build()
-            .await?;
+        let left_child = inputs.remove(0);
+        let right_child = inputs.remove(0);
 
         let hash_join_node = try_match_expand!(
             context.plan_node().get_node_body().unwrap(),

--- a/src/batch/src/executor/join/nested_loop_join.rs
+++ b/src/batch/src/executor/join/nested_loop_join.rs
@@ -21,7 +21,6 @@ use risingwave_common::array::column::Column;
 use risingwave_common::array::data_chunk_iter::RowRef;
 use risingwave_common::array::{ArrayBuilderImpl, DataChunk, Row};
 use risingwave_common::catalog::Schema;
-use risingwave_common::error::ErrorCode::InternalError;
 use risingwave_common::error::{ErrorCode, Result, RwError};
 use risingwave_common::types::{DataType, DatumRef};
 use risingwave_common::util::chunk_coalesce::{DataChunkBuilder, SlicedDataChunk};
@@ -192,8 +191,12 @@ impl NestedLoopJoinExecutor {
 impl BoxedExecutorBuilder for NestedLoopJoinExecutor {
     async fn new_boxed_executor<C: BatchTaskContext>(
         source: &ExecutorBuilder<C>,
+        mut inputs: Vec<BoxedExecutor>,
     ) -> Result<BoxedExecutor> {
-        ensure!(source.plan_node().get_children().len() == 2);
+        ensure!(
+            inputs.len() == 2,
+            "NestedLoopJoinExecutor should have 2 children!"
+        );
 
         let nested_loop_join_node = try_match_expand!(
             source.plan_node().get_node_body().unwrap(),
@@ -202,65 +205,57 @@ impl BoxedExecutorBuilder for NestedLoopJoinExecutor {
 
         let join_type = JoinType::from_prost(nested_loop_join_node.get_join_type()?);
         let join_expr = expr_build_from_prost(nested_loop_join_node.get_join_cond()?)?;
-        // Note: Assume that optimizer has set up probe side and build side. Left is the probe side,
-        // right is the build side. This is the same for all join executors.
-        let left_plan_opt = source.plan_node().get_children().get(0);
-        let right_plan_opt = source.plan_node().get_children().get(1);
-        match (left_plan_opt, right_plan_opt) {
-            (Some(left_plan), Some(right_plan)) => {
-                let left_child = source.clone_for_plan(left_plan).build().await?;
-                let probe_side_schema = left_child.schema().data_types();
-                let right_child = source.clone_for_plan(right_plan).build().await?;
 
-                // TODO(Bowen): Merge this with derive schema in Logical Join (#790).
-                let fields = match join_type {
-                    JoinType::LeftSemi => left_child.schema().fields.clone(),
-                    JoinType::LeftAnti => left_child.schema().fields.clone(),
-                    JoinType::RightSemi => right_child.schema().fields.clone(),
-                    JoinType::RightAnti => right_child.schema().fields.clone(),
-                    _ => left_child
-                        .schema()
-                        .fields
-                        .iter()
-                        .chain(right_child.schema().fields.iter())
-                        .cloned()
-                        .collect(),
-                };
+        let left_child = inputs.remove(0);
+        let probe_side_schema = left_child.schema().data_types();
+        let right_child = inputs.remove(0);
 
-                let schema = Schema { fields };
-                match join_type {
-                    JoinType::Inner
-                    | JoinType::LeftOuter
-                    | JoinType::RightOuter
-                    | JoinType::LeftSemi
-                    | JoinType::LeftAnti
-                    | JoinType::RightSemi
-                    | JoinType::RightAnti => {
-                        // TODO: Support FULL OUTER.
-                        let outer_table_source = RowLevelIter::new(left_child);
+        // TODO(Bowen): Merge this with derive schema in Logical Join (#790).
+        let fields = match join_type {
+            JoinType::LeftSemi => left_child.schema().fields.clone(),
+            JoinType::LeftAnti => left_child.schema().fields.clone(),
+            JoinType::RightSemi => right_child.schema().fields.clone(),
+            JoinType::RightAnti => right_child.schema().fields.clone(),
+            _ => left_child
+                .schema()
+                .fields
+                .iter()
+                .chain(right_child.schema().fields.iter())
+                .cloned()
+                .collect(),
+        };
 
-                        Ok(Box::new(Self {
-                            join_expr,
-                            join_type,
-                            chunk_builder: DataChunkBuilder::with_default_size(schema.data_types()),
-                            schema,
-                            last_chunk: None,
-                            probe_side_schema,
-                            probe_side_source: outer_table_source,
-                            build_table: RowLevelIter::new(right_child),
-                            probe_remain_chunk_idx: 0,
-                            probe_remain_row_idx: 0,
-                            identity: "NestedLoopJoinExecutor2".to_string(),
-                        }))
-                    }
-                    _ => Err(ErrorCode::NotImplemented(
-                        format!("Do not support {:?} join type now.", join_type),
-                        None.into(),
-                    )
-                    .into()),
-                }
+        let schema = Schema { fields };
+        match join_type {
+            JoinType::Inner
+            | JoinType::LeftOuter
+            | JoinType::RightOuter
+            | JoinType::LeftSemi
+            | JoinType::LeftAnti
+            | JoinType::RightSemi
+            | JoinType::RightAnti => {
+                // TODO: Support FULL OUTER.
+                let outer_table_source = RowLevelIter::new(left_child);
+
+                Ok(Box::new(Self {
+                    join_expr,
+                    join_type,
+                    chunk_builder: DataChunkBuilder::with_default_size(schema.data_types()),
+                    schema,
+                    last_chunk: None,
+                    probe_side_schema,
+                    probe_side_source: outer_table_source,
+                    build_table: RowLevelIter::new(right_child),
+                    probe_remain_chunk_idx: 0,
+                    probe_remain_row_idx: 0,
+                    identity: "NestedLoopJoinExecutor2".to_string(),
+                }))
             }
-            (_, _) => Err(InternalError("Filter must have one children".to_string()).into()),
+            _ => Err(ErrorCode::NotImplemented(
+                format!("Do not support {:?} join type now.", join_type),
+                None.into(),
+            )
+            .into()),
         }
     }
 }

--- a/src/batch/src/executor/merge_sort_exchange.rs
+++ b/src/batch/src/executor/merge_sort_exchange.rs
@@ -193,7 +193,12 @@ pub struct MergeSortExchangeExecutorBuilder {}
 impl BoxedExecutorBuilder for MergeSortExchangeExecutorBuilder {
     async fn new_boxed_executor<C: BatchTaskContext>(
         source: &ExecutorBuilder<C>,
+        inputs: Vec<BoxedExecutor>,
     ) -> Result<BoxedExecutor> {
+        ensure!(
+            inputs.is_empty(),
+            "MergeSortExchangeExecutor should not have child!"
+        );
         let sort_merge_node = try_match_expand!(
             source.plan_node().get_node_body().unwrap(),
             NodeBody::MergeSortExchange

--- a/src/batch/src/executor/order_by.rs
+++ b/src/batch/src/executor/order_by.rs
@@ -87,8 +87,12 @@ impl OrderByExecutor {
 impl BoxedExecutorBuilder for OrderByExecutor {
     async fn new_boxed_executor<C: BatchTaskContext>(
         source: &ExecutorBuilder<C>,
+        mut inputs: Vec<BoxedExecutor>,
     ) -> Result<BoxedExecutor> {
-        ensure!(source.plan_node().get_children().len() == 1);
+        ensure!(
+            inputs.len() == 1,
+            "OrderByExecutor should have only 1 child!"
+        );
 
         let order_by_node = try_match_expand!(
             source.plan_node().get_node_body().unwrap(),
@@ -100,23 +104,19 @@ impl BoxedExecutorBuilder for OrderByExecutor {
             .iter()
             .map(OrderPair::from_prost)
             .collect();
-        if let Some(child_plan) = source.plan_node.get_children().get(0) {
-            let child = source.clone_for_plan(child_plan).build().await?;
-            return Ok(Box::new(OrderByExecutor::new(
-                child,
-                vec![],
-                vec![],
-                vec![],
-                BinaryHeap::new(),
-                Arc::new(order_pairs),
-                vec![],
-                false,
-                false,
-                source.plan_node().get_identity().clone(),
-                DEFAULT_CHUNK_BUFFER_SIZE,
-            )));
-        }
-        Err(InternalError("OrderBy must have one child".to_string()).into())
+        Ok(Box::new(OrderByExecutor::new(
+            inputs.remove(0),
+            vec![],
+            vec![],
+            vec![],
+            BinaryHeap::new(),
+            Arc::new(order_pairs),
+            vec![],
+            false,
+            false,
+            source.plan_node().get_identity().clone(),
+            DEFAULT_CHUNK_BUFFER_SIZE,
+        )))
     }
 }
 

--- a/src/batch/src/executor/project.rs
+++ b/src/batch/src/executor/project.rs
@@ -16,7 +16,7 @@ use futures_async_stream::try_stream;
 use risingwave_common::array::column::Column;
 use risingwave_common::array::DataChunk;
 use risingwave_common::catalog::{Field, Schema};
-use risingwave_common::error::{ErrorCode, Result, RwError};
+use risingwave_common::error::{Result, RwError};
 use risingwave_expr::expr::{build_from_prost, BoxedExpression};
 use risingwave_pb::batch_plan::plan_node::NodeBody;
 
@@ -68,20 +68,17 @@ impl ProjectExecutor {
 impl BoxedExecutorBuilder for ProjectExecutor {
     async fn new_boxed_executor<C: BatchTaskContext>(
         source: &ExecutorBuilder<C>,
+        mut inputs: Vec<BoxedExecutor>,
     ) -> Result<BoxedExecutor> {
-        ensure!(source.plan_node().get_children().len() == 1);
+        ensure!(
+            inputs.len() == 1,
+            "Project executor should have only 1 child!"
+        );
 
         let project_node = try_match_expand!(
             source.plan_node().get_node_body().unwrap(),
             NodeBody::Project
         )?;
-
-        let proto_child = source.plan_node.get_children().get(0).ok_or_else(|| {
-            RwError::from(ErrorCode::InternalError(String::from(
-                "Child interpreting error",
-            )))
-        })?;
-        let child_node = source.clone_for_plan(proto_child).build().await?;
 
         let project_exprs = project_node
             .get_select_list()
@@ -96,7 +93,7 @@ impl BoxedExecutorBuilder for ProjectExecutor {
 
         Ok(Box::new(Self {
             expr: project_exprs,
-            child: child_node,
+            child: inputs.remove(0),
             schema: Schema { fields },
             identity: source.plan_node().get_identity().clone(),
         }))

--- a/src/batch/src/executor/row_seq_scan.rs
+++ b/src/batch/src/executor/row_seq_scan.rs
@@ -76,7 +76,12 @@ impl RowSeqScanExecutorBuilder {
 impl BoxedExecutorBuilder for RowSeqScanExecutorBuilder {
     async fn new_boxed_executor<C: BatchTaskContext>(
         source: &ExecutorBuilder<C>,
+        inputs: Vec<BoxedExecutor>,
     ) -> Result<BoxedExecutor> {
+        ensure!(
+            inputs.is_empty(),
+            "Row sequential scan should not have input executor!"
+        );
         let seq_scan_node = try_match_expand!(
             source.plan_node().get_node_body().unwrap(),
             NodeBody::RowSeqScan

--- a/src/batch/src/executor/update.rs
+++ b/src/batch/src/executor/update.rs
@@ -166,7 +166,9 @@ impl UpdateExecutor {
 impl BoxedExecutorBuilder for UpdateExecutor {
     async fn new_boxed_executor<C: BatchTaskContext>(
         source: &ExecutorBuilder<C>,
+        mut inputs: Vec<BoxedExecutor>,
     ) -> Result<BoxedExecutor> {
+        ensure!(inputs.len() == 1, "Update executor should have 1 child!");
         let update_node = try_match_expand!(
             source.plan_node().get_node_body().unwrap(),
             NodeBody::Update
@@ -180,17 +182,10 @@ impl BoxedExecutorBuilder for UpdateExecutor {
             .map(build_from_prost)
             .collect::<Result<Vec<BoxedExpression>>>()?;
 
-        let proto_child = source.plan_node.get_children().get(0).ok_or_else(|| {
-            RwError::from(ErrorCode::InternalError(String::from(
-                "Child interpreting error",
-            )))
-        })?;
-        let child = source.clone_for_plan(proto_child).build().await?;
-
         Ok(Box::new(Self::new(
             table_id,
             source.context().try_get_source_manager_ref()?,
-            child,
+            inputs.remove(0),
             exprs,
         )))
     }

--- a/src/batch/src/executor/values.rs
+++ b/src/batch/src/executor/values.rs
@@ -115,7 +115,7 @@ impl BoxedExecutorBuilder for ValuesExecutor {
         source: &ExecutorBuilder<C>,
         inputs: Vec<BoxedExecutor>,
     ) -> Result<BoxedExecutor> {
-        ensure!(inputs.len() == 1, "ValuesExecutor should have 1 child!");
+        ensure!(inputs.is_empty(), "ValuesExecutor should have no child!");
         let value_node = try_match_expand!(
             source.plan_node().get_node_body().unwrap(),
             NodeBody::Values

--- a/src/batch/src/executor/values.rs
+++ b/src/batch/src/executor/values.rs
@@ -113,7 +113,9 @@ impl ValuesExecutor {
 impl BoxedExecutorBuilder for ValuesExecutor {
     async fn new_boxed_executor<C: BatchTaskContext>(
         source: &ExecutorBuilder<C>,
+        inputs: Vec<BoxedExecutor>,
     ) -> Result<BoxedExecutor> {
+        ensure!(inputs.len() == 1, "ValuesExecutor should have 1 child!");
         let value_node = try_match_expand!(
             source.plan_node().get_node_body().unwrap(),
             NodeBody::Values


### PR DESCRIPTION
## What's changed and what's your intention?

***PLEASE DO NOT LEAVE THIS EMPTY !!!***

RT.
Prepare for further refactor of `BatchTaskContext`.

## Checklist

- [x] I have written necessary docs and comments
- [x] I have added necessary unit tests and integration tests
- [x] All checks passed in `./risedev check` (or alias, `./risedev c`)

## Refer to a related PR or issue link (optional)
