### PR TITLE
chore(risedev): tune etcd configuration.

### DIFF
--- a/src/risedevtool/src/task/etcd_service.rs
+++ b/src/risedevtool/src/task/etcd_service.rs
@@ -61,9 +61,11 @@ impl EtcdService {
             .arg("--max-txn-ops")
             .arg("999999")
             .arg("--auto-compaction-mode")
-            .arg("revision")
+            .arg("periodic")
             .arg("--auto-compaction-retention")
-            .arg("100");
+            .arg("1m")
+            .arg("--snapshot-count")
+            .arg("10000");
 
         if config.unsafe_no_fsync {
             cmd.arg("--unsafe-no-fsync");


### PR DESCRIPTION
## What's changed and what's your intention?

Fix https://github.com/singularity-data/risingwave/issues/3054.

Benchmark result of ./risedev d full in single machine:

- Etcd space quota is below 1.2GB.
- Etcd memory usage is below 10GB.

<img width="1458" alt="10000_2" src="https://user-images.githubusercontent.com/70626450/172839135-013f70db-084e-4c4d-b8dc-1cb0c9e47689.png">


## Checklist

- [x] All checks passed in `./risedev check` (or alias, `./risedev c`)

## Refer to a related PR or issue link (optional)
Close https://github.com/singularity-data/risingwave/issues/3054