### PR TITLE
fix: iter only need the pk prefix reference instead of ownership

### DIFF
--- a/src/storage/src/table/state_table.rs
+++ b/src/storage/src/table/state_table.rs
@@ -127,7 +127,7 @@ impl<S: StateStore> StateTable<S> {
     }
 
     /// This function scans rows from the relational table.
-    pub async fn iter(&self, epoch: u64) -> StorageResult<impl RowStream<'_>> {
+    pub async fn iter<'a>(&'a self, epoch: u64) -> StorageResult<impl Stream<Item = StorageResult<Cow<'a, Row>>>> {
         let cell_based_bounds = (Unbounded, Unbounded);
         let mem_table_bounds: (Bound<Vec<u8>>, Bound<Vec<u8>>) = (Unbounded, Unbounded);
         let mem_table_iter = self.mem_table.buffer.range(mem_table_bounds);
@@ -203,33 +203,47 @@ impl<S: StateStore> StateTable<S> {
     /// This function scans rows from the relational table with specific `pk_prefix`.
     pub async fn iter_with_pk_prefix(
         &self,
-        pk_prefix: Row,
+        pk_prefix: Option<&Row>,
         prefix_serializer: OrderedRowSerializer,
         epoch: u64,
     ) -> StorageResult<impl RowStream<'_>> {
-        let key_bytes = serialize_pk(&pk_prefix, &prefix_serializer);
-        let start_key_with_prefix = self.keyspace.prefixed_key(&key_bytes);
-        let cell_based_bounds = (
-            Included(start_key_with_prefix.clone()),
-            Excluded(next_key(start_key_with_prefix.as_slice())),
-        );
+        if let Some(pk_prefix) = pk_prefix {
+            let key_bytes = serialize_pk(pk_prefix, &prefix_serializer);
+            let start_key_with_prefix = self.keyspace.prefixed_key(&key_bytes);
+            let cell_based_bounds = (
+                Included(start_key_with_prefix.clone()),
+                Excluded(next_key(start_key_with_prefix.as_slice())),
+            );
 
-        let mem_table_bounds = (
-            Included(key_bytes.clone()),
-            Excluded(next_key(key_bytes.as_slice())),
-        );
-        let mem_table_iter = self.mem_table.buffer.range(mem_table_bounds);
-        Ok(StateTableRowIter::into_stream(
-            &self.keyspace,
-            self.column_descs.clone(),
-            mem_table_iter,
-            cell_based_bounds,
-            epoch,
-        ))
+            let mem_table_bounds = (
+                Included(key_bytes.clone()),
+                Excluded(next_key(key_bytes.as_slice())),
+            );
+            let mem_table_iter = self.mem_table.buffer.range(mem_table_bounds);
+            Ok(StateTableRowIter::into_stream(
+                &self.keyspace,
+                self.column_descs.clone(),
+                mem_table_iter,
+                cell_based_bounds,
+                epoch,
+            ))
+        } else {
+            self.iter(epoch).await
+            // let cell_based_bounds = (Unbounded, Unbounded);
+            // let mem_table_bounds: (Bound<Vec<u8>>, Bound<Vec<u8>>) = (Unbounded, Unbounded);
+            // let mem_table_iter = self.mem_table.buffer.range(mem_table_bounds);
+            // Ok(StateTableRowIter::into_stream(
+            //     &self.keyspace,
+            //     self.column_descs.clone(),
+            //     mem_table_iter,
+            //     cell_based_bounds,
+            //     epoch,
+            // ))
+        }
     }
 }
 
-pub trait RowStream<'a> = Stream<Item = StorageResult<Cow<'a, Row>>> + 'a;
+pub trait RowStream<'a> = Stream<Item = StorageResult<Cow<'a, Row>>>;
 
 struct StateTableRowIter<S: StateStore> {
     _phantom: PhantomData<S>,

--- a/src/storage/src/table/state_table.rs
+++ b/src/storage/src/table/state_table.rs
@@ -127,7 +127,7 @@ impl<S: StateStore> StateTable<S> {
     }
 
     /// This function scans rows from the relational table.
-    pub async fn iter<'a>(&'a self, epoch: u64) -> StorageResult<impl Stream<Item = StorageResult<Cow<'a, Row>>>> {
+    pub async fn iter(&self, epoch: u64) -> StorageResult<impl RowStream<'_>> {
         let cell_based_bounds = (Unbounded, Unbounded);
         let mem_table_bounds: (Bound<Vec<u8>>, Bound<Vec<u8>>) = (Unbounded, Unbounded);
         let mem_table_iter = self.mem_table.buffer.range(mem_table_bounds);
