### PR TITLE
refactor(kinesis): Correct `assume_role_external_id` spelling in Kine…

### DIFF
--- a/src/connector/src/kinesis/config.rs
+++ b/src/connector/src/kinesis/config.rs
@@ -117,7 +117,7 @@ impl AwsConfigInfo {
         if let Some(assume_role_arn) = properties.assume_role_arn {
             assume_role = Some(AwsAssumeRole {
                 arn: assume_role_arn,
-                external_id: properties.assume_role_externeal_id.clone(),
+                external_id: properties.assume_role_external_id.clone(),
             })
         }
 

--- a/src/connector/src/kinesis/mod.rs
+++ b/src/connector/src/kinesis/mod.rs
@@ -49,5 +49,5 @@ pub struct KinesisProperties {
     #[serde(rename = "kinesis.assumerole.arn")]
     pub assume_role_arn: Option<String>,
     #[serde(rename = "kinesis.assumerole.external_id")]
-    pub assume_role_externeal_id: Option<String>,
+    pub assume_role_external_id: Option<String>,
 }

--- a/src/connector/src/kinesis/source/reader.rs
+++ b/src/connector/src/kinesis/source/reader.rs
@@ -275,7 +275,7 @@ mod tests {
             stream_region: "cn-northwest-1".to_string(),
             endpoint: None,
             session_token: None,
-            assume_role_externeal_id: None,
+            assume_role_external_id: None,
         };
 
         let mut trim_horizen_reader = KinesisSplitReader::new(
@@ -326,7 +326,7 @@ mod tests {
             stream_region: "cn-northwest-1".to_string(),
             endpoint: None,
             session_token: None,
-            assume_role_externeal_id: None,
+            assume_role_external_id: None,
         };
 
         let splits = vec!["shardId-000000000000", "shardId-000000000001"]


### PR DESCRIPTION
…sis Connector

Signed-off-by: Ryan Russell <git@ryanrussell.org>

## What's changed and what's your intention?
`assume_role_externeal_id` -> `assume_role_external_id`

```
	modified:   src/connector/src/kinesis/config.rs
	modified:   src/connector/src/kinesis/mod.rs
	modified:   src/connector/src/kinesis/source/reader.rs
```
## Checklist

- [x] All checks passed in `./risedev check` (or alias, `./risedev c`)

## Refer to a related PR or issue link (optional)
