### PR TITLE
feat(storage): use exist_table_id to filter exist key when compaction

### DIFF
--- a/proto/hummock.proto
+++ b/proto/hummock.proto
@@ -140,8 +140,7 @@ message CompactTask {
   repeated common.ParallelUnitMapping vnode_mappings = 11;
   // compaction group the task belongs to
   uint64 compaction_group_id = 12;
-  
-  // exist_table_id for compaction drop key
+  // existing_table_ids for compaction drop key
   repeated uint32 existing_table_ids = 13;
 }
 

--- a/proto/hummock.proto
+++ b/proto/hummock.proto
@@ -140,6 +140,9 @@ message CompactTask {
   repeated common.ParallelUnitMapping vnode_mappings = 11;
   // compaction group the task belongs to
   uint64 compaction_group_id = 12;
+  
+  // exist_table_id for compaction drop key
+  repeated uint32 exist_table_id = 13;
 }
 
 message LevelHandler {

--- a/proto/hummock.proto
+++ b/proto/hummock.proto
@@ -142,7 +142,7 @@ message CompactTask {
   uint64 compaction_group_id = 12;
   
   // exist_table_id for compaction drop key
-  repeated uint32 exist_table_id = 13;
+  repeated uint32 existing_table_ids = 13;
 }
 
 message LevelHandler {

--- a/src/meta/src/hummock/compaction/mod.rs
+++ b/src/meta/src/hummock/compaction/mod.rs
@@ -127,6 +127,7 @@ impl CompactStatus {
         } else {
             ret.split_ranges
         };
+
         let compact_task = CompactTask {
             input_ssts: vec![ret.select_level, ret.target_level],
             splits,
@@ -157,6 +158,7 @@ impl CompactStatus {
             task_status: false,
             vnode_mappings: vec![],
             compaction_group_id,
+            exist_table_id: vec![],
         };
         Some(compact_task)
     }

--- a/src/meta/src/hummock/compaction/mod.rs
+++ b/src/meta/src/hummock/compaction/mod.rs
@@ -158,7 +158,7 @@ impl CompactStatus {
             task_status: false,
             vnode_mappings: vec![],
             compaction_group_id,
-            exist_table_id: vec![],
+            existing_table_ids: vec![],
         };
         Some(compact_task)
     }

--- a/src/meta/src/hummock/compactor_manager.rs
+++ b/src/meta/src/hummock/compactor_manager.rs
@@ -173,7 +173,7 @@ mod tests {
             task_status: false,
             vnode_mappings: vec![],
             compaction_group_id: StaticCompactionGroupId::SharedBuffer.into(),
-            exist_table_id: vec![],
+            existing_table_ids: vec![],
         }
     }
 

--- a/src/meta/src/hummock/compactor_manager.rs
+++ b/src/meta/src/hummock/compactor_manager.rs
@@ -173,6 +173,7 @@ mod tests {
             task_status: false,
             vnode_mappings: vec![],
             compaction_group_id: StaticCompactionGroupId::SharedBuffer.into(),
+            exist_table_id: vec![],
         }
     }
 

--- a/src/meta/src/hummock/hummock_manager.rs
+++ b/src/meta/src/hummock/hummock_manager.rs
@@ -636,7 +636,7 @@ where
 
                     // to found exist table_id from
                     if exist_table_id_from_meta.contains(&table_id) {
-                        compact_task.exist_table_id.push(table_id);
+                        compact_task.existing_table_ids.push(table_id);
                     }
                 }
 

--- a/src/meta/src/hummock/hummock_manager.rs
+++ b/src/meta/src/hummock/hummock_manager.rs
@@ -74,7 +74,7 @@ pub struct HummockManager<S: MetaStore> {
     // TODO: refactor to remove this field
     config: Arc<CompactionConfig>,
 
-    // for compaction to get some info (e.g. exist_table_id)
+    // for compaction to get some info (e.g. existing_table_ids)
     fragment_manager: FragmentManagerRef<S>,
 }
 
@@ -579,7 +579,7 @@ where
             task_id as HummockCompactionTaskId,
             compaction_group_id,
         );
