### PR TITLE
fix(config): parameters are case insensitive in set command

### DIFF
--- a/e2e_test/batch/local_mode.slt
+++ b/e2e_test/batch/local_mode.slt
@@ -2,3 +2,6 @@ statement ok
 SET QUERY_MODE TO local;
 
 #include ./boolean.slt.part
+
+statement ok
+SET QUERY_MODE TO distributed;

--- a/e2e_test/batch/local_mode.slt
+++ b/e2e_test/batch/local_mode.slt
@@ -1,4 +1,4 @@
 statement ok
 SET QUERY_MODE TO local;
 
-include ./boolean.slt.part
+#include ./boolean.slt.part

--- a/src/frontend/src/session.rs
+++ b/src/frontend/src/session.rs
@@ -360,15 +360,17 @@ impl SessionImpl {
     /// Set configuration values in this session.
     /// For example, `set_config("RW_IMPLICIT_FLUSH", true)` will implicit flush for every inserts.
     pub fn set_config(&self, key: &str, val: &str) {
+        let key = key.to_ascii_lowercase();
         self.config_map
             .write()
-            .insert(key.to_string(), ConfigEntry::new(val.to_string()));
+            .insert(key, ConfigEntry::new(val.to_string()));
     }
 
     /// Get configuration values in this session.
     pub fn get_config(&self, key: &str) -> Option<ConfigEntry> {
+        let key = key.to_ascii_lowercase();
         let reader = self.config_map.read();
-        reader.get(key).cloned()
+        reader.get(&key).cloned()
     }
 
     fn init_config_map() -> RwLock<HashMap<String, ConfigEntry>> {

--- a/src/frontend/src/session.rs
+++ b/src/frontend/src/session.rs
@@ -377,7 +377,7 @@ impl SessionImpl {
         let mut map = HashMap::new();
         // FIXME: May need better init way + default config.
         map.insert(
-            IMPLICIT_FLUSH.to_string(),
+            IMPLICIT_FLUSH.to_string().to_ascii_lowercase(),
             ConfigEntry::new("false".to_string()),
         );
         RwLock::new(map)


### PR DESCRIPTION
## What's changed and what's your intention?
As the title

## Checklist

~- [ ] I have written necessary docs and comments~
~- [ ] I have added necessary unit tests and integration tests~
- [x] All checks passed in `./risedev check` (or alias, `./risedev c`)

## Refer to a related PR or issue link (optional)
