### PR TITLE
fix(pg-wire): fix the simple extended query mode

### DIFF
--- a/src/utils/pgwire/src/pg_protocol.rs
+++ b/src/utils/pgwire/src/pg_protocol.rs
@@ -165,9 +165,6 @@ where
             FeMessage::Parse(m) => {
                 let query = cstr_to_str(&m.query_string).unwrap();
 
-                // TODO: make sure the query is a complete statement.
-                assert!(query.trim_end().ends_with(';'));
-
                 // 1. Create the types description.
                 let type_ids = m.type_ids;
                 let types: Vec<TypeOid> = type_ids

--- a/src/utils/pgwire/src/pg_server.rs
+++ b/src/utils/pgwire/src/pg_server.rs
@@ -165,8 +165,8 @@ mod tests {
                 .skip(1)
                 .map(|x| {
                     Some(
-                        x.trim_start_matches("\'")
-                            .trim_end_matches("\'")
+                        x.trim_start_matches('\'')
+                            .trim_end_matches('\'')
                             .to_string(),
                     )
                 })

--- a/src/utils/pgwire/src/pg_server.rs
+++ b/src/utils/pgwire/src/pg_server.rs
@@ -163,7 +163,13 @@ mod tests {
             let res: Vec<Option<String>> = sql
                 .split(&[' ', ',', ';'])
                 .skip(1)
-                .map(|x| Some(x.to_string()))
+                .map(|x| {
+                    Some(
+                        x.trim_start_matches("\'")
+                            .trim_end_matches("\'")
+                            .to_string(),
+                    )
+                })
                 .collect();
 
             Ok(PgResponse::new(

--- a/src/utils/pgwire/src/pg_server.rs
+++ b/src/utils/pgwire/src/pg_server.rs
@@ -160,6 +160,9 @@ mod tests {
             self: Arc<Self>,
             sql: &str,
         ) -> Result<PgResponse, Box<dyn Error + Send + Sync>> {
+            // split a statement and trim \' around the intput param to construct result.
+            // Ex:
+            //    SELECT 'a','b' -> result: a , b
             let res: Vec<Option<String>> = sql
                 .split(&[' ', ',', ';'])
                 .skip(1)


### PR DESCRIPTION
## What's changed and what's your intention?
fix the simple extended query mode 
- **add parse_params() to parse different param according to the type** 
  For the simple extended query mode, it just simply replaces the params. This causes problems when I test in local e2e mode. 
  For example:
   SELECT $1 => SELECT Hello,World ❌ （Expect: SELECT 'Hello,World' ✔）
Then I realized that we couldn't simply replace params, different params need different parse. Such as VARCHAR params need to add (**\'**) on both sides of it. So I add the parse_params() to parse the params and now it only supports the VARCHAR type. We can expand another kind in future.
## Checklist

- [x] I have written necessary docs and comments
- [x] I have added necessary unit tests and integration tests
- [x] All checks passed in `./risedev check` (or alias, `./risedev c`)

## Refer to a related PR or issue link (optional)
#2924