-        let exist_table_id_from_meta = self.fragment_manager.exist_table_ids().await?;
+        let existing_table_ids_from_meta = self.fragment_manager.existing_table_ids().await?;
         let ret = match compact_task {
             None => Ok(None),
             Some(mut compact_task) => {
@@ -635,7 +635,7 @@ where
                     }
 
                     // to found exist table_id from
-                    if exist_table_id_from_meta.contains(&table_id) {
+                    if existing_table_ids_from_meta.contains(&table_id) {
                         compact_task.existing_table_ids.push(table_id);
                     }
                 }

--- a/src/meta/src/hummock/hummock_manager.rs
+++ b/src/meta/src/hummock/hummock_manager.rs
@@ -51,6 +51,7 @@ use crate::manager::{IdCategory, MetaSrvEnv};
 use crate::model::{MetadataModel, ValTransaction, VarTransaction, Worker};
 use crate::rpc::metrics::MetaMetrics;
 use crate::storage::{MetaStore, Transaction};
+use crate::stream::FragmentManagerRef;
 
 // Update to states are performed as follow:
 // - Initialize ValTransaction for the meta state to update
@@ -72,6 +73,9 @@ pub struct HummockManager<S: MetaStore> {
     compaction_scheduler: parking_lot::RwLock<Option<CompactionRequestChannelRef>>,
     // TODO: refactor to remove this field
     config: Arc<CompactionConfig>,
+
+    // for compaction to get some info (e.g. exist_table_id)
+    fragment_manager: FragmentManagerRef<S>,
 }
 
 pub type HummockManagerRef<S> = Arc<HummockManager<S>>;
@@ -161,6 +165,7 @@ where
         cluster_manager: ClusterManagerRef<S>,
         metrics: Arc<MetaMetrics>,
         compaction_group_manager: CompactionGroupManagerRef<S>,
+        fragment_manager: FragmentManagerRef<S>,
     ) -> Result<HummockManager<S>> {
         let config = compaction_group_manager.config().clone();
         let instance = HummockManager {
@@ -172,6 +177,7 @@ where
             compaction_group_manager,
             compaction_scheduler: parking_lot::RwLock::new(None),
             config: Arc::new(config),
+            fragment_manager,
         };
 
         instance.load_meta_store_state().await?;
@@ -573,6 +579,7 @@ where
             task_id as HummockCompactionTaskId,
             compaction_group_id,
         );
+        let exist_table_id_from_meta = self.fragment_manager.exist_table_ids().await?;
         let ret = match compact_task {
             None => Ok(None),
             Some(mut compact_task) => {
@@ -590,22 +597,28 @@ where
                         .flat_map(|v| v.snapshot_id.clone())
                         .fold(max_committed_epoch, std::cmp::min)
                 };
+
+                // to get all relational table_id from sst_info
+                let table_ids = compact_task
+                    .input_ssts
+                    .iter()
+                    .flat_map(|level| {
+                        level
+                            .table_infos
+                            .iter()
+                            .flat_map(|sst_info| {
+                                sst_info.vnode_bitmaps.iter().map(|bitmap| bitmap.table_id)
+                            })
+                            .collect_vec()
+                    })
+                    .collect::<HashSet<u32>>();
+
                 if compact_task.target_level != 0 {
-                    let table_ids = compact_task
-                        .input_ssts
-                        .iter()
-                        .flat_map(|level| {
-                            level
-                                .table_infos
-                                .iter()
-                                .flat_map(|sst_info| {
-                                    sst_info.vnode_bitmaps.iter().map(|bitmap| bitmap.table_id)
-                                })
-                                .collect_vec()
-                        })
-                        .collect::<HashSet<u32>>();
                     compact_task.vnode_mappings.reserve_exact(table_ids.len());
-                    for table_id in table_ids {
+                }
+
+                for table_id in table_ids {
+                    if compact_task.target_level != 0 {
                         if let Some(vnode_mapping) = self
                             .env
                             .hash_mapping_manager()
@@ -619,6 +632,11 @@ where
                             };
                             compact_task.vnode_mappings.push(compressed_mapping);
                         }
+                    }
+
+                    // to found exist table_id from
+                    if exist_table_id_from_meta.contains(&table_id) {
+                        compact_task.exist_table_id.push(table_id);
                     }
                 }
 

