### PR TITLE
feat: apply relational refactor for hash agg (max, min)

### DIFF
--- a/src/storage/src/table/state_table.rs
+++ b/src/storage/src/table/state_table.rs
@@ -201,11 +201,11 @@ impl<S: StateStore> StateTable<S> {
     }
 
     /// This function scans rows from the relational table with specific `pk_prefix`.
-    pub async fn iter_with_pk_prefix<'a>(
-        &'a self,
-        pk_prefix: &'a Row,
+    pub async fn iter_with_pk_prefix(
+        &self,
+        pk_prefix: &Row,
         epoch: u64,
-    ) -> StorageResult<RowStream<'a, S>> {
+    ) -> StorageResult<RowStream<'_, S>> {
         let order_types = &self.pk_serializer.clone().into_order_types()[0..pk_prefix.size()];
         let prefix_serializer = OrderedRowSerializer::new(order_types.into());
         let encoded_prefix = serialize_pk(pk_prefix, &prefix_serializer);
@@ -213,10 +213,6 @@ impl<S: StateStore> StateTable<S> {
 
         self.iter_with_encoded_key_range(encoded_key_range, epoch)
             .await
-    }
-
-    pub fn is_dirty(&self) -> bool {
-        !self.mem_table.buffer.is_empty()
     }
 }
 

--- a/src/storage/src/table/state_table.rs
+++ b/src/storage/src/table/state_table.rs
@@ -218,6 +218,10 @@ impl<S: StateStore> StateTable<S> {
     pub fn pk_indices(&self) -> &[usize] {
         &self._pk_indices
     }
+
+    pub fn is_dirty(&self) -> bool {
+        !self.mem_table.buffer.is_empty()
+    }
 }
 
 pub type RowStream<'a, S: StateStore> = impl Stream<Item = StorageResult<Cow<'a, Row>>>;

--- a/src/storage/src/table/state_table.rs
+++ b/src/storage/src/table/state_table.rs
@@ -215,10 +215,6 @@ impl<S: StateStore> StateTable<S> {
             .await
     }
 
-    pub fn pk_indices(&self) -> &[usize] {
-        &self._pk_indices
-    }
-
     pub fn is_dirty(&self) -> bool {
         !self.mem_table.buffer.is_empty()
     }

--- a/src/storage/src/table/state_table.rs
+++ b/src/storage/src/table/state_table.rs
@@ -214,6 +214,10 @@ impl<S: StateStore> StateTable<S> {
         self.iter_with_encoded_key_range(encoded_key_range, epoch)
             .await
     }
+
+    pub fn pk_indices(&self) -> &[usize] {
+        &self._pk_indices
+    }
 }
 
 pub type RowStream<'a, S: StateStore> = impl Stream<Item = StorageResult<Cow<'a, Row>>>;

