### PR TITLE
refactor(meta): remove RefId proto in hummock

### DIFF
--- a/proto/hummock.proto
+++ b/proto/hummock.proto
@@ -6,10 +6,6 @@ import "common.proto";
 
 option optimize_for = SPEED;
 
-message SstableRefId {
-  uint64 id = 1;
-}
-
 message SstableIdInfo {
   uint64 id = 1;
   // Timestamp when the sstable id is created, in seconds.
@@ -41,10 +37,6 @@ message Level {
 message UncommittedEpoch {
   uint64 epoch = 1;
   repeated SstableInfo tables = 2;
-}
-
-message HummockVersionRefId {
-  uint64 id = 1;
 }
 
 message HummockVersion {
@@ -165,10 +157,6 @@ message CompactTaskAssignment {
   uint32 context_id = 2;
 }
 
-message CompactTaskRefId {
-  uint64 id = 1;
-}
-
 message GetCompactionTasksRequest {}
 
 message GetCompactionTasksResponse {
@@ -182,10 +170,6 @@ message ReportCompactionTasksRequest {
 
 message ReportCompactionTasksResponse {
   common.Status status = 1;
-}
-
-message HummockContextRefId {
-  uint32 id = 1;
 }
 
 message HummockPinnedVersion {

--- a/src/meta/src/hummock/hummock_manager.rs
+++ b/src/meta/src/hummock/hummock_manager.rs
@@ -217,7 +217,7 @@ where
             CompactTaskAssignment::list(self.env.meta_store())
                 .await?
                 .into_iter()
-                .map(|assigned| (assigned.key().unwrap().id, assigned))
+                .map(|assigned| (assigned.key().unwrap(), assigned))
                 .collect();
 
         let mut versioning_guard = self.versioning.write().await;

--- a/src/meta/src/hummock/hummock_manager_tests.rs
+++ b/src/meta/src/hummock/hummock_manager_tests.rs
@@ -24,7 +24,6 @@ use risingwave_hummock_sdk::{
 use risingwave_pb::common::{HostAddress, ParallelUnitType, WorkerType};
 use risingwave_pb::hummock::{
     HummockPinnedSnapshot, HummockPinnedVersion, HummockSnapshot, HummockVersion,
-    HummockVersionRefId,
 };
 
 use crate::hummock::error::Error;
@@ -143,15 +142,10 @@ async fn test_hummock_compaction_task() {
         .await
         .unwrap()
         .unwrap();
-    let hummock_version1 = HummockVersion::select(
-        env.meta_store(),
-        &HummockVersionRefId {
-            id: version_id1.id(),
-        },
-    )
-    .await
-    .unwrap()
-    .unwrap();
+    let hummock_version1 = HummockVersion::select(env.meta_store(), &version_id1.id())
+        .await
+        .unwrap()
+        .unwrap();
 
     // safe epoch should be INVALID before success compaction
     assert_eq!(INVALID_EPOCH, hummock_version1.safe_epoch);
@@ -194,15 +188,10 @@ async fn test_hummock_compaction_task() {
         .unwrap()
         .unwrap();
 
-    let hummock_version2 = HummockVersion::select(
-        env.meta_store(),
-        &HummockVersionRefId {
-            id: version_id2.id(),
-        },
-    )
-    .await
-    .unwrap()
-    .unwrap();
+    let hummock_version2 = HummockVersion::select(env.meta_store(), &version_id2.id())
+        .await
+        .unwrap()
+        .unwrap();
 
     // safe epoch should still be INVALID since comapction task is canceled
     assert_eq!(INVALID_EPOCH, hummock_version2.safe_epoch);
@@ -233,15 +222,10 @@ async fn test_hummock_compaction_task() {
         .unwrap()
         .unwrap();
 
-    let hummock_version3 = HummockVersion::select(
-        env.meta_store(),
-        &HummockVersionRefId {
-            id: version_id3.id(),
-        },
-    )
-    .await
-    .unwrap()
-    .unwrap();
+    let hummock_version3 = HummockVersion::select(env.meta_store(), &version_id3.id())
+        .await
+        .unwrap()
+        .unwrap();
 
     // Since there is no pinned epochs, the safe epoch in version should be max_committed_epoch
     assert_eq!(epoch, hummock_version3.safe_epoch);

--- a/src/meta/src/hummock/model/compact_task_assignment.rs
+++ b/src/meta/src/hummock/model/compact_task_assignment.rs
@@ -13,16 +13,17 @@
 // limitations under the License.
 
 use prost::Message;
-use risingwave_pb::hummock::{CompactTaskAssignment, CompactTaskRefId};
+use risingwave_hummock_sdk::HummockCompactionTaskId;
+use risingwave_pb::hummock::CompactTaskAssignment;
 
 use crate::model::MetadataModel;
 
-/// `cf(compact_task_assignment)`: `CompactTaskRefId` -> `CompactTaskAssignment`
+/// `cf(compact_task_assignment)`: `CompactTaskId` -> `CompactTaskAssignment`
 const HUMMOCK_COMPACT_TASK_ASSIGNMENT: &str = "cf/compact_task_assignment";
 
 /// `AssignedCompactTasks` tracks compact tasks assigned to context id.
 impl MetadataModel for CompactTaskAssignment {
-    type KeyType = CompactTaskRefId;
+    type KeyType = HummockCompactionTaskId;
     type ProstType = CompactTaskAssignment;
 
     fn cf_name() -> String {
@@ -42,8 +43,6 @@ impl MetadataModel for CompactTaskAssignment {
     }
 
     fn key(&self) -> risingwave_common::error::Result<Self::KeyType> {
-        Ok(CompactTaskRefId {
-            id: self.compact_task.as_ref().unwrap().task_id,
-        })
+        Ok(self.compact_task.as_ref().unwrap().task_id)
     }
 }

--- a/src/meta/src/hummock/model/current_version_id.rs
+++ b/src/meta/src/hummock/model/current_version_id.rs
@@ -14,14 +14,13 @@
 
 use risingwave_common::error::Result;
 use risingwave_hummock_sdk::{HummockVersionId, FIRST_VERSION_ID};
-use risingwave_pb::hummock::HummockVersionRefId;
 
 use crate::hummock::model::HUMMOCK_DEFAULT_CF_NAME;
 use crate::model::MetadataModel;
 use crate::storage::MetaStore;
 
 /// Hummock current version id key.
-/// `cf(hummock_default)`: `hummock_version_id_key` -> `HummockVersionRefId`
+/// `cf(hummock_default)`: `hummock_version_id_key` -> `HummockVersionId`
 const HUMMOCK_VERSION_ID_KEY: &str = "current_version_id";
 
 /// `CurrentHummockVersionId` tracks the current version id.
@@ -32,18 +31,18 @@ pub struct CurrentHummockVersionId {
 
 impl MetadataModel for CurrentHummockVersionId {
     type KeyType = String;
-    type ProstType = HummockVersionRefId;
+    type ProstType = HummockVersionId;
 
     fn cf_name() -> String {
         HUMMOCK_DEFAULT_CF_NAME.to_string()
     }
 
     fn to_protobuf(&self) -> Self::ProstType {
-        HummockVersionRefId { id: self.id }
+        self.id
     }
 
     fn from_protobuf(prost: Self::ProstType) -> Self {
-        Self { id: prost.id }
+        Self { id: prost }
     }
 
     fn key(&self) -> Result<Self::KeyType> {

--- a/src/meta/src/hummock/model/pinned_snapshot.rs
+++ b/src/meta/src/hummock/model/pinned_snapshot.rs
@@ -13,18 +13,18 @@
 // limitations under the License.
 
 use prost::Message;
-use risingwave_hummock_sdk::HummockEpoch;
-use risingwave_pb::hummock::{HummockContextRefId, HummockPinnedSnapshot};
+use risingwave_hummock_sdk::{HummockContextId, HummockEpoch};
+use risingwave_pb::hummock::HummockPinnedSnapshot;
 
 use crate::model::MetadataModel;
 
 /// Column family name for hummock pinned snapshot
-/// `cf(hummock_pinned_snapshot)`: `HummockContextRefId` -> `HummockPinnedSnapshot`
+/// `cf(hummock_pinned_snapshot)`: `HummockContextId` -> `HummockPinnedSnapshot`
 const HUMMOCK_PINNED_SNAPSHOT_CF_NAME: &str = "cf/hummock_pinned_snapshot";
 
 /// `HummockPinnedSnapshot` tracks pinned snapshots by given context id.
 impl MetadataModel for HummockPinnedSnapshot {
-    type KeyType = HummockContextRefId;
+    type KeyType = HummockContextId;
     type ProstType = HummockPinnedSnapshot;
 
     fn cf_name() -> String {
@@ -44,9 +44,7 @@ impl MetadataModel for HummockPinnedSnapshot {
     }
 
     fn key(&self) -> risingwave_common::error::Result<Self::KeyType> {
-        Ok(HummockContextRefId {
-            id: self.context_id,
-        })
+        Ok(self.context_id)
     }
 }
 

--- a/src/meta/src/hummock/model/pinned_version.rs
+++ b/src/meta/src/hummock/model/pinned_version.rs
@@ -13,18 +13,18 @@
 // limitations under the License.
 
 use prost::Message;
-use risingwave_hummock_sdk::HummockVersionId;
-use risingwave_pb::hummock::{HummockContextRefId, HummockPinnedVersion};
+use risingwave_hummock_sdk::{HummockContextId, HummockVersionId};
+use risingwave_pb::hummock::HummockPinnedVersion;
 
 use crate::model::MetadataModel;
 
 /// Column family name for hummock pinned version
-/// `cf(hummock_pinned_version)`: `HummockContextRefId` -> `HummockPinnedVersion`
+/// `cf(hummock_pinned_version)`: `HummockContextId` -> `HummockPinnedVersion`
 const HUMMOCK_PINNED_VERSION_CF_NAME: &str = "cf/hummock_pinned_version";
 
 /// `HummockPinnedVersion` tracks pinned versions by given context id.
 impl MetadataModel for HummockPinnedVersion {
-    type KeyType = HummockContextRefId;
+    type KeyType = HummockContextId;
     type ProstType = HummockPinnedVersion;
 
     fn cf_name() -> String {
@@ -44,9 +44,7 @@ impl MetadataModel for HummockPinnedVersion {
     }
 
     fn key(&self) -> risingwave_common::error::Result<Self::KeyType> {
-        Ok(HummockContextRefId {
-            id: self.context_id,
-        })
+        Ok(self.context_id)
     }
 }
 

--- a/src/meta/src/hummock/model/sstable_id_info.rs
+++ b/src/meta/src/hummock/model/sstable_id_info.rs
@@ -15,12 +15,13 @@
 use std::time::SystemTime;
 
 use prost::Message;
-use risingwave_pb::hummock::{SstableIdInfo, SstableRefId};
+use risingwave_hummock_sdk::HummockSSTableId;
+use risingwave_pb::hummock::SstableIdInfo;
 
 use crate::model::MetadataModel;
 
 /// Column family name for hummock sstable id.
-/// `cf(hummock_sstable_id)`: `SstableRefId` -> `SstableIdInfo`
+/// `cf(hummock_sstable_id)`: `SstableId` -> `SstableIdInfo`
 const HUMMOCK_SSTABLE_ID_CF_NAME: &str = "cf/hummock_sstable_id";
 
 pub const INVALID_TIMESTAMP: u64 = 0;
@@ -28,7 +29,7 @@ pub const INVALID_TIMESTAMP: u64 = 0;
 /// `SstableIdInfo` tracks when the sstable id is acquired from meta node and when the corresponding
 /// sstable is tracked in meta node.
 impl MetadataModel for SstableIdInfo {
-    type KeyType = SstableRefId;
+    type KeyType = HummockSSTableId;
     type ProstType = SstableIdInfo;
 
     fn cf_name() -> String {
@@ -48,7 +49,7 @@ impl MetadataModel for SstableIdInfo {
     }
 
     fn key(&self) -> risingwave_common::error::Result<Self::KeyType> {
-        Ok(SstableRefId { id: self.id })
+        Ok(self.id)
     }
 }
 

--- a/src/meta/src/hummock/model/stale_sstables.rs
+++ b/src/meta/src/hummock/model/stale_sstables.rs
@@ -13,17 +13,18 @@
 // limitations under the License.
 
 use prost::Message;
-use risingwave_pb::hummock::{HummockStaleSstables, HummockVersionRefId};
+use risingwave_hummock_sdk::HummockVersionId;
+use risingwave_pb::hummock::HummockStaleSstables;
 
 use crate::model::MetadataModel;
 
 /// Column family name for stale hummock sstables.
-/// `cf(hummock_stale_sstables)`: `HummockVersionRefId` -> `HummockStaleSstables`
+/// `cf(hummock_stale_sstables)`: `HummockVersionId` -> `HummockStaleSstables`
 const HUMMOCK_STALE_SSTABLES_CF_NAME: &str = "cf/hummock_stale_sstables";
 
 /// `HummockStaleSstables` tracks `SSTables` no longer needed after the given version.
 impl MetadataModel for HummockStaleSstables {
-    type KeyType = HummockVersionRefId;
+    type KeyType = HummockVersionId;
     type ProstType = HummockStaleSstables;
 
     fn cf_name() -> String {
@@ -43,8 +44,6 @@ impl MetadataModel for HummockStaleSstables {
     }
 
     fn key(&self) -> risingwave_common::error::Result<Self::KeyType> {
-        Ok(HummockVersionRefId {
-            id: self.version_id,
-        })
+        Ok(self.version_id)
     }
 }

--- a/src/meta/src/hummock/model/version.rs
+++ b/src/meta/src/hummock/model/version.rs
@@ -13,17 +13,18 @@
 // limitations under the License.
 
 use prost::Message;
-use risingwave_pb::hummock::{HummockVersion, HummockVersionRefId};
+use risingwave_hummock_sdk::HummockVersionId;
+use risingwave_pb::hummock::HummockVersion;
 
 use crate::model::MetadataModel;
 
 /// Column family name for hummock version.
-/// `cf(hummock_version)`: `HummockVersionRefId` -> `HummockVersion`
+/// `cf(hummock_version)`: `HummockVersionId` -> `HummockVersion`
 const HUMMOCK_VERSION_CF_NAME: &str = "cf/hummock_version";
 
 /// `HummockVersion` tracks `SSTables` in given version.
 impl MetadataModel for HummockVersion {
-    type KeyType = HummockVersionRefId;
+    type KeyType = HummockVersionId;
     type ProstType = HummockVersion;
 
     fn cf_name() -> String {
@@ -43,6 +44,6 @@ impl MetadataModel for HummockVersion {
     }
 
     fn key(&self) -> risingwave_common::error::Result<Self::KeyType> {
-        Ok(HummockVersionRefId { id: self.id })
+        Ok(self.id)
     }
 }


### PR DESCRIPTION
## What's changed and what's your intention?

We defined several wrapper type (*RefId) in hummock.proto, in order to use them as Key when writing to meta store.
It turns out we can use primitive type directly. So this PR removes these unnecessary types.

## Checklist

- [x] All checks passed in `./risedev check` (or alias, `./risedev c`)

## Refer to a related PR or issue link (optional)