--- a/src/meta/src/hummock/test_utils.rs
+++ b/src/meta/src/hummock/test_utils.rs
@@ -29,6 +29,7 @@ use crate::hummock::{HummockManager, HummockManagerRef};
 use crate::manager::MetaSrvEnv;
 use crate::rpc::metrics::MetaMetrics;
 use crate::storage::{MemStore, MetaStore};
+use crate::stream::FragmentManager;
 
 pub async fn add_test_tables<S>(
     hummock_manager: &HummockManager<S>,
@@ -166,12 +167,14 @@ pub async fn setup_compute_env(
         CompactionGroupManager::new_with_config(env.clone(), config.clone())
             .await
             .unwrap();
+    let fragment_manager = Arc::new(FragmentManager::new(env.clone()).await.unwrap());
     let hummock_manager = Arc::new(
         HummockManager::new(
             env.clone(),
             cluster_manager.clone(),
             Arc::new(MetaMetrics::new()),
             Arc::new(compaction_group_manager),
+            fragment_manager.clone(),
         )
         .await
         .unwrap(),

--- a/src/meta/src/rpc/server.rs
+++ b/src/meta/src/rpc/server.rs
@@ -130,6 +130,7 @@ pub async fn rpc_serve_with_store<S: MetaStore>(
             cluster_manager.clone(),
             meta_metrics.clone(),
             compaction_group_manager.clone(),
+            fragment_manager.clone(),
         )
         .await
         .unwrap(),

--- a/src/meta/src/stream/meta.rs
+++ b/src/meta/src/stream/meta.rs
@@ -467,8 +467,8 @@ where
         Ok(())
     }
 
-    // existing_table_ids include the table_ref_id (source and materialized_view) + internal_table_id
-    // (stateful executor)
+    // existing_table_ids include the table_ref_id (source and materialized_view) +
+    // internal_table_id (stateful executor)
     pub async fn existing_table_ids(&self) -> Result<HashSet<u32>> {
         let mut result_set = HashSet::default();
         let map = &self.core.read().await.table_fragments;

--- a/src/meta/src/stream/meta.rs
+++ b/src/meta/src/stream/meta.rs
@@ -467,9 +467,9 @@ where
         Ok(())
     }
 
-    // exist_table_id include the table_ref_id (source and materialized_view) + internal_table_id
+    // existing_table_ids include the table_ref_id (source and materialized_view) + internal_table_id
     // (stateful executor)
-    pub async fn exist_table_ids(&self) -> Result<HashSet<u32>> {
+    pub async fn existing_table_ids(&self) -> Result<HashSet<u32>> {
         let mut result_set = HashSet::default();
         let map = &self.core.read().await.table_fragments;
 

--- a/src/meta/src/stream/meta.rs
+++ b/src/meta/src/stream/meta.rs
@@ -466,4 +466,21 @@ where
         }
         Ok(())
     }
+
+    // exist_table_id include the table_ref_id (source and materialized_view) + internal_table_id
+    // (stateful executor)
+    pub async fn exist_table_ids(&self) -> Result<HashSet<u32>> {
+        let mut result_set = HashSet::default();
+        let map = &self.core.read().await.table_fragments;
+
+        for (k, v) in map {
+            result_set.insert(k.table_id());
+
+            for internal_table_id in v.internal_table_ids() {
+                result_set.insert(internal_table_id);
+            }
+        }
+
+        Ok(result_set)
+    }
 }

--- a/src/meta/src/stream/stream_manager.rs
+++ b/src/meta/src/stream/stream_manager.rs
@@ -838,6 +838,7 @@ mod tests {
                     cluster_manager.clone(),
                     meta_metrics.clone(),
                     compaction_group_manager.clone(),
+                    fragment_manager.clone(),
                 )
                 .await?,
             );

--- a/src/storage/src/hummock/compactor.rs
+++ b/src/storage/src/hummock/compactor.rs
@@ -381,7 +381,6 @@ impl Compactor {
             );
         }
 
