### PR TITLE
feat(storage): support concurrent upload in capacity split sst builder

### DIFF
--- a/src/storage/src/hummock/sstable/group_builder.rs
+++ b/src/storage/src/hummock/sstable/group_builder.rs
@@ -16,16 +16,15 @@ use std::collections::HashMap;
 use std::future::Future;
 use std::sync::Arc;
 
-use bytes::Bytes;
 use itertools::Itertools;
 use risingwave_hummock_sdk::compaction_group::{CompactionGroupId, Prefix};
 use risingwave_hummock_sdk::key::{get_table_id, FullKey};
 use risingwave_hummock_sdk::HummockSSTableId;
-use risingwave_pb::common::VNodeBitmap;
 
-use crate::hummock::multi_builder::CapacitySplitTableBuilder;
+use crate::hummock::multi_builder::{CapacitySplitTableBuilder, SealedSstableBuilder};
+use crate::hummock::sstable_store::SstableStoreRef;
 use crate::hummock::value::HummockValue;
-use crate::hummock::{HummockResult, SSTableBuilder, SstableMeta};
+use crate::hummock::{HummockResult, SSTableBuilder};
 
 pub type KeyValueGroupId = u64;
 const DEFAULT_KEY_VALUE_GROUP_ID: KeyValueGroupId = KeyValueGroupId::MAX;
@@ -116,6 +115,7 @@ pub struct GroupedSstableBuilder<B> {
     get_id_and_builder: B,
     grouping: KeyValueGroupingImpl,
     builders: HashMap<KeyValueGroupId, CapacitySplitTableBuilder<B>>,
+    sstable_store: SstableStoreRef,
 }
 
 impl<B, F> GroupedSstableBuilder<B>
@@ -123,14 +123,19 @@ where
     B: Clone + Fn() -> F,
     F: Future<Output = HummockResult<(HummockSSTableId, SSTableBuilder)>>,
 {
-    pub fn new(get_id_and_builder: B, grouping: KeyValueGroupingImpl) -> Self {
+    pub fn new(
+        get_id_and_builder: B,
+        grouping: KeyValueGroupingImpl,
+        sstable_store: SstableStoreRef,
+    ) -> Self {
         Self {
             get_id_and_builder: get_id_and_builder.clone(),
             grouping,
             builders: HashMap::from([(
                 DEFAULT_KEY_VALUE_GROUP_ID,
-                CapacitySplitTableBuilder::new(get_id_and_builder),
+                CapacitySplitTableBuilder::new(get_id_and_builder, sstable_store.clone()),
             )]),
+            sstable_store,
         }
     }
 
@@ -153,10 +158,12 @@ where
             .grouping
             .group(&full_key, &value)
             .unwrap_or(DEFAULT_KEY_VALUE_GROUP_ID);
-        let entry = self
-            .builders
-            .entry(group_id)
-            .or_insert_with(|| CapacitySplitTableBuilder::new(self.get_id_and_builder.clone()));
+        let entry = self.builders.entry(group_id).or_insert_with(|| {
+            CapacitySplitTableBuilder::new(
+                self.get_id_and_builder.clone(),
+                self.sstable_store.clone(),
+            )
+        });
         entry.add_full_key(full_key, value, allow_split).await
     }
 
@@ -166,7 +173,8 @@ where
             .for_each(|(_k, v)| v.seal_current());
     }
 
