### PR TITLE
fix: should always unpin epoch for dml query

### DIFF
--- a/src/frontend/src/scheduler/distributed/query_manager.rs
+++ b/src/frontend/src/scheduler/distributed/query_manager.rs
@@ -94,15 +94,13 @@ impl QueryManager {
             .get_epoch(query_id.clone())
             .await?;
 
-        if let Err(e) = compute_client
+        let creat_task_resp = compute_client
             .create_task(task_id.clone(), plan, epoch)
-            .await
-        {
-            self.hummock_snapshot_manager
-                .unpin_snapshot(epoch, &query_id)
-                .await?;
-            return Err(e);
-        }
+            .await;
+        self.hummock_snapshot_manager
+            .unpin_snapshot(epoch, &query_id)
+            .await?;
+        creat_task_resp?;
 
         let query_result_fetcher = QueryResultFetcher::new(
             epoch,

--- a/src/frontend/src/scheduler/hummock_snapshot_manager.rs
+++ b/src/frontend/src/scheduler/hummock_snapshot_manager.rs
@@ -49,6 +49,7 @@ impl HummockSnapshotManager {
             core_guard.epoch_to_query_ids.insert(epoch, HashSet::new());
         }
         let last_pinned = core_guard.last_pinned;
+        tracing::info!("Pin epoch {} for query {:?}", last_pinned, &query_id);
         core_guard
             .epoch_to_query_ids
             .get_mut(&last_pinned)
@@ -58,6 +59,7 @@ impl HummockSnapshotManager {
     }
 
     pub async fn unpin_snapshot(&self, epoch: u64, query_id: &QueryId) -> Result<()> {
+        tracing::info!("Unpin epoch {} for query {:?}", epoch, &query_id);
         let local_count = async {
             let mut core_guard = self.core.lock().await;
             let query_ids = core_guard.epoch_to_query_ids.get_mut(&epoch);


### PR DESCRIPTION
…ompaction process

## What's changed and what's your intention?

Previously we do not unpin the dml query (It is in single schedule and only unpin if err). 

Usually the dml is happen before query, so this makes the unpin never really happen (cuz there is always a older epoch being pinnned by the dml). 

Add two logs for testing locally. Glad to collect more opinions on where and how to write these logs.



## Checklist

- [x] I have written necessary docs and comments
- [x] I have added necessary unit tests and integration tests
- [x] All checks passed in `./risedev check` (or alias, `./risedev c`)

## Refer to a related PR or issue link (optional)
