### PR TITLE
perf(executor): implement dedup pk decoding for BatchQueryExecutor

### DIFF
--- a/proto/plan_common.proto
+++ b/proto/plan_common.proto
@@ -52,7 +52,7 @@ message ColumnCatalog {
 
 message CellBasedTableDesc {
   uint32 table_id = 1;
-  repeated OrderedColumnDesc pk = 2;
+  repeated OrderedColumnDesc order_keys = 2;
 }
 
 enum JoinType {

--- a/proto/plan_common.proto
+++ b/proto/plan_common.proto
@@ -52,7 +52,7 @@ message ColumnCatalog {
 
 message CellBasedTableDesc {
   uint32 table_id = 1;
-  repeated OrderedColumnDesc order_keys = 2;
+  repeated OrderedColumnDesc order_key = 2;
 }
 
 enum JoinType {

--- a/proto/stream_plan.proto
+++ b/proto/stream_plan.proto
@@ -151,7 +151,7 @@ message ChainNode {
 // BatchPlanNode is supposed to carry a batch plan that can be optimized with the streaming plan_common.
 // Currently, streaming to batch push down is not yet supported, BatchPlanNode is simply a table scan.
 message BatchPlanNode {
-  plan_common.TableRefId table_ref_id = 1;
+  plan_common.CellBasedTableDesc table_desc = 1;
   repeated plan_common.ColumnDesc column_descs = 2;
   repeated uint32 distribution_keys = 3;
   common.ParallelUnitMapping hash_mapping = 4;

--- a/src/batch/src/executor/row_seq_scan.rs
+++ b/src/batch/src/executor/row_seq_scan.rs
@@ -147,7 +147,7 @@ impl BoxedExecutorBuilder for RowSeqScanExecutorBuilder {
             .iter()
             .map(|column_desc| ColumnDesc::from(column_desc.clone()))
             .collect_vec();
-        let pk_descs_proto = &seq_scan_node.table_desc.as_ref().unwrap().pk;
+        let pk_descs_proto = &seq_scan_node.table_desc.as_ref().unwrap().order_keys;
         let pk_descs: Vec<OrderedColumnDesc> = pk_descs_proto.iter().map(|d| d.into()).collect();
         let order_types: Vec<OrderType> = pk_descs.iter().map(|desc| desc.order).collect();
         let ordered_row_serializer = OrderedRowSerializer::new(order_types);

--- a/src/batch/src/executor/row_seq_scan.rs
+++ b/src/batch/src/executor/row_seq_scan.rs
@@ -147,7 +147,7 @@ impl BoxedExecutorBuilder for RowSeqScanExecutorBuilder {
             .iter()
             .map(|column_desc| ColumnDesc::from(column_desc.clone()))
             .collect_vec();
-        let pk_descs_proto = &seq_scan_node.table_desc.as_ref().unwrap().order_keys;
+        let pk_descs_proto = &seq_scan_node.table_desc.as_ref().unwrap().order_key;
         let pk_descs: Vec<OrderedColumnDesc> = pk_descs_proto.iter().map(|d| d.into()).collect();
         let order_types: Vec<OrderType> = pk_descs.iter().map(|desc| desc.order).collect();
         let ordered_row_serializer = OrderedRowSerializer::new(order_types);

--- a/src/batch/src/executor/row_seq_scan.rs
+++ b/src/batch/src/executor/row_seq_scan.rs
@@ -168,7 +168,7 @@ impl BoxedExecutorBuilder for RowSeqScanExecutorBuilder {
             );
 
             let scan_type = if pk_prefix_value.size() == 0 && is_full_range(&next_col_bounds) {
-                let iter = table.iter_with_pk(source.epoch, pk_descs).await?;
+                let iter = table.iter_with_pk(source.epoch, &pk_descs).await?;
                 ScanType::TableScan(iter)
             } else if pk_prefix_value.size() == pk_descs.len() {
                 keyspace.state_store().wait_epoch(source.epoch).await?;

--- a/src/compute/tests/integration_tests.rs
+++ b/src/compute/tests/integration_tests.rs
@@ -221,7 +221,7 @@ async fn test_table_v2_materialize() -> Result<()> {
         table.schema().clone(),
         ScanType::TableScan(
             table
-                .iter_with_pk(u64::MAX, ordered_column_descs.clone())
+                .iter_with_pk(u64::MAX, &ordered_column_descs)
                 .await?,
         ),
         1024,
@@ -284,7 +284,7 @@ async fn test_table_v2_materialize() -> Result<()> {
         table.schema().clone(),
         ScanType::TableScan(
             table
-                .iter_with_pk(u64::MAX, ordered_column_descs.clone())
+                .iter_with_pk(u64::MAX, &ordered_column_descs)
                 .await?,
         ),
         1024,
@@ -356,7 +356,7 @@ async fn test_table_v2_materialize() -> Result<()> {
         table.schema().clone(),
         ScanType::TableScan(
             table
-                .iter_with_pk(u64::MAX, ordered_column_descs.clone())
+                .iter_with_pk(u64::MAX, &ordered_column_descs)
                 .await?,
         ),
         1024,
@@ -441,7 +441,7 @@ async fn test_row_seq_scan() -> Result<()> {
 
     let executor = Box::new(RowSeqScanExecutor::new(
         table.schema().clone(),
-        ScanType::TableScan(table.iter_with_pk(u64::MAX, pk_descs).await.unwrap()),
+        ScanType::TableScan(table.iter_with_pk(u64::MAX, &pk_descs).await.unwrap()),
         1,
         true,
         "RowSeqScanExecutor2".to_string(),

--- a/src/compute/tests/integration_tests.rs
+++ b/src/compute/tests/integration_tests.rs
@@ -219,11 +219,7 @@ async fn test_table_v2_materialize() -> Result<()> {
 
     let scan = Box::new(RowSeqScanExecutor::new(
         table.schema().clone(),
-        ScanType::TableScan(
-            table
-                .iter_with_pk(u64::MAX, &ordered_column_descs)
-                .await?,
-        ),
+        ScanType::TableScan(table.iter_with_pk(u64::MAX, &ordered_column_descs).await?),
         1024,
         true,
         "RowSeqExecutor2".to_string(),
@@ -282,11 +278,7 @@ async fn test_table_v2_materialize() -> Result<()> {
     // Scan the table again, we are able to get the data now!
     let scan = Box::new(RowSeqScanExecutor::new(
         table.schema().clone(),
-        ScanType::TableScan(
-            table
-                .iter_with_pk(u64::MAX, &ordered_column_descs)
-                .await?,
-        ),
+        ScanType::TableScan(table.iter_with_pk(u64::MAX, &ordered_column_descs).await?),
         1024,
         true,
         "RowSeqScanExecutor2".to_string(),
@@ -354,11 +346,7 @@ async fn test_table_v2_materialize() -> Result<()> {
     // Scan the table again, we are able to see the deletion now!
     let scan = Box::new(RowSeqScanExecutor::new(
         table.schema().clone(),
-        ScanType::TableScan(
-            table
-                .iter_with_pk(u64::MAX, &ordered_column_descs)
-                .await?,
-        ),
+        ScanType::TableScan(table.iter_with_pk(u64::MAX, &ordered_column_descs).await?),
         1024,
         true,
         "RowSeqScanExecutor2".to_string(),

--- a/src/frontend/src/optimizer/plan_node/batch_seq_scan.rs
+++ b/src/frontend/src/optimizer/plan_node/batch_seq_scan.rs
@@ -160,7 +160,7 @@ impl ToBatchProst for BatchSeqScan {
         NodeBody::RowSeqScan(RowSeqScanNode {
             table_desc: Some(CellBasedTableDesc {
                 table_id: self.logical.table_desc().table_id.into(),
-                pk: self
+                order_keys: self
                     .logical
                     .table_desc()
                     .order_desc

--- a/src/frontend/src/optimizer/plan_node/batch_seq_scan.rs
+++ b/src/frontend/src/optimizer/plan_node/batch_seq_scan.rs
@@ -160,7 +160,7 @@ impl ToBatchProst for BatchSeqScan {
         NodeBody::RowSeqScan(RowSeqScanNode {
             table_desc: Some(CellBasedTableDesc {
                 table_id: self.logical.table_desc().table_id.into(),
-                order_keys: self
+                order_key: self
                     .logical
                     .table_desc()
                     .order_desc

--- a/src/frontend/src/optimizer/plan_node/stream_index_scan.rs
+++ b/src/frontend/src/optimizer/plan_node/stream_index_scan.rs
@@ -87,9 +87,15 @@ impl StreamIndexScan {
         use risingwave_pb::stream_plan::*;
 
         let batch_plan_node = BatchPlanNode {
-            table_ref_id: Some(TableRefId {
-                table_id: self.logical.table_desc().table_id.table_id as i32,
-                schema_ref_id: Default::default(),
+            table_desc: Some(CellBasedTableDesc {
+                table_id: self.logical.table_desc().table_id.into(),
+                pk: self
+                    .logical
+                    .table_desc()
+                    .order_desc
+                    .iter()
+                    .map(|v| v.into())
+                    .collect(),
             }),
             column_descs: self
                 .schema()

--- a/src/frontend/src/optimizer/plan_node/stream_index_scan.rs
+++ b/src/frontend/src/optimizer/plan_node/stream_index_scan.rs
@@ -89,7 +89,7 @@ impl StreamIndexScan {
         let batch_plan_node = BatchPlanNode {
             table_desc: Some(CellBasedTableDesc {
                 table_id: self.logical.table_desc().table_id.into(),
-                pk: self
+                order_keys: self
                     .logical
                     .table_desc()
                     .order_desc

--- a/src/frontend/src/optimizer/plan_node/stream_index_scan.rs
+++ b/src/frontend/src/optimizer/plan_node/stream_index_scan.rs
@@ -89,7 +89,7 @@ impl StreamIndexScan {
         let batch_plan_node = BatchPlanNode {
             table_desc: Some(CellBasedTableDesc {
                 table_id: self.logical.table_desc().table_id.into(),
-                order_keys: self
+                order_key: self
                     .logical
                     .table_desc()
                     .order_desc

--- a/src/frontend/src/optimizer/plan_node/stream_table_scan.rs
+++ b/src/frontend/src/optimizer/plan_node/stream_table_scan.rs
@@ -94,7 +94,7 @@ impl StreamTableScan {
         let batch_plan_node = BatchPlanNode {
             table_desc: Some(CellBasedTableDesc {
                 table_id: self.logical.table_desc().table_id.into(),
-                order_keys: self
+                order_key: self
                     .logical
                     .table_desc()
                     .order_desc

--- a/src/frontend/src/optimizer/plan_node/stream_table_scan.rs
+++ b/src/frontend/src/optimizer/plan_node/stream_table_scan.rs
@@ -92,9 +92,15 @@ impl StreamTableScan {
         use risingwave_pb::stream_plan::*;
 
         let batch_plan_node = BatchPlanNode {
-            table_ref_id: Some(TableRefId {
-                table_id: self.logical.table_desc().table_id.table_id as i32,
-                schema_ref_id: Default::default(),
+            table_desc: Some(CellBasedTableDesc {
+                table_id: self.logical.table_desc().table_id.into(),
+                pk: self
+                    .logical
+                    .table_desc()
+                    .order_desc
+                    .iter()
+                    .map(|v| v.into())
+                    .collect(),
             }),
             column_descs: self
                 .schema()

--- a/src/frontend/src/optimizer/plan_node/stream_table_scan.rs
+++ b/src/frontend/src/optimizer/plan_node/stream_table_scan.rs
@@ -94,7 +94,7 @@ impl StreamTableScan {
         let batch_plan_node = BatchPlanNode {
             table_desc: Some(CellBasedTableDesc {
                 table_id: self.logical.table_desc().table_id.into(),
-                pk: self
+                order_keys: self
                     .logical
                     .table_desc()
                     .order_desc

--- a/src/frontend/test_runner/tests/testdata/stream_proto.yaml
+++ b/src/frontend/test_runner/tests/testdata/stream_proto.yaml
@@ -13,8 +13,15 @@
                   - 1
                 appendOnly: true
                 batchPlan:
-                  tableRefId:
+                  tableDesc:
                     tableId: 2
+                    pk:
+                      - columnDesc:
+                          columnType:
+                            typeName: INT64
+                            isNullable: true
+                          name: _row_id
+                        order: ASCENDING
                   columnDescs:
                     - columnType:
                         typeName: INT32
@@ -144,8 +151,15 @@
               - 1
             appendOnly: true
             batchPlan:
-              tableRefId:
+              tableDesc:
                 tableId: 2
+                pk:
+                  - columnDesc:
+                      columnType:
+                        typeName: INT64
+                        isNullable: true
+                      name: _row_id
+                    order: ASCENDING
               columnDescs:
                 - columnType:
                     typeName: INT32
@@ -245,8 +259,15 @@
               - 1
             appendOnly: true
             batchPlan:
-              tableRefId:
+              tableDesc:
                 tableId: 2
+                pk:
+                  - columnDesc:
+                      columnType:
+                        typeName: INT64
+                        isNullable: true
+                      name: _row_id
+                    order: ASCENDING
               columnDescs:
                 - columnType:
                     typeName: INT32
@@ -352,8 +373,15 @@
                       - 1
                     appendOnly: true
                     batchPlan:
-                      tableRefId:
+                      tableDesc:
                         tableId: 2
+                        pk:
+                          - columnDesc:
+                              columnType:
+                                typeName: INT64
+                                isNullable: true
+                              name: _row_id
+                            order: ASCENDING
                       columnDescs:
                         - columnType:
                             typeName: INT32
@@ -503,8 +531,15 @@
                               - 2
                             appendOnly: true
                             batchPlan:
-                              tableRefId:
+                              tableDesc:
                                 tableId: 2
+                                pk:
+                                  - columnDesc:
+                                      columnType:
+                                        typeName: INT64
+                                        isNullable: true
+                                      name: _row_id
+                                    order: ASCENDING
                               columnDescs:
                                 - columnType:
                                     typeName: INT32

--- a/src/frontend/test_runner/tests/testdata/stream_proto.yaml
+++ b/src/frontend/test_runner/tests/testdata/stream_proto.yaml
@@ -15,7 +15,7 @@
                 batchPlan:
                   tableDesc:
                     tableId: 2
-                    pk:
+                    orderKey:
                       - columnDesc:
                           columnType:
                             typeName: INT64
@@ -153,7 +153,7 @@
             batchPlan:
               tableDesc:
                 tableId: 2
-                pk:
+                orderKey:
                   - columnDesc:
                       columnType:
                         typeName: INT64
@@ -261,7 +261,7 @@
             batchPlan:
               tableDesc:
                 tableId: 2
-                pk:
+                orderKey:
                   - columnDesc:
                       columnType:
                         typeName: INT64
@@ -375,7 +375,7 @@
                     batchPlan:
                       tableDesc:
                         tableId: 2
-                        pk:
+                        orderKey:
                           - columnDesc:
                               columnType:
                                 typeName: INT64
@@ -533,7 +533,7 @@
                             batchPlan:
                               tableDesc:
                                 tableId: 2
-                                pk:
+                                orderKey:
                                   - columnDesc:
                                       columnType:
                                         typeName: INT64

--- a/src/storage/src/table/cell_based_table.rs
+++ b/src/storage/src/table/cell_based_table.rs
@@ -573,7 +573,7 @@ impl<S: StateStore> DedupPkCellBasedTableRowIter<S> {
         table_descs: Vec<ColumnDesc>,
         epoch: u64,
         _stats: Arc<StateStoreMetrics>,
-        pk_descs: &Vec<OrderedColumnDesc>,
+        pk_descs: &[OrderedColumnDesc],
     ) -> StorageResult<Self> {
         let inner =
             CellBasedTableRowIter::new(&keyspace, table_descs.clone(), epoch, _stats).await?;

--- a/src/storage/src/table/cell_based_table.rs
+++ b/src/storage/src/table/cell_based_table.rs
@@ -322,7 +322,7 @@ impl<S: StateStore> CellBasedTable<S> {
     pub async fn iter_with_pk(
         &self,
         epoch: u64,
-        pk_descs: Vec<OrderedColumnDesc>,
+        pk_descs: &Vec<OrderedColumnDesc>,
     ) -> StorageResult<DedupPkCellBasedTableRowIter<S>> {
         DedupPkCellBasedTableRowIter::new(
             self.keyspace.clone(),
@@ -573,7 +573,7 @@ impl<S: StateStore> DedupPkCellBasedTableRowIter<S> {
         table_descs: Vec<ColumnDesc>,
         epoch: u64,
         _stats: Arc<StateStoreMetrics>,
-        pk_descs: Vec<OrderedColumnDesc>,
+        pk_descs: &Vec<OrderedColumnDesc>,
     ) -> StorageResult<Self> {
         let inner =
             CellBasedTableRowIter::new(&keyspace, table_descs.clone(), epoch, _stats).await?;

--- a/src/storage/src/table/cell_based_table.rs
+++ b/src/storage/src/table/cell_based_table.rs
@@ -322,7 +322,7 @@ impl<S: StateStore> CellBasedTable<S> {
     pub async fn iter_with_pk(
         &self,
         epoch: u64,
-        pk_descs: &Vec<OrderedColumnDesc>,
+        pk_descs: &[OrderedColumnDesc],
     ) -> StorageResult<DedupPkCellBasedTableRowIter<S>> {
         DedupPkCellBasedTableRowIter::new(
             self.keyspace.clone(),

--- a/src/storage/src/table/test_relational_table.rs
+++ b/src/storage/src/table/test_relational_table.rs
@@ -1478,7 +1478,7 @@ async fn test_dedup_cell_based_table_iter_with(
     let mut actual_rows = vec![];
 
     // ---------- Init reader
-    let mut iter = table.iter_with_pk(epoch, pk_ordered_descs).await.unwrap();
+    let mut iter = table.iter_with_pk(epoch, &pk_ordered_descs).await.unwrap();
     for _ in 0..rows.len() {
         // ---------- Read + Deserialize from storage
         let actual = iter.next().await.unwrap();

--- a/src/stream/src/executor/batch_query.rs
+++ b/src/stream/src/executor/batch_query.rs
@@ -154,6 +154,9 @@ mod test {
 
     use super::*;
     use crate::executor::mview::test_utils::gen_basic_table;
+    use risingwave_common::types::DataType;
+    use risingwave_common::util::sort_util::OrderType;
+    use risingwave_common::catalog::{ColumnDesc, ColumnId};
 
     #[tokio::test]
     async fn test_basic() {
@@ -173,13 +176,24 @@ mod test {
             }
             builder.finish()
         };
+        let pk_descs = Arc::new(vec![
+            OrderedColumnDesc {
+                column_desc: ColumnDesc::unnamed(ColumnId::from(0), DataType::Int32),
+                order: OrderType::Ascending,
+            },
+            OrderedColumnDesc {
+                column_desc: ColumnDesc::unnamed(ColumnId::from(1), DataType::Int32),
+                order: OrderType::Descending,
+            },
+        ]);
+
         let executor = Box::new(BatchQueryExecutor::new(
             table,
             Some(test_batch_size),
             info,
             vec![],
             hash_filter,
-            Arc::new(vec![]), // TODO: update
+            pk_descs,
         ));
 
         let stream = executor.execute_with_epoch(u64::MAX);

--- a/src/stream/src/executor/batch_query.rs
+++ b/src/stream/src/executor/batch_query.rs
@@ -24,7 +24,7 @@ use risingwave_storage::StateStore;
 
 use super::error::StreamExecutorError;
 use super::{Executor, ExecutorInfo, Message};
-use crate::executor::{Arc, BoxedMessageStream};
+use crate::executor::BoxedMessageStream;
 
 pub struct BatchQueryExecutor<S: StateStore> {
     /// The [`CellBasedTable`] that needs to be queried
@@ -43,7 +43,7 @@ pub struct BatchQueryExecutor<S: StateStore> {
 
     /// public key field descriptors. Used to decode pk into datums
     /// for dedup pk encoding.
-    pk_descs: Arc<Vec<OrderedColumnDesc>>,
+    pk_descs: Vec<OrderedColumnDesc>,
 }
 
 impl<S> BatchQueryExecutor<S>
@@ -58,7 +58,7 @@ where
         info: ExecutorInfo,
         key_indices: Vec<usize>,
         hash_filter: Bitmap,
-        pk_descs: Arc<Vec<OrderedColumnDesc>>,
+        pk_descs: Vec<OrderedColumnDesc>,
     ) -> Self {
         Self {
             table,
@@ -175,7 +175,7 @@ mod test {
             }
             builder.finish()
         };
-        let pk_descs = Arc::new(vec![
+        let pk_descs = vec![
             OrderedColumnDesc {
                 column_desc: ColumnDesc::unnamed(ColumnId::from(0), DataType::Int32),
                 order: OrderType::Ascending,
@@ -184,7 +184,7 @@ mod test {
                 column_desc: ColumnDesc::unnamed(ColumnId::from(1), DataType::Int32),
                 order: OrderType::Descending,
             },
-        ]);
+        ];
 
         let executor = Box::new(BatchQueryExecutor::new(
             table,

--- a/src/stream/src/executor/batch_query.rs
+++ b/src/stream/src/executor/batch_query.rs
@@ -72,7 +72,6 @@ where
 
     #[try_stream(ok = Message, error = StreamExecutorError)]
     async fn execute_inner(self, epoch: u64) {
-        // FIXME: use pk_descs as a reference instead, since we only read from it.
         let mut iter = self.table.iter_with_pk(epoch, &self.pk_descs).await?;
 
         while let Some(data_chunk) = iter

--- a/src/stream/src/executor/batch_query.rs
+++ b/src/stream/src/executor/batch_query.rs
@@ -16,7 +16,7 @@ use futures::StreamExt;
 use futures_async_stream::try_stream;
 use risingwave_common::array::{DataChunk, Op, StreamChunk};
 use risingwave_common::buffer::{Bitmap, BitmapBuilder};
-use risingwave_common::catalog::Schema;
+use risingwave_common::catalog::{OrderedColumnDesc, Schema};
 use risingwave_common::hash::VIRTUAL_NODE_COUNT;
 use risingwave_common::util::hash_util::CRC32FastBuilder;
 use risingwave_storage::table::cell_based_table::{CellBasedTable, CellTableChunkIter};
@@ -40,6 +40,10 @@ pub struct BatchQueryExecutor<S: StateStore> {
 
     /// vnode bitmap used to filter data belong to this parallel unit.
     hash_filter: Bitmap,
+
+    /// public key field descriptors. Used to decode pk into datums
+    /// for dedup pk encoding.
+    pk_descs: Vec<OrderedColumnDesc>,
 }
 
 impl<S> BatchQueryExecutor<S>
@@ -54,6 +58,7 @@ where
         info: ExecutorInfo,
         key_indices: Vec<usize>,
         hash_filter: Bitmap,
+        pk_descs: Vec<OrderedColumnDesc>,
     ) -> Self {
         Self {
             table,
@@ -61,12 +66,14 @@ where
             info,
             key_indices,
             hash_filter,
+            pk_descs,
         }
     }
 
     #[try_stream(ok = Message, error = StreamExecutorError)]
     async fn execute_inner(self, epoch: u64) {
-        let mut iter = self.table.iter(epoch).await?;
+        // FIXME: use pk_descs as a reference instead
+        let mut iter = self.table.iter_with_pk(epoch, self.pk_descs.clone()).await?;
 
         while let Some(data_chunk) = iter
             .collect_data_chunk(self.schema(), Some(self.batch_size))
@@ -172,6 +179,7 @@ mod test {
             info,
             vec![],
             hash_filter,
+            vec![], // TODO: update
         ));
 
         let stream = executor.execute_with_epoch(u64::MAX);

--- a/src/stream/src/executor/batch_query.rs
+++ b/src/stream/src/executor/batch_query.rs
@@ -151,12 +151,12 @@ mod test {
     use std::vec;
 
     use futures_async_stream::for_await;
+    use risingwave_common::catalog::{ColumnDesc, ColumnId};
+    use risingwave_common::types::DataType;
+    use risingwave_common::util::sort_util::OrderType;
 
     use super::*;
     use crate::executor::mview::test_utils::gen_basic_table;
-    use risingwave_common::types::DataType;
-    use risingwave_common::util::sort_util::OrderType;
-    use risingwave_common::catalog::{ColumnDesc, ColumnId};
 
     #[tokio::test]
     async fn test_basic() {

--- a/src/stream/src/from_proto/batch_query.rs
+++ b/src/stream/src/from_proto/batch_query.rs
@@ -38,7 +38,7 @@ impl ExecutorBuilder for BatchQueryExecutorBuilder {
         let node = try_match_expand!(node.get_node_body().unwrap(), NodeBody::BatchPlan)?;
         let table_id = node.table_desc.as_ref().unwrap().table_id.into();
 
-        let pk_descs_proto = &node.table_desc.as_ref().unwrap().order_keys;
+        let pk_descs_proto = &node.table_desc.as_ref().unwrap().order_key;
         let pk_descs = pk_descs_proto.iter().map(|d| d.into()).collect();
 
         let column_descs = node

--- a/src/stream/src/from_proto/batch_query.rs
+++ b/src/stream/src/from_proto/batch_query.rs
@@ -82,7 +82,7 @@ impl ExecutorBuilder for BatchQueryExecutorBuilder {
             },
             key_indices,
             hash_filter,
-            pk_descs,
+            Arc::new(pk_descs),
         );
 
         Ok(executor.boxed())

--- a/src/stream/src/from_proto/batch_query.rs
+++ b/src/stream/src/from_proto/batch_query.rs
@@ -82,7 +82,7 @@ impl ExecutorBuilder for BatchQueryExecutorBuilder {
             },
             key_indices,
             hash_filter,
-            Arc::new(pk_descs),
+            pk_descs,
         );
 
         Ok(executor.boxed())

--- a/src/stream/src/from_proto/batch_query.rs
+++ b/src/stream/src/from_proto/batch_query.rs
@@ -38,7 +38,7 @@ impl ExecutorBuilder for BatchQueryExecutorBuilder {
         let node = try_match_expand!(node.get_node_body().unwrap(), NodeBody::BatchPlan)?;
         let table_id = node.table_desc.as_ref().unwrap().table_id.into();
 
-        let pk_descs_proto = &node.table_desc.as_ref().unwrap().pk;
+        let pk_descs_proto = &node.table_desc.as_ref().unwrap().order_keys;
         let pk_descs = pk_descs_proto.iter().map(|d| d.into()).collect();
 
         let column_descs = node

--- a/src/stream/src/from_proto/batch_query.rs
+++ b/src/stream/src/from_proto/batch_query.rs
@@ -16,7 +16,7 @@ use std::sync::Arc;
 
 use itertools::Itertools;
 use risingwave_common::buffer::{Bitmap, BitmapBuilder};
-use risingwave_common::catalog::{ColumnDesc, TableId};
+use risingwave_common::catalog::ColumnDesc;
 use risingwave_common::hash::VIRTUAL_NODE_COUNT;
 use risingwave_pb::common::ParallelUnitMapping;
 use risingwave_storage::monitor::StateStoreMetrics;
@@ -36,7 +36,7 @@ impl ExecutorBuilder for BatchQueryExecutorBuilder {
         _stream: &mut LocalStreamManagerCore,
     ) -> Result<BoxedExecutor> {
         let node = try_match_expand!(node.get_node_body().unwrap(), NodeBody::BatchPlan)?;
-        let table_id = TableId::from(&node.table_ref_id);
+        let table_id = node.table_desc.as_ref().unwrap().table_id.into();
         let column_descs = node
             .column_descs
             .iter()

--- a/src/stream/src/from_proto/batch_query.rs
+++ b/src/stream/src/from_proto/batch_query.rs
@@ -37,6 +37,10 @@ impl ExecutorBuilder for BatchQueryExecutorBuilder {
     ) -> Result<BoxedExecutor> {
         let node = try_match_expand!(node.get_node_body().unwrap(), NodeBody::BatchPlan)?;
         let table_id = node.table_desc.as_ref().unwrap().table_id.into();
+
+        let pk_descs_proto = &node.table_desc.as_ref().unwrap().pk;
+        let pk_descs = pk_descs_proto.iter().map(|d| d.into()).collect();
+
         let column_descs = node
             .column_descs
             .iter()
@@ -78,6 +82,7 @@ impl ExecutorBuilder for BatchQueryExecutorBuilder {
             },
             key_indices,
             hash_filter,
+            pk_descs,
         );
 
         Ok(executor.boxed())


### PR DESCRIPTION
## What's changed and what's your intention?

- Summarize your change (**mandatory**)
  - Continued from https://github.com/singularity-data/risingwave/pull/2957.
  - Adds dedup pk decoding to `BatchQueryExecutor`.
  - Changes `pk_descs` to pass by reference to `DedupPkCellBasedTableIter`. This avoids a `clone` of `pk_descs` each time we call the `execute_inner` method of `BatchQueryExecutor`.

## Checklist

- [x] I have written necessary docs and comments
- [x] I have added necessary unit tests and integration tests
- [x] All checks passed in `./risedev check` (or alias, `./risedev c`)

## Refer to a related PR or issue link (optional)

related #588