@@ -203,43 +203,29 @@ impl<S: StateStore> StateTable<S> {
     /// This function scans rows from the relational table with specific `pk_prefix`.
     pub async fn iter_with_pk_prefix(
         &self,
-        pk_prefix: Option<&Row>,
+        pk_prefix: &Row,
         prefix_serializer: OrderedRowSerializer,
         epoch: u64,
     ) -> StorageResult<impl RowStream<'_>> {
-        if let Some(pk_prefix) = pk_prefix {
-            let key_bytes = serialize_pk(pk_prefix, &prefix_serializer);
-            let start_key_with_prefix = self.keyspace.prefixed_key(&key_bytes);
-            let cell_based_bounds = (
-                Included(start_key_with_prefix.clone()),
-                Excluded(next_key(start_key_with_prefix.as_slice())),
-            );
+        let key_bytes = serialize_pk(pk_prefix, &prefix_serializer);
+        let start_key_with_prefix = self.keyspace.prefixed_key(&key_bytes);
+        let cell_based_bounds = (
+            Included(start_key_with_prefix.clone()),
+            Excluded(next_key(start_key_with_prefix.as_slice())),
+        );
 
-            let mem_table_bounds = (
-                Included(key_bytes.clone()),
-                Excluded(next_key(key_bytes.as_slice())),
-            );
-            let mem_table_iter = self.mem_table.buffer.range(mem_table_bounds);
-            Ok(StateTableRowIter::into_stream(
-                &self.keyspace,
-                self.column_descs.clone(),
-                mem_table_iter,
-                cell_based_bounds,
-                epoch,
-            ))
-        } else {
-            self.iter(epoch).await
-            // let cell_based_bounds = (Unbounded, Unbounded);
-            // let mem_table_bounds: (Bound<Vec<u8>>, Bound<Vec<u8>>) = (Unbounded, Unbounded);
-            // let mem_table_iter = self.mem_table.buffer.range(mem_table_bounds);
-            // Ok(StateTableRowIter::into_stream(
-            //     &self.keyspace,
-            //     self.column_descs.clone(),
-            //     mem_table_iter,
-            //     cell_based_bounds,
-            //     epoch,
-            // ))
-        }
+        let mem_table_bounds = (
+            Included(key_bytes.clone()),
+            Excluded(next_key(key_bytes.as_slice())),
+        );
+        let mem_table_iter = self.mem_table.buffer.range(mem_table_bounds);
+        Ok(StateTableRowIter::into_stream(
+            &self.keyspace,
+            self.column_descs.clone(),
+            mem_table_iter,
+            cell_based_bounds,
+            epoch,
+        ))
     }
 }
 

--- a/src/storage/src/table/state_table.rs
+++ b/src/storage/src/table/state_table.rs
@@ -203,29 +203,42 @@ impl<S: StateStore> StateTable<S> {
     /// This function scans rows from the relational table with specific `pk_prefix`.
     pub async fn iter_with_pk_prefix(
         &self,
-        pk_prefix: &Row,
+        pk_prefix: Option<&Row>,
         prefix_serializer: OrderedRowSerializer,
         epoch: u64,
     ) -> StorageResult<impl RowStream<'_>> {
-        let key_bytes = serialize_pk(pk_prefix, &prefix_serializer);
-        let start_key_with_prefix = self.keyspace.prefixed_key(&key_bytes);
-        let cell_based_bounds = (
-            Included(start_key_with_prefix.clone()),
-            Excluded(next_key(start_key_with_prefix.as_slice())),
-        );
+        if let Some(pk_prefix) = pk_prefix.as_ref() {
+            let key_bytes = serialize_pk(pk_prefix, &prefix_serializer);
+            let start_key_with_prefix = self.keyspace.prefixed_key(&key_bytes);
+            let cell_based_bounds = (
+                Included(start_key_with_prefix.clone()),
+                Excluded(next_key(start_key_with_prefix.as_slice())),
+            );
 
-        let mem_table_bounds = (
-            Included(key_bytes.clone()),
-            Excluded(next_key(key_bytes.as_slice())),
-        );
-        let mem_table_iter = self.mem_table.buffer.range(mem_table_bounds);
-        Ok(StateTableRowIter::into_stream(
-            &self.keyspace,
-            self.column_descs.clone(),
-            mem_table_iter,
-            cell_based_bounds,
-            epoch,
-        ))
+            let mem_table_bounds = (
+                Included(key_bytes.clone()),
+                Excluded(next_key(key_bytes.as_slice())),
+            );
+            let mem_table_iter = self.mem_table.buffer.range(mem_table_bounds);
+            Ok(StateTableRowIter::into_stream(
+                &self.keyspace,
+                self.column_descs.clone(),
+                mem_table_iter,
+                cell_based_bounds,
+                epoch,
+            ))
+        } else {
+            let cell_based_bounds = (Unbounded, Unbounded);
+            let mem_table_bounds: (Bound<Vec<u8>>, Bound<Vec<u8>>) = (Unbounded, Unbounded);
+            let mem_table_iter = self.mem_table.buffer.range(mem_table_bounds);
+            Ok(StateTableRowIter::into_stream(
+                &self.keyspace,
+                self.column_descs.clone(),
+                mem_table_iter,
+                cell_based_bounds,
+                epoch,
+            ))
+        }
     }
 }
 

--- a/src/storage/src/table/test_relational_table.rs
+++ b/src/storage/src/table/test_relational_table.rs
@@ -2030,7 +2030,7 @@ async fn test_state_table_iter_with_prefix() {
     let pk_prefix = Row(vec![Some(1_i32.into())]);
     let prefix_serializer = OrderedRowSerializer::new(vec![OrderType::Ascending]);
     let iter = state
-        .iter_with_pk_prefix(pk_prefix, prefix_serializer, epoch)
+        .iter_with_pk_prefix(&pk_prefix, prefix_serializer, epoch)
         .await
         .unwrap();
     pin_mut!(iter);

--- a/src/storage/src/table/test_relational_table.rs
+++ b/src/storage/src/table/test_relational_table.rs
@@ -2030,7 +2030,7 @@ async fn test_state_table_iter_with_prefix() {
     let pk_prefix = Row(vec![Some(1_i32.into())]);
     let prefix_serializer = OrderedRowSerializer::new(vec![OrderType::Ascending]);
     let iter = state
-        .iter_with_pk_prefix(&pk_prefix, prefix_serializer, epoch)
+        .iter_with_pk_prefix(Some(&pk_prefix), prefix_serializer, epoch)
         .await
         .unwrap();
     pin_mut!(iter);


### PR DESCRIPTION
## What's changed and what's your intention?

As title

## Checklist

- [x] I have written necessary docs and comments
- [x] I have added necessary unit tests and integration tests
- [x] All checks passed in `./risedev check` (or alias, `./risedev c`)

## Refer to a related PR or issue link (optional)
