### PR TITLE
feat: alias data type `STRING` to `VARCHAR`

### DIFF
--- a/e2e_test/batch/func.slt
+++ b/e2e_test/batch/func.slt
@@ -99,7 +99,7 @@ select concat_ws(',', 1, 1.01, 'A', true, NULL);
 1,1.01,A,true
 
 statement ok
-create table t (v1 varchar, v2 smallint, v3 int, v4 decimal, v5 real, v6 double, v7 bool, v8 varchar);
+create table t (v1 varchar, v2 smallint, v3 int, v4 decimal, v5 real, v6 double, v7 bool, v8 string);
 
 statement ok
 insert into t values (',', 1, 2, 3.01, 4, 5.01, true, NULL);

--- a/src/frontend/src/binder/expr/mod.rs
+++ b/src/frontend/src/binder/expr/mod.rs
@@ -382,7 +382,7 @@ pub fn bind_data_type(data_type: &AstDataType) -> Result<DataType> {
         AstDataType::Real | AstDataType::Float(Some(1..=24)) => DataType::Float32,
         AstDataType::Double | AstDataType::Float(Some(25..=53) | None) => DataType::Float64,
         AstDataType::Decimal(None, None) => DataType::Decimal,
-        AstDataType::Varchar(_) => DataType::Varchar,
+        AstDataType::Varchar(_) | AstDataType::String => DataType::Varchar,
         AstDataType::Date => DataType::Date,
         AstDataType::Time(false) => DataType::Time,
         AstDataType::Timestamp(false) => DataType::Timestamp,


### PR DESCRIPTION
## What's changed and what's your intention?

As title.

## Checklist

- [x] I have written necessary docs and comments
- [x] I have added necessary unit tests and integration tests
- [x] All checks passed in `./risedev check` (or alias, `./risedev c`)

## Refer to a related PR or issue link (optional)

#3007