### PR TITLE
feat: use unpin_snapshot_before in FE

### DIFF
--- a/src/frontend/src/lib.rs
+++ b/src/frontend/src/lib.rs
@@ -34,6 +34,8 @@
 #![feature(drain_filter)]
 #![feature(if_let_guard)]
 #![feature(assert_matches)]
+#![feature(map_first_last)]
+
 #[macro_use]
 pub mod catalog;
 pub mod binder;

--- a/src/frontend/src/scheduler/hummock_snapshot_manager.rs
+++ b/src/frontend/src/scheduler/hummock_snapshot_manager.rs
@@ -76,7 +76,7 @@ impl HummockSnapshotManager {
             // epoch to be unpin.
             let mut min_epoch = None;
             if let Some((epoch, query_ids)) = core_guard.epoch_to_query_ids.first_key_value() {
-                if !query_ids.is_empty() {
+                if query_ids.is_empty() {
                     min_epoch = Some(*epoch)
                 }
             }
@@ -93,6 +93,7 @@ impl HummockSnapshotManager {
         if let Some(epoch_inner) = need_to_request_meta {
             let meta_client = self.meta_client.clone();
             tokio::spawn(async move {
+                tracing::info!("Unpin epoch {:?} with RPC", epoch_inner);
                 let handle =
                     tokio::spawn(
                         async move { meta_client.unpin_snapshot_before(epoch_inner).await },

--- a/src/frontend/src/scheduler/hummock_snapshot_manager.rs
+++ b/src/frontend/src/scheduler/hummock_snapshot_manager.rs
@@ -72,19 +72,17 @@ impl HummockSnapshotManager {
                 }
             }
 
-            // Iterate for all query and calculate the min epoch.
             let mut min_epoch = None;
-            for (epoch, query_ids) in &core_guard.epoch_to_query_ids {
-                if query_ids.is_empty() {
-                    min_epoch = Some(*epoch);
-                    break;
+            if let Some((epoch, query_ids)) = core_guard.epoch_to_query_ids.first_key_value() {
+                if !query_ids.is_empty() {
+                    min_epoch = Some(*epoch)
                 }
             }
 
-            if let Some(epoch_inner) = min_epoch {
-                core_guard.epoch_to_query_ids.remove(&epoch_inner);
-                assert!(epoch_inner <= core_guard.last_pinned);
+            if let Some(min_epoch_inner) = min_epoch.as_ref() {
+                core_guard.epoch_to_query_ids.remove(min_epoch_inner);
             }
+
             min_epoch
         };
 


### PR DESCRIPTION
## What's changed and what's your intention?

Use the RPC `unpin_snapshot_before` introduced in #2964 in FE hummock manager. 

Different from previous, when unpin a epoch, we decrease the ref count in the maps then calculate the min epoch without query running on it (Note this epoch must <= max_committed_epoch) and tell meta to unpin all epochs before it. 
* Replace previous HashMap to BTreeMap (we can more easily find the lowest epoch)

Fact: unpin epoch b > epoch a do not will not make compaction/GC better cuz the storage only concerned about the min epoch level.

Tested locally and ensure that unpin is happening (log). Need to explore better visualization/test of pin/unpin

## Checklist

- [x] I have written necessary docs and comments
- [x] I have added necessary unit tests and integration tests
- [x] All checks passed in `./risedev check` (or alias, `./risedev c`)

## Refer to a related PR or issue link (optional)
Part of #2364 