### PR TITLE
feat: add hummock rpc `unpin_snapshot_before`

### DIFF
--- a/proto/buf.yaml
+++ b/proto/buf.yaml
@@ -13,6 +13,3 @@ lint:
     - PACKAGE_DIRECTORY_MATCH
     - RPC_REQUEST_RESPONSE_UNIQUE
     - RPC_RESPONSE_STANDARD_NAME
-
-  # We currently reuse some request/response, e.g. UnpinSnapshotRequest.
-  rpc_allow_same_request_response: true

--- a/proto/buf.yaml
+++ b/proto/buf.yaml
@@ -13,3 +13,6 @@ lint:
     - PACKAGE_DIRECTORY_MATCH
     - RPC_REQUEST_RESPONSE_UNIQUE
     - RPC_RESPONSE_STANDARD_NAME
+
+  # We currently reuse some request/response, e.g. UnpinSnapshotRequest.
+  rpc_allow_same_request_response: true

--- a/proto/hummock.proto
+++ b/proto/hummock.proto
@@ -84,10 +84,18 @@ message PinSnapshotResponse {
 message UnpinSnapshotRequest {
   uint32 context_id = 1;
   repeated HummockSnapshot snapshots = 2;
-  HummockSnapshot min_snapshot = 3;
 }
 
 message UnpinSnapshotResponse {
+  common.Status status = 1;
+}
+
+message UnpinSnapshotBeforeRequest {
+  uint32 context_id = 1;
+  HummockSnapshot min_snapshot = 3;
+}
+
+message UnpinSnapshotBeforeResponse {
   common.Status status = 1;
 }
 
@@ -223,7 +231,7 @@ service HummockManagerService {
   rpc ReportCompactionTasks(ReportCompactionTasksRequest) returns (ReportCompactionTasksResponse);
   rpc PinSnapshot(PinSnapshotRequest) returns (PinSnapshotResponse);
   rpc UnpinSnapshot(UnpinSnapshotRequest) returns (UnpinSnapshotResponse);
-  rpc UnpinSnapshotBefore(UnpinSnapshotRequest) returns (UnpinSnapshotResponse);
+  rpc UnpinSnapshotBefore(UnpinSnapshotBeforeRequest) returns (UnpinSnapshotBeforeResponse);
   rpc GetNewTableId(GetNewTableIdRequest) returns (GetNewTableIdResponse);
   rpc SubscribeCompactTasks(SubscribeCompactTasksRequest) returns (stream SubscribeCompactTasksResponse);
   rpc ReportVacuumTask(ReportVacuumTaskRequest) returns (ReportVacuumTaskResponse);

--- a/proto/hummock.proto
+++ b/proto/hummock.proto
@@ -84,6 +84,7 @@ message PinSnapshotResponse {
 message UnpinSnapshotRequest {
   uint32 context_id = 1;
   repeated HummockSnapshot snapshots = 2;
+  HummockSnapshot min_snapshot = 3;
 }
 
 message UnpinSnapshotResponse {
@@ -222,6 +223,7 @@ service HummockManagerService {
   rpc ReportCompactionTasks(ReportCompactionTasksRequest) returns (ReportCompactionTasksResponse);
   rpc PinSnapshot(PinSnapshotRequest) returns (PinSnapshotResponse);
   rpc UnpinSnapshot(UnpinSnapshotRequest) returns (UnpinSnapshotResponse);
+  rpc UnpinSnapshotBefore(UnpinSnapshotRequest) returns (UnpinSnapshotResponse);
   rpc GetNewTableId(GetNewTableIdRequest) returns (GetNewTableIdResponse);
   rpc SubscribeCompactTasks(SubscribeCompactTasksRequest) returns (stream SubscribeCompactTasksResponse);
   rpc ReportVacuumTask(ReportVacuumTaskRequest) returns (ReportVacuumTaskResponse);

--- a/src/frontend/src/meta_client.rs
+++ b/src/frontend/src/meta_client.rs
@@ -27,6 +27,8 @@ pub trait FrontendMetaClient: Send + Sync {
     async fn flush(&self) -> Result<()>;
 
     async fn unpin_snapshot(&self, epoch: u64) -> Result<()>;
+
+    async fn unpin_snapshot_before(&self, epoch: u64) -> Result<()>;
 }
 
 pub struct FrontendMetaClientImpl(pub MetaClient);
@@ -43,5 +45,9 @@ impl FrontendMetaClient for FrontendMetaClientImpl {
 
     async fn unpin_snapshot(&self, epoch: u64) -> Result<()> {
         self.0.unpin_snapshot(&[epoch]).await
+    }
+
+    async fn unpin_snapshot_before(&self, epoch: u64) -> Result<()> {
+        self.0.unpin_snapshot_before(epoch).await
     }
 }

--- a/src/frontend/src/test_utils.rs
+++ b/src/frontend/src/test_utils.rs
@@ -391,6 +391,10 @@ impl FrontendMetaClient for MockFrontendMetaClient {
     async fn unpin_snapshot(&self, _epoch: u64) -> Result<()> {
         Ok(())
     }
+
+    async fn unpin_snapshot_before(&self, _epoch: u64) -> Result<()> {
+        Ok(())
+    }
 }
 pub static PROTO_FILE_DATA: &str = r#"
     syntax = "proto3";

--- a/src/meta/src/hummock/hummock_manager.rs
+++ b/src/meta/src/hummock/hummock_manager.rs
@@ -485,6 +485,67 @@ where
         Ok(())
     }
 
+    /// Unpin all snapshots smaller than specified epoch for current context.
+    pub async fn unpin_snapshot_before(
+        &self,
+        context_id: HummockContextId,
+        hummock_snapshot: HummockSnapshot,
+    ) -> Result<()> {
+        let mut versioning_guard = self.versioning.write().await;
+
+        // Use the max_committed_epoch in storage as the snapshot ts so only committed changes are
+        // visible in the snapshot.
+        let version_id = versioning_guard.current_version_id.id();
+        let _max_committed_epoch = versioning_guard
+            .hummock_versions
+            .get(&version_id)
+            .unwrap()
+            .max_committed_epoch;
+        // Ensure the unpin will not clean the latest one.
+        #[cfg(not(test))]
+        {
+            assert!(hummock_snapshot.epoch <= _max_committed_epoch);
+        }
+
+        let mut pinned_snapshots = VarTransaction::new(&mut versioning_guard.pinned_snapshots);
+        let mut context_pinned_snapshot = match pinned_snapshots.new_entry_txn(context_id) {
+            None => {
+                return Ok(());
+            }
+            Some(context_pinned_snapshot) => context_pinned_snapshot,
+        };
+
+        let to_unpin = context_pinned_snapshot
+            .snapshot_id
+            .iter()
+            // hummock_snapshot.epoch should always <= max committed epoch.
+            .filter(|e| **e < hummock_snapshot.epoch)
+            .cloned()
+            .collect_vec();
+        // Unpin the snapshots pinned by meta but frontend doesn't know. Also equal to unpin all
+        // epochs below specific watermark.
+        // let mut snapshots_change = !to_unpin.is_empty();
+        tracing::info!("Unpin epochs {:?}", to_unpin);
+
+        for epoch in &to_unpin {
+            context_pinned_snapshot.unpin_snapshot(*epoch);
+        }
+
+        if !to_unpin.is_empty() {
+            commit_multi_var!(self, Some(context_id), context_pinned_snapshot)?;
+        } else {
+            abort_multi_var!(context_pinned_snapshot);
+        }
+
+        #[cfg(test)]
+        {
+            drop(versioning_guard);
+            self.check_state_consistency().await;
+        }
+
+        Ok(())
+    }
+
     pub async fn get_compact_task(&self) -> Result<Option<CompactTask>> {
         let start_time = Instant::now();
         let mut compaction_guard = self.compaction.write().await;

--- a/src/meta/src/hummock/mock_hummock_meta_client.rs
+++ b/src/meta/src/hummock/mock_hummock_meta_client.rs
@@ -88,6 +88,18 @@ impl HummockMetaClient for MockHummockMetaClient {
             .map_err(|e| e.into())
     }
 
+    async fn unpin_snapshot_before(&self, pinned_epochs: HummockEpoch) -> Result<()> {
+        self.hummock_manager
+            .unpin_snapshot_before(
+                self.context_id,
+                HummockSnapshot {
+                    epoch: pinned_epochs,
+                },
+            )
+            .await
+            .map_err(|e| e.into())
+    }
+
     async fn get_new_table_id(&self) -> Result<HummockSSTableId> {
         self.hummock_manager
             .get_new_table_id()

--- a/src/meta/src/rpc/service/hummock_service.rs
+++ b/src/meta/src/rpc/service/hummock_service.rs
@@ -146,6 +146,21 @@ where
         Ok(Response::new(UnpinSnapshotResponse { status: None }))
     }
 
+    async fn unpin_snapshot_before(
+        &self,
+        request: Request<UnpinSnapshotRequest>,
+    ) -> Result<Response<UnpinSnapshotResponse>, Status> {
+        let req = request.into_inner();
+        if let Err(e) = self
+            .hummock_manager
+            .unpin_snapshot_before(req.context_id, req.min_snapshot.unwrap())
+            .await
+        {
+            return Err(tonic_err(e));
+        }
+        Ok(Response::new(UnpinSnapshotResponse { status: None }))
+    }
+
     async fn get_new_table_id(
         &self,
         _request: Request<GetNewTableIdRequest>,

--- a/src/meta/src/rpc/service/hummock_service.rs
+++ b/src/meta/src/rpc/service/hummock_service.rs
@@ -148,8 +148,8 @@ where
 
     async fn unpin_snapshot_before(
         &self,
-        request: Request<UnpinSnapshotRequest>,
-    ) -> Result<Response<UnpinSnapshotResponse>, Status> {
+        request: Request<UnpinSnapshotBeforeRequest>,
+    ) -> Result<Response<UnpinSnapshotBeforeResponse>, Status> {
         let req = request.into_inner();
         if let Err(e) = self
             .hummock_manager
@@ -158,7 +158,7 @@ where
         {
             return Err(tonic_err(e));
         }
-        Ok(Response::new(UnpinSnapshotResponse { status: None }))
+        Ok(Response::new(UnpinSnapshotBeforeResponse { status: None }))
     }
 
     async fn get_new_table_id(

--- a/src/rpc_client/src/hummock_meta_client.rs
+++ b/src/rpc_client/src/hummock_meta_client.rs
@@ -26,6 +26,7 @@ pub trait HummockMetaClient: Send + Sync + 'static {
     async fn unpin_version(&self, pinned_version_ids: &[HummockVersionId]) -> Result<()>;
     async fn pin_snapshot(&self, last_pinned: HummockEpoch) -> Result<HummockEpoch>;
     async fn unpin_snapshot(&self, pinned_epochs: &[HummockEpoch]) -> Result<()>;
+    async fn unpin_snapshot_before(&self, pinned_epochs: HummockEpoch) -> Result<()>;
     async fn get_new_table_id(&self) -> Result<HummockSSTableId>;
     async fn report_compaction_task(&self, compact_task: CompactTask) -> Result<()>;
     // We keep `commit_epoch` only for test/benchmark like ssbench.

--- a/src/rpc_client/src/meta_client.rs
+++ b/src/rpc_client/src/meta_client.rs
@@ -397,8 +397,24 @@ impl HummockMetaClient for MetaClient {
                     epoch: epoch.to_owned(),
                 })
                 .collect(),
+            // For unpin_snapshot, we do not care about the min epoch. May need to change in future.
+            ..Default::default()
         };
         self.inner.unpin_snapshot(req).await?;
+        Ok(())
+    }
+
+    async fn unpin_snapshot_before(&self, pinned_epochs: HummockEpoch) -> Result<()> {
+        // tracing::info!("Unpin in meta client");
+        let req = UnpinSnapshotRequest {
+            context_id: self.worker_id(),
+            // For unpin_snapshot_before, we do not care about snapshots list but only min epoch.
+            snapshots: vec![],
+            min_snapshot: Some(HummockSnapshot {
+                epoch: pinned_epochs,
+            }),
+        };
+        self.inner.unpin_snapshot_before(req).await?;
         Ok(())
     }
 
@@ -517,6 +533,7 @@ macro_rules! for_all_meta_rpc {
             ,{ hummock_client, unpin_version, UnpinVersionRequest, UnpinVersionResponse }
             ,{ hummock_client, pin_snapshot, PinSnapshotRequest, PinSnapshotResponse }
             ,{ hummock_client, unpin_snapshot, UnpinSnapshotRequest, UnpinSnapshotResponse }
+            ,{ hummock_client, unpin_snapshot_before, UnpinSnapshotRequest, UnpinSnapshotResponse }
             ,{ hummock_client, report_compaction_tasks, ReportCompactionTasksRequest, ReportCompactionTasksResponse }
             ,{ hummock_client, get_new_table_id, GetNewTableIdRequest, GetNewTableIdResponse }
             ,{ hummock_client, subscribe_compact_tasks, SubscribeCompactTasksRequest, Streaming<SubscribeCompactTasksResponse> }

--- a/src/rpc_client/src/meta_client.rs
+++ b/src/rpc_client/src/meta_client.rs
@@ -41,8 +41,9 @@ use risingwave_pb::hummock::{
     PinSnapshotRequest, PinSnapshotResponse, PinVersionRequest, PinVersionResponse,
     ReportCompactionTasksRequest, ReportCompactionTasksResponse, ReportVacuumTaskRequest,
     ReportVacuumTaskResponse, SstableInfo, SubscribeCompactTasksRequest,
-    SubscribeCompactTasksResponse, UnpinSnapshotRequest, UnpinSnapshotResponse,
-    UnpinVersionRequest, UnpinVersionResponse, VacuumTask,
+    SubscribeCompactTasksResponse, UnpinSnapshotBeforeRequest, UnpinSnapshotBeforeResponse,
+    UnpinSnapshotRequest, UnpinSnapshotResponse, UnpinVersionRequest, UnpinVersionResponse,
+    VacuumTask,
 };
 use risingwave_pb::meta::cluster_service_client::ClusterServiceClient;
 use risingwave_pb::meta::heartbeat_service_client::HeartbeatServiceClient;
@@ -397,19 +398,15 @@ impl HummockMetaClient for MetaClient {
                     epoch: epoch.to_owned(),
                 })
                 .collect(),
-            // For unpin_snapshot, we do not care about the min epoch. May need to change in future.
-            ..Default::default()
         };
         self.inner.unpin_snapshot(req).await?;
         Ok(())
     }
 
     async fn unpin_snapshot_before(&self, pinned_epochs: HummockEpoch) -> Result<()> {
-        // tracing::info!("Unpin in meta client");
-        let req = UnpinSnapshotRequest {
+        let req = UnpinSnapshotBeforeRequest {
             context_id: self.worker_id(),
             // For unpin_snapshot_before, we do not care about snapshots list but only min epoch.
-            snapshots: vec![],
             min_snapshot: Some(HummockSnapshot {
                 epoch: pinned_epochs,
             }),
@@ -533,7 +530,7 @@ macro_rules! for_all_meta_rpc {
             ,{ hummock_client, unpin_version, UnpinVersionRequest, UnpinVersionResponse }
             ,{ hummock_client, pin_snapshot, PinSnapshotRequest, PinSnapshotResponse }
             ,{ hummock_client, unpin_snapshot, UnpinSnapshotRequest, UnpinSnapshotResponse }
-            ,{ hummock_client, unpin_snapshot_before, UnpinSnapshotRequest, UnpinSnapshotResponse }
+            ,{ hummock_client, unpin_snapshot_before, UnpinSnapshotBeforeRequest, UnpinSnapshotBeforeResponse }
             ,{ hummock_client, report_compaction_tasks, ReportCompactionTasksRequest, ReportCompactionTasksResponse }
             ,{ hummock_client, get_new_table_id, GetNewTableIdRequest, GetNewTableIdResponse }
             ,{ hummock_client, subscribe_compact_tasks, SubscribeCompactTasksRequest, Streaming<SubscribeCompactTasksResponse> }

--- a/src/storage/src/hummock/hummock_meta_client.rs
+++ b/src/storage/src/hummock/hummock_meta_client.rs
@@ -71,6 +71,10 @@ impl HummockMetaClient for MonitoredHummockMetaClient {
         res
     }
 
+    async fn unpin_snapshot_before(&self, _min_epoch: HummockEpoch) -> Result<()> {
+        unreachable!("Currently CNs should not call this function")
+    }
+
     async fn get_new_table_id(&self) -> Result<HummockSSTableId> {
         self.stats.get_new_table_id_counts.inc();
         let timer = self.stats.get_new_table_id_latency.start_timer();


### PR DESCRIPTION
## What's changed and what's your intention?

I actually already finished some development of using this RPC in frontend manager. But I'd like to make the PR small.

The main idea is `unpin_snapshot_before(min_epoch)`. This is to allow the meta to **unpin all epoch < min_epoch**. The implementation is learned from the retryable pin snapshot. Calcualting all pinned snapshot that is smaller than specified epoch and unpin them all.



## Checklist

- [x] I have written necessary docs and comments
- [x] I have added necessary unit tests and integration tests
- [x] All checks passed in `./risedev check` (or alias, `./risedev c`)

## Refer to a related PR or issue link (optional)
Part of #2364 