### PR TITLE
refactor(session): error when setting unrecognized configuration parameter

### DIFF
--- a/src/common/src/error.rs
+++ b/src/common/src/error.rs
@@ -137,6 +137,9 @@ pub enum ErrorCode {
     #[error("Unknown worker")]
     UnknownWorker,
 
+    #[error("unrecognized configuration parameter \"{0}\"")]
+    UnrecognizedConfigurationParameter(String),
+
     /// `Eof` represents an upstream node will not generate new data. This error is rare in our
     /// system, currently only used in the `BatchQueryExecutor` as an ephemeral solution.
     #[error("End of the stream")]
@@ -312,6 +315,7 @@ impl ErrorCode {
             ErrorCode::UnknownWorker => 24,
             ErrorCode::ConnectorError(_) => 25,
             ErrorCode::InvalidParameterValue(_) => 26,
+            ErrorCode::UnrecognizedConfigurationParameter(_) => 27,
             ErrorCode::UnknownError(_) => 101,
         }
     }

--- a/src/common/src/lib.rs
+++ b/src/common/src/lib.rs
@@ -51,6 +51,7 @@ pub mod config;
 pub mod hash;
 pub mod monitor;
 pub mod service;
+pub mod session_config;
 #[cfg(test)]
 pub mod test_utils;
 pub mod types;

--- a/src/common/src/session_config.rs
+++ b/src/common/src/session_config.rs
@@ -1,3 +1,17 @@
+// Copyright 2022 Singularity Data
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 /// If `RW_IMPLICIT_FLUSH` is on, then every INSERT/UPDATE/DELETE statement will block
 /// until the entire dataflow is refreshed. In other words, every related table & MV will
 /// be able to see the write.

--- a/src/common/src/session_config.rs
+++ b/src/common/src/session_config.rs
@@ -1,0 +1,11 @@
+/// If `RW_IMPLICIT_FLUSH` is on, then every INSERT/UPDATE/DELETE statement will block
+/// until the entire dataflow is refreshed. In other words, every related table & MV will
+/// be able to see the write.
+pub const IMPLICIT_FLUSH: &str = "RW_IMPLICIT_FLUSH";
+
+/// A temporary config variable to force query running in either local or distributed mode.
+/// It will be removed in the future.
+pub const QUERY_MODE: &str = "QUERY_MODE";
+
+/// To force the usage of delta join in streaming execution.
+pub const DELTA_JOIN: &str = "RW_FORCE_DELTA_JOIN";

--- a/src/frontend/src/config.rs
+++ b/src/frontend/src/config.rs
@@ -16,10 +16,9 @@
 
 use risingwave_common::error::ErrorCode::InvalidConfigValue;
 use risingwave_common::error::RwError;
+use risingwave_common::session_config::QUERY_MODE;
 
 use crate::config::QueryMode::{Distributed, Local};
