### PR TITLE
fix: fix the table descs of value state

### DIFF
--- a/src/stream/src/executor/managed_state/aggregation/value.rs
+++ b/src/stream/src/executor/managed_state/aggregation/value.rs
@@ -57,7 +57,8 @@ impl ManagedValueState {
                 .get_row(pk.unwrap_or(&Row(vec![])), epoch)
                 .await?;
 
-            raw_data.and_then(|row| row.values().next().cloned())
+            // According to row layout, the last field of the row is value.
+            raw_data.map(|row| row.0[row.0.len() - 1].clone())
         } else {
             None
         };
@@ -110,9 +111,11 @@ impl ManagedValueState {
         // cause incorrect result: it will only produce more I/O.
         debug_assert!(self.is_dirty());
 
-        // Persist value into relational table.
-        let v = self.state.get_output()?;
-        state_table.insert(self.pk.as_ref().unwrap_or(&Row(vec![])), Row(vec![v]))?;
+        // Persist value into relational table. The inserted row should concat with pk (pk is in
+        // front of value). In this case, the pk is just group key.
+        let mut v = vec![self.state.get_output()?];
+        v.extend(self.pk.as_ref().unwrap_or(&Row(vec![])).0.iter().cloned());
+        state_table.insert(self.pk.as_ref().unwrap_or(&Row(vec![])), Row::new(v))?;
 
         self.is_dirty = false;
         Ok(())

--- a/src/stream/src/executor/managed_state/aggregation/value.rs
+++ b/src/stream/src/executor/managed_state/aggregation/value.rs
@@ -57,8 +57,9 @@ impl ManagedValueState {
                 .get_row(pk.unwrap_or(&Row(vec![])), epoch)
                 .await?;
 
-            // According to row layout, the last field of the row is value.
-            raw_data.map(|row| row.0[row.0.len() - 1].clone())
+            // According to row layout, the last field of the row is value and we sure the row is
+            // not empty.
+            raw_data.map(|row| row.0.last().unwrap().clone())
         } else {
             None
         };


### PR DESCRIPTION
## What's changed and what's your intention?

Previously I misunderstand state table. The insert was done like `insert(pk: group_key, value: agg_value)`.
But in fact, it should be done like `insert(pk: group_key, value: [group_key, agg_value])`. Otherwise the pk_indices in future refactor won't work. 


## Checklist

- [x] I have written necessary docs and comments
- [x] I have added necessary unit tests and integration tests
- [x] All checks passed in `./risedev check` (or alias, `./risedev c`)

## Refer to a related PR or issue link (optional)
