### PR TITLE
chore(ci): ci upload failure logs

### DIFF
--- a/ci/plugins/upload-failure-logs/hooks/post-command
+++ b/ci/plugins/upload-failure-logs/hooks/post-command
@@ -1,0 +1,10 @@
+#!/bin/bash
+
+set -euo pipefail
+
+if [ $BUILDKITE_COMMAND_EXIT_STATUS -ne 0 ]; then
+  mkdir risedev-logs && cp .risingwave/log/* risedev-logs
+  zip -q -r risedev-logs.zip risedev-logs/
+  buildkite-agent artifact upload "risedev-logs/*"
+  buildkite-agent artifact upload risedev-logs.zip
+fi

--- a/ci/workflows/main-cron.yml
+++ b/ci/workflows/main-cron.yml
@@ -17,6 +17,7 @@ steps:
           run: rw-build-env
           config: ci/docker-compose.yml
           mount-buildkite-agent: true
+      - ./ci/plugins/upload-failure-logs
     timeout_in_minutes: 10
 
   - label: "end-to-end source test"
@@ -27,6 +28,7 @@ steps:
           run: rw-build-env
           config: ci/docker-compose.yml
           mount-buildkite-agent: true
+      - ./ci/plugins/upload-failure-logs
     timeout_in_minutes: 5
 
   - label: "unit test"

--- a/ci/workflows/main.yml
+++ b/ci/workflows/main.yml
@@ -35,6 +35,7 @@ steps:
           run: rw-build-env
           config: ci/docker-compose.yml
           mount-buildkite-agent: true
+      - ./ci/plugins/upload-failure-logs
     matrix:
       setup:
         profile:
@@ -50,6 +51,7 @@ steps:
           run: rw-build-env
           config: ci/docker-compose.yml
           mount-buildkite-agent: true
+      - ./ci/plugins/upload-failure-logs
     matrix:
       setup:
         profile:
@@ -64,6 +66,7 @@ steps:
           run: rw-build-env
           config: ci/docker-compose.yml
           mount-buildkite-agent: true
+      - ./ci/plugins/upload-failure-logs
     timeout_in_minutes: 5
 
   - label: "unit test"

--- a/ci/workflows/pull-request.yml
+++ b/ci/workflows/pull-request.yml
@@ -17,6 +17,7 @@ steps:
           run: rw-build-env
           config: ci/docker-compose.yml
           mount-buildkite-agent: true
+      - ./ci/plugins/upload-failure-logs
     timeout_in_minutes: 10
 
   - label: "end-to-end test (parallel)"
@@ -27,6 +28,7 @@ steps:
           run: rw-build-env
           config: ci/docker-compose.yml
           mount-buildkite-agent: true
+      - ./ci/plugins/upload-failure-logs
     timeout_in_minutes: 10
 
   - label: "end-to-end source test"
@@ -37,6 +39,7 @@ steps:
           run: rw-build-env
           config: ci/docker-compose.yml
           mount-buildkite-agent: true
+      - ./ci/plugins/upload-failure-logs
     timeout_in_minutes: 5
 
   - label: "unit test"


### PR DESCRIPTION
## What's changed and what's your intention?

upload error logs after Buildkite CI command failed.

## Checklist

~~- [ ] I have written necessary docs and comments~~
~~- [ ] I have added necessary unit tests and integration tests~~
~~- [ ] All checks passed in `./risedev check` (or alias, `./risedev c`)~~

## Refer to a related PR or issue link (optional)
issue: https://github.com/singularity-data/risingwave/issues/2898
