### PR TITLE
chore: do not #[allow(unused)]

### DIFF
--- a/src/frontend/src/lib.rs
+++ b/src/frontend/src/lib.rs
@@ -42,7 +42,7 @@ pub mod handler;
 pub mod observer;
 pub mod optimizer;
 pub mod planner;
-#[allow(unused)]
+#[allow(dead_code)]
 mod scheduler;
 pub mod session;
 pub mod stream_fragmenter;

--- a/src/frontend/src/scheduler/distributed/query.rs
+++ b/src/frontend/src/scheduler/distributed/query.rs
@@ -202,7 +202,7 @@ impl QueryExecution {
     }
 
     /// Cancel execution of this query.
-    #[allow(unused)]
+    #[allow(dead_code)]
     pub async fn abort(&mut self) -> Result<()> {
         todo!()
     }
@@ -257,7 +257,8 @@ impl QueryRunner {
                         info!("Query {:?} has scheduled all of its stages that have table scan (iterator creation).", self.query.query_id);
                         self.hummock_snapshot_manager
                             .clone()
-                            .unpin_snapshot(self.epoch, self.query.query_id());
+                            .unpin_snapshot(self.epoch, self.query.query_id())
+                            .await?;
                     }
 
                     if self.scheduled_stages_count == self.stage_executions.len() {

--- a/src/frontend/src/scheduler/distributed/query.rs
+++ b/src/frontend/src/scheduler/distributed/query.rs
@@ -202,7 +202,6 @@ impl QueryExecution {
     }
 
     /// Cancel execution of this query.
-    #[allow(dead_code)]
     pub async fn abort(&mut self) -> Result<()> {
         todo!()
     }

--- a/src/frontend/src/scheduler/distributed/stage.rs
+++ b/src/frontend/src/scheduler/distributed/stage.rs
@@ -26,7 +26,7 @@ use risingwave_pb::batch_plan::{
     TaskId as TaskIdProst, TaskOutputId,
 };
 use risingwave_pb::common::HostAddress;
-use risingwave_rpc_client::{ComputeClient, ComputeClientPoolRef};
+use risingwave_rpc_client::ComputeClientPoolRef;
 use tokio::spawn;
 use tokio::sync::mpsc::{channel, Receiver, Sender};
 use tokio::sync::RwLock;

--- a/src/frontend/src/scheduler/local.rs
+++ b/src/frontend/src/scheduler/local.rs
@@ -19,14 +19,14 @@ use risingwave_batch::executor::ExecutorBuilder;
 use risingwave_batch::task::TaskId;
 use risingwave_common::array::DataChunk;
 use risingwave_common::error::{internal_error, Result, RwError};
-use risingwave_pb::batch_plan::{PlanFragment, PlanNode as PlanNodeProst, TaskId as TaskIdProst};
+use risingwave_pb::batch_plan::{PlanFragment, PlanNode as PlanNodeProst};
 use tracing::debug;
 use uuid::Uuid;
 
 use crate::optimizer::plan_node::PlanNodeType;
 use crate::scheduler::plan_fragmenter::{ExecutionPlanNode, Query};
 use crate::scheduler::task_context::FrontendBatchTaskContext;
-use crate::scheduler::{DataChunkStream, HummockSnapshotManagerRef};
+use crate::scheduler::HummockSnapshotManagerRef;
 
 pub struct LocalQueryExecution {
     sql: String,

--- a/src/frontend/src/scheduler/plan_fragmenter.rs
+++ b/src/frontend/src/scheduler/plan_fragmenter.rs
@@ -18,7 +18,7 @@ use std::sync::Arc;
 
 use risingwave_common::error::Result;
 use risingwave_pb::batch_plan::plan_node::NodeBody;
-use risingwave_pb::batch_plan::{ExchangeInfo, PlanNode};
+use risingwave_pb::batch_plan::ExchangeInfo;
 use risingwave_pb::plan_common::Field as FieldProst;
 use uuid::Uuid;
 
@@ -142,7 +142,7 @@ impl Query {
         self.stage_graph
             .stages
             .iter()
-            .filter(|(stage_id, stage_query)| stage_query.has_table_scan)
+            .filter(|(_stage_id, stage_query)| stage_query.has_table_scan)
             .map(|(id, _)| *id)
             .collect::<Vec<_>>()
     }

--- a/src/frontend/src/scheduler/query_manager.rs
+++ b/src/frontend/src/scheduler/query_manager.rs
@@ -13,7 +13,6 @@
 // limitations under the License.
 
 use std::fmt::{Debug, Formatter};
-use std::sync::Arc;
 
 use futures::Stream;
 use futures_async_stream::try_stream;
@@ -22,9 +21,7 @@ use risingwave_common::array::DataChunk;
 use risingwave_common::error::{Result, RwError};
 use risingwave_pb::batch_plan::{PlanNode as BatchPlanProst, TaskId, TaskOutputId};
 use risingwave_pb::common::HostAddress;
-use risingwave_rpc_client::{
-    ComputeClient, ComputeClientPool, ComputeClientPoolRef, ExchangeSource,
-};
+use risingwave_rpc_client::{ComputeClientPoolRef, ExchangeSource};
 use uuid::Uuid;
 
 use super::HummockSnapshotManagerRef;
@@ -187,8 +184,6 @@ impl QueryResultFetcher {
         while let Some(chunk) = source.take_data().await? {
             yield chunk;
         }
-
-        let epoch = self.epoch;
     }
 }
 

--- a/src/frontend/src/scheduler/task_context.rs
+++ b/src/frontend/src/scheduler/task_context.rs
@@ -15,8 +15,8 @@
 use std::sync::Arc;
 
 use risingwave_batch::executor::BatchMetrics;
-use risingwave_batch::task::{BatchTaskContext, TaskId, TaskOutput, TaskOutputId};
-use risingwave_common::error::{Result, RwError};
+use risingwave_batch::task::{BatchTaskContext, TaskOutput, TaskOutputId};
+use risingwave_common::error::Result;
 use risingwave_common::util::addr::HostAddr;
 use risingwave_source::SourceManagerRef;
 
@@ -29,7 +29,7 @@ impl BatchTaskContext for FrontendBatchTaskContext {
         todo!()
     }
 
-    fn is_local_addr(&self, peer_addr: &HostAddr) -> bool {
+    fn is_local_addr(&self, _peer_addr: &HostAddr) -> bool {
         todo!()
     }
 

--- a/src/storage/src/hummock/iterator/backward_user.rs
+++ b/src/storage/src/hummock/iterator/backward_user.rs
@@ -278,7 +278,7 @@ impl DirectedUserIteratorBuilder for BackwardUserIterator {
     }
 }
 
-#[allow(unused)]
+#[allow(unused_variables)]
 #[cfg(test)]
 mod tests {
     use std::cmp::Reverse;
@@ -289,7 +289,6 @@ mod tests {
     use rand::distributions::Alphanumeric;
     use rand::{thread_rng, Rng};
     use risingwave_hummock_sdk::key::{prev_key, user_key};
-    use risingwave_hummock_sdk::VersionedComparator;
 
     use super::*;
     use crate::hummock::iterator::test_utils::{
@@ -297,13 +296,12 @@ mod tests {
         gen_iterator_test_sstable_from_kv_pair, iterator_test_key_of, iterator_test_key_of_epoch,
         iterator_test_value_of, mock_sstable_store, TEST_KEYS_COUNT,
     };
-    use crate::hummock::iterator::{BoxedBackwardHummockIterator, BoxedForwardHummockIterator};
-    use crate::hummock::sstable::{SSTableIteratorType, Sstable};
+    use crate::hummock::iterator::BoxedBackwardHummockIterator;
+    use crate::hummock::sstable::Sstable;
     use crate::hummock::test_utils::{create_small_table_cache, gen_test_sstable};
     use crate::hummock::value::HummockValue;
     use crate::hummock::{BackwardSSTableIterator, SstableStoreRef};
     use crate::monitor::StateStoreMetrics;
-    use crate::storage_value::ValueMeta;
 
     #[tokio::test]
     async fn test_backward_user_basic() {


### PR DESCRIPTION
## What's changed and what's your intention?

which is lint group for: unused-imports, unused-variables, unused-assignments, dead-code, unused-mut, unreachable-code, unreachable-patterns, unused-must-use, unused-unsafe, path-statements, unused-attributes, unused-macros, unused-allocation, unused-doc-comments, unused-extern-crates, unused-features, unused-labels, unused-parens, unused-braces, redundant-semicolons 🙀 


## Checklist

- ~~[ ] I have written necessary docs and comments~~
- ~~[ ] I have added necessary unit tests and integration tests~~
- [x] All checks passed in `./risedev check` (or alias, `./risedev c`)

## Refer to a related PR or issue link (optional)
