### PR TITLE
feat(vnode mapping): persist seq of vnode mappings

### DIFF
--- a/proto/meta.proto
+++ b/proto/meta.proto
@@ -51,6 +51,7 @@ message TableFragments {
     // Vnode mapping (which should be set in upstream dispatcher) of the fragment.
     common.ParallelUnitMapping vnode_mapping = 5;
   }
+  // Sequence number to let compact scheduler check whether mapping of the fragment that certain SST belongs to is outdated
   uint64 seq = 1;
   uint32 table_id = 2;
   map<uint32, Fragment> fragments = 3;

--- a/proto/meta.proto
+++ b/proto/meta.proto
@@ -51,10 +51,11 @@ message TableFragments {
     // Vnode mapping (which should be set in upstream dispatcher) of the fragment.
     common.ParallelUnitMapping vnode_mapping = 5;
   }
-  uint32 table_id = 1;
-  map<uint32, Fragment> fragments = 2;
-  map<uint32, ActorStatus> actor_status = 3;
-  repeated uint32 internal_table_ids = 4;
+  uint64 seq = 1;
+  uint32 table_id = 2;
+  map<uint32, Fragment> fragments = 3;
+  map<uint32, ActorStatus> actor_status = 4;
+  repeated uint32 internal_table_ids = 5;
 }
 
 // TODO: remove this when dashboard refactored.

--- a/src/meta/src/model/stream.rs
+++ b/src/meta/src/model/stream.rs
@@ -93,7 +93,7 @@ impl TableFragments {
         internal_table_id_set: HashSet<u32>,
     ) -> Self {
         Self {
-            seq: 0,
+            seq: 1,
             table_id,
             fragments,
             actor_status: BTreeMap::default(),

--- a/src/meta/src/model/stream.rs
+++ b/src/meta/src/model/stream.rs
@@ -37,6 +37,9 @@ const TABLE_FRAGMENTS_CF_NAME: &str = "cf/table_fragments";
 /// `table_id` => `TableFragments`.
 #[derive(Debug, Clone)]
 pub struct TableFragments {
+    /// Sequence number
+    pub(crate) seq: u64,
+
     /// The table id.
     table_id: TableId,
 
@@ -60,6 +63,7 @@ impl MetadataModel for TableFragments {
 
     fn to_protobuf(&self) -> Self::ProstType {
         Self::ProstType {
+            seq: self.seq,
             table_id: self.table_id.table_id(),
             fragments: self.fragments.clone().into_iter().collect(),
             actor_status: self.actor_status.clone().into_iter().collect(),
@@ -69,6 +73,7 @@ impl MetadataModel for TableFragments {
 
     fn from_protobuf(prost: Self::ProstType) -> Self {
         Self {
+            seq: prost.seq,
             table_id: TableId::new(prost.table_id),
             fragments: prost.fragments.into_iter().collect(),
             actor_status: prost.actor_status.into_iter().collect(),
@@ -88,6 +93,7 @@ impl TableFragments {
         internal_table_id_set: HashSet<u32>,
     ) -> Self {
         Self {
+            seq: 0,
             table_id,
             fragments,
             actor_status: BTreeMap::default(),

--- a/src/meta/src/stream/meta.rs
+++ b/src/meta/src/stream/meta.rs
@@ -90,11 +90,12 @@ where
         Ok(map.values().cloned().collect())
     }
 
-    pub async fn update_table_fragments(&self, table_fragment: TableFragments) -> Result<()> {
+    pub async fn update_table_fragments(&self, mut table_fragment: TableFragments) -> Result<()> {
         let map = &mut self.core.write().await.table_fragments;
 
         match map.entry(table_fragment.table_id()) {
             Entry::Occupied(mut entry) => {
+                table_fragment.seq = entry.get().seq + 1;
                 table_fragment.insert(&*self.meta_store).await?;
                 entry.insert(table_fragment);
 
@@ -124,7 +125,10 @@ where
 
     /// Start create a new `TableFragments` and insert it into meta store, currently the actors'
     /// state is `ActorState::Inactive`.
-    pub async fn start_create_table_fragments(&self, table_fragment: TableFragments) -> Result<()> {
+    pub async fn start_create_table_fragments(
+        &self,
+        mut table_fragment: TableFragments,
+    ) -> Result<()> {
         let map = &mut self.core.write().await.table_fragments;
 
         match map.entry(table_fragment.table_id()) {
@@ -133,6 +137,7 @@ where
                 table_fragment.table_id()
             )))),
             Entry::Vacant(v) => {
+                table_fragment.seq = 1;
                 table_fragment.insert(&*self.meta_store).await?;
                 v.insert(table_fragment);
                 Ok(())

--- a/src/meta/src/stream/meta.rs
+++ b/src/meta/src/stream/meta.rs
@@ -125,10 +125,7 @@ where
 
     /// Start create a new `TableFragments` and insert it into meta store, currently the actors'
     /// state is `ActorState::Inactive`.
-    pub async fn start_create_table_fragments(
-        &self,
-        mut table_fragment: TableFragments,
-    ) -> Result<()> {
+    pub async fn start_create_table_fragments(&self, table_fragment: TableFragments) -> Result<()> {
         let map = &mut self.core.write().await.table_fragments;
 
         match map.entry(table_fragment.table_id()) {
@@ -137,7 +134,6 @@ where
                 table_fragment.table_id()
             )))),
             Entry::Vacant(v) => {
-                table_fragment.seq = 1;
                 table_fragment.insert(&*self.meta_store).await?;
                 v.insert(table_fragment);
                 Ok(())

--- a/src/meta/src/stream/meta.rs
+++ b/src/meta/src/stream/meta.rs
@@ -90,12 +90,11 @@ where
         Ok(map.values().cloned().collect())
     }
 
-    pub async fn update_table_fragments(&self, mut table_fragment: TableFragments) -> Result<()> {
+    pub async fn update_table_fragments(&self, table_fragment: TableFragments) -> Result<()> {
         let map = &mut self.core.write().await.table_fragments;
 
         match map.entry(table_fragment.table_id()) {
             Entry::Occupied(mut entry) => {
-                table_fragment.seq = entry.get().seq + 1;
                 table_fragment.insert(&*self.meta_store).await?;
                 entry.insert(table_fragment);
 


### PR DESCRIPTION
## What's changed and what's your intention?

persist sequence number of vnode mappings
sequence number is used for find out SSTs with deprecated mapping in order to consolidate them
after parallel unit reschedule, all existing SSTs will become deprecated

## Checklist

- [x] I have written necessary docs and comments

## Refer to a related PR or issue link (optional)
