### PR TITLE
feat(storage): limit SSTBuilder's memory usage

### DIFF
--- a/src/bench/ss_bench/main.rs
+++ b/src/bench/ss_bench/main.rs
@@ -25,6 +25,8 @@ use risingwave_meta::hummock::test_utils::setup_compute_env;
 use risingwave_meta::hummock::MockHummockMetaClient;
 use risingwave_storage::hummock::compaction_executor::CompactionExecutor;
 use risingwave_storage::hummock::compactor::{get_remote_sstable_id_generator, CompactorContext};
+use risingwave_storage::hummock::restricted_builder::ResourceLimiter;
+use risingwave_storage::hummock::sst_writer::SstWriter;
 use risingwave_storage::monitor::{ObjectStoreMetrics, StateStoreMetrics};
 use risingwave_storage::{dispatch_state_store, StateStoreImpl};
 
@@ -188,6 +190,8 @@ async fn main() {
                 compaction_executor: Some(Arc::new(CompactionExecutor::new(Some(
                     config.share_buffer_compaction_worker_threads_number as usize,
                 )))),
+                sst_writer: Arc::new(SstWriter::new(hummock.inner().sstable_store())),
+                sst_builder_limiter: Arc::new(ResourceLimiter::new(1024 * 1024 * 1024)),
             }),
             hummock.inner().local_version_manager().clone(),
         ));

