### PR TITLE
refactor: using barrier to initialize the source actor

### DIFF
--- a/proto/data.proto
+++ b/proto/data.proto
@@ -158,6 +158,7 @@ message UpdateMutation {
 
 message AddMutation {
   repeated DispatcherMutation mutations = 1;
+  repeated SourceChangeSplit splits = 2;
 }
 
 message SourceChangeSplitMutation {

--- a/proto/stream_plan.proto
+++ b/proto/stream_plan.proto
@@ -24,15 +24,6 @@ message SourceNode {
   plan_common.TableRefId table_ref_id = 1;
   repeated int32 column_ids = 2;
   SourceType source_type = 3;
-  // split allocation information,
-  // and in the future will distinguish between `StreamSource` and `TableSource`
-  // so that there is no need to put many fields that are not common into the same SourceNode structure
-  StreamSourceState stream_source_state = 4;
-}
-
-message StreamSourceState {
-  string split_type = 1;
-  repeated bytes stream_source_splits = 2;
 }
 
 message ProjectNode {

--- a/src/compute/tests/integration_tests.rs
+++ b/src/compute/tests/integration_tests.rs
@@ -149,7 +149,6 @@ async fn test_table_v2_materialize() -> Result<()> {
         1,
         "SourceExecutor".to_string(),
         Arc::new(StreamingMetrics::unused()),
-        vec![],
         u64::MAX,
     )?;
 

--- a/src/frontend/src/optimizer/plan_node/stream_source.rs
+++ b/src/frontend/src/optimizer/plan_node/stream_source.rs
@@ -79,7 +79,6 @@ impl ToStreamProst for StreamSource {
                 .map(|c| c.column_id().into())
                 .collect(),
             source_type: self.logical.source_catalog.source_type as i32,
-            stream_source_state: None,
         })
     }
 }

--- a/src/meta/src/barrier/command.rs
+++ b/src/meta/src/barrier/command.rs
@@ -18,11 +18,12 @@ use futures::future::try_join_all;
 use risingwave_common::catalog::TableId;
 use risingwave_common::error::{Result, RwError, ToRwResult};
 use risingwave_common::util::epoch::Epoch;
-
-use risingwave_connector::{SplitImpl};
+use risingwave_connector::SplitImpl;
 use risingwave_pb::common::ActorInfo;
 use risingwave_pb::data::barrier::Mutation;
-use risingwave_pb::data::{AddMutation, DispatcherMutation, NothingMutation, StopMutation};
+use risingwave_pb::data::{
+    AddMutation, DispatcherMutation, NothingMutation, SourceChangeSplit, StopMutation,
+};
 use risingwave_pb::stream_service::DropActorsRequest;
 use risingwave_rpc_client::StreamClientPoolRef;
 use uuid::Uuid;
@@ -132,7 +133,11 @@ where
                 Mutation::Stop(StopMutation { actors })
             }
 
-            Command::CreateMaterializedView { dispatches, .. } => {
+            Command::CreateMaterializedView {
+                dispatches,
+                source_state,
+                ..
+            } => {
                 let mutations = dispatches
                     .iter()
                     .map(
@@ -143,7 +148,24 @@ where
                         },
                     )
                     .collect();
-                Mutation::Add(AddMutation { mutations })
+
+                let splits = source_state
+                    .iter()
+                    .filter(|(_, splits)| !splits.is_empty())
+                    .map(|(actor_id, splits)| {
+                        let split_type = splits.iter().next().unwrap().get_type();
+                        SourceChangeSplit {
+                            actor_id: *actor_id,
+                            split_type,
+                            source_splits: splits
+                                .iter()
+                                .map(|split| split.to_json_bytes().to_vec())
+                                .collect(),
+                        }
+                    })
+                    .collect();
+
+                Mutation::Add(AddMutation { mutations, splits })
             }
         };
 

--- a/src/meta/src/barrier/command.rs
+++ b/src/meta/src/barrier/command.rs
@@ -18,8 +18,8 @@ use futures::future::try_join_all;
 use risingwave_common::catalog::TableId;
 use risingwave_common::error::{Result, RwError, ToRwResult};
 use risingwave_common::util::epoch::Epoch;
-use risingwave_connector::state::SourceState;
-use risingwave_connector::{ConnectorState, SplitImpl};
+
+use risingwave_connector::{SplitImpl};
 use risingwave_pb::common::ActorInfo;
 use risingwave_pb::data::barrier::Mutation;
 use risingwave_pb::data::{AddMutation, DispatcherMutation, NothingMutation, StopMutation};

