### PR TITLE
feat(pgwire): introduce simple extended query mode

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2948,6 +2948,7 @@ dependencies = [
  "bytes",
  "madsim",
  "madsim-tokio",
+ "regex",
  "thiserror",
  "tokio-postgres",
  "tracing",

--- a/src/utils/pgwire/Cargo.toml
+++ b/src/utils/pgwire/Cargo.toml
@@ -9,6 +9,7 @@ async-trait = "0.1"
 byteorder = "1.4"
 bytes = "1"
 madsim = "=0.2.0-alpha.3"
+regex = "1.5"
 thiserror = "1"
 tokio = { version = "=0.2.0-alpha.3", package = "madsim-tokio", features = ["rt", "macros"] }
 tracing = { version = "0.1" }

--- a/src/utils/pgwire/src/lib.rs
+++ b/src/utils/pgwire/src/lib.rs
@@ -15,6 +15,7 @@
 // limitations under the License.
 
 pub mod error;
+pub mod pg_extended;
 pub mod pg_field_descriptor;
 pub mod pg_message;
 pub mod pg_protocol;

--- a/src/utils/pgwire/src/pg_extended.rs
+++ b/src/utils/pgwire/src/pg_extended.rs
@@ -1,0 +1,108 @@
+use bytes::{Bytes, BytesMut};
+use regex::Regex;
+
+use crate::pg_field_descriptor::{PgFieldDescriptor, TypeOid};
+
+// NOTE : Code dundancy , may need to modify later
+fn cstr_to_str(b: &Bytes) -> &str {
+    let without_null = if b.last() == Some(&0) {
+        &b[..b.len() - 1]
+    } else {
+        &b[..]
+    };
+    std::str::from_utf8(without_null).unwrap()
+}
+
+pub struct pg_statement {
+    name: String,
+    query_string: Bytes,
+    type_description: Vec<TypeOid>,
+    row_description: Vec<PgFieldDescriptor>,
+}
+
+impl pg_statement {
+    pub fn new(
+        name: String,
+        query_string: Bytes,
+        type_description: Vec<TypeOid>,
+        row_description: Vec<PgFieldDescriptor>,
+    ) -> Self {
+        // LIMIT: the number of type_description should equal to the number of generic parameter
+        {
+            let parameter_parttern = Regex::new(r"\$[0-9][0-9]*").unwrap();
+            let s = cstr_to_str(&query_string);
+            let count = parameter_parttern.find_iter(s).count();
+            assert_eq!(count, type_description.len());
+        }
+        pg_statement {
+            name,
+            query_string,
+            type_description,
+            row_description,
+        }
+    }
+
+    pub fn get_name(&self) -> String {
+        self.name.clone()
+    }
+
+    pub fn get_type_desc(&self) -> Vec<TypeOid> {
+        self.type_description.clone()
+    }
+
+    pub fn get_row_desc(&self) -> Vec<PgFieldDescriptor> {
+        self.row_description.clone()
+    }
+
+    pub fn instance(&self, name: String, params: &Vec<Bytes>) -> pg_portal {
+        let statement = cstr_to_str(&self.query_string).to_owned();
+        // Step 1 Identify all the $n
+        let parameter_parttern = Regex::new(r"\$[0-9][0-9]*").unwrap();
+        let mut generic_params: Vec<&str> = parameter_parttern
+            .find_iter(statement.as_str())
+            .map(|mat| mat.as_str())
+            .collect();
+        // Step 2 Sort by len (From large to small )
+        generic_params.sort_by(|a, b| {
+            let a_num: i32 = a.trim_start_matches("$").parse().unwrap();
+            let b_num: i32 = b.trim_start_matches("$").parse().unwrap();
+            b_num.cmp(&a_num)
+        });
+        // LTIMIT: may need modify later;
+        {
+            assert!(generic_params.starts_with(&[format!("${}", generic_params.len()).as_str()]));
+            assert_eq!(generic_params.len(), params.len());
+        }
+        // Step 3 replace top-down
+        let mut tmp = statement.clone();
+        for i in 0..generic_params.len() {
+            let parttern = Regex::new(format!(r"\{}", generic_params[i]).as_str()).unwrap();
+            let param = cstr_to_str(&params[i]);
+            tmp = parttern.replace_all(tmp.as_str(), param).to_string();
+        }
+        // Step 4 Create a new portal
+        pg_portal {
+            name: name,
+            query_string: Bytes::from(tmp.to_owned()),
+        }
+    }
+}
+
+pub struct pg_portal {
+    name: String,
+    query_string: Bytes,
+}
+
+impl pg_portal {
+    pub fn new(name: String, query_string: Bytes) -> Self {
+        pg_portal { name, query_string }
+    }
+
+    pub fn get_name(&self) -> String {
+        self.name.clone()
+    }
+
+    pub fn get_query_string(&self) -> Bytes {
+        self.query_string.clone()
+    }
+}

--- a/src/utils/pgwire/src/pg_field_descriptor.rs
+++ b/src/utils/pgwire/src/pg_field_descriptor.rs
@@ -109,7 +109,7 @@ impl TypeOid {
     pub fn as_type(oid: i32) -> Result<TypeOid, String> {
         match oid {
             1043 => Ok(TypeOid::Varchar),
-            _ => Err("didn't implement".to_string()),
+            _ => todo!(),
         }
     }
 

--- a/src/utils/pgwire/src/pg_field_descriptor.rs
+++ b/src/utils/pgwire/src/pg_field_descriptor.rs
@@ -105,6 +105,14 @@ pub enum TypeOid {
 }
 
 impl TypeOid {
+    // Error handle need modify later!
+    pub fn as_type(oid: i32) -> Result<TypeOid, String> {
+        match oid {
+            1043 => Ok(TypeOid::Varchar),
+            _ => Err("didn't implement".to_string()),
+        }
+    }
+
     pub fn as_number(&self) -> i32 {
         match self {
             TypeOid::Boolean => 16,

--- a/src/utils/pgwire/src/pg_server.rs
+++ b/src/utils/pgwire/src/pg_server.rs
@@ -162,4 +162,35 @@ mod tests {
         let value: &str = rows[0].get(0);
         assert_eq!(value, "Hello, World");
     }
+    /*
+    #[tokio::test]
+    // The test is to test the explicit paramter type support
+    async fn test_psql_extended_mode_exlicit() {
+        let session_mgr = Arc::new(MockSessionManager {});
+        tokio::spawn(async move { pg_serve("127.0.0.1:10000", session_mgr).await });
+
+        // Connect to the database.
+        let (client, connection) = tokio_postgres::connect("host=localhost port=10000", NoTls)
+            .await
+            .unwrap();
+
+        // The connection object performs the actual communication with the database,
+        // so spawn it off to run on its own.
+        tokio::spawn(async move {
+            if let Err(e) = connection.await {
+                eprintln!("connection error: {}", e);
+            }
+        });
+
+        let statement = client.prepare_typed("SELECT $1", &[TEXT]).await.unwrap();
+        let rows = client.query(&statement, &[&"Hello, World"]).await.unwrap();
+        let value: &str = rows[0].get(0);
+        assert_eq!(value, "Hello, World");
+        let rows = client
+            .query(&statement, &[&"Statement is still useful"])
+            .await
+            .unwrap();
+        let value: &str = rows[0].get(0);
+        assert_eq!(value, "Statement is still useful");
+    }*/
 }


### PR DESCRIPTION
## What's changed and what's your intention?
- This is PR about the simple extended query mode. 
- The detail of this design and its restriction is in the #2924.
- It supports the concept of "prepared statement" and "portal" in the pgwire semantically. To support generic parameters, its implementation is based on the regular expression replace. It didn't use any parse or infer technology and that's why this feature is limited. 

### Something may need to be modified 
- [x] Error handle: For the specific behavior of the client driver(tokio_postgres), I use unwrap() as an error handler for some behavior because I think it will always be correct when the client driver is tokio_postgres. (Such as "named_portals.get(&portal_name).unwrap()", I can sure the portal_name always will be valid when the client driver is tokio_postgres) I add the comment ("// NOTE: error handle need to modify later;") in these places.
- [x] "cstr_to_str" occur in pg_extended.rs and pg_protocal.rs, I think it's maybe the code redundancy. Should we place it in another place such as "lib.rs"?


## Checklist

- [x] I have written necessary docs and comments
- [x] I have added necessary unit tests and integration tests


## Refer to a related PR or issue link (optional)
ref: #2924.
