### PR TITLE
chore: remove scan_with_start_key

### DIFF
--- a/src/storage/src/keyspace.rs
+++ b/src/storage/src/keyspace.rs
@@ -93,7 +93,6 @@ impl<S: StateStore> Keyspace<S> {
         self.store.get(&self.prefixed_key(key), epoch).await
     }
 
-
     /// Scans `limit` keys from the keyspace and get their values. If `limit` is None, all keys of
     /// the given prefix will be scanned. Note that the prefix of this keyspace will be stripped.
     /// The returned values are based on a snapshot corresponding to the given `epoch`

--- a/src/storage/src/keyspace.rs
+++ b/src/storage/src/keyspace.rs
@@ -93,24 +93,6 @@ impl<S: StateStore> Keyspace<S> {
         self.store.get(&self.prefixed_key(key), epoch).await
     }
 
-    /// Scans `limit` keys from the keyspace using an inclusive `start_key` and get their values. If
-    /// `limit` is None, all keys of the given prefix will be scanned. Note that the prefix of this
-    /// keyspace will be stripped. The returned values are based on a snapshot corresponding to
-    /// the given `epoch`
-    pub async fn scan_with_start_key(
-        &self,
-        start_key: Vec<u8>,
-        limit: Option<usize>,
-        epoch: u64,
-    ) -> StorageResult<Vec<(Bytes, Bytes)>> {
-        let start_key_with_prefix = [self.prefix.as_slice(), start_key.as_slice()].concat();
-        let range = start_key_with_prefix..next_key(self.prefix.as_slice());
-        let mut pairs = self.store.scan(range, limit, epoch).await?;
-        pairs
-            .iter_mut()
-            .for_each(|(k, _v)| *k = k.slice(self.prefix.len()..));
-        Ok(pairs)
-    }
 
     /// Scans `limit` keys from the keyspace and get their values. If `limit` is None, all keys of
     /// the given prefix will be scanned. Note that the prefix of this keyspace will be stripped.


### PR DESCRIPTION
## What's changed and what's your intention?
As title.

## Checklist

- [x] I have written necessary docs and comments
- [x] I have added necessary unit tests and integration tests
- [x] All checks passed in `./risedev check` (or alias, `./risedev c`)

## Refer to a related PR or issue link (optional)