--- a/src/meta/src/barrier/command.rs
+++ b/src/meta/src/barrier/command.rs
@@ -18,6 +18,8 @@ use futures::future::try_join_all;
 use risingwave_common::catalog::TableId;
 use risingwave_common::error::{Result, RwError, ToRwResult};
 use risingwave_common::util::epoch::Epoch;
+use risingwave_connector::state::SourceState;
+use risingwave_connector::{ConnectorState, SplitImpl};
 use risingwave_pb::common::ActorInfo;
 use risingwave_pb::data::barrier::Mutation;
 use risingwave_pb::data::{AddMutation, DispatcherMutation, NothingMutation, StopMutation};
@@ -60,6 +62,7 @@ pub enum Command {
         table_fragments: TableFragments,
         table_sink_map: HashMap<TableId, Vec<ActorId>>,
         dispatches: HashMap<(ActorId, DispatcherId), Vec<ActorInfo>>,
+        source_state: HashMap<ActorId, Vec<SplitImpl>>,
     },
 }
 
@@ -194,6 +197,7 @@ where
                 table_fragments,
                 dispatches,
                 table_sink_map,
+                source_state: _source_state,
             } => {
                 let mut dependent_table_actors = Vec::with_capacity(table_sink_map.len());
                 for (table_id, actors) in table_sink_map {

--- a/src/meta/src/stream/source_manager.rs
+++ b/src/meta/src/stream/source_manager.rs
@@ -12,18 +12,21 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+
+use std::borrow::BorrowMut;
 use std::collections::{BTreeMap, HashMap, HashSet};
-use std::sync::Arc;
+use std::sync::{Arc};
 use std::time::Duration;
 
 use futures::future::try_join_all;
 use itertools::Itertools;
-use risingwave_common::error::ErrorCode::{ConnectorError, InternalError};
+use risingwave_common::catalog::TableId;
+use risingwave_common::error::ErrorCode::{InternalError};
 use risingwave_common::error::{internal_error, Result, RwError, ToRwResult};
-use risingwave_common::{ensure, try_match_expand};
+use risingwave_common::{try_match_expand};
 use risingwave_connector::{ConnectorProperties, SplitEnumeratorImpl, SplitImpl};
 use risingwave_pb::catalog::source::Info;
-use risingwave_pb::catalog::{Source};
+use risingwave_pb::catalog::Source;
 use risingwave_pb::common::worker_node::State::Running;
 use risingwave_pb::common::WorkerType;
 use risingwave_pb::stream_service::{
@@ -31,9 +34,10 @@ use risingwave_pb::stream_service::{
     DropSourceRequest as ComputeNodeDropSourceRequest,
 };
 use risingwave_rpc_client::StreamClient;
-use tokio::sync::{Mutex};
+use tokio::sync::{Mutex, oneshot};
 use tokio::task::JoinHandle;
-use tokio::time;
+use tokio::{select, time};
+use tokio::sync::mpsc::{UnboundedReceiver, UnboundedSender};
 use tokio::time::MissedTickBehavior;
 
 use crate::barrier::BarrierManagerRef;
@@ -88,40 +92,51 @@ impl ConnectorSourceWorker {
         })
     }
 
-    pub async fn run(&mut self) {
+    pub async fn run(&mut self, mut sync_call_rx: UnboundedReceiver<oneshot::Sender<Result<()>>>) {
         let mut interval = time::interval(self.period);
         interval.set_missed_tick_behavior(MissedTickBehavior::Skip);
         loop {
-            interval.tick().await;
-
-            let splits = match self.enumerator.list_splits().await {
-                Ok(s) => s,
-                Err(e) => {
-                    log::error!(
-                        "error happened when fetching split from source {}, {}",
-                        self.source_id,
-                        e.to_string()
-                    );
-                    continue;
+            select! {
+                biased;
+                tx = sync_call_rx.borrow_mut().recv() => {
+                    if let Some(tx) = tx {
+                        let _ = tx.send(self.tick().await);
+                    }
                 }
-            };
-
-            let mut current_splits = self.current_splits.lock().await;
-            current_splits.splits.replace(
-                splits
-                    .into_iter()
-                    .map(|split| (split.id(), split))
-                    .collect(),
-            );
+                _ = interval.tick() => {
+                    if let Err(e) = self.tick().await {
+                        log::error!("error happened when tick from connector source worker: {}", e.to_string());
+                    }
+                }
+            }
         }
     }
+
+    async fn tick(&mut self) -> Result<()> {
+        let splits = self.enumerator.list_splits().await.to_rw_result()?;
+        let mut current_splits = self.current_splits.lock().await;
+        current_splits.splits.replace(
+            splits
+                .into_iter()
+                .map(|split| (split.id(), split))
+                .collect(),
+        );
+
+        Ok(())
+    }
+}
+
+pub struct ConnectorSourceWorkerHandle {
+    handle: JoinHandle<()>,
+    sync_call_tx: UnboundedSender<oneshot::Sender<Result<()>>>,
+    splits: SharedSplitMapRef,
 }
 
 pub struct SourceManagerCore<S: MetaStore> {
     pub fragment_manager: FragmentManagerRef<S>,
 
     // may fetch from catalog
-    pub managed_sources: HashMap<SourceId, (SharedSplitMapRef, JoinHandle<()>)>,
+    pub managed_sources: HashMap<SourceId, ConnectorSourceWorkerHandle>,
 
     // may fetch from catalog
     pub source_fragments: HashMap<SourceId, Vec<FragmentId>>,
@@ -142,8 +157,6 @@ impl<S> SourceManagerCore<S>
             actor_splits: HashMap::new(),
         }
     }
-
-    // async fn register_source(&self, source: &Source) -> Result<()> {}
 
     // async fn diff(&mut self) -> Result<HashMap<ActorId, Vec<SplitImpl>>> {
     //     // first, list all fragment, so that we can get `FragmentId` -> `Vec<ActorId>` map
@@ -208,48 +221,48 @@ impl<S> SourceManagerCore<S>
     //
     //     Ok(changed_actors)
     // }
+}
 
