### PR TITLE
chore(risedev): allow minio to be used on non-root disk

### DIFF
--- a/src/risedevtool/src/task/minio_service.rs
+++ b/src/risedevtool/src/task/minio_service.rs
@@ -49,6 +49,9 @@ impl MinioService {
             .env("MINIO_ROOT_USER", &config.root_user)
             .env("MINIO_ROOT_PASSWORD", &config.root_password)
             .env("MINIO_PROMETHEUS_AUTH_TYPE", "public")
+            // Allow MinIO to be used on root disk, bypass restriction.
+            // https://github.com/singularity-data/risingwave/pull/3012
+            // https://docs.min.io/minio/baremetal/installation/deploy-minio-single-node-single-drive.html#id3
             .env("MINIO_CI_CD", "1");
 
         let provide_prometheus = config.provide_prometheus.as_ref().unwrap();

--- a/src/risedevtool/src/task/minio_service.rs
+++ b/src/risedevtool/src/task/minio_service.rs
@@ -48,7 +48,8 @@ impl MinioService {
             .arg(format!("{}:{}", config.listen_address, config.console_port))
             .env("MINIO_ROOT_USER", &config.root_user)
             .env("MINIO_ROOT_PASSWORD", &config.root_password)
-            .env("MINIO_PROMETHEUS_AUTH_TYPE", "public");
+            .env("MINIO_PROMETHEUS_AUTH_TYPE", "public")
+            .env("MINIO_CI_CD", "1");
 
         let provide_prometheus = config.provide_prometheus.as_ref().unwrap();
         match provide_prometheus.len() {


### PR DESCRIPTION
Signed-off-by: Alex Chi <iskyzh@gmail.com>

## What's changed and what's your intention?

https://docs.min.io/minio/baremetal/installation/deploy-minio-single-node-single-drive.html#id3

MinIO [RELEASE.2022-06-02T02-11-04Z](https://github.com/minio/minio/releases/tag/RELEASE.2022-06-02T02-11-04Z) doesn't allow using MinIO on root disk. We bypass this restriction.

## Checklist

- [x] I have written necessary docs and comments
- [x] I have added necessary unit tests and integration tests
- [x] All checks passed in `./risedev check` (or alias, `./risedev c`)

## Refer to a related PR or issue link (optional)
