### PR TITLE
binder: support string interval

### DIFF
--- a/e2e_test/batch/types/interval.slt
+++ b/e2e_test/batch/types/interval.slt
@@ -2,3 +2,33 @@ query TTTTT
 select interval '500' year, interval '-50' month, interval '5' hour, interval '5' minute, interval '5' second;
 ----
 500 years 00:00:00 -4 years -2 mons 00:00:00 05:00:00 00:05:00 00:00:05
+
+query TTTTT
+SELECT interval '1 year', interval '1 y', interval '1 yr';
+----
+1 year 00:00:00 1 year 00:00:00 1 year 00:00:00
+
+query TTTTT
+SELECT interval '2 month', interval '2 mon';
+----
+2 mons 00:00:00 2 mons 00:00:00
+
+query TTTTT
+SELECT interval '3 day';
+----
+3 days 00:00:00
+
+query TTTTT
+SELECT interval '4 hour';
+----
+04:00:00
+
+query TTTTT
+SELECT interval '5 minute', interval '2 m';
+----
+00:05:00 00:02:00
+
+query TTTTT
+SELECT interval '6 second';
+----
+00:00:06

--- a/src/frontend/src/binder/expr/value.rs
+++ b/src/frontend/src/binder/expr/value.rs
@@ -192,7 +192,7 @@ fn convert_unit(c: &mut String, t: &mut Vec<TimeStrToken>) -> Result<()> {
     Ok(())
 }
 
-pub fn parse_interval(s: &String) -> Result<Vec<TimeStrToken>> {
+pub fn parse_interval(s: &str) -> Result<Vec<TimeStrToken>> {
     let s = s.trim();
     let mut tokens = Vec::new();
     let mut num_buf = "".to_string();
@@ -202,7 +202,7 @@ pub fn parse_interval(s: &String) -> Result<Vec<TimeStrToken>> {
             '-' => {
                 num_buf.push(c);
             }
-            c if c.is_digit(10) => {
+            c if c.is_ascii_digit() => {
                 convert_unit(&mut char_buf, &mut tokens)?;
                 num_buf.push(c);
             }

--- a/src/frontend/src/binder/expr/value.rs
+++ b/src/frontend/src/binder/expr/value.rs
@@ -322,4 +322,56 @@ mod tests {
         let expr = build_from_prost(&expr_pb).unwrap();
         assert_eq!(expr.return_type(), DataType::Int32);
     }
+
+    #[test]
+    fn test_bind_interval() {
+        use super::*;
+
+        let mut binder = mock_binder();
+        let values = vec![
+            "1 hour",
+            "1 h",
+            "1 year",
+            "6 second",
+            "2 minutes",
+            "1 month",
+        ];
+        let data = vec![
+            Ok(Literal::new(
+                Some(ScalarImpl::Interval(IntervalUnit::from_minutes(60))),
+                DataType::Interval,
+            )),
+            Ok(Literal::new(
+                Some(ScalarImpl::Interval(IntervalUnit::from_minutes(60))),
+                DataType::Interval,
+            )),
+            Ok(Literal::new(
+                Some(ScalarImpl::Interval(IntervalUnit::from_ymd(1, 0, 0))),
+                DataType::Interval,
+            )),
+            Ok(Literal::new(
+                Some(ScalarImpl::Interval(IntervalUnit::from_millis(6 * 1000))),
+                DataType::Interval,
+            )),
+            Ok(Literal::new(
+                Some(ScalarImpl::Interval(IntervalUnit::from_minutes(2))),
+                DataType::Interval,
+            )),
+            Ok(Literal::new(
+                Some(ScalarImpl::Interval(IntervalUnit::from_month(1))),
+                DataType::Interval,
+            )),
+        ];
+
+        for i in 0..values.len() {
+            let value = Value::Interval {
+                value: values[i].to_string(),
+                leading_field: None,
+                leading_precision: None,
+                last_field: None,
+                fractional_seconds_precision: None,
+            };
+            assert_eq!(binder.bind_value(value), data[i]);
+        }
+    }
 }

--- a/src/risedevtool/src/bin/risedev-playground.rs
+++ b/src/risedevtool/src/bin/risedev-playground.rs
@@ -214,7 +214,7 @@ fn task_main(
                 writeln!(
                     log_buffer,
                     "* Run {} to start Postgres interactive shell.",
-                    style(format!("psql -h localhost -p {}", c.port))
+                    style(format!("psql -h localhost -p {} -d dev", c.port))
                         .blue()
                         .bold()
                 )?;

--- a/src/sqlparser/src/ast/value.rs
+++ b/src/sqlparser/src/ast/value.rs
@@ -13,7 +13,9 @@
 #[cfg(not(feature = "std"))]
 use alloc::string::String;
 use core::fmt;
+use core::str::FromStr;
 
+use risingwave_common::error::{ErrorCode, RwError};
 #[cfg(feature = "serde")]
 use serde::{Deserialize, Serialize};
 
@@ -131,6 +133,22 @@ impl fmt::Display for DateTimeField {
             DateTimeField::Minute => "MINUTE",
             DateTimeField::Second => "SECOND",
         })
+    }
+}
+
+impl FromStr for DateTimeField {
+    type Err = RwError;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s.to_lowercase().as_str() {
+            "years" | "year" | "yrs" | "yr" | "y" => Ok(Self::Year),
+            "days" | "day" | "d" => Ok(Self::Day),
+            "hours" | "hour" | "hrs" | "hr" | "h" => Ok(Self::Hour),
+            "minutes" | "minute" | "mins" | "min" | "m" => Ok(Self::Minute),
+            "months" | "month" | "mons" | "mon" => Ok(Self::Month),
+            "seconds" | "second" | "secs" | "sec" | "s" => Ok(Self::Second),
+            _ => Err(ErrorCode::InvalidInputSyntax(format!("unknown unit {}", s)).into()),
+        }
     }
 }
 


### PR DESCRIPTION
## What's changed and what's your intention?

Please explain **IN DETAIL** what the changes are in this PR and why they are needed:

- Summarize your change (**mandatory**)
Add a func to parse the argument of interval with specific syntax. Like @xiangjinwu point out in issue.
But now only support like `select interval '5 days'; `

## Checklist

- [x] I have written necessary docs and comments
- [x] I have added necessary unit tests and integration tests
- [x] All checks passed in `./risedev check` (or alias, `./risedev c`)

## Refer to a related PR or issue link (optional)
close #3003