-    fn diff_splits(
-        mut prev_actor_splits: HashMap<ActorId, Vec<SplitImpl>>,
-        discovered_splits: &BTreeMap<String, SplitImpl>,
-    ) -> Result<Option<HashMap<ActorId, Vec<SplitImpl>>>> {
-        let prev_split_ids: HashSet<_> = prev_actor_splits
-            .values()
-            .flat_map(|splits| splits.iter().map(SplitImpl::id))
-            .collect();
+fn diff_splits(
+    mut prev_actor_splits: HashMap<ActorId, Vec<SplitImpl>>,
+    discovered_splits: &BTreeMap<String, SplitImpl>,
+) -> Option<HashMap<ActorId, Vec<SplitImpl>>> {
+    let prev_split_ids: HashSet<_> = prev_actor_splits
+        .values()
+        .flat_map(|splits| splits.iter().map(SplitImpl::id))
+        .collect();
 
-        if discovered_splits
-            .keys()
-            .all(|split_id| prev_split_ids.contains(split_id))
-        {
-            return Ok(None);
-        }
-
-        let mut new_discovered_splits = HashSet::new();
-        for (split_id, split) in discovered_splits {
-            if !prev_split_ids.contains(split_id) {
-                new_discovered_splits.insert(split.id());
-            }
-        }
-
-        let mut result = HashMap::new();
-
-        let actors = prev_actor_splits.keys().cloned().collect_vec();
-        let actor_len = actors.len();
-
-        for (index, split_id) in new_discovered_splits.into_iter().enumerate() {
-            let target_actor_id = actors[index % actor_len];
-            let split = discovered_splits.get(&split_id).unwrap().clone();
-
-            result
-                .entry(target_actor_id)
-                .or_insert_with(|| prev_actor_splits.remove(&target_actor_id).unwrap());
-
-            result.get_mut(&target_actor_id).unwrap().push(split);
-        }
-
-        Ok(Some(result))
+    if discovered_splits
+        .keys()
+        .all(|split_id| prev_split_ids.contains(split_id))
+    {
+        return None;
     }
+
+    let mut new_discovered_splits = HashSet::new();
+    for (split_id, split) in discovered_splits {
+        if !prev_split_ids.contains(split_id) {
+            new_discovered_splits.insert(split.id());
+        }
+    }
+
+    let mut result = HashMap::new();
+
+    let actors = prev_actor_splits.keys().cloned().collect_vec();
+    let actor_len = actors.len();
+
+    for (index, split_id) in new_discovered_splits.into_iter().enumerate() {
+        let target_actor_id = actors[index % actor_len];
+        let split = discovered_splits.get(&split_id).unwrap().clone();
+
+        result
+            .entry(target_actor_id)
+            .or_insert_with(|| prev_actor_splits.remove(&target_actor_id).unwrap());
+
+        result.get_mut(&target_actor_id).unwrap().push(split);
+    }
+
+    Some(result)
 }
 
 impl<S> SourceManager<S>
@@ -274,107 +287,71 @@ impl<S> SourceManager<S>
         })
     }
 