-
-pub static QUERY_MODE: &str = "query_mode";
 
 #[derive(Debug, Clone)]
 pub enum QueryMode {

--- a/src/frontend/src/handler/dml.rs
+++ b/src/frontend/src/handler/dml.rs
@@ -15,6 +15,7 @@
 use futures_async_stream::for_await;
 use pgwire::pg_response::{PgResponse, StatementType};
 use risingwave_common::error::Result;
+use risingwave_common::session_config::IMPLICIT_FLUSH;
 use risingwave_sqlparser::ast::Statement;
 
 use crate::binder::Binder;
@@ -22,11 +23,6 @@ use crate::handler::util::{to_pg_field, to_pg_rows};
 use crate::planner::Planner;
 use crate::scheduler::{ExecutionContext, ExecutionContextRef};
 use crate::session::{OptimizerContext, SessionImpl};
-
-/// If `RW_IMPLICIT_FLUSH` is on, then every INSERT/UPDATE/DELETE statement will block
-/// until the entire dataflow is refreshed. In other words, every related table & MV will
-/// be able to see the write.
-pub static IMPLICIT_FLUSH: &str = "RW_IMPLICIT_FLUSH";
 
 pub async fn handle_dml(context: OptimizerContext, stmt: Statement) -> Result<PgResponse> {
     let stmt_type = to_statement_type(&stmt);

--- a/src/frontend/src/handler/query.rs
+++ b/src/frontend/src/handler/query.rs
@@ -17,6 +17,7 @@ use pgwire::pg_field_descriptor::PgFieldDescriptor;
 use pgwire::pg_response::{PgResponse, StatementType};
 use risingwave_batch::executor::BoxedDataChunkStream;
 use risingwave_common::error::Result;
+use risingwave_common::session_config::QUERY_MODE;
 use risingwave_sqlparser::ast::Statement;
 use tracing::info;
 
@@ -28,8 +29,6 @@ use crate::scheduler::{
     BatchPlanFragmenter, ExecutionContext, ExecutionContextRef, LocalQueryExecution,
 };
 use crate::session::OptimizerContext;
-
-pub static QUERY_MODE: &str = "query_mode";
 
 pub async fn handle_query(context: OptimizerContext, stmt: Statement) -> Result<PgResponse> {
     let stmt_type = to_statement_type(&stmt);

--- a/src/frontend/src/handler/set.rs
+++ b/src/frontend/src/handler/set.rs
@@ -26,7 +26,7 @@ pub(super) fn handle_set(
     let string_val = to_string(&value[0]);
     // Currently store the config variable simply as String -> ConfigEntry(String).
     // In future we can add converter/parser to make the API more robust.
-    context.session_ctx.set_config(&name.value, &string_val);
+    context.session_ctx.set_config(&name.value, &string_val)?;
 
     Ok(PgResponse::empty_result(StatementType::SET_OPTION))
 }

--- a/src/frontend/src/optimizer/plan_node/stream_hash_join.rs
+++ b/src/frontend/src/optimizer/plan_node/stream_hash_join.rs
@@ -15,6 +15,7 @@
 use std::fmt;
 
 use itertools::Itertools;
+use risingwave_common::session_config::DELTA_JOIN;
 use risingwave_pb::plan_common::JoinType;
 use risingwave_pb::stream_plan::stream_node::NodeBody;
 use risingwave_pb::stream_plan::HashJoinNode;
@@ -42,8 +43,6 @@ pub struct StreamHashJoin {
     /// only. Will remove after we have fully support shared state and index.
     is_delta: bool,
 }
-
-pub static DELTA_JOIN: &str = "RW_FORCE_DELTA_JOIN";
 
 impl StreamHashJoin {
     pub fn new(logical: LogicalJoin, eq_join_predicate: EqJoinPredicate) -> Self {

--- a/src/frontend/src/session.rs
+++ b/src/frontend/src/session.rs
@@ -374,17 +374,14 @@ impl SessionImpl {
     /// Set configuration values in this session.
     /// For example, `set_config("RW_IMPLICIT_FLUSH", true)` will implicit flush for every inserts.
     pub fn set_config(&self, key: &str, val: &str) -> Result<()> {
-        let key = key.to_ascii_lowercase();
+        let lower_key = key.to_ascii_lowercase();
         self.config_map
             .read()
-            .get(&key)
-            .ok_or_else(|| ErrorCode::InvalidConfigValue {
-                config_entry: key.clone(),
-                config_value: val.to_string(),
-            })?;
+            .get(&lower_key)
+            .ok_or_else(|| ErrorCode::UnrecognizedConfigurationParameter(key.to_string()))?;
         self.config_map
             .write()
-            .insert(key, ConfigEntry::new(val.to_string()));
+            .insert(lower_key, ConfigEntry::new(val.to_string()));
         Ok(())
     }
 

--- a/src/frontend/src/session.rs
+++ b/src/frontend/src/session.rs
@@ -25,7 +25,8 @@ use parking_lot::RwLock;
 use pgwire::pg_response::PgResponse;
 use pgwire::pg_server::{BoxedError, Session, SessionManager};
 use risingwave_common::config::FrontendConfig;
-use risingwave_common::error::{Result, RwError};
+use risingwave_common::error::{ErrorCode, Result, RwError};
+use risingwave_common::session_config::{DELTA_JOIN, IMPLICIT_FLUSH, QUERY_MODE};
 use risingwave_common::util::addr::HostAddr;
 use risingwave_pb::common::WorkerType;
 use risingwave_rpc_client::{ComputeClientPool, MetaClient};
@@ -36,7 +37,6 @@ use tokio::task::JoinHandle;
 
 use crate::catalog::catalog_service::{CatalogReader, CatalogWriter, CatalogWriterImpl};
 use crate::catalog::root_catalog::Catalog;
-use crate::handler::dml::IMPLICIT_FLUSH;
 use crate::handler::handle;
 use crate::meta_client::{FrontendMetaClient, FrontendMetaClientImpl};
 use crate::observer::observer_manager::ObserverManager;
@@ -331,6 +331,20 @@ impl ConfigEntry {
     }
 }
 
+fn build_default_session_config_map() -> HashMap<String, String> {
+    let mut m = HashMap::new();
+    m.insert(IMPLICIT_FLUSH.to_ascii_lowercase(), "false".to_string());
+    m.insert(DELTA_JOIN.to_ascii_lowercase(), "false".to_string());
+    m.insert(QUERY_MODE.to_ascii_lowercase(), "distributed".to_string());
+    m
+}
+
+lazy_static::lazy_static! {
+    static ref DEFAULT_SESSION_CONFIG_MAP: HashMap<String, String> = {
+        build_default_session_config_map()
+    };
+}
+
 impl SessionImpl {
     pub fn new(env: FrontendEnv, database: String) -> Self {
         Self {
@@ -359,11 +373,19 @@ impl SessionImpl {
 
     /// Set configuration values in this session.
     /// For example, `set_config("RW_IMPLICIT_FLUSH", true)` will implicit flush for every inserts.
-    pub fn set_config(&self, key: &str, val: &str) {
+    pub fn set_config(&self, key: &str, val: &str) -> Result<()> {
         let key = key.to_ascii_lowercase();
+        self.config_map
+            .read()
+            .get(&key)
+            .ok_or_else(|| ErrorCode::InvalidConfigValue {
+                config_entry: key.clone(),
+                config_value: val.to_string(),
+            })?;
         self.config_map
             .write()
             .insert(key, ConfigEntry::new(val.to_string()));
+        Ok(())
     }
 
     /// Get configuration values in this session.
@@ -375,11 +397,9 @@ impl SessionImpl {
 
     fn init_config_map() -> RwLock<HashMap<String, ConfigEntry>> {
         let mut map = HashMap::new();
-        // FIXME: May need better init way + default config.
-        map.insert(
-            IMPLICIT_FLUSH.to_string().to_ascii_lowercase(),
-            ConfigEntry::new("false".to_string()),
-        );
+        for (key, value) in &*DEFAULT_SESSION_CONFIG_MAP {
+            map.insert(key.clone(), ConfigEntry::new(value.clone()));
+        }
         RwLock::new(map)
     }
 }

--- a/src/frontend/test_runner/src/lib.rs
+++ b/src/frontend/test_runner/src/lib.rs
@@ -178,7 +178,7 @@ impl TestCase {
 
         if let Some(ref config_map) = self.with_config_map {
             for (key, val) in config_map {
-                session.set_config(key, val);
+                session.set_config(key, val).unwrap();
             }
         }
 


### PR DESCRIPTION
## What's changed and what's your intention?
#3036 , make sure every session config parameter has a default value.

Error when setting a unsupported configuration parameter.

## Checklist

- [x] I have written necessary docs and comments
~- [ ] I have added necessary unit tests and integration tests~
- [x] All checks passed in `./risedev check` (or alias, `./risedev c`)

## Refer to a related PR or issue link (optional)
closes #3036 