### PR TITLE
feat(risedev): support ipv6 in config

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3716,6 +3716,7 @@ dependencies = [
  "tower-http",
  "tracing",
  "twox-hash",
+ "url",
  "value-encoding",
  "workspace-hack",
 ]

--- a/risedev.yml
+++ b/risedev.yml
@@ -39,6 +39,17 @@ risedev:
     # - use: kafka
     #   persist-data: true
 
+  default-v6:
+    - use: meta-node
+      address: "[::1]"
+      listen-address: "[::]"
+    - use: compute-node
+      address: "[::1]"
+      listen-address: "[::]"
+    - use: frontend
+      address: "[::1]"
+      listen-address: "[::]"
+
   # `dev-compute-node` have the same settings as default except the the compute node will be started by user.
   dev-compute-node:
     - use: meta-node

--- a/src/common/Cargo.toml
+++ b/src/common/Cargo.toml
@@ -41,6 +41,7 @@ tower = { version = "0.4", features = ["util", "load-shed"] }
 tower-http = { version = "0.3", features = ["add-extension", "cors"] }
 tracing = { version = "0.1" }
 twox-hash = "1"
+url = "2"
 value-encoding = { path = "../utils/value-encoding" }
 workspace-hack = { version = "0.1", path = "../workspace-hack" }
 

--- a/src/common/src/error.rs
+++ b/src/common/src/error.rs
@@ -146,6 +146,10 @@ pub enum ErrorCode {
     UnknownError(String),
 }
 
+pub fn internal_err(msg: impl Into<anyhow::Error>) -> RwError {
+    ErrorCode::InternalError(msg.into().to_string()).into()
+}
+
 pub fn internal_error(msg: impl Into<String>) -> RwError {
     ErrorCode::InternalError(msg.into()).into()
 }