-    pub async fn register_source(
-        &self,
-        source_fragments: HashMap<SourceId, Vec<FragmentId>>,
-        affiliated_source: Option<Source>,
-    ) -> Result<()> {
+    pub async fn patch_update(&self,
+                              source_fragments: Option<HashMap<SourceId, Vec<FragmentId>>>,
+                              actor_splits: Option<HashMap<ActorId, Vec<SplitImpl>>>) {
         let mut core = self.core.lock().await;
-
-        let source_ref = &affiliated_source;
-
-        if let Some(source) = source_ref {
-            ensure!(
-                source_fragments.len() == 1,
-                "only one source should exist when creating materialized source"
-            );
-            let mut source_entry = source_fragments.into_iter().next().unwrap();
-            ensure!(source_entry.0 == source.id);
-            core.source_fragments
-                .entry(source.id)
-                .or_insert(vec![])
-                .append(&mut source_entry.1);
-        } else {
-            for (source_id, mut fragments) in source_fragments {
-                core.source_fragments
-                    .entry(source_id)
-                    .or_insert(vec![])
-                    .append(&mut fragments);
+        if let Some(source_fragments) = source_fragments {
+            for (source_id, mut fragment_ids) in source_fragments {
+                core.source_fragments.entry(source_id).or_insert(vec![]).append(&mut fragment_ids);
             }
         }
 
-        Ok(())
-    }
-
-    async fn fetch_splits_for_source(&self, source: &Source) -> Result<Vec<SplitImpl>> {
-        let info = match source.get_info()? {
-            Info::StreamSource(s) => s,
-            _ => {
-                return Err(RwError::from(InternalError(
-                    "for now we only support StreamSource in source manager".to_string(),
-                )));
+        if let Some(actor_splits) = actor_splits {
+            for (actor_id, mut splits) in actor_splits {
+                core.actor_splits.entry(actor_id).or_insert(vec![]).append(&mut splits);
+                //TODO store state
             }
-        };
-
-        let properties = ConnectorProperties::extract(info.properties.clone())
-            .map_err(|e| RwError::from(ConnectorError(e.to_string())))?;
-
-        SplitEnumeratorImpl::create(properties)
-            .await
-            .to_rw_result()?
-            .list_splits()
-            .await
-            .to_rw_result()
+        }
     }
 
-    /// Perform one-time split scheduling, using the round-robin method to assign splits to the
-    /// source actor under the same fragment Note that the same Materialized View will have
-    /// multiple identical Sources to join, so there will be multiple groups of Actors under same
-    /// `SourceId`
-    pub async fn schedule_split_for_actors(
+    pub async fn pre_allocate_splits(
         &self,
-        actors: HashMap<SourceId, Vec<Vec<ActorId>>>,
-        affiliated_source: Option<Source>,
+        table_id: &TableId,
+        source_fragments: HashMap<SourceId, Vec<FragmentId>>,
     ) -> Result<HashMap<ActorId, Vec<SplitImpl>>> {
-        let source_ref = &affiliated_source;
-        let source_splits = try_join_all(actors.keys().map(|source_id| async move {
-            if let Some(affiliated_source) = source_ref && *source_id == affiliated_source.get_id() {
-                // we are creating materialized source
-                self.fetch_splits_for_source(affiliated_source).await
-            } else {
-                let catalog_guard = self.catalog_manager.get_catalog_core_guard().await;
-                let source = catalog_guard.get_source(*source_id).await?.ok_or_else(|| {
-                    RwError::from(InternalError(format!(
-                        "could not find source catalog for {}",
-                        source_id
-                    )))
-                })?;
-                self.fetch_splits_for_source(&source).await
-            }
-        }))
+        let core = self.core.lock().await;
+        let table_fragments = core
+            .fragment_manager
+            .select_table_fragments_by_table_id(table_id)
             .await?;
-        let mut result = HashMap::new();
 
-        for (splits, fragments) in source_splits.into_iter().zip_eq(actors.into_values()) {
-            log::debug!("found {} splits", splits.len());
-            for actors in fragments {
-                let actor_count = actors.len();
-                let mut chunks = vec![vec![]; actor_count];
-                for (i, split) in splits.iter().enumerate() {
-                    chunks[i % actor_count].push(split.clone());
+        let mut assigned = HashMap::new();
+
+        for (source_id, fragments) in source_fragments {
+            let handle = core
+                .managed_sources
+                .get(&source_id)
+                .ok_or_else(|| internal_error(format!(
+                    "could not found source {}",
+                    source_id
+                )))?;
+
+            if handle.splits.lock().await.splits.is_none() {
+                // force refresh source
+                let (tx, rx) = oneshot::channel();
+                handle.sync_call_tx.send(tx).to_rw_result()?;
+                rx.await.map_err(|e| internal_error(e.to_string()))??;
+            }
+
+            if let Some(splits) = &handle.splits.lock().await.splits {
+                for fragment_id in fragments {
+                    let empty_actor_splits = table_fragments
+                        .fragments
+                        .get(&fragment_id)
+                        .ok_or_else(|| internal_error(format!(
+                            "could not found source {}",
+                            source_id
+                        )))?.actors.iter().map(|actor| (actor.actor_id, vec![])).collect();
+
+                    assigned.extend(diff_splits(empty_actor_splits, splits).unwrap());
                 }
-
-                actors
-                    .into_iter()
-                    .zip_eq(chunks)
-                    .into_iter()
-                    .for_each(|(actor_id, splits)| {
-                        result.insert(actor_id, splits.to_vec());
-                    })
+            } else {
+                unreachable!();
             }
         }
 
-        Ok(result)
+        Ok(assigned)
     }
 
     async fn all_stream_clients(&self) -> Result<impl Iterator<Item=StreamClient>> {
@@ -423,9 +400,16 @@ impl<S> SourceManager<S>
         let mut worker = ConnectorSourceWorker::create(source, Duration::from_secs(10)).await?;
         let current_splits_ref = worker.current_splits.clone();
         log::info!("Spawning new watcher for source {}", source.id);
-        let handle = tokio::spawn(async move { worker.run().await });
+
+        let (sync_call_tx, sync_call_rx) = tokio::sync::mpsc::unbounded_channel();
+
+        let handle = tokio::spawn(async move { worker.run(sync_call_rx).await });
         core.managed_sources
-            .insert(source.id, (current_splits_ref, handle));
+            .insert(source.id, ConnectorSourceWorkerHandle {
+                handle,
+                sync_call_tx,
+                splits: current_splits_ref,
+            });
 
         Ok(())
     }
@@ -442,17 +426,17 @@ impl<S> SourceManager<S>
         let _responses: Vec<_> = try_join_all(futures).await?;
 
         let mut core = self.core.lock().await;
-        if let Some((_, handle)) = core.managed_sources.remove(&source_id) {
-            handle.abort()
+        if let Some(handle) = core.managed_sources.remove(&source_id) {
+            handle.handle.abort();
         }
 
         Ok(())
     }
 
     async fn tick(&self) -> Result<()> {
-        let mut core_guard = self.core.lock().await;
+        let core_guard = self.core.lock().await;
 
-        for (id, x) in core_guard.managed_sources.iter() {
+        for (id, x) in &core_guard.managed_sources {
             let catalog_guard = self.catalog_manager.get_catalog_core_guard().await;
             let source = catalog_guard.get_source(*id).await?.ok_or_else(|| {
                 RwError::from(InternalError(format!(
@@ -461,8 +445,7 @@ impl<S> SourceManager<S>
                 )))
             })?;
 
-
-            let guard = x.0.lock().await;
+            let guard = x.splits.lock().await;
             println!("source: {}", source.name);
 
             if let Some(splits) = &guard.splits {
@@ -472,7 +455,6 @@ impl<S> SourceManager<S>
             }
         }
 
-
         // let x = {
         //     let mut core_guard = self.core.lock().await;
         //     core_guard.diff().await
@@ -480,7 +462,6 @@ impl<S> SourceManager<S>
         //
         // println!("{:?}", x);
         //
-
 
         Ok(())
     }

--- a/src/meta/src/stream/stream_manager.rs
+++ b/src/meta/src/stream/stream_manager.rs
@@ -597,8 +597,6 @@ where
             .pre_allocate_splits(&table_id, source_fragments.clone())
             .await?;
 
-        println!("result {:?}", init_split_assignment);
-
         if let Err(err) = self
             .barrier_manager
             .run_command(Command::CreateMaterializedView {

--- a/src/meta/src/stream/stream_manager.rs
+++ b/src/meta/src/stream/stream_manager.rs
@@ -26,7 +26,7 @@ use risingwave_pb::catalog::Source;
 use risingwave_pb::common::{ActorInfo, ParallelUnitMapping, WorkerType};
 use risingwave_pb::meta::table_fragments::{ActorState, ActorStatus};
 use risingwave_pb::stream_plan::stream_node::NodeBody;
-use risingwave_pb::stream_plan::{ActorMapping, DispatcherType, StreamNode, StreamSourceState};
+use risingwave_pb::stream_plan::{ActorMapping, DispatcherType, StreamNode};
 use risingwave_pb::stream_service::{
     BroadcastActorInfoTableRequest, BuildActorsRequest, HangingChannel, UpdateActorsRequest,
 };
@@ -293,7 +293,7 @@ where
             mut upstream_node_actors,
             table_sink_map,
             dependent_table_ids,
-            affiliated_source,
+            affiliated_source: _,
             table_id_offset: _,
             internal_table_id_set: _,
         }: CreateMaterializedViewContext,
@@ -434,80 +434,7 @@ where
             .collect();
 
         table_fragments.set_actor_status(actor_info);
-        let mut actor_map = table_fragments.actor_map();
-
-        let mut source_fragments = HashMap::new();
-        for fragment in table_fragments.fragments() {
-            for actor in &fragment.actors {
-                if let Some(source_id) =
-                    TableFragments::fetch_stream_source_id(actor.nodes.as_ref().unwrap())
-                {
-                    source_fragments
-                        .entry(source_id)
-                        .or_insert(vec![])
-                        .push(fragment.fragment_id as FragmentId);
-                }
-            }
-        }
-
-        self.source_manager
-            .register_source(source_fragments, affiliated_source.clone())
-            .await?;
-
-        let mut source_actors_group_by_fragment = HashMap::new();
-        for fragment in table_fragments.fragments() {
-            let mut source_actors = HashMap::new();
-            for actor in &fragment.actors {
-                if let Some(source_id) =
-                    TableFragments::fetch_stream_source_id(actor.nodes.as_ref().unwrap())
-                {
-                    source_actors
-                        .entry(source_id)
-                        .or_insert(vec![])
-                        .push(actor.actor_id as ActorId)
-                }
-            }
-
-            for (source_id, actors) in source_actors {
-                source_actors_group_by_fragment
-                    .entry(source_id)
-                    .or_insert(vec![])
-                    .push(actors)
-            }
-        }
-
-        let split_assignment = self
-            .source_manager
-            .schedule_split_for_actors(source_actors_group_by_fragment, affiliated_source)
-            .await?;
-
-        // patch source actors with splits
-        for (actor_id, actor) in &mut actor_map {
-            if let Some(splits) = split_assignment.get(actor_id) {
-                let mut node = actor.nodes.as_mut().unwrap();
-                while !node.input.is_empty() {
-                    node = node.input.first_mut().unwrap();
-                }
-
-                if let Some(NodeBody::Source(s)) = node.node_body.as_mut() {
-                    log::debug!(
-                        "patching source node #{} with splits {:?}",
-                        actor_id,
-                        splits
-                    );
-
-                    if !splits.is_empty() {
-                        s.stream_source_state = Some(StreamSourceState {
-                            split_type: splits.first().unwrap().get_type(),
-                            stream_source_splits: splits
-                                .iter()
-                                .map(|split| split.to_json_bytes().to_vec())
-                                .collect(),
-                        });
-                    }
-                }
-            }
-        }
+        let actor_map = table_fragments.actor_map();
 
         // Actors on each stream node will need to know where their upstream lies. `actor_info`
         // includes such information. It contains: 1. actors in the current create
@@ -645,11 +572,30 @@ where
                 .to_rw_result_with(|| format!("failed to connect to {}", node_id))?;
         }
 
+        let mut source_fragments = HashMap::new();
+        for fragment in table_fragments.fragments() {
+            for actor in &fragment.actors {
+                if let Some(source_id) =
+                    TableFragments::fetch_stream_source_id(actor.nodes.as_ref().unwrap())
+                {
+                    source_fragments
+                        .entry(source_id)
+                        .or_insert(vec![])
+                        .push(fragment.fragment_id as FragmentId);
+                }
+            }
+        }
+
         // Add table fragments to meta store with state: `State::Creating`.
         self.fragment_manager
             .start_create_table_fragments(table_fragments.clone())
             .await?;
+
         let table_id = table_fragments.table_id();
+        let result = self.source_manager.pre_allocate_splits(&table_id, source_fragments).await?;
+
+        println!("result {:?}", result);
+
         if let Err(err) = self
             .barrier_manager
             .run_command(Command::CreateMaterializedView {

--- a/src/meta/src/stream/test_fragmenter.rs
+++ b/src/meta/src/stream/test_fragmenter.rs
@@ -111,7 +111,6 @@ fn make_stream_node() -> StreamNode {
             table_ref_id: Some(table_ref_id),
             column_ids: vec![1, 2, 0],
             source_type: SourceType::Table as i32,
-            stream_source_state: None,
         })),
         pk_indices: vec![2],
         ..Default::default()

--- a/src/stream/src/executor/chain.rs
+++ b/src/stream/src/executor/chain.rs
@@ -145,7 +145,7 @@ mod test {
 
     use super::ChainExecutor;
     use crate::executor::test_utils::MockSource;
-    use crate::executor::{ActorInfo, Barrier, Executor, Message, Mutation, PkIndices};
+    use crate::executor::{ActorInfo, AddOutput, Barrier, Executor, Message, Mutation, PkIndices};
     use crate::task::{CreateMviewProgress, LocalBarrierManager};
 
     #[tokio::test]
@@ -168,16 +168,19 @@ mod test {
             PkIndices::new(),
             vec![
                 Message::Barrier(
-                    Barrier::new_test_barrier(1).with_mutation(Mutation::AddOutput({
-                        let mut actors = HashMap::default();
-                        actors.insert(
-                            (0, 233),
-                            vec![ActorInfo {
-                                actor_id: 0,
-                                host: None,
-                            }],
-                        );
-                        actors
+                    Barrier::new_test_barrier(1).with_mutation(Mutation::AddOutput(AddOutput {
+                        map: {
+                            let mut actors = HashMap::default();
+                            actors.insert(
+                                (0, 233),
+                                vec![ActorInfo {
+                                    actor_id: 0,
+                                    host: None,
+                                }],
+                            );
+                            actors
+                        },
+                        splits: Default::default(),
                     })),
                 ),
                 Message::Chunk(StreamChunk::from_pretty("I\n + 3")),

--- a/src/stream/src/executor/dispatch.rs
+++ b/src/stream/src/executor/dispatch.rs
@@ -221,8 +221,9 @@ impl DispatchExecutorInner {
 
             Mutation::AddOutput(adds) => {
                 for dispatcher in &mut self.dispatchers {
-                    if let Some(downstream_actor_infos) =
-                        adds.get(&(self.actor_id, dispatcher.get_dispatcher_id()))
+                    if let Some(downstream_actor_infos) = adds
+                        .map
+                        .get(&(self.actor_id, dispatcher.get_dispatcher_id()))
                     {
                         let mut outputs_to_add = Vec::with_capacity(downstream_actor_infos.len());
                         for downstream_actor_info in downstream_actor_infos {
@@ -783,7 +784,7 @@ mod tests {
 
     use super::*;
     use crate::executor::receiver::ReceiverExecutor;
-    use crate::executor::ActorContext;
+    use crate::executor::{ActorContext, AddOutput};
     use crate::task::{LOCAL_OUTPUT_CHANNEL_SIZE, LOCAL_TEST_ADDR};
 
     #[derive(Debug)]
@@ -985,13 +986,16 @@ mod tests {
         add_local_channels(ctx.clone(), vec![(233, 245)]);
         add_remote_channels(ctx.clone(), 233, vec![246]);
         tx.send(Message::Barrier(
-            Barrier::new_test_barrier(1).with_mutation(Mutation::AddOutput({
-                let mut actors = HashMap::default();
-                actors.insert(
-                    (233, 666),
-                    vec![helper_make_local_actor(245), helper_make_remote_actor(246)],
-                );
-                actors
+            Barrier::new_test_barrier(1).with_mutation(Mutation::AddOutput(AddOutput {
+                map: {
+                    let mut actors = HashMap::default();
+                    actors.insert(
+                        (233, 666),
+                        vec![helper_make_local_actor(245), helper_make_remote_actor(246)],
+                    );
+                    actors
+                },
+                splits: HashMap::new(),
             })),
         ))
         .await

--- a/src/stream/src/executor/mod.rs
+++ b/src/stream/src/executor/mod.rs
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use std::borrow::Borrow;
 use std::fmt::Debug;
 use std::sync::Arc;
 
@@ -19,6 +20,7 @@ use enum_as_inner::EnumAsInner;
 use error::StreamExecutorResult;
 use futures::stream::BoxStream;
 use futures::{Stream, StreamExt};
+use itertools::Itertools;
 use madsim::collections::{HashMap, HashSet};
 use risingwave_common::array::column::Column;
 use risingwave_common::array::{ArrayImpl, ArrayRef, DataChunk, StreamChunk};
@@ -101,6 +103,7 @@ pub use union::UnionExecutor;
 pub type BoxedExecutor = Box<dyn Executor>;
 pub type BoxedMessageStream = BoxStream<'static, StreamExecutorResult<Message>>;
 pub type MessageStreamItem = StreamExecutorResult<Message>;
+
 pub trait MessageStream = futures::Stream<Item = MessageStreamItem> + Send;
 
 /// The maximum chunk length produced by executor at a time.
@@ -162,11 +165,18 @@ pub const INVALID_EPOCH: u64 = 0;
 
 pub trait ExprFn = Fn(&DataChunk) -> Result<Bitmap> + Send + Sync + 'static;
 
+#[derive(Debug, PartialEq, Clone)]
+pub struct AddOutput {
+    map: HashMap<(ActorId, DispatcherId), Vec<ActorInfo>>,
+    splits: HashMap<ActorId, Vec<SplitImpl>>,
+}
+
 #[derive(Debug, Clone, PartialEq)]
 pub enum Mutation {
     Stop(HashSet<ActorId>),
     UpdateOutputs(HashMap<(ActorId, DispatcherId), Vec<ActorInfo>>),
-    AddOutput(HashMap<(ActorId, DispatcherId), Vec<ActorInfo>>),
+    // AddOutput(HashMap<(ActorId, DispatcherId), Vec<ActorInfo>>),
+    AddOutput(AddOutput),
     SourceChangeSplit(HashMap<ActorId, ConnectorState>),
 }
 
@@ -258,7 +268,7 @@ impl Barrier {
     pub fn is_to_add_output(&self, actor_id: ActorId) -> bool {
         matches!(
             self.mutation.as_deref(),
-            Some(Mutation::AddOutput(map)) if map
+            Some(Mutation::AddOutput(map)) if map.map
                 .values()
                 .flatten()
                 .any(|info| info.actor_id == actor_id)
@@ -311,6 +321,7 @@ impl Barrier {
                 }
                 Some(Mutation::AddOutput(adds)) => Some(ProstMutation::Add(AddMutation {
                     mutations: adds
+                        .map
                         .iter()
                         .map(|(&(actor_id, dispatcher_id), actors)| DispatcherMutation {
                             actor_id,
@@ -318,6 +329,7 @@ impl Barrier {
                             info: actors.clone(),
                         })
                         .collect(),
+                    splits: vec![],
                 })),
                 Some(Mutation::SourceChangeSplit(changes)) => {
                     Some(ProstMutation::Splits(SourceChangeSplitMutation {
@@ -368,8 +380,9 @@ impl Barrier {
                 .into(),
             ),
             ProstMutation::Add(adds) => Some(
-                Mutation::AddOutput(
-                    adds.mutations
+                Mutation::AddOutput(AddOutput {
+                    map: adds
+                        .mutations
                         .iter()
                         .map(|mutation| {
                             (
@@ -378,7 +391,27 @@ impl Barrier {
                             )
                         })
                         .collect::<HashMap<(ActorId, DispatcherId), Vec<ActorInfo>>>(),
-                )
+                    splits: adds
+                        .splits
+                        .iter()
+                        .map(|split| {
+                            (
+                                split.actor_id,
+                                split
+                                    .source_splits
+                                    .iter()
+                                    .map(|s| {
+                                        SplitImpl::restore_from_bytes(
+                                            split.borrow().split_type.clone(),
+                                            s,
+                                        )
+                                        .unwrap()
+                                    })
+                                    .collect_vec(),
+                            )
+                        })
+                        .collect(),
+                })
                 .into(),
             ),
             ProstMutation::Splits(s) => {

--- a/src/stream/src/from_proto/source.rs
+++ b/src/stream/src/from_proto/source.rs
@@ -13,8 +13,6 @@
 // limitations under the License.
 
 use risingwave_common::catalog::{ColumnId, Field, Schema, TableId};
-use risingwave_common::error::ToRwResult;
-use risingwave_connector::SplitImpl;
 use tokio::sync::mpsc::unbounded_channel;
 
 use super::*;
@@ -38,16 +36,6 @@ impl ExecutorBuilder for SourceExecutorBuilder {
 
         let source_id = TableId::from(&node.table_ref_id);
         let source_desc = params.env.source_manager().get_source(&source_id)?;
-
-        let stream_source_splits = match &node.stream_source_state {
-            Some(splits) => splits
-                .stream_source_splits
-                .iter()
-                .map(|split| SplitImpl::restore_from_bytes(splits.get_split_type().clone(), split))
-                .collect::<anyhow::Result<Vec<SplitImpl>>>()
-                .to_rw_result(),
-            _ => Ok(vec![]),
-        }?;
 
         let column_ids: Vec<_> = node
             .get_column_ids()
@@ -79,7 +67,6 @@ impl ExecutorBuilder for SourceExecutorBuilder {
             params.operator_id,
             params.op_info,
             params.executor_stats,
-            stream_source_splits,
             stream.config.checkpoint_interval_ms as u64,
         )?))
     }


### PR DESCRIPTION
## What's changed and what's your intention?

This PR tries to use `Barrier` to initialize the Source Actor, replacing the original Protobuf field

When the `create source` statement is executed, the `source_manager` spawns a loop coroutine to poll the source with the corresponding `SplitEnumerator`  and store the result in memory.

At the end of `create materialized view`, `stream_manager` executes `run_command(Command::CreateMaterializedView)` to generate an `AddMutation` Barrier to initialize the entire DAG, and this PR tries to put the split initialization of the source actor into this Barrier.

## Checklist

- [ ] I have written necessary docs and comments
- [ ] I have added necessary unit tests and integration tests
- [ ] All checks passed in `./risedev check` (or alias, `./risedev c`)

## Refer to a related PR or issue link (optional)
