### PR TITLE
chore: Ignore commits in the blame view

### DIFF
--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -1,2 +1,20 @@
 # chore: split plan.proto and rename projection to project #2083
 d57c97d4393733a4d3016e35b737f5cd6681aa05
+
+# chore: remove v2 naming related to legacy frontend #2572
+59a023ef55880c67c29c0d6d18f1d40370faa544
+
+# refactor(stream): remove executor v1 #2240
+2d30fda2459e223507a5ec3aa39c1c0b2e30fff9
+
+# refactor(batch): rename executor2 to executor #2842
+9ff2f46867cbcd743c3ebc49eac2a7a9a80993d4
+
+# style(proto): unify StreamPlanNode and BatchPlanNode style #2255
+56d2f5635bc5a3d2bb3403c59e175fefede45afa
+
+# refactor(stream): rename executor_v2 back to executor #2292
+f2c5758789ddd22ba6edbfeb6d7f5279ac919f9c
+
+# chore: rename rust -> src #1551
+0f2d391c420276bf8ae36f7c619ba32a64be5bb6

--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -1,0 +1,2 @@
+# chore: split plan.proto and rename projection to project #2083
+d57c97d4393733a4d3016e35b737f5cd6681aa05


### PR DESCRIPTION
## What's changed and what's your intention?
as title
https://docs.github.com/en/repositories/working-with-files/using-files/viewing-a-file#ignore-commits-in-the-blame-view

### On GitHub

before 
<img width="923" alt="image" src="https://user-images.githubusercontent.com/37948597/172110715-c71eeff6-8029-47c2-8a49-495b2f8cb4e0.png">

after
<img width="973" alt="image" src="https://user-images.githubusercontent.com/37948597/172110732-15300684-04bc-459e-8b99-d902ee0e1591.png">

### Enable Locally
```bash
git config blame.ignoreRevsFile .git-blame-ignore-revs
```

## Checklist

- ~~[ ] I have written necessary docs and comments~~
- ~~[ ] I have added necessary unit tests and integration tests~~
- ~~[ ] All checks passed in `./risedev check` (or alias, `./risedev c`)~~

## Refer to a related PR or issue link (optional)
