### PR TITLE
fix(meta): use CompactionConfigBuilder

### DIFF
--- a/src/meta/src/hummock/compaction_group/manager.rs
+++ b/src/meta/src/hummock/compaction_group/manager.rs
@@ -21,6 +21,7 @@ use risingwave_hummock_sdk::CompactionGroupId;
 use risingwave_pb::hummock::CompactionConfig;
 use tokio::sync::RwLock;
 
+use crate::hummock::compaction::compaction_config::CompactionConfigBuilder;
 use crate::hummock::compaction_group::CompactionGroup;
 use crate::hummock::error::{Error, Result};
 use crate::manager::MetaSrvEnv;
@@ -37,7 +38,7 @@ pub struct CompactionGroupManager<S: MetaStore> {
 
 impl<S: MetaStore> CompactionGroupManager<S> {
     pub async fn new(env: MetaSrvEnv<S>) -> Result<Self> {
-        let config = CompactionConfig::default();
+        let config = CompactionConfigBuilder::new().build();
         Self::new_with_config(env, config).await
     }
 

--- a/src/storage/src/hummock/compactor.rs
+++ b/src/storage/src/hummock/compactor.rs
@@ -98,6 +98,7 @@ trait CompactionFilter {
     }
 }
 
+#[derive(Default, Clone)]
 pub struct DummyCompactionFilter;
 impl CompactionFilter for DummyCompactionFilter {}
 
@@ -107,6 +108,7 @@ pub struct StateCleanUpCompactionFilter {
 }
 
 impl StateCleanUpCompactionFilter {
+    #[allow(unused)]
     fn new(table_id_set: HashSet<u32>) -> Self {
         StateCleanUpCompactionFilter {
             existing_table_ids: table_id_set,
@@ -381,8 +383,11 @@ impl Compactor {
             );
         }
 
-        let compaction_filter =
-            StateCleanUpCompactionFilter::new(HashSet::from_iter(compact_task.existing_table_ids));
+        // TODO: Temporarily disable StateCleanUpCompactionFilter, because meta is not providing the
+        // correct `existing_table_ids` in 9a34de40.
+        let compaction_filter = DummyCompactionFilter::default();
+        // let compaction_filter =
+        // StateCleanUpCompactionFilter::new(HashSet::from_iter(compact_task.existing_table_ids));
 
         for (split_index, _) in compact_task.splits.iter().enumerate() {
             let compactor = compactor.clone();

--- a/src/storage/src/hummock/compactor_tests.rs
+++ b/src/storage/src/hummock/compactor_tests.rs
@@ -168,7 +168,9 @@ mod tests {
         assert!(compact_task.is_none());
     }
 
+    // TODO: enable after fix incorrect existing_table_id
     #[tokio::test]
+    #[ignore]
     async fn test_compaction_drop_all_key() {
         let (_env, hummock_manager_ref, _cluster_manager_ref, worker_node) =
             setup_compute_env(8080).await;
@@ -246,7 +248,9 @@ mod tests {
         assert!(compact_task.is_none());
     }
 
+    // TODO: enable after fix incorrect existing_table_id
     #[tokio::test]
+    #[ignore]
     async fn test_compaction_drop_key_by_existing_table_id() {
         let (_env, hummock_manager_ref, _cluster_manager_ref, worker_node) =
             setup_compute_env(8080).await;


### PR DESCRIPTION
## What's changed and what's your intention?

Fix incorrect usage of CompactionConfig::default.
Should use CompactionConfigBuilder.

Temporarily disable StateCleanUpCompactionFilter, because compaction group manager is not providing the correct `existing_table_ids` in 9a34de40.

## Checklist

- [x] All checks passed in `./risedev check` (or alias, `./risedev c`)

## Refer to a related PR or issue link (optional)
