### PR TITLE
feat(streaming): source executor use table_id for keyspace prefix

### DIFF
--- a/src/stream/src/from_proto/source.rs
+++ b/src/stream/src/from_proto/source.rs
@@ -64,7 +64,7 @@ impl ExecutorBuilder for SourceExecutorBuilder {
             Field::with_name(column_desc.data_type.clone(), column_desc.name.clone())
         }));
         let schema = Schema::new(fields);
-        let keyspace = Keyspace::executor_root(store, params.executor_id);
+        let keyspace = Keyspace::table_root(store, &source_id);
 
         Ok(Box::new(SourceExecutor::new(
             params.actor_id,


### PR DESCRIPTION
## What's changed and what's your intention?

source executor use table_id for keyspace prefix

- use keyspace::table_root to replace keyspace::executor_root same as materialized_executor

## Checklist

- [x] I have written necessary docs and comments
- [x] I have added necessary unit tests and integration tests

## Refer to a related PR or issue link (optional)
- https://github.com/singularity-data/risingwave/pull/2992/files