-        // let existing_table_id: HashSet<u32> = HashSet::from_iter(compact_task.exist_table_id);
         let compaction_filter =
             StateCleanUpCompactionFilter::new(HashSet::from_iter(compact_task.existing_table_ids));
 
@@ -801,17 +800,6 @@ impl Compactor {
         let mut skip_key = BytesMut::new();
         let mut last_key = BytesMut::new();
 
-        // let mut use_compaction_filter = false;
-        // let use_compaction_filter = match compaction_filter_option {
-        //     None => false,
-        //     Some(_) => true,
-        // };
-
-        // let compaction_filter = nullptr;
-        // if use_compaction_filter {
-        //     compaction_filter = compaction_filter_option.unwrap();
-        // }
-
         while iter.is_valid() {
             let iter_key = iter.key();
 
@@ -849,7 +837,11 @@ impl Compactor {
                 if iter.value().is_delete() && !has_user_key_overlap {
                     drop = true;
                 }
-            } else if !compaction_filter.filter(iter_key) {
+            }
+
+            // in our design, frontend avoid to access keys which had be deleted, so we dont need to
+            // consider the epoch when the compaction_filter match (it means that mv had drop)
+            if !compaction_filter.filter(iter_key) {
                 drop = true;
             }
 

--- a/src/storage/src/hummock/compactor.rs
+++ b/src/storage/src/hummock/compactor.rs
@@ -841,7 +841,7 @@ impl Compactor {
 
             // in our design, frontend avoid to access keys which had be deleted, so we dont need to
             // consider the epoch when the compaction_filter match (it means that mv had drop)
-            if !compaction_filter.filter(iter_key) {
+            if !drop && !compaction_filter.filter(iter_key) {
                 drop = true;
             }
 

--- a/src/storage/src/hummock/compactor_tests.rs
+++ b/src/storage/src/hummock/compactor_tests.rs
@@ -18,10 +18,14 @@ mod tests {
     use std::sync::Arc;
 
     use bytes::Bytes;
+    use rand::Rng;
+    use risingwave_common::catalog::TableId;
     use risingwave_common::config::StorageConfig;
     use risingwave_hummock_sdk::compaction_group::StaticCompactionGroupId;
+    use risingwave_hummock_sdk::key::get_table_id;
     use risingwave_meta::hummock::test_utils::setup_compute_env;
     use risingwave_meta::hummock::MockHummockMetaClient;
+    use risingwave_pb::hummock::HummockVersion;
     use risingwave_rpc_client::HummockMetaClient;
 
     use crate::hummock::compactor::{get_remote_sstable_id_generator, Compactor, CompactorContext};
@@ -29,7 +33,7 @@ mod tests {
     use crate::hummock::HummockStorage;
     use crate::monitor::{StateStoreMetrics, StoreLocalStatistic};
     use crate::storage_value::StorageValue;
-    use crate::StateStore;
+    use crate::{Keyspace, StateStore};
 
     async fn get_hummock_storage(
         hummock_meta_client: Arc<dyn HummockMetaClient>,
@@ -140,6 +144,7 @@ mod tests {
             .await
             .unwrap();
         let target_table_size = storage.options().sstable_size_mb * (1 << 20);
+
         assert!(
             table.value().meta.estimated_size > target_table_size,
             "table.meta.estimated_size {} <= target_table_size {}",
@@ -161,5 +166,202 @@ mod tests {
             .unwrap();
 
         assert!(compact_task.is_none());
+    }
+
+    #[tokio::test]
+    async fn test_compaction_drop_all_key() {
+        let (_env, hummock_manager_ref, _cluster_manager_ref, worker_node) =
+            setup_compute_env(8080).await;
+        let hummock_meta_client = Arc::new(MockHummockMetaClient::new(
+            hummock_manager_ref.clone(),
+            worker_node.id,
+        ));
+        let storage = get_hummock_storage(hummock_meta_client.clone()).await;
+        let compact_ctx = CompactorContext {
+            options: storage.options().clone(),
+            sstable_store: storage.sstable_store(),
+            hummock_meta_client: hummock_meta_client.clone(),
+            stats: Arc::new(StateStoreMetrics::unused()),
+            is_share_buffer_compact: false,
+            sstable_id_generator: get_remote_sstable_id_generator(hummock_meta_client.clone()),
+            compaction_executor: None,
+        };
+
+        // 1. add sstables
+        let val = Bytes::from(b"0"[..].repeat(4 << 20)); // 4MB value
+
+        let keyspace = Keyspace::table_root(storage.clone(), &TableId::new(1));
+        let kv_count = 128;
+        let mut epoch: u64 = 1;
+        for _ in 0..kv_count {
+            let mut write_batch = keyspace.state_store().start_write_batch();
+            let mut local = write_batch.prefixify(&keyspace);
+            epoch += 1;
+
+            let ramdom_key = rand::thread_rng().gen::<[u8; 32]>();
+            local.put(ramdom_key, StorageValue::new_default_put(val.clone()));
+            write_batch.ingest(epoch).await.unwrap();
+
+            storage.sync(Some(epoch)).await.unwrap();
+            hummock_meta_client
+                .commit_epoch(
+                    epoch,
+                    storage.local_version_manager.get_uncommitted_ssts(epoch),
+                )
+                .await
+                .unwrap();
+        }
+
+        // 2. get compact task
+        let compact_task = hummock_manager_ref
+            .get_compact_task(StaticCompactionGroupId::StateDefault.into())
+            .await
+            .unwrap()
+            .unwrap();
+        hummock_manager_ref
+            .assign_compaction_task(&compact_task, worker_node.id, async { true })
+            .await
+            .unwrap();
+
+        // assert compact_task
+        assert_eq!(
+            compact_task.input_ssts.first().unwrap().table_infos.len(),
+            kv_count
+        );
+
+        // 3. compact
+        Compactor::compact(Arc::new(compact_ctx), compact_task.clone()).await;
+
+        // 4. get the latest version and check
+        let version = hummock_manager_ref.get_current_version().await;
+        let output_level_info = version.get_levels().last().unwrap();
+        assert_eq!(0, output_level_info.total_file_size);
+
+        // 5. get compact task and there should be none
+        let compact_task = hummock_manager_ref
+            .get_compact_task(StaticCompactionGroupId::StateDefault.into())
+            .await
+            .unwrap();
+
+        assert!(compact_task.is_none());
+    }
+
+    #[tokio::test]
+    async fn test_compaction_drop_key_by_existing_table_id() {
+        let (_env, hummock_manager_ref, _cluster_manager_ref, worker_node) =
+            setup_compute_env(8080).await;
+        let hummock_meta_client = Arc::new(MockHummockMetaClient::new(
+            hummock_manager_ref.clone(),
+            worker_node.id,
+        ));
+        let storage = get_hummock_storage(hummock_meta_client.clone()).await;
+        let compact_ctx = CompactorContext {
+            options: storage.options().clone(),
+            sstable_store: storage.sstable_store(),
+            hummock_meta_client: hummock_meta_client.clone(),
+            stats: Arc::new(StateStoreMetrics::unused()),
+            is_share_buffer_compact: false,
+            sstable_id_generator: get_remote_sstable_id_generator(hummock_meta_client.clone()),
+            compaction_executor: None,
+        };
+
+        // 1. add sstables
+        let val = Bytes::from(b"0"[..].repeat(4 << 20)); // 4MB value
+
+        let drop_table_id = 1;
+        let exist_table_id = 2;
+        let kv_count = 128;
+        let mut epoch: u64 = 1;
+        for index in 0..kv_count {
+            let table_id = if index % 2 == 0 {
+                drop_table_id
+            } else {
+                exist_table_id
+            };
+            let keyspace = Keyspace::table_root(storage.clone(), &TableId::new(table_id));
+            let mut write_batch = keyspace.state_store().start_write_batch();
+            let mut local = write_batch.prefixify(&keyspace);
+            epoch += 1;
+
+            let ramdom_key = rand::thread_rng().gen::<[u8; 32]>();
+            local.put(ramdom_key, StorageValue::new_default_put(val.clone()));
+            write_batch.ingest(epoch).await.unwrap();
+
+            storage.sync(Some(epoch)).await.unwrap();
+            hummock_meta_client
+                .commit_epoch(
+                    epoch,
+                    storage.local_version_manager.get_uncommitted_ssts(epoch),
+                )
+                .await
+                .unwrap();
+        }
+
+        // 2. get compact task
+        let mut compact_task = hummock_manager_ref
+            .get_compact_task(StaticCompactionGroupId::StateDefault.into())
+            .await
+            .unwrap()
+            .unwrap();
+        compact_task.existing_table_ids.push(2);
+
+        hummock_manager_ref
+            .assign_compaction_task(&compact_task, worker_node.id, async { true })
+            .await
+            .unwrap();
+
+        // assert compact_task
+        assert_eq!(
+            compact_task.input_ssts.first().unwrap().table_infos.len(),
+            kv_count
+        );
+
+        // 3. compact
+        Compactor::compact(Arc::new(compact_ctx), compact_task.clone()).await;
+
+        // 4. get the latest version and check
+        let version: HummockVersion = hummock_manager_ref.get_current_version().await;
+        let table_ids_from_version: Vec<_> = version
+            .get_levels()
+            .iter()
+            .flat_map(|level| level.table_infos.iter())
+            .map(|table_info| table_info.id)
+            .collect::<Vec<_>>();
+
+        let mut key_count = 0;
+        for table_id in table_ids_from_version {
+            key_count += storage
+                .sstable_store()
+                .sstable(table_id, &mut StoreLocalStatistic::default())
+                .await
+                .unwrap()
+                .value()
+                .meta
+                .key_count;
+        }
+        assert_eq!((kv_count / 2) as u32, key_count);
+
+        // 5. get compact task and there should be none
+        let compact_task = hummock_manager_ref
+            .get_compact_task(StaticCompactionGroupId::StateDefault.into())
+            .await
+            .unwrap();
+        assert!(compact_task.is_none());
+
+        epoch += 1;
+        // to update version for hummock_storage
+        storage
+            .local_version_manager()
+            .try_update_pinned_version(version);
+
+        // 6. scan kv to check key table_id
+        let scan_result = storage.scan::<_, Vec<u8>>(.., None, epoch).await.unwrap();
+        let mut scan_count = 0;
+        for (k, _) in scan_result {
+            let table_id = get_table_id(&k).unwrap();
+            assert_eq!(table_id, exist_table_id);
+            scan_count += 1;
+        }
+        assert_eq!(key_count, scan_count);
     }
 }

--- a/src/storage/src/hummock/compactor_tests.rs
+++ b/src/storage/src/hummock/compactor_tests.rs
@@ -269,14 +269,14 @@ mod tests {
         let val = Bytes::from(b"0"[..].repeat(4 << 20)); // 4MB value
 
         let drop_table_id = 1;
-        let exist_table_id = 2;
+        let existing_table_ids = 2;
         let kv_count = 128;
         let mut epoch: u64 = 1;
         for index in 0..kv_count {
             let table_id = if index % 2 == 0 {
                 drop_table_id
             } else {
-                exist_table_id
+                existing_table_ids
             };
             let keyspace = Keyspace::table_root(storage.clone(), &TableId::new(table_id));
             let mut write_batch = keyspace.state_store().start_write_batch();
@@ -359,7 +359,7 @@ mod tests {
         let mut scan_count = 0;
         for (k, _) in scan_result {
             let table_id = get_table_id(&k).unwrap();
-            assert_eq!(table_id, exist_table_id);
+            assert_eq!(table_id, existing_table_ids);
             scan_count += 1;
         }
         assert_eq!(key_count, scan_count);


### PR DESCRIPTION
## What's changed and what's your intention?

To support clean expired key when compaction

Please explain **IN DETAIL** what the changes are in this PR and why they are needed:

- to get the all TableFragments exist_table_ids by fragment_manager
- compact_task collect the exist_table_id via SSTableInfo
- compactor reclaim the expired_key by compare the table_id ( which decode from key_prefix) with exist_table_id

## Checklist
- [x] I have written necessary docs and comments
- [x] I have added necessary unit tests and integration tests

## Refer to a related PR or issue link (optional)
- https://github.com/singularity-data/risingwave/issues/2908