### PR TITLE
feat(storage): optimize get existing table ids when compact

### DIFF
--- a/src/meta/src/hummock/compaction_group/manager.rs
+++ b/src/meta/src/hummock/compaction_group/manager.rs
@@ -147,7 +147,7 @@ impl<S: MetaStore> CompactionGroupManager<S> {
         compaction_group_id: u64,
     ) -> Result<HashSet<u32>> {
         let inner = self.inner.read().await;
-        let prefix_set = inner.get_prefixs_by_compaction_group_id(compaction_group_id)?;
+        let prefix_set = inner.prefixs_by_compaction_group_id(compaction_group_id)?;
 
         Ok(prefix_set.into_iter().map(u32::from).collect())
     }
@@ -256,10 +256,7 @@ impl CompactionGroupManagerInner {
         Ok(())
     }
 
-    fn get_prefixs_by_compaction_group_id(
-        &self,
-        compaction_group_id: u64,
-    ) -> Result<HashSet<Prefix>> {
+    fn prefixs_by_compaction_group_id(&self, compaction_group_id: u64) -> Result<HashSet<Prefix>> {
         match self.compaction_groups.get(&compaction_group_id) {
             Some(compaction_group) => Ok(compaction_group.member_prefixes.clone()),
 

--- a/src/meta/src/hummock/test_utils.rs
+++ b/src/meta/src/hummock/test_utils.rs
@@ -29,7 +29,6 @@ use crate::hummock::{HummockManager, HummockManagerRef};
 use crate::manager::MetaSrvEnv;
 use crate::rpc::metrics::MetaMetrics;
 use crate::storage::{MemStore, MetaStore};
-use crate::stream::FragmentManager;
 
 pub async fn add_test_tables<S>(
     hummock_manager: &HummockManager<S>,
@@ -168,18 +167,13 @@ pub async fn setup_compute_env(
             .await
             .unwrap(),
     );
-    let fragment_manager = Arc::new(
-        FragmentManager::new(env.clone(), compaction_group_manager.clone())
-            .await
-            .unwrap(),
-    );
+
     let hummock_manager = Arc::new(
         HummockManager::new(
             env.clone(),
             cluster_manager.clone(),
             Arc::new(MetaMetrics::new()),
             compaction_group_manager,
-            fragment_manager.clone(),
         )
         .await
         .unwrap(),

--- a/src/meta/src/rpc/server.rs
+++ b/src/meta/src/rpc/server.rs
@@ -134,7 +134,6 @@ pub async fn rpc_serve_with_store<S: MetaStore>(
             cluster_manager.clone(),
             meta_metrics.clone(),
             compaction_group_manager.clone(),
-            fragment_manager.clone(),
         )
         .await
         .unwrap(),

--- a/src/meta/src/stream/meta.rs
+++ b/src/meta/src/stream/meta.rs
@@ -501,21 +501,4 @@ where
         }
         Ok(())
     }
-
-    // existing_table_ids include the table_ref_id (source and materialized_view) +
-    // internal_table_id (stateful executor)
-    pub async fn existing_table_ids(&self) -> Result<HashSet<u32>> {
-        let mut result_set = HashSet::default();
-        let map = &self.core.read().await.table_fragments;
-
-        for (k, v) in map {
-            result_set.insert(k.table_id());
-
-            for internal_table_id in v.internal_table_ids() {
-                result_set.insert(internal_table_id);
-            }
-        }
-
-        Ok(result_set)
-    }
 }

--- a/src/meta/src/stream/stream_manager.rs
+++ b/src/meta/src/stream/stream_manager.rs
@@ -841,7 +841,6 @@ mod tests {
                     cluster_manager.clone(),
                     meta_metrics.clone(),
                     compaction_group_manager.clone(),
-                    fragment_manager.clone(),
                 )
                 .await?,
             );


### PR DESCRIPTION
## What's changed and what's your intention?
optimize get existing table ids when compact

Please explain **IN DETAIL** what the changes are in this PR and why they are needed:

- remove the dependent of fragment when HummockManager construct
- optimize get existing_table_ids range which limit to compaction_group 

## Checklist

- [x] I have written necessary docs and comments
- [x] I have added necessary unit tests and integration tests

## Refer to a related PR or issue link (optional)
- https://github.com/singularity-data/risingwave/pull/3038
- https://github.com/singularity-data/risingwave/pull/3044