-    pub fn finish(self) -> Vec<(u64, Bytes, SstableMeta, Vec<VNodeBitmap>)> {
+    pub fn finish(mut self) -> Vec<SealedSstableBuilder> {
+        self.seal_current();
         self.builders
             .into_iter()
             .flat_map(|(_k, v)| v.finish())
@@ -182,6 +190,7 @@ mod tests {
     use bytes::Buf;
 
     use super::*;
+    use crate::hummock::iterator::test_utils::mock_sstable_store;
     use crate::hummock::sstable::utils::CompressionAlgorithm;
     use crate::hummock::{SSTableBuilderOptions, DEFAULT_RESTART_INTERVAL};
 
@@ -207,7 +216,8 @@ mod tests {
         let grouping = KeyValueGroupingImpl::CompactionGroup(CompactionGroupGrouping::new(
             HashMap::from([(prefix.into(), 1.into())]),
         ));
-        let mut builder = GroupedSstableBuilder::new(get_id_and_builder, grouping);
+        let mut builder =
+            GroupedSstableBuilder::new(get_id_and_builder, grouping, mock_sstable_store());
         for i in 0..10 {
             // key value belongs to no compaction group
             builder

--- a/src/storage/src/hummock/sstable/multi_builder.rs
+++ b/src/storage/src/hummock/sstable/multi_builder.rs
@@ -12,20 +12,23 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use bytes::Bytes;
 use futures::Future;
 use risingwave_hummock_sdk::key::{Epoch, FullKey};
 use risingwave_hummock_sdk::HummockSSTableId;
 use risingwave_pb::common::VNodeBitmap;
+use tokio::task::JoinHandle;
 
 use super::SstableMeta;
+use crate::hummock::sstable_store::SstableStoreRef;
 use crate::hummock::value::HummockValue;
-use crate::hummock::{HummockResult, SSTableBuilder};
+use crate::hummock::{CachePolicy, HummockResult, SSTableBuilder, Sstable};
 
-struct SSTableBuilderWrapper {
-    id: HummockSSTableId,
-    builder: SSTableBuilder,
-    sealed: bool,
+pub struct SealedSstableBuilder {
+    pub id: HummockSSTableId,
+    pub meta: SstableMeta,
+    pub vnode_bitmaps: Vec<VNodeBitmap>,
+    pub upload_join_handle: JoinHandle<HummockResult<()>>,
+    pub data_len: usize,
 }
 
 /// A wrapper for [`SSTableBuilder`] which automatically split key-value pairs into multiple tables,
@@ -37,8 +40,11 @@ pub struct CapacitySplitTableBuilder<B> {
     /// options.
     get_id_and_builder: B,
 
-    /// Wrapped [`SSTableBuilder`]s. The last one is what we are operating on.
-    builders: Vec<SSTableBuilderWrapper>,
+    sealed_builders: Vec<SealedSstableBuilder>,
+
+    current_builder: Option<(HummockSSTableId, SSTableBuilder)>,
+
+    sstable_store: SstableStoreRef,
 }
 
 impl<B, F> CapacitySplitTableBuilder<B>
@@ -47,21 +53,23 @@ where
     F: Future<Output = HummockResult<(HummockSSTableId, SSTableBuilder)>>,
 {
     /// Creates a new [`CapacitySplitTableBuilder`] using given configuration generator.
-    pub fn new(get_id_and_builder: B) -> Self {
+    pub fn new(get_id_and_builder: B, sstable_store: SstableStoreRef) -> Self {
         Self {
             get_id_and_builder,
-            builders: Vec::new(),
+            sealed_builders: Vec::new(),
+            current_builder: None,
+            sstable_store,
         }
     }
 
     /// Returns the number of [`SSTableBuilder`]s.
     pub fn len(&self) -> usize {
-        self.builders.len()
+        self.sealed_builders.len() + if self.current_builder.is_some() { 1 } else { 0 }
     }
 
     /// Returns true if no builder is created.
     pub fn is_empty(&self) -> bool {
-        self.builders.is_empty()
+        self.sealed_builders.is_empty() && self.current_builder.is_none()
     }
 
     /// Adds a user key-value pair to the underlying builders, with given `epoch`.
@@ -93,23 +101,19 @@ where
         value: HummockValue<&[u8]>,
         allow_split: bool,
     ) -> HummockResult<()> {
-        let last_is_full = self
-            .builders
-            .last()
-            .map(|b| b.builder.reach_capacity() || b.sealed)
-            .unwrap_or(true);
-        let new_builder_required = self.builders.is_empty() || (allow_split && last_is_full);
-
-        if new_builder_required {
-            let (id, builder) = (self.get_id_and_builder)().await?;
-            self.builders.push(SSTableBuilderWrapper {
-                id,
-                builder,
-                sealed: false,
-            });
+        if let Some((_, builder)) = self.current_builder.as_ref() {
+            if allow_split && builder.reach_capacity() {
+                self.seal_current();
+            }
         }
 
-        let builder = &mut self.builders.last_mut().unwrap().builder;
+        if self.current_builder.is_none() {
+            let _ = self
+                .current_builder
+                .insert((self.get_id_and_builder)().await?);
+        }
+
+        let (_, builder) = self.current_builder.as_mut().unwrap();
         builder.add(full_key.into_inner(), value);
         Ok(())
     }
@@ -119,20 +123,37 @@ where
     /// If there's no builder created, or current one is already sealed before, then this function
     /// will be no-op.
     pub fn seal_current(&mut self) {
-        if let Some(b) = self.builders.last_mut() {
-            b.sealed = true;
+        if let Some((table_id, builder)) = self.current_builder.take() {
+            let (data, meta, vnode_bitmap) = builder.finish();
+            let len = data.len();
+            let sstable_store = self.sstable_store.clone();
+            let meta_clone = meta.clone();
+            let upload_join_handle = tokio::spawn(async move {
+                sstable_store
+                    .put(
+                        Sstable {
+                            id: table_id,
+                            meta: meta_clone,
+                        },
+                        data,
+                        CachePolicy::Fill,
+                    )
+                    .await
+            });
+            self.sealed_builders.push(SealedSstableBuilder {
+                id: table_id,
+                meta,
+                vnode_bitmaps: vnode_bitmap,
+                upload_join_handle,
+                data_len: len,
+            })
         }
     }
 
     /// Finalizes all the tables to be ids, blocks and metadata.
-    pub fn finish(self) -> Vec<(HummockSSTableId, Bytes, SstableMeta, Vec<VNodeBitmap>)> {
-        self.builders
-            .into_iter()
-            .map(|b| {
-                let (data, meta, vnode_bitmaps) = b.builder.finish();
-                (b.id, data, meta, vnode_bitmaps)
-            })
-            .collect()
+    pub fn finish(mut self) -> Vec<SealedSstableBuilder> {
+        self.seal_current();
+        self.sealed_builders
     }
 }
 
@@ -144,6 +165,7 @@ mod tests {
     use itertools::Itertools;
 
     use super::*;
+    use crate::hummock::iterator::test_utils::mock_sstable_store;
     use crate::hummock::sstable::utils::CompressionAlgorithm;
     use crate::hummock::test_utils::default_builder_opt_for_test;
     use crate::hummock::{SSTableBuilderOptions, DEFAULT_RESTART_INTERVAL};
@@ -165,7 +187,7 @@ mod tests {
                 }),
             ))
         };
-        let builder = CapacitySplitTableBuilder::new(get_id_and_builder);
+        let builder = CapacitySplitTableBuilder::new(get_id_and_builder, mock_sstable_store());
         let results = builder.finish();
         assert!(results.is_empty());
     }
@@ -188,7 +210,7 @@ mod tests {
                 }),
             ))
         };
-        let mut builder = CapacitySplitTableBuilder::new(get_id_and_builder);
+        let mut builder = CapacitySplitTableBuilder::new(get_id_and_builder, mock_sstable_store());
 
         for i in 0..table_capacity {
             builder
@@ -203,18 +225,21 @@ mod tests {
 
         let results = builder.finish();
         assert!(results.len() > 1);
-        assert_eq!(results.iter().map(|p| p.0).duplicates().count(), 0);
+        assert_eq!(results.iter().map(|p| p.id).duplicates().count(), 0);
     }
 
     #[tokio::test]
     async fn test_table_seal() {
         let next_id = AtomicU64::new(1001);
-        let mut builder = CapacitySplitTableBuilder::new(|| async {
-            Ok((
-                next_id.fetch_add(1, SeqCst),
-                SSTableBuilder::new(default_builder_opt_for_test()),
-            ))
-        });
+        let mut builder = CapacitySplitTableBuilder::new(
+            || async {
+                Ok((
+                    next_id.fetch_add(1, SeqCst),
+                    SSTableBuilder::new(default_builder_opt_for_test()),
+                ))
+            },
+            mock_sstable_store(),
+        );
         let mut epoch = 100;
 
         macro_rules! add {
@@ -250,12 +275,15 @@ mod tests {
     #[tokio::test]
     async fn test_initial_not_allowed_split() {
         let next_id = AtomicU64::new(1001);
-        let mut builder = CapacitySplitTableBuilder::new(|| async {
-            Ok((
-                next_id.fetch_add(1, SeqCst),
-                SSTableBuilder::new(default_builder_opt_for_test()),
-            ))
-        });
+        let mut builder = CapacitySplitTableBuilder::new(
+            || async {
+                Ok((
+                    next_id.fetch_add(1, SeqCst),
+                    SSTableBuilder::new(default_builder_opt_for_test()),
+                ))
+            },
+            mock_sstable_store(),
+        );
 
         builder
             .add_full_key(


### PR DESCRIPTION
## What's changed and what's your intention?

Currently when we do compaction, we first build all the ssts, and then upload the ssts in parallel. Uploading is IO intensive, while building ssts is CPU intensive. Therefore, the time for IO is wasted while we are building ssts. In this PR, instead of waiting for all ssts to be generated, we will issue an upload tokio task whenever we generate a new sst, and we join all the upload tasks at the end of compaction. In this way, generating ssts and uploading can be done in parallel.

## Checklist

- [x] I have written necessary docs and comments
- [x] I have added necessary unit tests and integration tests
- [x] All checks passed in `./risedev check` (or alias, `./risedev c`)

## Refer to a related PR or issue link (optional)