--- a/src/stream/src/executor/aggregation/agg_state.rs
+++ b/src/stream/src/executor/aggregation/agg_state.rs
@@ -102,14 +102,14 @@ impl<S: StateStore> AggState<S> {
         builders: &mut [ArrayBuilderImpl],
         new_ops: &mut Vec<Op>,
         epoch: u64,
-        state_table: &[StateTable<S>],
+        state_tables: &[StateTable<S>],
     ) -> StreamExecutorResult<usize> {
         if !self.is_dirty() {
             return Ok(0);
         }
 
         let row_count = self
-            .row_count(epoch, &state_table[ROW_COUNT_COLUMN])
+            .row_count(epoch, &state_tables[ROW_COUNT_COLUMN])
             .await?;
         let prev_row_count = self.prev_row_count();
 
@@ -135,7 +135,7 @@ impl<S: StateStore> AggState<S> {
                 for ((builder, state), state_table) in builders
                     .iter_mut()
                     .zip_eq(self.managed_states.iter_mut())
-                    .zip_eq(state_table.iter())
+                    .zip_eq(state_tables.iter())
                 {
                     let data = state.get_output(epoch, state_table).await?;
                     trace!("append_datum (0 -> N): {:?}", &data);
@@ -169,7 +169,7 @@ impl<S: StateStore> AggState<S> {
                     builders.iter_mut(),
                     self.prev_states.as_ref().unwrap().iter(),
                     self.managed_states.iter_mut(),
-                    state_table.iter(),
+                    state_tables.iter(),
                 )) {
                     let cur_state = cur_state.get_output(epoch, state_table).await?;
                     trace!(

--- a/src/stream/src/executor/aggregation/agg_state.rs
+++ b/src/stream/src/executor/aggregation/agg_state.rs
@@ -45,7 +45,11 @@ impl<S: StateStore> Debug for AggState<S> {
 pub const ROW_COUNT_COLUMN: usize = 0;
 
 impl<S: StateStore> AggState<S> {
-    pub async fn row_count(&mut self, epoch: u64, state_table: &StateTable<S>) -> StreamExecutorResult<i64> {
+    pub async fn row_count(
+        &mut self,
+        epoch: u64,
+        state_table: &StateTable<S>,
+    ) -> StreamExecutorResult<i64> {
         Ok(self.managed_states[ROW_COUNT_COLUMN]
             .get_output(epoch, state_table)
             .await?
@@ -104,7 +108,9 @@ impl<S: StateStore> AggState<S> {
             return Ok(0);
         }
 
-        let row_count = self.row_count(epoch, &state_table[0]).await?;
+        let row_count = self
+            .row_count(epoch, &state_table[ROW_COUNT_COLUMN])
+            .await?;
         let prev_row_count = self.prev_row_count();
 
         trace!(

--- a/src/stream/src/executor/aggregation/agg_state.rs
+++ b/src/stream/src/executor/aggregation/agg_state.rs
@@ -17,6 +17,7 @@ use std::fmt::Debug;
 use itertools::Itertools;
 use risingwave_common::array::{ArrayBuilderImpl, Op};
 use risingwave_common::types::Datum;
+use risingwave_storage::table::state_table::StateTable;
 use risingwave_storage::StateStore;
 
 use crate::executor::error::StreamExecutorResult;
@@ -44,9 +45,9 @@ impl<S: StateStore> Debug for AggState<S> {
 pub const ROW_COUNT_COLUMN: usize = 0;
 
 impl<S: StateStore> AggState<S> {
-    pub async fn row_count(&mut self, epoch: u64) -> StreamExecutorResult<i64> {
+    pub async fn row_count(&mut self, epoch: u64, state_table: &StateTable<S>) -> StreamExecutorResult<i64> {
         Ok(self.managed_states[ROW_COUNT_COLUMN]
-            .get_output(epoch)
+            .get_output(epoch, state_table)
             .await?
             .map(|x| *x.as_int64())
             .unwrap_or(0))
@@ -71,14 +72,18 @@ impl<S: StateStore> AggState<S> {
     /// changes to the state. If the state is already marked dirty in this epoch, this function does
     /// no-op.
     /// After calling this function, `self.is_dirty()` will return `true`.
-    pub async fn may_mark_as_dirty(&mut self, epoch: u64) -> StreamExecutorResult<()> {
+    pub async fn may_mark_as_dirty(
+        &mut self,
+        epoch: u64,
+        state_tables: &[StateTable<S>],
+    ) -> StreamExecutorResult<()> {
         if self.is_dirty() {
             return Ok(());
         }
 
         let mut outputs = vec![];
-        for state in &mut self.managed_states {
-            outputs.push(state.get_output(epoch).await?);
+        for (state, state_table) in self.managed_states.iter_mut().zip_eq(state_tables.iter()) {
+            outputs.push(state.get_output(epoch, state_table).await?);
         }
         self.prev_states = Some(outputs);
         Ok(())
@@ -93,12 +98,13 @@ impl<S: StateStore> AggState<S> {
         builders: &mut [ArrayBuilderImpl],
         new_ops: &mut Vec<Op>,
         epoch: u64,
+        state_table: &[StateTable<S>],
     ) -> StreamExecutorResult<usize> {
         if !self.is_dirty() {
             return Ok(0);
         }
 
-        let row_count = self.row_count(epoch).await?;
+        let row_count = self.row_count(epoch, &state_table[0]).await?;
         let prev_row_count = self.prev_row_count();
 
         trace!(
@@ -120,8 +126,12 @@ impl<S: StateStore> AggState<S> {
                 // previous state is empty, current state is not empty, insert one `Insert` op.
                 new_ops.push(Op::Insert);
 
-                for (builder, state) in builders.iter_mut().zip_eq(self.managed_states.iter_mut()) {
-                    let data = state.get_output(epoch).await?;
+                for ((builder, state), state_table) in builders
+                    .iter_mut()
+                    .zip_eq(self.managed_states.iter_mut())
+                    .zip_eq(state_table.iter())
+                {
+                    let data = state.get_output(epoch, state_table).await?;
                     trace!("append_datum (0 -> N): {:?}", &data);
                     builder.append_datum(&data)?;
                 }
@@ -149,12 +159,13 @@ impl<S: StateStore> AggState<S> {
                 new_ops.push(Op::UpdateDelete);
                 new_ops.push(Op::UpdateInsert);
 
-                for (builder, prev_state, cur_state) in itertools::multizip((
+                for (builder, prev_state, cur_state, state_table) in itertools::multizip((
                     builders.iter_mut(),
                     self.prev_states.as_ref().unwrap().iter(),
                     self.managed_states.iter_mut(),
+                    state_table.iter(),
                 )) {
-                    let cur_state = cur_state.get_output(epoch).await?;
+                    let cur_state = cur_state.get_output(epoch, state_table).await?;
                     trace!(
                         "append_datum (N -> N): prev = {:?}, cur = {:?}",
                         prev_state,

--- a/src/stream/src/executor/aggregation/mod.rs
+++ b/src/stream/src/executor/aggregation/mod.rs
@@ -470,9 +470,7 @@ pub async fn generate_managed_agg_state<S: StateStore>(
 
         if idx == ROW_COUNT_COLUMN {
             // For the rowcount state, we should record the rowcount.
-            let output = managed_state
-                .get_output(epoch, &state_tables[idx])
-                .await?;
+            let output = managed_state.get_output(epoch, &state_tables[idx]).await?;
             row_count = Some(output.as_ref().map(|x| *x.as_int64() as usize).unwrap_or(0));
         }
 

--- a/src/stream/src/executor/aggregation/mod.rs
+++ b/src/stream/src/executor/aggregation/mod.rs
@@ -470,7 +470,9 @@ pub async fn generate_managed_agg_state<S: StateStore>(
 
         if idx == ROW_COUNT_COLUMN {
             // For the rowcount state, we should record the rowcount.
-            let output = managed_state.get_output(epoch).await?;
+            let output = managed_state
+                .get_output(epoch, &state_tables[idx])
+                .await?;
             row_count = Some(output.as_ref().map(|x| *x.as_int64() as usize).unwrap_or(0));
         }
 

--- a/src/stream/src/executor/global_simple_agg.rs
+++ b/src/stream/src/executor/global_simple_agg.rs
@@ -110,7 +110,7 @@ impl<S: StateStore> SimpleAggExecutor<S> {
                 ks.clone(),
                 agg_call,
                 &key_indices,
-                &pk_indices,
+                &input_info.pk_indices,
                 &schema,
                 input.as_ref(),
             ));

--- a/src/stream/src/executor/global_simple_agg.rs
+++ b/src/stream/src/executor/global_simple_agg.rs
@@ -181,9 +181,7 @@ impl<S: StateStore> SimpleAggExecutor<S> {
         let states = states.as_mut().unwrap();
 
         // 2. Mark the state as dirty by filling prev states
-        states
-            .may_mark_as_dirty(epoch, state_tables)
-            .await?;
+        states.may_mark_as_dirty(epoch, state_tables).await?;
 
         // 3. Apply batch to each of the state (per agg_call)
         for ((agg_state, data), state_table) in states
@@ -224,9 +222,7 @@ impl<S: StateStore> SimpleAggExecutor<S> {
             .iter_mut()
             .zip_eq(state_tables.iter_mut())
         {
-            state
-                .flush(&mut write_batch, state_table)
-                .await?;
+            state.flush(&mut write_batch, state_table).await?;
         }
         write_batch.ingest(epoch).await?;
 
@@ -243,7 +239,7 @@ impl<S: StateStore> SimpleAggExecutor<S> {
 
         // --- Retrieve modified states and put the changes into the builders ---
         states
-            .build_changes(&mut builders, &mut new_ops, epoch, &state_tables)
+            .build_changes(&mut builders, &mut new_ops, epoch, state_tables)
             .await?;
 
         let columns: Vec<Column> = builders

--- a/src/stream/src/executor/hash_agg.rs
+++ b/src/stream/src/executor/hash_agg.rs
@@ -12,10 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-
 use std::marker::PhantomData;
-
-use std::sync::{Arc};
+use std::sync::Arc;
 
 use futures::{stream, StreamExt};
 use futures_async_stream::try_stream;

--- a/src/stream/src/executor/managed_state/aggregation/extreme.rs
+++ b/src/stream/src/executor/managed_state/aggregation/extreme.rs
@@ -316,26 +316,22 @@ where
             // account. EXTREME_MIN and EXTREME_MAX will significantly impact the
             // following logic.
 
-            let all_data_iter = if let Some(gk) = self.group_key.as_ref() {
-                state_table
-                    .iter_with_pk_prefix(
-                        gk,
-                        OrderedRowSerializer::new(vec![
-                            if EXTREME_TYPE == variants::EXTREME_MAX {
-                                OrderType::Descending
-                            } else {
-                                OrderType::Ascending
-                            };
-                            self.group_key
-                                .as_ref()
-                                .map_or(0, |key| key.size())
-                        ]),
-                        epoch,
-                    )
-                    .await?
-            } else {
-                state_table.iter(epoch).await?
-            };
+            let all_data_iter = state_table
+                .iter_with_pk_prefix(
+                    self.group_key.as_ref().unwrap_or(&Row::default()),
+                    OrderedRowSerializer::new(vec![
+                        if EXTREME_TYPE == variants::EXTREME_MAX {
+                            OrderType::Descending
+                        } else {
+                            OrderType::Ascending
+                        };
+                        self.group_key
+                            .as_ref()
+                            .map_or(0, |key| key.size())
+                    ]),
+                    epoch,
+                )
+                .await?;
             pin_mut!(all_data_iter);
 
             for _ in 0..self.top_n_count.unwrap_or(usize::MAX) {

--- a/src/stream/src/executor/managed_state/aggregation/extreme.rs
+++ b/src/stream/src/executor/managed_state/aggregation/extreme.rs
@@ -316,22 +316,26 @@ where
             // account. EXTREME_MIN and EXTREME_MAX will significantly impact the
             // following logic.
 
-            let all_data_iter = state_table
-                .iter_with_pk_prefix(
-                    self.group_key.as_ref(),
-                    OrderedRowSerializer::new(vec![
-                        if EXTREME_TYPE == variants::EXTREME_MAX {
-                            OrderType::Descending
-                        } else {
-                            OrderType::Ascending
-                        };
-                        self.group_key
-                            .as_ref()
-                            .map_or(0, |key| key.size())
-                    ]),
-                    epoch,
-                )
-                .await?;
+            let all_data_iter = if let Some(gk) = self.group_key.as_ref() {
+                state_table
+                    .iter_with_pk_prefix(
+                        gk,
+                        OrderedRowSerializer::new(vec![
+                            if EXTREME_TYPE == variants::EXTREME_MAX {
+                                OrderType::Descending
+                            } else {
+                                OrderType::Ascending
+                            };
+                            self.group_key
+                                .as_ref()
+                                .map_or(0, |key| key.size())
+                        ]),
+                        epoch,
+                    )
+                    .await?
+            } else {
+                state_table.iter(epoch).await?
+            };
             pin_mut!(all_data_iter);
 
             for _ in 0..self.top_n_count.unwrap_or(usize::MAX) {

--- a/src/stream/src/executor/managed_state/aggregation/extreme_serializer.rs
+++ b/src/stream/src/executor/managed_state/aggregation/extreme_serializer.rs
@@ -51,6 +51,7 @@ impl<K: Scalar, const EXTREME_TYPE: usize> ExtremeSerializer<K, EXTREME_TYPE> {
         }
     }
 
+    #[allow(dead_code)]
     fn is_reversed_order(&self) -> bool {
         match EXTREME_TYPE {
             variants::EXTREME_MAX => true,
@@ -62,6 +63,7 @@ impl<K: Scalar, const EXTREME_TYPE: usize> ExtremeSerializer<K, EXTREME_TYPE> {
     /// Serialize key and `pk` (or, `row_id`s) into a sort key
     ///
     /// TODO: support `&K` instead of `K` as parameter.
+    #[allow(dead_code)]
     pub fn serialize(&self, key: Option<K>, pk: &ExtremePk) -> StreamExecutorResult<Vec<u8>> {
         let mut serializer = memcomparable::Serializer::new(vec![]);
         serializer.set_reverse(self.is_reversed_order());
@@ -82,6 +84,7 @@ impl<K: Scalar, const EXTREME_TYPE: usize> ExtremeSerializer<K, EXTREME_TYPE> {
     }
 
     /// Extract the pks from the sort key
+    #[allow(dead_code)]
     pub fn get_pk(&self, data: &[u8]) -> StreamExecutorResult<ExtremePk> {
         if self.pk_data_types.is_empty() {
             return Ok(ExtremePk::default());

--- a/src/stream/src/executor/managed_state/aggregation/mod.rs
+++ b/src/stream/src/executor/managed_state/aggregation/mod.rs
@@ -81,10 +81,10 @@ impl<S: StateStore> ManagedStateImpl<S> {
     }
 
     /// Get the output of the state. Must flush before getting output.
-    pub async fn get_output(&mut self, epoch: u64) -> StreamExecutorResult<Datum> {
+    pub async fn get_output(&mut self, epoch: u64, state_table: &StateTable<S>) -> StreamExecutorResult<Datum> {
         match self {
             Self::Value(state) => state.get_output().await,
-            Self::Table(state) => state.get_output(epoch).await,
+            Self::Table(state) => state.get_output(epoch, state_table).await,
         }
     }
 
@@ -99,12 +99,12 @@ impl<S: StateStore> ManagedStateImpl<S> {
     /// Flush the internal state to a write batch.
     pub async fn flush(
         &mut self,
-        // write_batch: &mut WriteBatch<S>,
+        write_batch: &mut WriteBatch<S>,
         state_table: &mut StateTable<S>,
     ) -> StreamExecutorResult<()> {
         match self {
             Self::Value(state) => state.flush(state_table).await,
-            Self::Table(state) => state.flush(state_table),
+            Self::Table(state) => state.flush(write_batch, state_table),
         }
     }
 

--- a/src/stream/src/executor/managed_state/aggregation/mod.rs
+++ b/src/stream/src/executor/managed_state/aggregation/mod.rs
@@ -68,10 +68,15 @@ impl<S: StateStore> ManagedStateImpl<S> {
         visibility: Option<&Bitmap>,
         data: &[&ArrayImpl],
         epoch: u64,
+        state_table: &mut StateTable<S>,
     ) -> StreamExecutorResult<()> {
         match self {
             Self::Value(state) => state.apply_batch(ops, visibility, data).await,
-            Self::Table(state) => state.apply_batch(ops, visibility, data, epoch).await,
+            Self::Table(state) => {
+                state
+                    .apply_batch(ops, visibility, data, epoch, state_table)
+                    .await
+            }
         }
     }
 
@@ -94,12 +99,12 @@ impl<S: StateStore> ManagedStateImpl<S> {
     /// Flush the internal state to a write batch.
     pub async fn flush(
         &mut self,
-        write_batch: &mut WriteBatch<S>,
+        // write_batch: &mut WriteBatch<S>,
         state_table: &mut StateTable<S>,
     ) -> StreamExecutorResult<()> {
         match self {
-            Self::Value(state) => state.flush(write_batch, state_table).await,
-            Self::Table(state) => state.flush(write_batch),
+            Self::Value(state) => state.flush(state_table).await,
+            Self::Table(state) => state.flush(state_table),
         }
     }
 

--- a/src/stream/src/executor/managed_state/aggregation/mod.rs
+++ b/src/stream/src/executor/managed_state/aggregation/mod.rs
@@ -81,7 +81,11 @@ impl<S: StateStore> ManagedStateImpl<S> {
     }
 
     /// Get the output of the state. Must flush before getting output.
-    pub async fn get_output(&mut self, epoch: u64, state_table: &StateTable<S>) -> StreamExecutorResult<Datum> {
+    pub async fn get_output(
+        &mut self,
+        epoch: u64,
+        state_table: &StateTable<S>,
+    ) -> StreamExecutorResult<Datum> {
         match self {
             Self::Value(state) => state.get_output().await,
             Self::Table(state) => state.get_output(epoch, state_table).await,

--- a/src/stream/src/executor/managed_state/aggregation/mod.rs
+++ b/src/stream/src/executor/managed_state/aggregation/mod.rs
@@ -103,7 +103,7 @@ impl<S: StateStore> ManagedStateImpl<S> {
         state_table: &mut StateTable<S>,
     ) -> StreamExecutorResult<()> {
         match self {
-            Self::Value(state) => state.flush(state_table).await,
+            Self::Value(state) => state.flush(write_batch, state_table).await,
             Self::Table(state) => state.flush(write_batch, state_table),
         }
     }
@@ -142,6 +142,7 @@ impl<S: StateStore> ManagedStateImpl<S> {
                             Some(1024),
                             pk_data_types,
                             key_hash_code,
+                            pk,
                         )
                         .await?,
                     ))

--- a/src/stream/src/executor/managed_state/aggregation/string_agg.rs
+++ b/src/stream/src/executor/managed_state/aggregation/string_agg.rs
@@ -162,6 +162,7 @@ impl<S: StateStore> ManagedTableState<S> for ManagedStringAggState<S> {
         visibility: Option<&Bitmap>,
         data: &[&ArrayImpl],
         epoch: u64,
+        state_table: &mut StateTable<S>
     ) -> StreamExecutorResult<()> {
         debug_assert!(super::verify_batch(ops, visibility, data));
         for sort_key_index in &self.sort_key_indices {

--- a/src/stream/src/executor/managed_state/aggregation/string_agg.rs
+++ b/src/stream/src/executor/managed_state/aggregation/string_agg.rs
@@ -248,21 +248,20 @@ impl<S: StateStore> ManagedTableState<S> for ManagedStringAggState<S> {
             return Ok(());
         }
 
-        // let mut local = write_batch.prefixify(&self.keyspace);
+        let mut local = write_batch.prefixify(&self.keyspace);
 
         for (key, value) in std::mem::take(&mut self.cache) {
             let value = value.into_option();
             match value {
                 Some(val) => {
                     // TODO(Yuanxin): Implement value meta
-                    // local.put(
-                    //     key,
-                    //     StorageValue::new_default_put(serialize_cell(&Some(val))?),
-                    // );
+                    local.put(
+                        key,
+                        StorageValue::new_default_put(serialize_cell(&Some(val))?),
+                    );
                 }
                 None => {
-                    // local.delete(key);
-                    // state_table.delete()
+                    local.delete(key);
                 }
             }
         }

--- a/src/stream/src/executor/managed_state/aggregation/value.rs
+++ b/src/stream/src/executor/managed_state/aggregation/value.rs
@@ -103,11 +103,7 @@ impl ManagedValueState {
     }
 
     /// Flush the internal state to a write batch.
-    pub async fn flush<S: StateStore>(
-        &mut self,
-        _write_batch: &mut WriteBatch<S>,
-        state_table: &mut StateTable<S>,
-    ) -> StreamExecutorResult<()> {
+    pub async fn flush<S: StateStore>(&mut self, state_table: &mut StateTable<S>) -> StreamExecutorResult<()> {
         // If the managed state is not dirty, the caller should not flush. But forcing a flush won't
         // cause incorrect result: it will only produce more I/O.
         debug_assert!(self.is_dirty());

--- a/src/stream/src/executor/managed_state/aggregation/value.rs
+++ b/src/stream/src/executor/managed_state/aggregation/value.rs
@@ -191,7 +191,7 @@ mod tests {
         );
 
         // reload the state and check the output
-        let mut managed_state =
+        let managed_state =
             ManagedValueState::new(create_test_count_state(), None, None, &state_table)
                 .await
                 .unwrap();
@@ -262,7 +262,7 @@ mod tests {
         );
 
         // reload the state and check the output
-        let mut managed_state =
+        let managed_state =
             ManagedValueState::new(create_test_max_agg_append_only(), None, None, &state_table)
                 .await
                 .unwrap();

--- a/src/stream/src/executor/managed_state/aggregation/value.rs
+++ b/src/stream/src/executor/managed_state/aggregation/value.rs
@@ -17,7 +17,7 @@ use risingwave_common::array::{ArrayImpl, Row};
 use risingwave_common::buffer::Bitmap;
 use risingwave_common::types::Datum;
 use risingwave_storage::table::state_table::StateTable;
-use risingwave_storage::write_batch::WriteBatch;
+
 use risingwave_storage::StateStore;
 
 use crate::executor::aggregation::{create_streaming_agg_state, AggCall, StreamingAggStateImpl};
@@ -92,7 +92,7 @@ impl ManagedValueState {
     /// Get the output of the state. Note that in our case, getting the output is very easy, as the
     /// output is the same as the aggregation state. In other aggregators, like min and max,
     /// `get_output` might involve a scan from the state store.
-    pub async fn get_output(&mut self) -> StreamExecutorResult<Datum> {
+    pub async fn get_output(&self) -> StreamExecutorResult<Datum> {
         debug_assert!(!self.is_dirty());
         self.state.get_output()
     }

--- a/src/stream/src/executor/managed_state/aggregation/value.rs
+++ b/src/stream/src/executor/managed_state/aggregation/value.rs
@@ -17,7 +17,7 @@ use risingwave_common::array::{ArrayImpl, Row};
 use risingwave_common::buffer::Bitmap;
 use risingwave_common::types::Datum;
 use risingwave_storage::table::state_table::StateTable;
-
+use risingwave_storage::write_batch::WriteBatch;
 use risingwave_storage::StateStore;
 
 use crate::executor::aggregation::{create_streaming_agg_state, AggCall, StreamingAggStateImpl};
@@ -103,7 +103,11 @@ impl ManagedValueState {
     }
 
     /// Flush the internal state to a write batch.
-    pub async fn flush<S: StateStore>(&mut self, state_table: &mut StateTable<S>) -> StreamExecutorResult<()> {
+    pub async fn flush<S: StateStore>(
+        &mut self,
+        _write_batch: &mut WriteBatch<S>,
+        state_table: &mut StateTable<S>,
+    ) -> StreamExecutorResult<()> {
         // If the managed state is not dirty, the caller should not flush. But forcing a flush won't
         // cause incorrect result: it will only produce more I/O.
         debug_assert!(self.is_dirty());


### PR DESCRIPTION
## What's changed and what's your intention?

Sorry for the huge PR, but this should be the min efforts to introduce the relational refactor. Mainly change is the AggState interface (mostly`get_output`), now we pass StateTable as & or &mut. 

After this PR, besides StringAgg (we currently do not have e2e test in it so i prefer not include here), all other agg call should use the relational table. 

* Change the function signature. Add &StateTable or &mut StateTable
  * `get_output(epoch)` -> `get_output(epoch, &StateTable<S>)`. The states may need to fetch data from remote store.
  * Same for `row_count`, `mark_as_dirty`.
* For HashAgg, I wrap a `Arc<Mutex<>>` for all State Tables cuz I do not want to solve too difficult Multi-thread problems in this PR. Discussed and we thought `apply_batch` (Mostly mem_table write) should not be parallelized so the lock is not a significant problem. 


There will be a lot of TODOs to make code more simple and clear:
See #3235.

## Checklist

- [x] I have written necessary docs and comments
- [x] I have added necessary unit tests and integration tests
- [x] All checks passed in `./risedev check` (or alias, `./risedev c`)

## Refer to a related PR or issue link (optional)
