### PR TITLE
refactor(DataChunk): use `new` rather than `DataChunkBuilder` or `try_from`

### DIFF
--- a/e2e_test/batch/join.slt
+++ b/e2e_test/batch/join.slt
@@ -40,3 +40,8 @@ drop table t2;
 
 statement ok
 drop table t3;
+
+query I
+select count(*) from (values (1, 2), (3, 4)) as a, (values (9),(4),(1)) as b;
+----
+6

--- a/src/batch/src/executor/generate_series.rs
+++ b/src/batch/src/executor/generate_series.rs
@@ -105,8 +105,9 @@ where
             }
 
             let arr = builder.finish()?;
+            let len = arr.len();
             let columns = vec![Column::new(Arc::new(arr.into()))];
-            let chunk: DataChunk = DataChunk::builder().columns(columns).build();
+            let chunk: DataChunk = DataChunk::new(columns, len);
 
             yield chunk;
         }

--- a/src/batch/src/executor/hash_agg.rs
+++ b/src/batch/src/executor/hash_agg.rs
@@ -232,8 +232,10 @@ impl<K: HashKey + Send + Sync> HashAggExecutor<K> {
                 .collect::<Result<Vec<_>>>()?;
 
             let mut has_next = false;
+            let mut array_len = 0;
             for (key, states) in result.by_ref().take(cardinality) {
                 has_next = true;
+                array_len += 1;
                 key.deserialize_to_builders(&mut group_builders[..])?;
                 states
                     .into_iter()
@@ -250,7 +252,7 @@ impl<K: HashKey + Send + Sync> HashAggExecutor<K> {
                 .map(|b| Ok(Column::new(Arc::new(b.finish()?))))
                 .collect::<Result<Vec<_>>>()?;
 
-            let output = DataChunk::builder().columns(columns).build();
+            let output = DataChunk::new(columns, array_len);
             yield output;
         }
     }

--- a/src/batch/src/executor/join/hash_join.rs
+++ b/src/batch/src/executor/join/hash_join.rs
@@ -402,6 +402,7 @@ mod tests {
     struct DataChunkMerger {
         data_types: Vec<DataType>,
         array_builders: Vec<ArrayBuilderImpl>,
+        array_len: usize,
     }
 
     impl DataChunkMerger {
@@ -414,6 +415,7 @@ mod tests {
             Ok(Self {
                 data_types,
                 array_builders,
+                array_len: 0,
             })
         }
 
@@ -422,6 +424,7 @@ mod tests {
             for idx in 0..self.array_builders.len() {
                 self.array_builders[idx].append_array(data_chunk.column_at(idx).array_ref())?;
             }
+            self.array_len += data_chunk.capacity();
 
             Ok(())
         }
@@ -433,7 +436,7 @@ mod tests {
                 .map(|array_builder| array_builder.finish().map(|arr| Column::new(Arc::new(arr))))
                 .collect::<Result<Vec<Column>>>()?;
 
-            DataChunk::try_from(columns)
+            Ok(DataChunk::new(columns, self.array_len))
         }
     }
 

--- a/src/batch/src/executor/join/nested_loop_join.rs
+++ b/src/batch/src/executor/join/nested_loop_join.rs
@@ -172,7 +172,7 @@ impl NestedLoopJoinExecutor {
             .map(|builder| builder.finish().map(|arr| Column::new(Arc::new(arr))))
             .collect::<Result<Vec<Column>>>()?;
 
-        Ok(DataChunk::builder().columns(result_columns).build())
+        Ok(DataChunk::new(result_columns, num_tuples))
     }
 
     /// Create constant data chunk (one tuple repeat `num_tuples` times).

--- a/src/batch/src/executor/join/nested_loop_join.rs
+++ b/src/batch/src/executor/join/nested_loop_join.rs
@@ -19,7 +19,7 @@ use futures_async_stream::try_stream;
 use itertools::Itertools;
 use risingwave_common::array::column::Column;
 use risingwave_common::array::data_chunk_iter::RowRef;
-use risingwave_common::array::{ArrayBuilderImpl, DataChunk, Row};
+use risingwave_common::array::{ArrayBuilderImpl, DataChunk, Row, Vis};
 use risingwave_common::catalog::Schema;
 use risingwave_common::error::{ErrorCode, Result, RwError};
 use risingwave_common::types::{DataType, DatumRef};
@@ -550,10 +550,10 @@ impl NestedLoopJoinExecutor {
         concated_columns.extend_from_slice(left.columns());
         concated_columns.extend_from_slice(right.columns());
         // Only handle one side is constant row chunk: One of visibility must be None.
-        let vis = match (left.visibility(), right.visibility()) {
-            (None, _) => right.visibility().cloned(),
-            (_, None) => left.visibility().cloned(),
-            (Some(_), Some(_)) => {
+        let vis = match (left.vis(), right.vis()) {
+            (Vis::Compact(_), _) => right.vis().clone(),
+            (_, Vis::Compact(_)) => left.vis().clone(),
+            (Vis::Bitmap(_), Vis::Bitmap(_)) => {
                 return Err(ErrorCode::NotImplemented(
                     "The concatenate behaviour of two chunk with visibility is undefined"
                         .to_string(),
@@ -562,12 +562,7 @@ impl NestedLoopJoinExecutor {
                 .into())
             }
         };
-        let builder = DataChunk::builder().columns(concated_columns);
-        let data_chunk = if let Some(vis) = vis {
-            builder.visibility(vis).build()
-        } else {
-            builder.build()
-        };
+        let data_chunk = DataChunk::new(concated_columns, vis);
         Ok(data_chunk)
     }
 }

--- a/src/batch/src/executor/sort_agg.rs
+++ b/src/batch/src/executor/sort_agg.rs
@@ -173,7 +173,7 @@ impl SortAggExecutor {
                         .map(|b| Ok(Column::new(Arc::new(b.finish()?))))
                         .collect::<Result<Vec<_>>>()?;
 
-                    let output = DataChunk::builder().columns(columns).build();
+                    let output = DataChunk::new(columns, self.output_size_limit);
                     yield output;
 
                     // reset builders and capactiy to build next output chunk
@@ -207,11 +207,7 @@ impl SortAggExecutor {
             .map(|b| Ok(Column::new(Arc::new(b.finish()?))))
             .collect::<Result<Vec<_>>>()?;
 
-        let output = match columns.is_empty() {
-            // Zero group column means SimpleAgg, which always returns 1 row.
-            true => DataChunk::new_dummy(1),
-            false => DataChunk::builder().columns(columns).build(),
-        };
+        let output = DataChunk::new(columns, self.output_size_limit - left_capacity + 1);
 
         yield output;
     }

--- a/src/batch/src/executor/values.rs
+++ b/src/batch/src/executor/values.rs
@@ -75,35 +75,29 @@ impl ValuesExecutor {
             let cardinality = self.rows.len();
             ensure!(cardinality > 0);
 
-            if self.schema.fields.is_empty() {
-                let cardinality = self.rows.len();
-                self.rows = vec![].into_iter();
-                yield DataChunk::new_dummy(cardinality);
-            } else {
-                while !self.rows.is_empty() {
-                    // We need a one row chunk rather than an empty chunk because constant
-                    // expression's eval result is same size as input chunk
-                    // cardinality.
-                    let one_row_chunk = DataChunk::new_dummy(1);
+            while !self.rows.is_empty() {
+                // We need a one row chunk rather than an empty chunk because constant
+                // expression's eval result is same size as input chunk
+                // cardinality.
+                let one_row_chunk = DataChunk::new_dummy(1);
 
-                    let chunk_size = self.chunk_size.min(self.rows.len());
-                    let mut array_builders = self.schema.create_array_builders(chunk_size)?;
-                    for row in self.rows.by_ref().take(chunk_size) {
-                        for (expr, builder) in row.into_iter().zip_eq(&mut array_builders) {
-                            let out = expr.eval(&one_row_chunk)?;
-                            builder.append_array(&out)?;
-                        }
+                let chunk_size = self.chunk_size.min(self.rows.len());
+                let mut array_builders = self.schema.create_array_builders(chunk_size)?;
+                for row in self.rows.by_ref().take(chunk_size) {
+                    for (expr, builder) in row.into_iter().zip_eq(&mut array_builders) {
+                        let out = expr.eval(&one_row_chunk)?;
+                        builder.append_array(&out)?;
                     }
-
-                    let columns = array_builders
-                        .into_iter()
-                        .map(|builder| builder.finish().map(|arr| Column::new(Arc::new(arr))))
-                        .collect::<Result<Vec<Column>>>()?;
-
-                    let chunk = DataChunk::builder().columns(columns).build();
-
-                    yield chunk
                 }
+
+                let columns = array_builders
+                    .into_iter()
+                    .map(|builder| builder.finish().map(|arr| Column::new(Arc::new(arr))))
+                    .collect::<Result<Vec<Column>>>()?;
+
+                let chunk = DataChunk::new(columns, chunk_size);
+
+                yield chunk
             }
         }
     }

--- a/src/common/src/array/data_chunk.rs
+++ b/src/common/src/array/data_chunk.rs
@@ -22,7 +22,7 @@ use risingwave_pb::data::DataChunk as ProstDataChunk;
 
 use crate::array::column::Column;
 use crate::array::data_chunk_iter::{Row, RowRef};
-use crate::array::{ArrayBuilderImpl, ArrayImpl};
+use crate::array::ArrayBuilderImpl;
 use crate::buffer::Bitmap;
 use crate::error::{Result, RwError};
 use crate::hash::HashCode;
@@ -454,25 +454,6 @@ impl fmt::Debug for DataChunk {
             self.capacity(),
             self.to_pretty_string()
         )
-    }
-}
-
-impl TryFrom<Vec<Column>> for DataChunk {
-    type Error = RwError;
-
-    fn try_from(columns: Vec<Column>) -> Result<Self> {
-        ensure!(!columns.is_empty(), "Columns can't be empty!");
-        ensure!(
-            columns
-                .iter()
-                .map(Column::array_ref)
-                .map(ArrayImpl::len)
-                .all_equal(),
-            "Not all columns length same!"
-        );
-
-        let len = columns[0].array_ref().len();
-        Ok(DataChunk::new(columns, len))
     }
 }
 

--- a/src/common/src/array/data_chunk.rs
+++ b/src/common/src/array/data_chunk.rs
@@ -299,7 +299,6 @@ impl DataChunk {
         if chunks.is_empty() {
             return Ok(Vec::new());
         }
-        assert!(!chunks[0].columns.is_empty());
 
         let mut total_capacity = chunks
             .iter()
@@ -319,6 +318,7 @@ impl DataChunk {
             .iter()
             .map(|col| col.array_ref().create_builder(new_chunk_require))
             .try_collect()?;
+        let mut array_len = new_chunk_require;
         let mut new_chunks = Vec::with_capacity(num_chunks);
         while chunk_idx < chunks.len() {
             let capacity = chunks[chunk_idx].capacity();
@@ -361,10 +361,11 @@ impl DataChunk {
                     .map(|col_type| col_type.array_ref().create_builder(new_chunk_require))
                     .try_collect()?;
 
-                let data_chunk = DataChunk::builder().columns(new_columns).build();
+                let data_chunk = DataChunk::new(new_columns, array_len);
                 new_chunks.push(data_chunk);
 
                 new_chunk_require = std::cmp::min(total_capacity, each_size_limit);
+                array_len = new_chunk_require;
             }
         }
 

--- a/src/common/src/array/data_chunk.rs
+++ b/src/common/src/array/data_chunk.rs
@@ -49,13 +49,6 @@ impl DataChunkBuilder {
         }
     }
 
-    pub fn visibility(self, visibility: Bitmap) -> DataChunkBuilder {
-        DataChunkBuilder {
-            columns: self.columns,
-            visibility: Some(visibility),
-        }
-    }
-
     pub fn build(self) -> DataChunk {
         let vis = if let Some(bitmap) = self.visibility {
             // with visibility bitmap

--- a/src/common/src/array/data_chunk.rs
+++ b/src/common/src/array/data_chunk.rs
@@ -220,19 +220,14 @@ impl DataChunk {
     }
 
     pub fn from_protobuf(proto: &ProstDataChunk) -> Result<Self> {
-        if proto.columns.is_empty() {
-            // Dummy chunk, we should deserialize cardinality
-            Ok(DataChunk::new_dummy(proto.cardinality as usize))
-        } else {
-            let mut columns = vec![];
-            for any_col in proto.get_columns() {
-                let cardinality = proto.get_cardinality() as usize;
-                columns.push(Column::from_protobuf(any_col, cardinality)?);
-            }
-
-            let chunk = DataChunk::new(columns, proto.cardinality as usize);
-            Ok(chunk)
+        let mut columns = vec![];
+        for any_col in proto.get_columns() {
+            let cardinality = proto.get_cardinality() as usize;
+            columns.push(Column::from_protobuf(any_col, cardinality)?);
         }
+
+        let chunk = DataChunk::new(columns, proto.cardinality as usize);
+        Ok(chunk)
     }
 
     /// `rechunk` creates a new vector of data chunk whose size is `each_size_limit`.

--- a/src/common/src/util/chunk_coalesce.rs
+++ b/src/common/src/util/chunk_coalesce.rs
@@ -62,14 +62,12 @@ impl DataChunkBuilder {
     }
 
     fn ensure_builders(&mut self) -> Result<()> {
-        if self.array_builders.is_empty() {
+        if self.buffered_count == 0 && self.array_builders.is_empty() {
             self.array_builders = self
                 .data_types
                 .iter()
                 .map(|data_type| data_type.create_array_builder(self.batch_size))
                 .collect::<Result<Vec<ArrayBuilderImpl>>>()?;
-
-            self.buffered_count = 0;
         }
 
         Ok(())

--- a/src/common/src/util/chunk_coalesce.rs
+++ b/src/common/src/util/chunk_coalesce.rs
@@ -62,12 +62,14 @@ impl DataChunkBuilder {
     }
 
     fn ensure_builders(&mut self) -> Result<()> {
-        if self.buffered_count == 0 && self.array_builders.is_empty() {
+        if self.array_builders.len() != self.data_types.len() {
             self.array_builders = self
                 .data_types
                 .iter()
                 .map(|data_type| data_type.create_array_builder(self.batch_size))
                 .collect::<Result<Vec<ArrayBuilderImpl>>>()?;
+
+            ensure!(self.buffered_count == 0);
         }
 
         Ok(())


### PR DESCRIPTION
## What's changed and what's your intention?

Part 3/3 of actual refactor #2663 (Earlier parts: #2934 #2936)

This PR removes `DataChunkBuilder` and `TryFrom<Vec<Column>>`. All callers have been migrated to `new` with an extra cardinality parameter.

## Checklist

~~- [ ] I have written necessary docs and comments~~
- [x] I have added necessary unit tests and integration tests
- [x] All checks passed in `./risedev check` (or alias, `./risedev c`)

## Refer to a related PR or issue link (optional)
