### PR TITLE
feat(storage): introduce non-proto type for vnode bitmap

### DIFF
--- a/src/common/src/buffer/bitmap.rs
+++ b/src/common/src/buffer/bitmap.rs
@@ -100,7 +100,7 @@ impl BitmapBuilder {
     }
 }
 
-#[derive(Clone)]
+#[derive(Clone, Default)]
 pub struct Bitmap {
     pub bits: Bytes,
 

--- a/src/common/src/buffer/bitmap.rs
+++ b/src/common/src/buffer/bitmap.rs
@@ -100,7 +100,7 @@ impl BitmapBuilder {
     }
 }
 
-#[derive(Clone, Default)]
+#[derive(Clone)]
 pub struct Bitmap {
     pub bits: Bytes,
 

--- a/src/common/src/consistent_hash/mod.rs
+++ b/src/common/src/consistent_hash/mod.rs
@@ -1,0 +1,2 @@
+mod vnode;
+pub use vnode::*;

--- a/src/common/src/consistent_hash/mod.rs
+++ b/src/common/src/consistent_hash/mod.rs
@@ -1,2 +1,16 @@
+// Copyright 2022 Singularity Data
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 mod vnode;
 pub use vnode::*;

--- a/src/common/src/consistent_hash/vnode.rs
+++ b/src/common/src/consistent_hash/vnode.rs
@@ -1,3 +1,17 @@
+// Copyright 2022 Singularity Data
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 /// `VirtualNode` is the logical key for consistent hash. Virtual nodes stand for the intermediate
 /// layer between data and physical nodes.
 pub type VirtualNode = u16;

--- a/src/common/src/consistent_hash/vnode.rs
+++ b/src/common/src/consistent_hash/vnode.rs
@@ -1,0 +1,48 @@
+/// `VirtualNode` is the logical key for consistent hash. Virtual nodes stand for the intermediate
+/// layer between data and physical nodes.
+pub type VirtualNode = u16;
+pub const VNODE_BITS: usize = 11;
+pub const VIRTUAL_NODE_COUNT: usize = 1 << VNODE_BITS;
+pub const VNODE_BITMAP_LEN: usize = 1 << (VNODE_BITS - 3);
+
+// `VNodeBitmap` is a bitmap of vnodes for a state table, which indicates the vnodes that the state
+// table owns.
+#[derive(Clone, Default)]
+pub struct VNodeBitmap {
+    table_id: u32,
+    bitmap: Vec<u8>,
+}
+
+impl From<risingwave_pb::common::VNodeBitmap> for VNodeBitmap {
+    fn from(proto: risingwave_pb::common::VNodeBitmap) -> Self {
+        Self {
+            table_id: proto.table_id,
+            bitmap: proto.bitmap,
+        }
+    }
+}
+
+impl VNodeBitmap {
+    pub fn new(table_id: u32, bitmap: Vec<u8>) -> Self {
+        Self { table_id, bitmap }
+    }
+
+    pub fn check_overlap(&self, bitmaps: &[risingwave_pb::common::VNodeBitmap]) -> bool {
+        if bitmaps.is_empty() {
+            return true;
+        }
+        if let Ok(pos) =
+            bitmaps.binary_search_by_key(&self.table_id, |bitmap| bitmap.get_table_id())
+        {
+            let text = &bitmaps[pos];
+            assert_eq!(self.bitmap.len(), VNODE_BITMAP_LEN);
+            assert_eq!(text.bitmap.len(), VNODE_BITMAP_LEN);
+            for i in 0..VNODE_BITMAP_LEN as usize {
+                if (self.bitmap[i] & text.get_bitmap()[i]) != 0 {
+                    return true;
+                }
+            }
+        }
+        false
+    }
+}

--- a/src/common/src/consistent_hash/vnode.rs
+++ b/src/common/src/consistent_hash/vnode.rs
@@ -19,8 +19,8 @@ pub const VNODE_BITS: usize = 11;
 pub const VIRTUAL_NODE_COUNT: usize = 1 << VNODE_BITS;
 pub const VNODE_BITMAP_LEN: usize = 1 << (VNODE_BITS - 3);
 
-// `VNodeBitmap` is a bitmap of vnodes for a state table, which indicates the vnodes that the state
-// table owns.
+/// `VNodeBitmap` is a bitmap of vnodes for a state table, which indicates the vnodes that the state
+/// table owns.
 #[derive(Clone, Default)]
 pub struct VNodeBitmap {
     /// Id of state table that the bitmap belongs to.

--- a/src/common/src/lib.rs
+++ b/src/common/src/lib.rs
@@ -47,6 +47,7 @@ pub mod cache;
 pub mod catalog;
 pub mod collection;
 pub mod config;
+pub mod consistent_hash;
 pub mod hash;
 pub mod monitor;
 pub mod service;

--- a/src/storage/src/hummock/shared_buffer/mod.rs
+++ b/src/storage/src/hummock/shared_buffer/mod.rs
@@ -21,9 +21,9 @@ use std::collections::{BTreeMap, HashMap};
 use std::ops::RangeBounds;
 
 use itertools::Itertools;
+use risingwave_common::consistent_hash::VNodeBitmap;
 use risingwave_hummock_sdk::is_remote_sst_id;
 use risingwave_hummock_sdk::key::user_key;
-use risingwave_pb::common::VNodeBitmap;
 use risingwave_pb::hummock::{KeyRange, SstableInfo};
 
 use self::shared_buffer_batch::SharedBufferBatch;

--- a/src/storage/src/hummock/state_store.rs
+++ b/src/storage/src/hummock/state_store.rs
@@ -19,9 +19,9 @@ use std::sync::Arc;
 
 use bytes::Bytes;
 use itertools::Itertools;
+use risingwave_common::consistent_hash::VNodeBitmap;
 use risingwave_hummock_sdk::key::key_with_epoch;
 use risingwave_hummock_sdk::HummockEpoch;
-use risingwave_pb::common::VNodeBitmap;
 use risingwave_pb::hummock::SstableInfo;
 
 use super::iterator::{

--- a/src/storage/src/hummock/state_store_tests.rs
+++ b/src/storage/src/hummock/state_store_tests.rs
@@ -15,11 +15,11 @@
 use std::sync::Arc;
 
 use bytes::{BufMut, Bytes, BytesMut};
+use risingwave_common::consistent_hash::VNodeBitmap;
 use risingwave_common::hash::VNODE_BITMAP_LEN;
 use risingwave_hummock_sdk::HummockEpoch;
 use risingwave_meta::hummock::test_utils::setup_compute_env;
 use risingwave_meta::hummock::MockHummockMetaClient;
-use risingwave_pb::common::VNodeBitmap;
 use risingwave_rpc_client::HummockMetaClient;
 
 use super::HummockStorage;
@@ -220,10 +220,7 @@ async fn test_vnode_filter() {
         .get_with_vnode_set(
             &Bytes::from(&b"t\0\0\0\0"[..]),
             epoch,
-            Some(VNodeBitmap {
-                table_id: 0,
-                bitmap: [1; VNODE_BITMAP_LEN].to_vec(),
-            }),
+            Some(VNodeBitmap::new(0, [1; VNODE_BITMAP_LEN].to_vec())),
         )
         .await
         .unwrap();
@@ -233,10 +230,7 @@ async fn test_vnode_filter() {
         .get_with_vnode_set(
             &Bytes::from(&b"t\0\0\0\0"[..]),
             epoch,
-            Some(VNodeBitmap {
-                table_id: 0,
-                bitmap: [0; VNODE_BITMAP_LEN].to_vec(),
-            }),
+            Some(VNodeBitmap::new(0, [0; VNODE_BITMAP_LEN].to_vec())),
         )
         .await
         .unwrap();
@@ -246,10 +240,7 @@ async fn test_vnode_filter() {
         .get_with_vnode_set(
             &Bytes::from(&b"t\0\0\0\0"[..]),
             epoch,
-            Some(VNodeBitmap {
-                table_id: 5,
-                bitmap: [1; VNODE_BITMAP_LEN].to_vec(),
-            }),
+            Some(VNodeBitmap::new(5, [1; VNODE_BITMAP_LEN].to_vec())),
         )
         .await
         .unwrap();


### PR DESCRIPTION
## What's changed and what's your intention?

### Summarize your change 

Introduce non-proto type for vnode bitmap.

## Checklist

- [x] I have written necessary docs and comments
- [x] I have added necessary unit tests and integration tests
- [x] All checks passed in `./risedev check` (or alias, `./risedev c`)

## Refer to a related PR or issue link (optional)

#2882 should depend on this PR. More specifically, the non-proto type introduced by this PR will be used in keyspace and interfaces of state store (get, scan, etc.).