### PR TITLE
fix: remove unsafe impl Sync trait for LruCacheShard

### DIFF
--- a/src/common/src/cache.rs
+++ b/src/common/src/cache.rs
@@ -321,7 +321,6 @@ pub struct LruCacheShard<K: LruKey, T: LruValue> {
 }
 
 unsafe impl<K: LruKey, T: LruValue> Send for LruCacheShard<K, T> {}
-unsafe impl<K: LruKey, T: LruValue> Sync for LruCacheShard<K, T> {}
 
 impl<K: LruKey, T: LruValue> LruCacheShard<K, T> {
     fn new(capacity: usize, object_capacity: usize) -> Self {


### PR DESCRIPTION
## What's changed and what's your intention?

`LruCacheShard` only need to be `Send` for the async environment. It's not thread-safe and is protected by `Mutex` in `LruCache`.

## Checklist

- [x] I have written necessary docs and comments
- [x] I have added necessary unit tests and integration tests
- [x] All checks passed in `./risedev check` (or alias, `./risedev c`)

## Refer to a related PR or issue link (optional)