--- a/src/storage/src/hummock/compactor_tests.rs
+++ b/src/storage/src/hummock/compactor_tests.rs
@@ -25,6 +25,8 @@ mod tests {
 
     use crate::hummock::compactor::{get_remote_sstable_id_generator, Compactor, CompactorContext};
     use crate::hummock::iterator::test_utils::mock_sstable_store;
+    use crate::hummock::restricted_builder::ResourceLimiter;
+    use crate::hummock::sst_writer::SstWriter;
     use crate::hummock::HummockStorage;
     use crate::monitor::{StateStoreMetrics, StoreLocalStatistic};
     use crate::storage_value::StorageValue;
@@ -77,6 +79,8 @@ mod tests {
             is_share_buffer_compact: false,
             sstable_id_generator: get_remote_sstable_id_generator(hummock_meta_client.clone()),
             compaction_executor: None,
+            sst_writer: Arc::new(SstWriter::new(storage.sstable_store.clone())),
+            sst_builder_limiter: Arc::new(ResourceLimiter::new(1024 * 1024 * 256)),
         };
 
         // 1. add sstables

--- a/src/storage/src/hummock/iterator/mod.rs
+++ b/src/storage/src/hummock/iterator/mod.rs
@@ -31,7 +31,7 @@ mod merge_inner;
 pub use forward_user::*;
 
 #[cfg(test)]
-pub(crate) mod test_utils;
+pub mod test_utils;
 
 use async_trait::async_trait;
 

--- a/src/storage/src/hummock/sstable/mod.rs
+++ b/src/storage/src/hummock/sstable/mod.rs
@@ -34,6 +34,8 @@ use risingwave_hummock_sdk::HummockSSTableId;
 use risingwave_pb::hummock::{KeyRange, SstableInfo};
 
 pub mod group_builder;
+pub mod restricted_builder;
+pub mod sst_writer;
 mod utils;
 
 pub use utils::CompressionAlgorithm;

--- a/src/storage/src/hummock/sstable/multi_builder.rs
+++ b/src/storage/src/hummock/sstable/multi_builder.rs
@@ -22,10 +22,10 @@ use super::SstableMeta;
 use crate::hummock::value::HummockValue;
 use crate::hummock::{HummockResult, SSTableBuilder};
 
-struct SSTableBuilderWrapper {
-    id: HummockSSTableId,
-    builder: SSTableBuilder,
-    sealed: bool,
+pub struct SSTableBuilderWrapper {
+    pub id: HummockSSTableId,
+    pub builder: SSTableBuilder,
+    pub sealed: bool,
 }
 
 /// A wrapper for [`SSTableBuilder`] which automatically split key-value pairs into multiple tables,

--- a/src/storage/src/hummock/sstable/restricted_builder.rs
+++ b/src/storage/src/hummock/sstable/restricted_builder.rs
@@ -200,7 +200,7 @@ where
         let mut ssts = Vec::with_capacity(self.write_results.len());
         let results = try_join_all(self.write_results)
             .await
-            .map_err(|_| HummockError::other(format!("Unable to get write result")))?;
+            .map_err(|_| HummockError::other("Unable to get write result".to_string()))?;
         for write_result in results {
             ssts.push(write_result?);
         }

--- a/src/storage/src/hummock/sstable/restricted_builder.rs
+++ b/src/storage/src/hummock/sstable/restricted_builder.rs
@@ -1,0 +1,208 @@
+// Copyright 2022 Singularity Data
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::collections::VecDeque;
+use std::future::Future;
+use std::sync::Arc;
+
+use itertools::Itertools;
+use parking_lot::RwLock;
+use risingwave_hummock_sdk::key::FullKey;
+use risingwave_hummock_sdk::HummockSSTableId;
+use risingwave_pb::common::VNodeBitmap;
+use tokio::sync::oneshot::Sender;
+use tokio::task::JoinHandle;
+
+use crate::hummock::multi_builder::SSTableBuilderWrapper;
+use crate::hummock::sstable::sst_writer::SstWriter;
+use crate::hummock::value::HummockValue;
+use crate::hummock::{HummockError, HummockResult, SSTableBuilder, Sstable};
+
+pub type SstWriteResult = JoinHandle<HummockResult<Sstable>>;
+
+pub struct ResourceLimiter {
+    inner: RwLock<ResourceLimiterInner>,
+}
+
+struct ResourceLimiterInner {
+    current_size: u64,
+    max_size: u64,
+    notifiers: VecDeque<(u64, Sender<()>)>,
+}
+
+impl ResourceLimiter {
+    pub fn new(max_size: u64) -> Self {
+        assert!(max_size > 0, "max_size should be greater than 0");
+        let inner = ResourceLimiterInner {
+            current_size: 0,
+            max_size,
+            notifiers: Default::default(),
+        };
+        Self {
+            inner: RwLock::new(inner),
+        }
+    }
+
+    pub fn request_resource(&self, request_size: u64, notifier: Sender<()>) {
+        let mut guard = self.inner.write();
+        if guard.current_size != 0 && guard.current_size + request_size > guard.max_size {
+            guard.notifiers.push_back((request_size, notifier));
+            return;
+        }
+        if notifier.send(()).is_err() {
+            tracing::warn!("receiver has already been deallocated");
+            return;
+        }
+        guard.current_size += request_size;
+    }
+
+    pub fn free_resource(&self, free_size: u64) {
+        let mut guard = self.inner.write();
+        assert!(guard.current_size >= free_size);
+        guard.current_size -= free_size;
+        while let Some((request_size, notifier)) = guard.notifiers.pop_front() {
+            if guard.current_size != 0 && guard.current_size + request_size > guard.max_size {
+                guard.notifiers.push_front((request_size, notifier));
+                return;
+            }
+            if notifier.send(()).is_err() {
+                tracing::warn!("receiver has already been deallocated");
+                return;
+            }
+            guard.current_size += request_size;
+        }
+    }
+}
+
+pub struct RestrictedBuilder<B> {
+    get_id_and_builder: B,
+
+    current_builder: Option<SSTableBuilderWrapper>,
+
+    write_results: Vec<SstWriteResult>,
+
+    writer: Arc<SstWriter>,
+
+    limiter: Arc<ResourceLimiter>,
+
+    vnode_bitmaps: Vec<Vec<VNodeBitmap>>,
+
+    resource_size: u64,
+}
+
+impl<B, F> RestrictedBuilder<B>
+where
+    B: Clone + Fn() -> F,
+    F: Future<Output = HummockResult<(HummockSSTableId, SSTableBuilder)>>,
+{
+    pub fn new(
+        get_id_and_builder: B,
+        writer: Arc<SstWriter>,
+        limiter: Arc<ResourceLimiter>,
+        resource_size: u64,
+    ) -> Self {
+        Self {
+            get_id_and_builder,
+            current_builder: None,
+            write_results: Default::default(),
+            writer,
+            limiter,
+            vnode_bitmaps: Default::default(),
+            resource_size,
+        }
+    }
+
+    pub fn len(&self) -> usize {
+        let mut len = self.write_results.len();
+        if self.current_builder.is_some() {
+            len += 1;
+        }
+        len
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.current_builder.is_none() && self.write_results.is_empty()
+    }
+
+    pub async fn add_full_key(
+        &mut self,
+        full_key: FullKey<&[u8]>,
+        value: HummockValue<&[u8]>,
+        allow_split: bool,
+    ) -> HummockResult<()> {
+        let new_builder_required = match self.current_builder.as_ref() {
+            None => true,
+            Some(b) => allow_split && (b.builder.reach_capacity() || b.sealed),
+        };
+
+        if new_builder_required {
+            self.finish_current_builder();
+            let (id, builder) = (self.get_id_and_builder)().await?;
+            self.current_builder = Some(SSTableBuilderWrapper {
+                id,
+                builder,
+                sealed: false,
+            });
+            let (rx, tx) = tokio::sync::oneshot::channel();
+            self.limiter.request_resource(self.resource_size, rx);
+            if let Err(e) = tx.await {
+                return Err(HummockError::other(format!(
+                    "Cannot request resource.\n{:#?}",
+                    e
+                )));
+            }
+        }
+
+        let builder = &mut self.current_builder.as_mut().unwrap().builder;
+        builder.add(full_key.into_inner(), value);
+        Ok(())
+    }
+
+    pub fn seal_current(&mut self) {
+        if let Some(b) = &mut self.current_builder {
+            b.sealed = true;
+        }
+    }
+
+    fn finish_current_builder(&mut self) {
+        if let Some(current_builder) = self.current_builder.take() {
+            let id = current_builder.id;
+            let (data, meta, vnode_bitmaps) = current_builder.builder.finish();
+            let (tx, rx) = tokio::sync::oneshot::channel::<HummockResult<Sstable>>();
+            self.writer.write(Sstable { id, meta }, data, tx);
+            self.vnode_bitmaps.push(vnode_bitmaps);
+            let limiter = self.limiter.clone();
+            let resource_size = self.resource_size;
+            self.write_results.push(tokio::spawn(async move {
+                let result = rx
+                    .await
+                    .map_err(|_| HummockError::other("Unable to get write result"));
+                limiter.free_resource(resource_size);
+                result?
+            }));
+        }
+    }
+
+    pub async fn finish(mut self) -> HummockResult<Vec<(Sstable, Vec<VNodeBitmap>)>> {
+        self.finish_current_builder();
+        let mut ssts = Vec::with_capacity(self.write_results.len());
+        for write_result in self.write_results {
+            let sst = write_result
+                .await
+                .map_err(|_| HummockError::other("Unable to get write result"))??;
+            ssts.push(sst);
+        }
+        Ok(ssts.into_iter().zip_eq(self.vnode_bitmaps).collect_vec())
+    }
+}

--- a/src/storage/src/hummock/sstable/sst_writer.rs
+++ b/src/storage/src/hummock/sstable/sst_writer.rs
@@ -1,0 +1,45 @@
+// Copyright 2022 Singularity Data
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use bytes::Bytes;
+
+use crate::hummock::sstable_store::SstableStoreRef;
+use crate::hummock::{CachePolicy, HummockResult, Sstable};
+
+pub struct SstWriter {
+    sstable_store: SstableStoreRef,
+}
+
+impl SstWriter {
+    pub fn new(sstable_store: SstableStoreRef) -> Self {
+        Self { sstable_store }
+    }
+
+    pub fn write(
+        &self,
+        sst: Sstable,
+        data: Bytes,
+        notifier: tokio::sync::oneshot::Sender<HummockResult<Sstable>>,
+    ) {
+        let sstable_store = self.sstable_store.clone();
+        tokio::spawn(async move {
+            let result = sstable_store
+                .put(sst.clone(), data, CachePolicy::Fill)
+                .await;
+            if notifier.send(result.map(|_| sst)).is_err() {
+                tracing::warn!("receiver has already been deallocated");
+            }
+        });
+    }
+}


### PR DESCRIPTION
## What's changed and what's your intention?

#### Changes

- Add `SstWriter` to upload SST asynchronously right after it's built.
- Add `ResourceLimiter` to limit number of concurrent SSTBuilders in one worker.

#### Benchmark

A benchmark shows 

- This PR can reduce compactor node's memory footprint(orange line), according to figure1 versus figure2 and figure3.
- `SstWriter` helps most, while `ResourceLimiter` doesn't make significant difference,  as compactor node's memory usage in figure2 and figure3 are quit similar.
 
1. Before this PR
<img width="733" alt="Screen Shot 2022-06-08 at 10 12 43 AM" src="https://user-images.githubusercontent.com/70626450/172516547-2f667f30-33ed-4e4b-9d01-99f31cb37242.png">

2. After this PR, with resource max size = 1GB
<img width="730" alt="Screen Shot 2022-06-08 at 10 14 17 AM" src="https://user-images.githubusercontent.com/70626450/172516629-40dee425-0014-471b-9440-5df53ace6e29.png">

3. After this PR, with resource max size = 1TB
<img width="731" alt="Screen Shot 2022-06-08 at 10 14 34 AM" src="https://user-images.githubusercontent.com/70626450/172516678-d9052252-0afc-413f-9bde-2c1aa13bf9cb.png">

#### TODO
- Verify if `ResourceLimiter` will begin to take effect in heavier workload.
- Take memory used for reading blocks into consideration. As in figure 2/3 we can still observe another 5GB memory usage at most (the other 5GB of the total 10GB is block cache), which is unclear yet.

## Checklist

- [ ] I have written necessary docs and comments
- [ ] I have added necessary unit tests and integration tests
- [ ] All checks passed in `./risedev check` (or alias, `./risedev c`)

## Refer to a related PR or issue link (optional)
