### PR TITLE
feat(Meta) Separate inject_barrier_RPC and collect_over_RPC

### DIFF
--- a/proto/meta.proto
+++ b/proto/meta.proto
@@ -72,6 +72,22 @@ message FlushResponse {
 service StreamManagerService {
   rpc Flush(FlushRequest) returns (FlushResponse);
 }
+message CollectOverRequest {
+  message CreateMviewProgress {
+    uint32 chain_actor_id = 1;
+    bool done = 2;
+    uint64 consumed_epoch = 3;
+  }
+  repeated CreateMviewProgress create_mview_progress = 1;
+  repeated hummock.SstableInfo sycned_sstables = 2;
+  uint32 node_id = 3;
+}
+message CollectOverResponse {
+  common.Status status = 1;
+}
+service BarrierManagerService{
+  rpc CollectOver(CollectOverRequest) returns (CollectOverResponse);
+}
 
 // Below for cluster service.
 

--- a/proto/stream_service.proto
+++ b/proto/stream_service.proto
@@ -66,6 +66,7 @@ message InjectBarrierRequest {
   data.Barrier barrier = 2;
   repeated uint32 actor_ids_to_send = 3;
   repeated uint32 actor_ids_to_collect = 4;
+  uint32 node_id = 5;
 }
 
 message InjectBarrierResponse {

--- a/proto/stream_service.proto
+++ b/proto/stream_service.proto
@@ -69,15 +69,8 @@ message InjectBarrierRequest {
 }
 
 message InjectBarrierResponse {
-  message CreateMviewProgress {
-    uint32 chain_actor_id = 1;
-    bool done = 2;
-    uint64 consumed_epoch = 3;
-  }
   string request_id = 1;
   common.Status status = 2;
-  repeated CreateMviewProgress create_mview_progress = 3;
-  repeated hummock.SstableInfo sycned_sstables = 4;
 }
 
 // Before starting streaming, the leader node broadcast the actor-host table to needed workers.

--- a/src/compute/src/server.rs
+++ b/src/compute/src/server.rs
@@ -157,6 +157,7 @@ pub async fn compute_node_serve(
         stream_config,
         worker_id,
         state_store,
+        meta_client.clone(),
     );
 
     // Boot the runtime gRPC services.

--- a/src/meta/src/barrier/progress.rs
+++ b/src/meta/src/barrier/progress.rs
@@ -17,7 +17,7 @@ use std::collections::HashMap;
 
 use itertools::Itertools;
 use risingwave_common::util::epoch::Epoch;
-use risingwave_pb::stream_service::inject_barrier_response::CreateMviewProgress;
+use risingwave_pb::meta::collect_over_request::CreateMviewProgress;
 
 use super::notifier::Notifier;
 use crate::model::ActorId;

--- a/src/meta/src/barrier/recovery.rs
+++ b/src/meta/src/barrier/recovery.rs
@@ -22,7 +22,7 @@ use risingwave_common::error::{ErrorCode, Result, RwError, ToRwResult};
 use risingwave_common::util::epoch::Epoch;
 use risingwave_pb::common::ActorInfo;
 use risingwave_pb::data::Epoch as ProstEpoch;
-use risingwave_pb::stream_service::inject_barrier_response::CreateMviewProgress;
+use risingwave_pb::meta::collect_over_request::CreateMviewProgress;
 use risingwave_pb::stream_service::{
     BroadcastActorInfoTableRequest, BuildActorsRequest, ForceStopActorsRequest, SyncSourcesRequest,
     UpdateActorsRequest,

--- a/src/meta/src/rpc/service/mod.rs
+++ b/src/meta/src/rpc/service/mod.rs
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+pub mod barrier_service;
 pub mod cluster_service;
 pub mod ddl_service;
 pub mod heartbeat_service;

--- a/src/meta/src/stream/stream_manager.rs
+++ b/src/meta/src/stream/stream_manager.rs
@@ -752,6 +752,7 @@ mod tests {
             &self,
             _request: Request<InjectBarrierRequest>,
         ) -> std::result::Result<Response<InjectBarrierResponse>, Status> {
+            //tokio::spawn()
             Ok(Response::new(InjectBarrierResponse::default()))
         }
 

--- a/src/rpc_client/src/meta_client.rs
+++ b/src/rpc_client/src/meta_client.rs
@@ -45,15 +45,16 @@ use risingwave_pb::hummock::{
     UnpinSnapshotRequest, UnpinSnapshotResponse, UnpinVersionRequest, UnpinVersionResponse,
     VacuumTask,
 };
+use risingwave_pb::meta::barrier_manager_service_client::BarrierManagerServiceClient;
 use risingwave_pb::meta::cluster_service_client::ClusterServiceClient;
 use risingwave_pb::meta::heartbeat_service_client::HeartbeatServiceClient;
 use risingwave_pb::meta::notification_service_client::NotificationServiceClient;
 use risingwave_pb::meta::stream_manager_service_client::StreamManagerServiceClient;
 use risingwave_pb::meta::{
     ActivateWorkerNodeRequest, ActivateWorkerNodeResponse, AddWorkerNodeRequest,
-    AddWorkerNodeResponse, DeleteWorkerNodeRequest, DeleteWorkerNodeResponse, FlushRequest,
-    FlushResponse, HeartbeatRequest, HeartbeatResponse, ListAllNodesRequest, ListAllNodesResponse,
-    SubscribeRequest, SubscribeResponse,
+    AddWorkerNodeResponse, CollectOverRequest, CollectOverResponse, DeleteWorkerNodeRequest,
+    DeleteWorkerNodeResponse, FlushRequest, FlushResponse, HeartbeatRequest, HeartbeatResponse,
+    ListAllNodesRequest, ListAllNodesResponse, SubscribeRequest, SubscribeResponse,
 };
 use risingwave_pb::stream_plan::StreamFragmentGraph;
 use risingwave_pb::user::user_service_client::UserServiceClient;
@@ -74,7 +75,7 @@ type DatabaseId = u32;
 type SchemaId = u32;
 
 /// Client to meta server. Cloning the instance is lightweight.
-#[derive(Clone)]
+#[derive(Clone, Debug)]
 pub struct MetaClient {
     worker_id: Option<u32>,
     pub inner: GrpcMetaClient,
@@ -358,6 +359,11 @@ impl MetaClient {
         self.inner.flush(request).await?;
         Ok(())
     }
+
+    pub async fn collect_over(&self, request: CollectOverRequest) -> Result<()> {
+        self.inner.collect_over(request).await?;
+        Ok(())
+    }
 }
 
 #[async_trait]
@@ -458,6 +464,7 @@ pub struct GrpcMetaClient {
     pub notification_client: NotificationServiceClient<Channel>,
     pub stream_client: StreamManagerServiceClient<Channel>,
     pub user_client: UserServiceClient<Channel>,
+    pub barrier_client: BarrierManagerServiceClient<Channel>,
 }
 
 impl GrpcMetaClient {
@@ -475,7 +482,8 @@ impl GrpcMetaClient {
         let hummock_client = HummockManagerServiceClient::new(channel.clone());
         let notification_client = NotificationServiceClient::new(channel.clone());
         let stream_client = StreamManagerServiceClient::new(channel.clone());
-        let user_client = UserServiceClient::new(channel);
+        let user_client = UserServiceClient::new(channel.clone());
+        let barrier_client = BarrierManagerServiceClient::new(channel);
         Ok(Self {
             cluster_client,
             heartbeat_client,
@@ -484,6 +492,7 @@ impl GrpcMetaClient {
             notification_client,
             stream_client,
             user_client,
+            barrier_client,
         })
     }
 }
@@ -539,6 +548,7 @@ macro_rules! for_all_meta_rpc {
             ,{ user_client, drop_user, DropUserRequest, DropUserResponse }
             ,{ user_client, grant_privilege, GrantPrivilegeRequest, GrantPrivilegeResponse }
             ,{ user_client, revoke_privilege, RevokePrivilegeRequest, RevokePrivilegeResponse }
+            ,{ barrier_client, collect_over, CollectOverRequest, CollectOverResponse }
         }
     };
 }

--- a/src/stream/src/task/barrier_manager.rs
+++ b/src/stream/src/task/barrier_manager.rs
@@ -15,7 +15,7 @@
 use madsim::collections::{HashMap, HashSet};
 use risingwave_common::error::Result;
 use risingwave_pb::hummock::SstableInfo;
-use risingwave_pb::stream_service::inject_barrier_response::CreateMviewProgress as ProstCreateMviewProgress;
+use risingwave_pb::meta::collect_over_request::CreateMviewProgress as ProstCreateMviewProgress;
 use tokio::sync::mpsc::UnboundedSender;
 use tokio::sync::oneshot;
 

--- a/src/stream/src/task/barrier_manager/managed_state.rs
+++ b/src/stream/src/task/barrier_manager/managed_state.rs
@@ -16,7 +16,7 @@ use std::collections::HashMap;
 use std::iter::once;
 
 use madsim::collections::HashSet;
-use risingwave_pb::stream_service::inject_barrier_response::CreateMviewProgress;
+use risingwave_pb::meta::collect_over_request::CreateMviewProgress;
 use tokio::sync::oneshot;
 
 use super::progress::ChainState;

--- a/src/stream/src/task/stream_manager.rs
+++ b/src/stream/src/task/stream_manager.rs
@@ -13,6 +13,8 @@
 // limitations under the License.
 
 use std::fmt::Debug;
+use std::future::Future;
+use std::pin::Pin;
 use std::rc::Rc;
 use std::sync::Arc;
 
@@ -48,6 +50,8 @@ use crate::task::{
 lazy_static::lazy_static! {
     pub static ref LOCAL_TEST_ADDR: HostAddr = "127.0.0.1:2333".parse().unwrap();
 }
+
+// type CollectFuture = Pin<Box<dyn Future<Output = ()> + Send>>;
 
 pub type ActorHandle = JoinHandle<()>;
 
@@ -179,35 +183,37 @@ impl LocalStreamManager {
     /// Broadcast a barrier to all senders. Returns when the barrier is fully collected.
     pub async fn send_and_collect_barrier(
         &self,
-        barrier: &Barrier,
+        barrier: Barrier,
         actor_ids_to_send: impl IntoIterator<Item = ActorId>,
         actor_ids_to_collect: impl IntoIterator<Item = ActorId>,
         need_sync: bool,
-    ) -> Result<CollectResult> {
-        let rx = self.send_barrier(barrier, actor_ids_to_send, actor_ids_to_collect)?;
+    ) -> Result<Pin<Box<dyn Future<Output = CollectResult> + Send>>> {
+        let rx = self.send_barrier(&barrier, actor_ids_to_send, actor_ids_to_collect)?;
 
-        // Wait for all actors finishing this barrier.
-        let mut collect_result = rx.await.unwrap();
+        let state_store = self.state_store();
+        Ok(Box::pin(async move {
+            // Wait for all actors finishing this barrier.
+            let mut collect_result = rx.await.unwrap();
 
-        // Sync states from shared buffer to S3 before telling meta service we've done.
-        if need_sync {
-            dispatch_state_store!(self.state_store(), store, {
-                match store.sync(Some(barrier.epoch.prev)).await {
-                    Ok(_) => {
-                        collect_result.synced_sstables =
-                            store.get_uncommitted_ssts(barrier.epoch.prev);
+            // Sync states from shared buffer to S3 before telling meta service we've done.
+            if need_sync {
+                dispatch_state_store!(state_store, store, {
+                    match store.sync(Some(barrier.epoch.prev)).await {
+                        Ok(_) => {
+                            collect_result.synced_sstables =
+                                store.get_uncommitted_ssts(barrier.epoch.prev);
+                        }
+                        // TODO: Handle sync failure by propagating it
+                        // back to global barrier manager
+                        Err(e) => panic!(
+                            "Failed to sync state store after receiving barrier {:?} due to {}",
+                            barrier, e
+                        ),
                     }
-                    // TODO: Handle sync failure by propagating it
-                    // back to global barrier manager
-                    Err(e) => panic!(
-                        "Failed to sync state store after receiving barrier {:?} due to {}",
-                        barrier, e
-                    ),
-                }
-            });
-        }
-
-        Ok(collect_result)
+                });
+            }
+            collect_result
+        }))
     }
 
     /// Broadcast a barrier to all senders. Returns immediately, and caller won't be notified when
@@ -249,8 +255,9 @@ impl LocalStreamManager {
             span: tracing::Span::none(),
         };
 
-        self.send_and_collect_barrier(&barrier, actor_ids_to_send, actor_ids_to_collect, false)
-            .await?;
+        self.send_and_collect_barrier(barrier, actor_ids_to_send, actor_ids_to_collect, false)
+            .await?
+            .await;
         self.core.lock().drop_all_actors();
 
         Ok(())


### PR DESCRIPTION
## What's changed and what's your intention?
We separate inject_barrier_RPC and collect_over_RPC.
Previously, When we inject barrier to CN, the RPC did not return until all collection tasks were complete.
Now , the inject_barrier_RPC can return when we send barrier to all source actor, CN will send collect_over_RPC to barrier_manager if they collect from all actor.

In concurrent checkpoint, We need source to send the barrier in order. So we separate inject_barrier_RPC and collect_over_RPC. We can inject barrier with single thread to ensure orderly, and concurrently wait for the collection.

## Checklist

- [ ] I have written necessary docs and comments
- [ ] I have added necessary unit tests and integration tests
- [ ] All checks passed in `./risedev check` (or alias, `./risedev c`)

## Refer to a related PR or issue link (optional)
