### PR TITLE
refactor(storage): support zstd compression in block

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4263,6 +4263,7 @@ dependencies = [
  "uuid 1.1.0",
  "value-encoding",
  "workspace-hack",
+ "zstd",
 ]
 
 [[package]]

--- a/src/storage/Cargo.toml
+++ b/src/storage/Cargo.toml
@@ -70,6 +70,7 @@ tracing = { version = "0.1" }
 twox-hash = "1"
 value-encoding = { path = "../utils/value-encoding" }
 workspace-hack = { version = "0.1", path = "../workspace-hack" }
+zstd = "0.11.2"
 
 [target.'cfg(target_os = "linux")'.dependencies]
 procinfo = { git = "https://github.com/tikv/procinfo-rs", rev = "6599eb9dca74229b2c1fcc44118bef7eff127128" }

--- a/src/storage/src/hummock/sstable/block.rs
+++ b/src/storage/src/hummock/sstable/block.rs
@@ -45,28 +45,25 @@ impl Block {
 
         // Decompress.
         let compression = CompressionAlgorithm::decode(&mut &buf[buf.len() - 9..buf.len() - 8])?;
+        let compressed_data = &buf[..buf.len() - 9];
         let buf = match compression {
             CompressionAlgorithm::None => buf.slice(..buf.len() - 9),
             CompressionAlgorithm::Lz4 => {
-                let mut decoder = lz4::Decoder::new(buf.reader())
-                    .map_err(HummockError::decode_error)
-                    .unwrap();
+                let mut decoder = lz4::Decoder::new(compressed_data.reader())
+                    .map_err(HummockError::decode_error)?;
                 let mut decoded = Vec::with_capacity(DEFAULT_BLOCK_SIZE);
                 decoder
                     .read_to_end(&mut decoded)
-                    .map_err(HummockError::decode_error)
-                    .unwrap();
+                    .map_err(HummockError::decode_error)?;
                 Bytes::from(decoded)
             }
             CompressionAlgorithm::Zstd => {
-                let mut decoder = zstd::Decoder::new(buf[..buf.len() - 9].reader())
-                    .map_err(HummockError::decode_error)
-                    .unwrap();
+                let mut decoder = zstd::Decoder::new(compressed_data.reader())
+                    .map_err(HummockError::decode_error)?;
                 let mut decoded = Vec::with_capacity(DEFAULT_BLOCK_SIZE);
                 decoder
                     .read_to_end(&mut decoded)
-                    .map_err(HummockError::decode_error)
-                    .unwrap();
+                    .map_err(HummockError::decode_error)?;
                 Bytes::from(decoded)
             }
         };

--- a/src/storage/src/hummock/sstable/block.rs
+++ b/src/storage/src/hummock/sstable/block.rs
@@ -17,8 +17,8 @@ use std::io::{Read, Write};
 use std::ops::Range;
 
 use bytes::{Buf, BufMut, Bytes, BytesMut};
-use lz4::Decoder;
 use risingwave_hummock_sdk::VersionedComparator;
+use {lz4, zstd};
 
 use super::utils::{
     bytes_diff, var_u32_len, xxhash64_verify, BufExt, BufMutExt, CompressionAlgorithm,
@@ -48,7 +48,18 @@ impl Block {
         let buf = match compression {
             CompressionAlgorithm::None => buf.slice(..buf.len() - 9),
             CompressionAlgorithm::Lz4 => {
-                let mut decoder = Decoder::new(buf.reader())
+                let mut decoder = lz4::Decoder::new(buf.reader())
+                    .map_err(HummockError::decode_error)
+                    .unwrap();
+                let mut decoded = Vec::with_capacity(DEFAULT_BLOCK_SIZE);
+                decoder
+                    .read_to_end(&mut decoded)
+                    .map_err(HummockError::decode_error)
+                    .unwrap();
+                Bytes::from(decoded)
+            }
+            CompressionAlgorithm::Zstd => {
+                let mut decoder = zstd::Decoder::new(buf[..buf.len() - 9].reader())
                     .map_err(HummockError::decode_error)
                     .unwrap();
                 let mut decoded = Vec::with_capacity(DEFAULT_BLOCK_SIZE);
@@ -298,6 +309,21 @@ impl BlockBuilder {
                 result.map_err(HummockError::encode_error).unwrap();
                 writer.into_inner()
             }
+            CompressionAlgorithm::Zstd => {
+                let mut encoder =
+                    zstd::Encoder::new(BytesMut::with_capacity(self.buf.len()).writer(), 4)
+                        .map_err(HummockError::encode_error)
+                        .unwrap();
+                encoder
+                    .write(&self.buf[..])
+                    .map_err(HummockError::encode_error)
+                    .unwrap();
+                let writer = encoder
+                    .finish()
+                    .map_err(HummockError::encode_error)
+                    .unwrap();
+                writer.into_inner()
+            }
         };
         self.compression_algorithm.encode(&mut buf);
         let checksum = xxhash64_checksum(&buf);
@@ -354,41 +380,80 @@ mod tests {
 
     #[test]
     fn test_compressed_block_enc_dec() {
-        let options = BlockBuilderOptions {
-            compression_algorithm: CompressionAlgorithm::Lz4,
-            ..Default::default()
-        };
-        let mut builder = BlockBuilder::new(options);
-        builder.add(&full_key(b"k1", 1), b"v01");
-        builder.add(&full_key(b"k2", 2), b"v02");
-        builder.add(&full_key(b"k3", 3), b"v03");
-        builder.add(&full_key(b"k4", 4), b"v04");
-        let buf = builder.build();
-        let block = Box::new(Block::decode(buf).unwrap());
-        let mut bi = BlockIterator::new(BlockHolder::from_owned_block(block));
+        {
+            let options = BlockBuilderOptions {
+                compression_algorithm: CompressionAlgorithm::Lz4,
+                ..Default::default()
+            };
+            let mut builder = BlockBuilder::new(options);
+            builder.add(&full_key(b"k1", 1), b"v01");
+            builder.add(&full_key(b"k2", 2), b"v02");
+            builder.add(&full_key(b"k3", 3), b"v03");
+            builder.add(&full_key(b"k4", 4), b"v04");
+            let buf = builder.build();
+            let block = Box::new(Block::decode(buf).unwrap());
+            let mut bi = BlockIterator::new(BlockHolder::from_owned_block(block));
 
-        bi.seek_to_first();
-        assert!(bi.is_valid());
-        assert_eq!(&full_key(b"k1", 1)[..], bi.key());
-        assert_eq!(b"v01", bi.value());
+            bi.seek_to_first();
+            assert!(bi.is_valid());
+            assert_eq!(&full_key(b"k1", 1)[..], bi.key());
+            assert_eq!(b"v01", bi.value());
 
-        bi.next();
-        assert!(bi.is_valid());
-        assert_eq!(&full_key(b"k2", 2)[..], bi.key());
-        assert_eq!(b"v02", bi.value());
+            bi.next();
+            assert!(bi.is_valid());
+            assert_eq!(&full_key(b"k2", 2)[..], bi.key());
+            assert_eq!(b"v02", bi.value());
 
-        bi.next();
-        assert!(bi.is_valid());
-        assert_eq!(&full_key(b"k3", 3)[..], bi.key());
-        assert_eq!(b"v03", bi.value());
+            bi.next();
+            assert!(bi.is_valid());
+            assert_eq!(&full_key(b"k3", 3)[..], bi.key());
+            assert_eq!(b"v03", bi.value());
 
-        bi.next();
-        assert!(bi.is_valid());
-        assert_eq!(&full_key(b"k4", 4)[..], bi.key());
-        assert_eq!(b"v04", bi.value());
+            bi.next();
+            assert!(bi.is_valid());
+            assert_eq!(&full_key(b"k4", 4)[..], bi.key());
+            assert_eq!(b"v04", bi.value());
 
-        bi.next();
-        assert!(!bi.is_valid());
+            bi.next();
+            assert!(!bi.is_valid());
+        }
+        {
+            let options = BlockBuilderOptions {
+                compression_algorithm: CompressionAlgorithm::Zstd,
+                ..Default::default()
+            };
+            let mut builder = BlockBuilder::new(options);
+            builder.add(&full_key(b"k1", 1), b"v01");
+            builder.add(&full_key(b"k2", 2), b"v02");
+            builder.add(&full_key(b"k3", 3), b"v03");
+            builder.add(&full_key(b"k4", 4), b"v04");
+            let buf = builder.build();
+            let block = Box::new(Block::decode(buf).unwrap());
+            let mut bi = BlockIterator::new(BlockHolder::from_owned_block(block));
+
+            bi.seek_to_first();
+            assert!(bi.is_valid());
+            assert_eq!(&full_key(b"k1", 1)[..], bi.key());
+            assert_eq!(b"v01", bi.value());
+
+            bi.next();
+            assert!(bi.is_valid());
+            assert_eq!(&full_key(b"k2", 2)[..], bi.key());
+            assert_eq!(b"v02", bi.value());
+
+            bi.next();
+            assert!(bi.is_valid());
+            assert_eq!(&full_key(b"k3", 3)[..], bi.key());
+            assert_eq!(b"v03", bi.value());
+
+            bi.next();
+            assert!(bi.is_valid());
+            assert_eq!(&full_key(b"k4", 4)[..], bi.key());
+            assert_eq!(b"v04", bi.value());
+
+            bi.next();
+            assert!(!bi.is_valid());
+        }
     }
 
     pub fn full_key(user_key: &[u8], epoch: u64) -> Bytes {

--- a/src/storage/src/hummock/sstable/block.rs
+++ b/src/storage/src/hummock/sstable/block.rs
@@ -380,80 +380,46 @@ mod tests {
 
     #[test]
     fn test_compressed_block_enc_dec() {
-        {
-            let options = BlockBuilderOptions {
-                compression_algorithm: CompressionAlgorithm::Lz4,
-                ..Default::default()
-            };
-            let mut builder = BlockBuilder::new(options);
-            builder.add(&full_key(b"k1", 1), b"v01");
-            builder.add(&full_key(b"k2", 2), b"v02");
-            builder.add(&full_key(b"k3", 3), b"v03");
-            builder.add(&full_key(b"k4", 4), b"v04");
-            let buf = builder.build();
-            let block = Box::new(Block::decode(buf).unwrap());
-            let mut bi = BlockIterator::new(BlockHolder::from_owned_block(block));
+        inner_test_compressed(CompressionAlgorithm::Lz4);
+        inner_test_compressed(CompressionAlgorithm::Zstd);
+    }
 
-            bi.seek_to_first();
-            assert!(bi.is_valid());
-            assert_eq!(&full_key(b"k1", 1)[..], bi.key());
-            assert_eq!(b"v01", bi.value());
+    fn inner_test_compressed(algo: CompressionAlgorithm) {
+        let options = BlockBuilderOptions {
+            compression_algorithm: algo,
+            ..Default::default()
+        };
+        let mut builder = BlockBuilder::new(options);
+        builder.add(&full_key(b"k1", 1), b"v01");
+        builder.add(&full_key(b"k2", 2), b"v02");
+        builder.add(&full_key(b"k3", 3), b"v03");
+        builder.add(&full_key(b"k4", 4), b"v04");
+        let buf = builder.build();
+        let block = Box::new(Block::decode(buf).unwrap());
+        let mut bi = BlockIterator::new(BlockHolder::from_owned_block(block));
 
-            bi.next();
-            assert!(bi.is_valid());
-            assert_eq!(&full_key(b"k2", 2)[..], bi.key());
-            assert_eq!(b"v02", bi.value());
+        bi.seek_to_first();
+        assert!(bi.is_valid());
+        assert_eq!(&full_key(b"k1", 1)[..], bi.key());
+        assert_eq!(b"v01", bi.value());
 
-            bi.next();
-            assert!(bi.is_valid());
-            assert_eq!(&full_key(b"k3", 3)[..], bi.key());
-            assert_eq!(b"v03", bi.value());
+        bi.next();
+        assert!(bi.is_valid());
+        assert_eq!(&full_key(b"k2", 2)[..], bi.key());
+        assert_eq!(b"v02", bi.value());
 
-            bi.next();
-            assert!(bi.is_valid());
-            assert_eq!(&full_key(b"k4", 4)[..], bi.key());
-            assert_eq!(b"v04", bi.value());
+        bi.next();
+        assert!(bi.is_valid());
+        assert_eq!(&full_key(b"k3", 3)[..], bi.key());
+        assert_eq!(b"v03", bi.value());
 
-            bi.next();
-            assert!(!bi.is_valid());
-        }
-        {
-            let options = BlockBuilderOptions {
-                compression_algorithm: CompressionAlgorithm::Zstd,
-                ..Default::default()
-            };
-            let mut builder = BlockBuilder::new(options);
-            builder.add(&full_key(b"k1", 1), b"v01");
-            builder.add(&full_key(b"k2", 2), b"v02");
-            builder.add(&full_key(b"k3", 3), b"v03");
-            builder.add(&full_key(b"k4", 4), b"v04");
-            let buf = builder.build();
-            let block = Box::new(Block::decode(buf).unwrap());
-            let mut bi = BlockIterator::new(BlockHolder::from_owned_block(block));
+        bi.next();
+        assert!(bi.is_valid());
+        assert_eq!(&full_key(b"k4", 4)[..], bi.key());
+        assert_eq!(b"v04", bi.value());
 
-            bi.seek_to_first();
-            assert!(bi.is_valid());
-            assert_eq!(&full_key(b"k1", 1)[..], bi.key());
-            assert_eq!(b"v01", bi.value());
-
-            bi.next();
-            assert!(bi.is_valid());
-            assert_eq!(&full_key(b"k2", 2)[..], bi.key());
-            assert_eq!(b"v02", bi.value());
-
-            bi.next();
-            assert!(bi.is_valid());
-            assert_eq!(&full_key(b"k3", 3)[..], bi.key());
-            assert_eq!(b"v03", bi.value());
-
-            bi.next();
-            assert!(bi.is_valid());
-            assert_eq!(&full_key(b"k4", 4)[..], bi.key());
-            assert_eq!(b"v04", bi.value());
-
-            bi.next();
-            assert!(!bi.is_valid());
-        }
+        bi.next();
+        assert!(!bi.is_valid());
     }
 
     pub fn full_key(user_key: &[u8], epoch: u64) -> Bytes {

--- a/src/storage/src/hummock/sstable/utils.rs
+++ b/src/storage/src/hummock/sstable/utils.rs
@@ -154,6 +154,7 @@ pub fn get_length_prefixed_slice(buf: &mut &[u8]) -> Vec<u8> {
 pub enum CompressionAlgorithm {
     None,
     Lz4,
+    Zstd,
 }
 
 impl CompressionAlgorithm {
@@ -161,6 +162,7 @@ impl CompressionAlgorithm {
         let v = match self {
             Self::None => 0,
             Self::Lz4 => 1,
+            Self::Zstd => 2,
         };
         buf.put_u8(v);
     }
@@ -169,6 +171,7 @@ impl CompressionAlgorithm {
         match buf.get_u8() {
             0 => Ok(Self::None),
             1 => Ok(Self::Lz4),
+            2 => Ok(Self::Zstd),
             _ => Err(HummockError::decode_error(
                 "not valid compression algorithm",
             )),
@@ -181,6 +184,7 @@ impl From<CompressionAlgorithm> for u8 {
         match ca {
             CompressionAlgorithm::None => 0,
             CompressionAlgorithm::Lz4 => 1,
+            CompressionAlgorithm::Zstd => 2,
         }
     }
 }
@@ -190,6 +194,7 @@ impl From<CompressionAlgorithm> for u64 {
         match ca {
             CompressionAlgorithm::None => 0,
             CompressionAlgorithm::Lz4 => 1,
+            CompressionAlgorithm::Zstd => 2,
         }
     }
 }
@@ -201,6 +206,7 @@ impl TryFrom<u8> for CompressionAlgorithm {
         match v {
             0 => Ok(Self::None),
             1 => Ok(Self::Lz4),
+            2 => Ok(Self::Zstd),
             _ => Err(HummockError::decode_error(
                 "not valid compression algorithm",
             )),


### PR DESCRIPTION
Signed-off-by: Shmiwy <wyf000219@gmail.com>

## What's changed and what's your intention?

In this PR, I support zstd compression for blocks.
I just append a possible kinds of compression algorithm  called `Zstd` to `CompressionAlgorithm` enumeration.  I also append the corresponding match arm, which encodes and decodes data using the interface provided by 'zstd' crate
## Checklist 

- [x] I have written necessary docs and comments
- [x] I have added necessary unit tests and integration tests
- [x] All checks passed in `./risedev check` (or alias, `./risedev c`)

## Refer to a related PR or issue link (optional)
#2800 