--- a/src/risedevtool/src/bin/risedev-playground.rs
+++ b/src/risedevtool/src/bin/risedev-playground.rs
@@ -173,7 +173,8 @@ fn task_main(
                     ExecuteContext::new(&mut logger, manager.new_progress(), status_dir.clone());
                 let mut service = PrometheusService::new(c.clone())?;
                 service.execute(&mut ctx)?;
-                let mut task = risedev::ConfigureGrpcNodeTask::new(c.port, false)?;
+                let mut task =
+                    risedev::ConfigureGrpcNodeTask::new(c.address.clone(), c.port, false)?;
                 task.execute(&mut ctx)?;
                 ctx.pb
                     .set_message(format!("api http://{}:{}/", c.address, c.port));
@@ -184,7 +185,8 @@ fn task_main(
                 let mut service = ComputeNodeService::new(c.clone())?;
                 service.execute(&mut ctx)?;
 
-                let mut task = risedev::ConfigureGrpcNodeTask::new(c.port, c.user_managed)?;
+                let mut task =
+                    risedev::ConfigureGrpcNodeTask::new(c.address.clone(), c.port, c.user_managed)?;
                 task.execute(&mut ctx)?;
                 ctx.pb
                     .set_message(format!("api grpc://{}:{}/", c.address, c.port));
@@ -194,7 +196,8 @@ fn task_main(
                     ExecuteContext::new(&mut logger, manager.new_progress(), status_dir.clone());
                 let mut service = MetaNodeService::new(c.clone())?;
                 service.execute(&mut ctx)?;
-                let mut task = risedev::ConfigureGrpcNodeTask::new(c.port, c.user_managed)?;
+                let mut task =
+                    risedev::ConfigureGrpcNodeTask::new(c.address.clone(), c.port, c.user_managed)?;
                 task.execute(&mut ctx)?;
                 ctx.pb.set_message(format!(
                     "api grpc://{}:{}/, dashboard http://{}:{}/",
@@ -206,7 +209,8 @@ fn task_main(
                     ExecuteContext::new(&mut logger, manager.new_progress(), status_dir.clone());
                 let mut service = FrontendService::new(c.clone())?;
                 service.execute(&mut ctx)?;
-                let mut task = risedev::ConfigureGrpcNodeTask::new(c.port, c.user_managed)?;
+                let mut task =
+                    risedev::ConfigureGrpcNodeTask::new(c.address.clone(), c.port, c.user_managed)?;
                 task.execute(&mut ctx)?;
                 ctx.pb
                     .set_message(format!("api postgres://{}:{}/", c.address, c.port));
@@ -224,7 +228,8 @@ fn task_main(
                     ExecuteContext::new(&mut logger, manager.new_progress(), status_dir.clone());
                 let mut service = CompactorService::new(c.clone())?;
                 service.execute(&mut ctx)?;
-                let mut task = risedev::ConfigureGrpcNodeTask::new(c.port, c.user_managed)?;
+                let mut task =
+                    risedev::ConfigureGrpcNodeTask::new(c.address.clone(), c.port, c.user_managed)?;
                 task.execute(&mut ctx)?;
                 ctx.pb
                     .set_message(format!("compactor {}:{}", c.address, c.port));
@@ -234,7 +239,8 @@ fn task_main(
                     ExecuteContext::new(&mut logger, manager.new_progress(), status_dir.clone());
                 let mut service = GrafanaService::new(c.clone())?;
                 service.execute(&mut ctx)?;
-                let mut task = risedev::ConfigureGrpcNodeTask::new(c.port, false)?;
+                let mut task =
+                    risedev::ConfigureGrpcNodeTask::new(c.address.clone(), c.port, false)?;
                 task.execute(&mut ctx)?;
                 ctx.pb
                     .set_message(format!("dashboard http://{}:{}/", c.address, c.port));
@@ -244,7 +250,11 @@ fn task_main(
                     ExecuteContext::new(&mut logger, manager.new_progress(), status_dir.clone());
                 let mut service = JaegerService::new(c.clone())?;
                 service.execute(&mut ctx)?;
-                let mut task = risedev::ConfigureGrpcNodeTask::new(c.dashboard_port, false)?;
+                let mut task = risedev::ConfigureGrpcNodeTask::new(
+                    c.dashboard_address.clone(),
+                    c.dashboard_port,
+                    false,
+                )?;
                 task.execute(&mut ctx)?;
                 ctx.pb.set_message(format!(
                     "dashboard http://{}:{}/",
@@ -279,7 +289,8 @@ fn task_main(
                     ExecuteContext::new(&mut logger, manager.new_progress(), status_dir.clone());
                 let mut service = ZooKeeperService::new(c.clone())?;
                 service.execute(&mut ctx)?;
-                let mut task = risedev::ConfigureGrpcNodeTask::new(c.port, false)?;
+                let mut task =
+                    risedev::ConfigureGrpcNodeTask::new(c.address.clone(), c.port, false)?;
                 task.execute(&mut ctx)?;
                 ctx.pb
                     .set_message(format!("zookeeper {}:{}", c.address, c.port));

--- a/src/risedevtool/src/task/task_configure_grpc_node.rs
+++ b/src/risedevtool/src/task/task_configure_grpc_node.rs
@@ -17,19 +17,24 @@ use anyhow::Result;
 use super::{ExecuteContext, Task};
 
 pub struct ConfigureGrpcNodeTask {
+    advertise_address: String,
     port: u16,
     user_managed: bool,
 }
 
 impl ConfigureGrpcNodeTask {
-    pub fn new(port: u16, user_managed: bool) -> Result<Self> {
-        Ok(Self { port, user_managed })
+    pub fn new(advertise_address: String, port: u16, user_managed: bool) -> Result<Self> {
+        Ok(Self {
+            advertise_address,
+            port,
+            user_managed,
+        })
     }
 }
 
 impl Task for ConfigureGrpcNodeTask {
     fn execute(&mut self, ctx: &mut ExecuteContext<impl std::io::Write>) -> anyhow::Result<()> {
-        let address = format!("127.0.0.1:{}", self.port);
+        let address = format!("{}:{}", self.advertise_address, self.port);
 
         if self.user_managed {
             ctx.pb.set_message(


### PR DESCRIPTION
Signed-off-by: Alex Chi <iskyzh@gmail.com>

## What's changed and what's your intention?

The original HostAddr parsing doesn't work on IPv6 address. This PR fixes this, while supporting IPv6 across all worker nodes.

## Checklist

- [x] I have written necessary docs and comments
- [x] I have added necessary unit tests and integration tests
- [x] All checks passed in `./risedev check` (or alias, `./risedev c`)

## Refer to a related PR or issue link (optional)

close https://github.com/singularity-data/risingwave/issues/3005
