### PR TITLE
refactor(test_decimal_e_m): Fix `exponents`

### DIFF
--- a/src/utils/memcomparable/src/ser.rs
+++ b/src/utils/memcomparable/src/ser.rs
@@ -784,7 +784,7 @@ mod tests {
     fn test_decimal_e_m() {
         // from: https://sqlite.org/src4/doc/trunk/www/key_encoding.wiki
         let cases = vec![
-            // (decimal, exponets, significand)
+            // (decimal, exponents, significand)
             ("1.0", 1, "02"),
             ("10.0", 1, "14"),
             ("10", 1, "14"),
@@ -818,10 +818,10 @@ mod tests {
             ("9223372036854775807", 10, "13 2d 43 91 07 89 6d 9b 75 0e"),
         ];
 
-        for (decimal, exponets, significand) in cases {
+        for (decimal, exponents, significand) in cases {
             let d = decimal.parse::<rust_decimal::Decimal>().unwrap();
             let (exp, sig) = Serializer::<Vec<u8>>::decimal_e_m(d.mantissa(), d.scale() as u8);
-            assert_eq!(exp, exponets, "wrong exponets for decimal: {decimal}");
+            assert_eq!(exp, exponents, "wrong exponents for decimal: {decimal}");
             assert_eq!(
                 sig.iter()
                     .map(|b| format!("{b:02x}"))


### PR DESCRIPTION
Signed-off-by: Ryan Russell <git@ryanrussell.org>

## What's changed and what's your intention?
Fix `test_decimal_e_m()`; `exponets` -> `exponents`

## Checklist

- [x] I have written necessary docs and comments
- [x] All checks passed in `./risedev check` (or alias, `./risedev c`)
