### PR TITLE
chore(config): set meta cache to 1gb

### DIFF
--- a/src/config/risingwave.toml
+++ b/src/config/risingwave.toml
@@ -13,4 +13,4 @@ block_size_kb = 64
 bloom_false_positive = 0.01
 data_directory = "hummock_001"
 block_cache_capacity_mb = 4096
-meta_cache_capacity_mb = 256
+meta_cache_capacity_mb = 1024


### PR DESCRIPTION
## What's changed and what's your intention?

During benchmarks, 256MB of meta cache will cause very high object storage throughput. 1GB seems like a reasonable value.

Also, we'd better find a way to determine the right size of meta cache. e.g. if meta cache misses frequently on one file, we should dynamically increase the meta cache size.

## Checklist

- [x] I have written necessary docs and comments
- [x] I have added necessary unit tests and integration tests
- [x] All checks passed in `./risedev check` (or alias, `./risedev c`)

## Refer to a related PR or issue link (optional)
