### PR TITLE
fix(types): reduce [Struct/List]Value memory usage and fix Decimal data_size

### DIFF
--- a/src/common/src/array/list_array.rs
+++ b/src/common/src/array/list_array.rs
@@ -285,7 +285,7 @@ impl ListArray {
 
 #[derive(Clone, Debug, Eq, Default, PartialEq, Hash)]
 pub struct ListValue {
-    values: Vec<Datum>,
+    values: Box<[Datum]>,
 }
 
 impl fmt::Display for ListValue {
@@ -313,7 +313,9 @@ impl Ord for ListValue {
 
 impl ListValue {
     pub fn new(values: Vec<Datum>) -> Self {
-        Self { values }
+        Self {
+            values: values.into_boxed_slice(),
+        }
     }
 
     pub fn values(&self) -> &[Datum] {

--- a/src/common/src/array/mod.rs
+++ b/src/common/src/array/mod.rs
@@ -666,6 +666,7 @@ mod tests {
         }
     }
 }
+
 #[cfg(test)]
 mod test_util {
     use std::hash::{BuildHasher, Hasher};

--- a/src/common/src/array/struct_array.rs
+++ b/src/common/src/array/struct_array.rs
@@ -273,7 +273,7 @@ impl StructArray {
 
 #[derive(Clone, Debug, Eq, Default, PartialEq, Hash)]
 pub struct StructValue {
-    fields: Vec<Datum>,
+    fields: Box<[Datum]>,
 }
 
 impl fmt::Display for StructValue {
@@ -308,7 +308,9 @@ impl Ord for StructValue {
 
 impl StructValue {
     pub fn new(fields: Vec<Datum>) -> Self {
-        Self { fields }
+        Self {
+            fields: fields.into_boxed_slice(),
+        }
     }
 
     pub fn fields(&self) -> &[Datum] {

--- a/src/common/src/types/mod.rs
+++ b/src/common/src/types/mod.rs
@@ -197,7 +197,7 @@ impl DataType {
             DataType::Int64 => DataSize::Fixed(size_of::<i64>()),
             DataType::Float32 => DataSize::Fixed(size_of::<OrderedF32>()),
             DataType::Float64 => DataSize::Fixed(size_of::<OrderedF64>()),
-            DataType::Decimal => DataSize::Fixed(16),
+            DataType::Decimal => DataSize::Fixed(size_of::<Decimal>()),
             DataType::Varchar => DataSize::Variable,
             DataType::Date => DataSize::Fixed(size_of::<NaiveDateWrapper>()),
             DataType::Time => DataSize::Fixed(size_of::<NaiveTimeWrapper>()),
@@ -893,5 +893,15 @@ mod tests {
         let decoded_floats = memcomparables.into_iter().map(deserialize).collect_vec();
         assert!(decoded_floats.is_sorted());
         assert_eq!(floats, decoded_floats);
+    }
+
+    #[test]
+    fn test_size() {
+        assert_eq!(std::mem::size_of::<StructValue>(), 16);
+        assert_eq!(std::mem::size_of::<ListValue>(), 16);
+        // TODO: try to reduce the memory usage of `Decimal`, `ScalarImpl` and `Datum`.
+        assert_eq!(std::mem::size_of::<Decimal>(), 20);
+        assert_eq!(std::mem::size_of::<ScalarImpl>(), 32);
+        assert_eq!(std::mem::size_of::<Datum>(), 32);
     }
 }


### PR DESCRIPTION
Signed-off-by: TennyZhuang <zty0826@gmail.com>

## What's changed and what's your intention?

***PLEASE DO NOT LEAVE THIS EMPTY !!!***

The PR fixes two things:

1. Use boxed slice in `StructValue` and `ListValue`, which use 16 bytes (`Vec` uses 24).
2. Fix the incorrect calculation of Decimal size, which is 20 now instead of 16, need to be optimized later.

We store Vec<Datum> in our state store, so the memory usage of Datum is critical.

## Checklist

- [x] I have written necessary docs and comments
- [x] I have added necessary unit tests and integration tests
- [x] All checks passed in `./risedev check` (or alias, `./risedev c`)

## Refer to a related PR or issue link (optional)
