### PR TITLE
refactor(stream): use hash map for flush_buffer in join

### DIFF
--- a/src/stream/src/executor/managed_state/flush_status.rs
+++ b/src/stream/src/executor/managed_state/flush_status.rs
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use madsim::collections::btree_map;
+use madsim::collections::{btree_map, hash_map};
 
 macro_rules! impl_flush_status {
     ([], $( { $entry_type:ty, $struct_name:ident } ),*) => {
@@ -110,8 +110,8 @@ macro_rules! for_all_entry {
         ($macro:ident $(, $x:tt)*) => {
                 $macro! {
                         [$($x),*],
-                        { btree_map::Entry<K, Self>, BtreeMapFlushStatus }
-                        // { hash_map::Entry<K, Self>, HashMapFlushStatus }
+                        { btree_map::Entry<K, Self>, BtreeMapFlushStatus },
+                        { hash_map::Entry<K, Self>, HashMapFlushStatus }
                 }
         };
 }

--- a/src/stream/src/executor/managed_state/join/join_entry_state.rs
+++ b/src/stream/src/executor/managed_state/join/join_entry_state.rs
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use std::collections::HashMap;
 use std::sync::Arc;
 
 use bytes::Bytes;
@@ -23,7 +24,7 @@ use risingwave_storage::storage_value::StorageValue;
 use risingwave_storage::write_batch::WriteBatch;
 use risingwave_storage::{Keyspace, StateStore};
 
-use super::super::flush_status::BtreeMapFlushStatus as FlushStatus;
+use super::super::flush_status::HashMapFlushStatus as FlushStatus;
 use super::*;
 
 type JoinEntryStateIter<'a> = btree_map::Iter<'a, PkType, StateValueType>;
@@ -40,7 +41,7 @@ pub struct JoinEntryState<S: StateStore> {
     cached: Option<BTreeMap<PkType, StateValueType>>,
 
     /// The actions that will be taken on next flush
-    flush_buffer: BTreeMap<PkType, FlushStatus<StateValueType>>,
+    flush_buffer: HashMap<PkType, FlushStatus<StateValueType>>,
 
     /// Data types of the sort column
     data_types: Arc<[DataType]>,
@@ -60,7 +61,7 @@ impl<S: StateStore> JoinEntryState<S> {
     ) -> Self {
         Self {
             cached: None,
-            flush_buffer: BTreeMap::new(),
+            flush_buffer: HashMap::new(),
             data_types,
             pk_data_types,
             keyspace,
@@ -79,7 +80,7 @@ impl<S: StateStore> JoinEntryState<S> {
             let cached = Self::fill_cached(all_data, data_types.clone(), pk_data_types.clone())?;
             Ok(Some(Self {
                 cached: Some(cached),
-                flush_buffer: BTreeMap::new(),
+                flush_buffer: HashMap::new(),
                 data_types,
                 pk_data_types,
                 keyspace,


### PR DESCRIPTION
## What's changed and what's your intention?
`flush_buffer` does not actually require any order here. And `write_batch` would sort everything(not just stuff in this join, so the order of kvs is messed up anyway) before flushing, so `hash_map` should be better here.

## Checklist

~- [ ] I have written necessary docs and comments~
~- [ ] I have added necessary unit tests and integration tests~
- [x] All checks passed in `./risedev check` (or alias, `./risedev c`)

## Refer to a related PR or issue link (optional)
