### PR TITLE
refactor(common): extend `CheckedAdd` with `Rhs` and `Output`

### DIFF
--- a/src/batch/src/executor/table_function.rs
+++ b/src/batch/src/executor/table_function.rs
@@ -49,7 +49,7 @@ where
     T: Array,
     S: Array,
     T::OwnedItem: PartialOrd<T::OwnedItem>,
-    T::OwnedItem: for<'a> CheckedAdd<S::RefItem<'a>>,
+    T::OwnedItem: for<'a> CheckedAdd<S::RefItem<'a>, Output = T::OwnedItem>,
 {
     #[try_stream(boxed, ok = DataChunk, error = RwError)]
     async fn eval(self) {
@@ -70,7 +70,9 @@ where
                     break;
                 }
                 builder.append(Some(cur.as_scalar_ref())).unwrap();
-                cur = cur.checked_add(step.as_scalar_ref())?;
+                cur = cur
+                    .checked_add(step.as_scalar_ref())
+                    .ok_or(ErrorCode::NumericValueOutOfRange)?;
             }
 
             let arr = builder.finish()?;

--- a/src/common/src/types/chrono_wrapper.rs
+++ b/src/common/src/types/chrono_wrapper.rs
@@ -213,7 +213,9 @@ fn is_leap_year(year: i32) -> bool {
 }
 
 impl CheckedAdd<IntervalUnit> for NaiveDateTimeWrapper {
-    fn checked_add(&self, rhs: IntervalUnit) -> Result<NaiveDateTimeWrapper> {
+    type Output = NaiveDateTimeWrapper;
+
+    fn checked_add(self, rhs: IntervalUnit) -> Option<NaiveDateTimeWrapper> {
         let mut date = self.0.date();
         if rhs.get_months() != 0 {
             // NaiveDate don't support add months. We need calculate manually
@@ -246,13 +248,9 @@ impl CheckedAdd<IntervalUnit> for NaiveDateTimeWrapper {
             date = NaiveDate::from_ymd(year, month as u32, day as u32);
         }
         let mut datetime = NaiveDateTime::new(date, self.0.time());
-        datetime = datetime
-            .checked_add_signed(Duration::days(rhs.get_days().into()))
-            .ok_or_else(|| InternalError("Date out of range".to_string()))?;
-        datetime = datetime
-            .checked_add_signed(Duration::milliseconds(rhs.get_ms()))
-            .ok_or_else(|| InternalError("Date out of range".to_string()))?;
+        datetime = datetime.checked_add_signed(Duration::days(rhs.get_days().into()))?;
+        datetime = datetime.checked_add_signed(Duration::milliseconds(rhs.get_ms()))?;
 
-        Ok(NaiveDateTimeWrapper::new(datetime))
+        Some(NaiveDateTimeWrapper::new(datetime))
     }
 }

--- a/src/common/src/types/ops.rs
+++ b/src/common/src/types/ops.rs
@@ -12,19 +12,15 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use crate::error::ErrorCode::InternalError;
-use crate::error::Result;
-pub trait CheckedAdd<T>
-where
-    Self: Sized,
-{
-    fn checked_add(&self, rhs: T) -> Result<Self>;
+pub trait CheckedAdd<Rhs = Self> {
+    type Output;
+    fn checked_add(self, rhs: Rhs) -> Option<Self::Output>;
 }
 
 impl<T: num_traits::CheckedAdd> CheckedAdd<T> for T {
-    fn checked_add(&self, rhs: T) -> Result<Self> {
-        let res = <Self as num_traits::CheckedAdd>::checked_add(self, &rhs)
-            .ok_or_else(|| InternalError("CheckedAdd Error".to_string()))?;
-        Ok(res)
+    type Output = T;
+
+    fn checked_add(self, rhs: T) -> Option<Self> {
+        num_traits::CheckedAdd::checked_add(&self, &rhs)
     }
 }

--- a/src/common/src/types/ops.rs
+++ b/src/common/src/types/ops.rs
@@ -12,12 +12,21 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+/// A more general version of [`num_traits::CheckedAdd`] that allows `Rhs` and `Output` to be
+/// different.
+///
+/// Its signature follows [`std::ops::Add`] to take `self` and `Rhs` rather than references used in
+/// [`num_traits::CheckedAdd`]. If we need to implement ops on references, it can be `impl
+/// CheckedAdd<&Bar> for &Foo`.
 pub trait CheckedAdd<Rhs = Self> {
     type Output;
     fn checked_add(self, rhs: Rhs) -> Option<Self::Output>;
 }
 
-impl<T: num_traits::CheckedAdd> CheckedAdd<T> for T {
+/// Types already impl [`num_traits::CheckedAdd`] automatically impl this extended trait. Note that
+/// this only covers `T + T` but not `T + &T`, `&T + T` or `&T + &T`, which is used less frequently
+/// for `Copy` types.
+impl<T: num_traits::CheckedAdd> CheckedAdd for T {
     type Output = T;
 
     fn checked_add(self, rhs: T) -> Option<Self> {

--- a/src/expr/src/vector_op/arithmetic_op.rs
+++ b/src/expr/src/vector_op/arithmetic_op.rs
@@ -16,10 +16,9 @@ use std::any::type_name;
 use std::convert::TryInto;
 use std::fmt::Debug;
 
-use num_traits::{CheckedAdd, CheckedDiv, CheckedMul, CheckedNeg, CheckedRem, CheckedSub, Signed};
+use num_traits::{CheckedDiv, CheckedMul, CheckedNeg, CheckedRem, CheckedSub, Signed};
 use risingwave_common::types::{
-    CheckedAdd as NaiveDateTimeCheckedAdd, Decimal, IntervalUnit, NaiveDateTimeWrapper,
-    NaiveDateWrapper,
+    CheckedAdd, Decimal, IntervalUnit, NaiveDateTimeWrapper, NaiveDateWrapper,
 };
 
 use super::cast::date_to_timestamp;
@@ -30,10 +29,10 @@ pub fn general_add<T1, T2, T3>(l: T1, r: T2) -> Result<T3>
 where
     T1: TryInto<T3> + Debug,
     T2: TryInto<T3> + Debug,
-    T3: CheckedAdd,
+    T3: CheckedAdd<Output = T3>,
 {
     general_atm(l, r, |a, b| {
-        a.checked_add(&b).ok_or(ExprError::NumericOutOfRange)
+        a.checked_add(b).ok_or(ExprError::NumericOutOfRange)
     })
 }
 
@@ -139,7 +138,7 @@ pub fn interval_timestamp_add<T1, T2, T3>(
     l: IntervalUnit,
     r: NaiveDateTimeWrapper,
 ) -> Result<NaiveDateTimeWrapper> {
-    r.checked_add(l).map_err(ExprError::Array)
+    r.checked_add(l).ok_or(ExprError::NumericOutOfRange)
 }
 
 #[inline(always)]


### PR DESCRIPTION
## What's changed and what's your intention?

`num_traits::CheckedAdd` requires the rhs and output to be the same as self. `std::ops::Add` allows them to be different but does not return err. We define our own trait to get the best of both worlds.

## Checklist

- [x] I have written necessary docs and comments
- [x] I have added necessary unit tests and integration tests
- [x] All checks passed in `./risedev check` (or alias, `./risedev c`)

## Refer to a related PR or issue link (optional)
