### PR TITLE
chore(streaming): add assert check for internal_table_id_set to avoid…

### DIFF
--- a/src/meta/src/rpc/service/ddl_service.rs
+++ b/src/meta/src/rpc/service/ddl_service.rs
@@ -434,6 +434,11 @@ where
             &mut ctx,
         )
         .await?;
+        assert_eq!(
+            fragment_graph.table_ids_cnt,
+            ctx.internal_table_id_set.len() as u32
+        );
+
         let table_fragments =
             TableFragments::new(mview_id, graph, ctx.internal_table_id_set.clone());
 


### PR DESCRIPTION
## What's changed and what's your intention?
To avoid table_id legacy

Please explain **IN DETAIL** what the changes are in this PR and why they are needed:
- add assert check for internal_table_ids cnt
## Checklist

- [x] I have written necessary docs and comments
- [x] I have added necessary unit tests and integration tests

## Refer to a related PR or issue link (optional)
- https://github.com/singularity-data/risingwave/pull/3002