### PR TITLE
chore(risedev): store kafka and frontend config when compose deploy

### DIFF
--- a/src/risedevtool/src/bin/risedev-compose.rs
+++ b/src/risedevtool/src/bin/risedev-compose.rs
@@ -158,15 +158,16 @@ fn main() -> Result<()> {
             }
             ServiceConfig::FrontendV2(c) => {
                 if opts.deploy {
+                    let arg = format!("--frontend {} --frontend-port {}", c.address, c.port);
                     writeln!(
                         log_buffer,
                         "-- Frontend --\nAccess inside cluster: {}\ntpch-bench args: {}\n",
                         style(format!("psql -d dev -h {} -p {}", c.address, c.port)).green(),
-                        style(format!(
-                            "--frontend {} --frontend-port {}",
-                            c.address, c.port
-                        ))
-                        .green()
+                        style(&arg).green()
+                    )?;
+                    fs::write(
+                        Path::new(&opts.directory).join("tpch-bench-args-frontend"),
+                        arg,
                     )?;
                 }
                 (c.address.clone(), c.compose(&compose_config)?)
@@ -203,10 +204,15 @@ fn main() -> Result<()> {
             ServiceConfig::AwsS3(_) => continue,
             ServiceConfig::RedPanda(c) => {
                 if opts.deploy {
+                    let arg = format!("--kafka-addr {}:{}", c.address, c.internal_port);
                     writeln!(
                         log_buffer,
                         "-- Redpanda --\ntpch-bench: {}\n",
-                        style(format!("--kafka-addr {}:{}", c.address, c.internal_port)).green()
+                        style(&arg).green()
+                    )?;
+                    fs::write(
+                        Path::new(&opts.directory).join("tpch-bench-args-kafka"),
+                        arg,
                     )?;
                 }
                 volumes.insert(c.id.clone(), ComposeVolume::default());


### PR DESCRIPTION
Signed-off-by: Alex Chi <iskyzh@gmail.com>

## What's changed and what's your intention?

Store Kafka and frontend info to risingwave deployment directory, so that we don't need to manually copy them to the script.

## Checklist

- [x] I have written necessary docs and comments
- [x] I have added necessary unit tests and integration tests
- [x] All checks passed in `./risedev check` (or alias, `./risedev c`)

## Refer to a related PR or issue link (optional)
