### PR TITLE
refactor(array): introduce ArrayError & unify `ensure!` by `anyhow!`

### DIFF
--- a/src/batch/src/executor/hash_agg.rs
+++ b/src/batch/src/executor/hash_agg.rs
@@ -215,13 +215,13 @@ impl<K: HashKey + Send + Sync> HashAggExecutor<K> {
         let mut result = groups.into_iter();
         let cardinality = DEFAULT_CHUNK_BUFFER_SIZE;
         loop {
-            let mut group_builders = self
+            let mut group_builders: Vec<_> = self
                 .group_key_types
                 .iter()
                 .map(|datatype| datatype.create_array_builder(cardinality))
-                .collect::<Result<Vec<_>>>()?;
+                .try_collect()?;
 
-            let mut agg_builders = self
+            let mut agg_builders: Vec<_> = self
                 .agg_factories
                 .iter()
                 .map(|agg_factory| {
@@ -229,7 +229,7 @@ impl<K: HashKey + Send + Sync> HashAggExecutor<K> {
                         .get_return_type()
                         .create_array_builder(cardinality)
                 })
-                .collect::<Result<Vec<_>>>()?;
+                .try_collect()?;
 
             let mut has_next = false;
             let mut array_len = 0;

--- a/src/batch/src/executor/join/hash_join.rs
+++ b/src/batch/src/executor/join/hash_join.rs
@@ -410,7 +410,7 @@ mod tests {
             let array_builders = data_types
                 .iter()
                 .map(|data_type| data_type.create_array_builder(1024))
-                .collect::<Result<Vec<ArrayBuilderImpl>>>()?;
+                .try_collect()?;
 
             Ok(Self {
                 data_types,
@@ -434,7 +434,7 @@ mod tests {
                 .array_builders
                 .into_iter()
                 .map(|array_builder| array_builder.finish().map(|arr| Column::new(Arc::new(arr))))
-                .collect::<Result<Vec<Column>>>()?;
+                .try_collect()?;
 
             Ok(DataChunk::new(columns, self.array_len))
         }

--- a/src/batch/src/executor/join/hash_join_state.rs
+++ b/src/batch/src/executor/join/hash_join_state.rs
@@ -198,7 +198,7 @@ impl<K: HashKey> TryFrom<BuildTable> for ProbeTable<K> {
             .full_data_types()
             .iter()
             .map(|data_type| data_type.create_array_builder(build_table.params.batch_size()))
-            .collect::<Result<Vec<_>>>()?;
+            .try_collect()?;
 
         Ok(Self {
             build_table: hash_map,
@@ -350,7 +350,7 @@ impl<K: HashKey> ProbeTable<K> {
         assert_eq!(result_row_id, chunk_len);
         // push the last probe_match vec back because the probe may not be finished
         probe_matched_list.push_back(last_probe_matched.unwrap());
-        new_filter.try_into()
+        new_filter.try_into().map_err(Into::into)
     }
 
     fn remove_duplicate_rows_for_left_semi(&mut self, filter: Bitmap) -> Result<Bitmap> {
@@ -390,7 +390,7 @@ impl<K: HashKey> ProbeTable<K> {
         assert_eq!(result_row_id, chunk_len);
         // push the last probe_match vec back because the probe may not be finished
         probe_matched_list.push_back(last_probe_matched.unwrap());
-        new_filter.try_into()
+        new_filter.try_into().map_err(Into::into)
     }
 
     fn remove_duplicate_rows_for_left_anti(&mut self, filter: Bitmap) -> Result<Bitmap> {
@@ -433,7 +433,7 @@ impl<K: HashKey> ProbeTable<K> {
         assert_eq!(result_row_id, chunk_len);
         // push the last probe_match vec back because the probe may not be finished
         probe_matched_list.push_back(last_probe_matched.unwrap());
-        new_filter.try_into()
+        new_filter.try_into().map_err(Into::into)
     }
 
     fn remove_duplicate_rows_for_right_outer(&mut self, filter: Bitmap) -> Result<Bitmap> {
@@ -469,7 +469,7 @@ impl<K: HashKey> ProbeTable<K> {
                 new_filter.push(filter_bit);
             }
         }
-        new_filter.try_into()
+        new_filter.try_into().map_err(Into::into)
     }
 
     fn remove_duplicate_rows_for_right_anti(&mut self, filter: Bitmap) -> Result<Bitmap> {
@@ -538,7 +538,7 @@ impl<K: HashKey> ProbeTable<K> {
         // push the last probe_match vec back because the probe may not be finished
         probe_matched_list.push_back(last_probe_matched.unwrap());
         self.probe_matched_list = Some(probe_matched_list);
-        new_filter.try_into()
+        new_filter.try_into().map_err(Into::into)
     }
 
     fn remove_duplicate_rows(&mut self, filter: Bitmap) -> Result<Bitmap> {
@@ -617,7 +617,7 @@ impl<K: HashKey> ProbeTable<K> {
 
     fn get_non_equi_cond_filter(&mut self, data_chunk: &DataChunk) -> Result<Bitmap> {
         let array = self.params.cond.as_mut().unwrap().eval(data_chunk)?;
-        array.as_bool().try_into()
+        array.as_bool().try_into().map_err(Into::into)
     }
 
     pub(super) fn join_remaining(&mut self) -> Result<Option<DataChunk>> {
@@ -1018,12 +1018,12 @@ impl<K: HashKey> ProbeTable<K> {
             .full_data_types()
             .iter()
             .map(|data_type| data_type.create_array_builder(self.params.batch_size()))
-            .collect::<Result<Vec<_>>>()?;
+            .try_collect()?;
 
-        let new_arrays = mem::replace(&mut self.array_builders, new_array_builders)
+        let new_arrays: Vec<_> = mem::replace(&mut self.array_builders, new_array_builders)
             .into_iter()
             .map(|builder| builder.finish())
-            .collect::<Result<Vec<_>>>()?;
+            .try_collect()?;
         let new_len = mem::replace(&mut self.array_len, 0);
 
         let new_columns = new_arrays

--- a/src/batch/src/executor/join/nested_loop_join.rs
+++ b/src/batch/src/executor/join/nested_loop_join.rs
@@ -19,7 +19,7 @@ use futures_async_stream::try_stream;
 use itertools::Itertools;
 use risingwave_common::array::column::Column;
 use risingwave_common::array::data_chunk_iter::RowRef;
-use risingwave_common::array::{ArrayBuilderImpl, DataChunk, Row, Vis};
+use risingwave_common::array::{DataChunk, Row, Vis};
 use risingwave_common::catalog::Schema;
 use risingwave_common::error::{ErrorCode, Result, RwError};
 use risingwave_common::types::{DataType, DatumRef};

--- a/src/batch/src/executor/join/nested_loop_join.rs
+++ b/src/batch/src/executor/join/nested_loop_join.rs
@@ -156,10 +156,10 @@ impl NestedLoopJoinExecutor {
         num_tuples: usize,
         data_types: &[DataType],
     ) -> Result<DataChunk> {
-        let mut output_array_builders = data_types
+        let mut output_array_builders: Vec<_> = data_types
             .iter()
             .map(|data_type| data_type.create_array_builder(num_tuples))
-            .collect::<Result<Vec<ArrayBuilderImpl>>>()?;
+            .try_collect()?;
         for _i in 0..num_tuples {
             for (builder, datum_ref) in output_array_builders.iter_mut().zip_eq(datum_refs) {
                 builder.append_datum_ref(*datum_ref)?;
@@ -170,7 +170,7 @@ impl NestedLoopJoinExecutor {
         let result_columns = output_array_builders
             .into_iter()
             .map(|builder| builder.finish().map(|arr| Column::new(Arc::new(arr))))
-            .collect::<Result<Vec<Column>>>()?;
+            .try_collect()?;
 
         Ok(DataChunk::new(result_columns, num_tuples))
     }

--- a/src/batch/src/executor/merge_sort_exchange.rs
+++ b/src/batch/src/executor/merge_sort_exchange.rs
@@ -18,7 +18,7 @@ use std::sync::Arc;
 
 use futures_async_stream::try_stream;
 use risingwave_common::array::column::Column;
-use risingwave_common::array::{ArrayBuilderImpl, DataChunk};
+use risingwave_common::array::DataChunk;
 use risingwave_common::catalog::{Field, Schema};
 use risingwave_common::error::{Result, RwError};
 use risingwave_common::types::ToOwnedDatum;

--- a/src/batch/src/executor/merge_sort_exchange.rs
+++ b/src/batch/src/executor/merge_sort_exchange.rs
@@ -136,7 +136,7 @@ impl<CS: 'static + CreateSource, C: BatchTaskContext> MergeSortExchangeExecutorI
             // we may run out of input data chunks from sources.
             let mut want_to_produce = K_PROCESSING_WINDOW_SIZE;
 
-            let mut builders = self
+            let mut builders: Vec<_> = self
                 .schema()
                 .fields
                 .iter()
@@ -145,7 +145,7 @@ impl<CS: 'static + CreateSource, C: BatchTaskContext> MergeSortExchangeExecutorI
                         .data_type
                         .create_array_builder(K_PROCESSING_WINDOW_SIZE)
                 })
-                .collect::<Result<Vec<ArrayBuilderImpl>>>()?;
+                .try_collect()?;
             let mut array_len = 0;
             while want_to_produce > 0 && !self.min_heap.is_empty() {
                 let top_elem = self.min_heap.pop().unwrap();

--- a/src/batch/src/executor/sort_agg.rs
+++ b/src/batch/src/executor/sort_agg.rs
@@ -248,12 +248,12 @@ impl SortAggExecutor {
         let group_builders = group_keys
             .iter()
             .map(|e| e.return_type().create_array_builder(1))
-            .collect::<Result<Vec<_>>>();
+            .try_collect();
 
         let agg_builders = agg_states
             .iter()
             .map(|e| e.return_type().create_array_builder(1))
-            .collect::<Result<Vec<_>>>();
+            .try_collect();
 
         (group_builders.unwrap(), agg_builders.unwrap())
     }

--- a/src/batch/src/executor/update.rs
+++ b/src/batch/src/executor/update.rs
@@ -123,7 +123,7 @@ impl UpdateExecutor {
             let columns = builders
                 .into_iter()
                 .map(|b| b.finish().map(|a| a.into()))
-                .collect::<Result<Vec<_>>>()?;
+                .try_collect()?;
 
             let ops = [Op::UpdateDelete, Op::UpdateInsert]
                 .into_iter()

--- a/src/batch/src/executor/values.rs
+++ b/src/batch/src/executor/values.rs
@@ -93,7 +93,7 @@ impl ValuesExecutor {
                 let columns = array_builders
                     .into_iter()
                     .map(|builder| builder.finish().map(|arr| Column::new(Arc::new(arr))))
-                    .collect::<Result<Vec<Column>>>()?;
+                    .try_collect()?;
 
                 let chunk = DataChunk::new(columns, chunk_size);
 

--- a/src/common/src/array/bool_array.rs
+++ b/src/common/src/array/bool_array.rs
@@ -16,10 +16,11 @@ use std::hash::{Hash, Hasher};
 
 use risingwave_pb::data::{Array as ProstArray, ArrayType};
 
-use super::{Array, ArrayBuilder, ArrayIterator, ArrayMeta, NULL_VAL_FOR_HASH};
+use super::{
+    Array, ArrayBuilder, ArrayError, ArrayIterator, ArrayMeta, ArrayResult, NULL_VAL_FOR_HASH,
+};
 use crate::array::ArrayBuilderImpl;
 use crate::buffer::{Bitmap, BitmapBuilder};
-use crate::error::Result;
 
 #[derive(Debug)]
 pub struct BoolArray {
@@ -33,7 +34,7 @@ impl BoolArray {
         Self { bitmap, data }
     }
 
-    pub fn from_slice(data: &[Option<bool>]) -> Result<Self> {
+    pub fn from_slice(data: &[Option<bool>]) -> ArrayResult<Self> {
         let mut builder = <Self as Array>::Builder::new(data.len())?;
         for i in data {
             builder.append(*i)?;
@@ -103,7 +104,7 @@ impl Array for BoolArray {
         }
     }
 
-    fn create_builder(&self, capacity: usize) -> Result<ArrayBuilderImpl> {
+    fn create_builder(&self, capacity: usize) -> ArrayResult<ArrayBuilderImpl> {
         let array_builder = BoolArrayBuilder::new(capacity)?;
         Ok(ArrayBuilderImpl::Bool(array_builder))
     }
@@ -119,14 +120,14 @@ pub struct BoolArrayBuilder {
 impl ArrayBuilder for BoolArrayBuilder {
     type ArrayType = BoolArray;
 
-    fn with_meta(capacity: usize, _meta: ArrayMeta) -> Result<Self> {
+    fn with_meta(capacity: usize, _meta: ArrayMeta) -> ArrayResult<Self> {
         Ok(Self {
             bitmap: BitmapBuilder::with_capacity(capacity),
             data: BitmapBuilder::with_capacity(capacity),
         })
     }
 
-    fn append(&mut self, value: Option<bool>) -> Result<()> {
+    fn append(&mut self, value: Option<bool>) -> ArrayResult<()> {
         match value {
             Some(x) => {
                 self.bitmap.append(true);
@@ -140,7 +141,7 @@ impl ArrayBuilder for BoolArrayBuilder {
         Ok(())
     }
 
-    fn append_array(&mut self, other: &BoolArray) -> Result<()> {
+    fn append_array(&mut self, other: &BoolArray) -> ArrayResult<()> {
         for bit in other.bitmap.iter() {
             self.bitmap.append(bit);
         }
@@ -152,7 +153,7 @@ impl ArrayBuilder for BoolArrayBuilder {
         Ok(())
     }
 
-    fn finish(self) -> Result<BoolArray> {
+    fn finish(self) -> ArrayResult<BoolArray> {
         Ok(BoolArray {
             bitmap: self.bitmap.finish(),
             data: self.data.finish(),

--- a/src/common/src/array/bool_array.rs
+++ b/src/common/src/array/bool_array.rs
@@ -16,9 +16,7 @@ use std::hash::{Hash, Hasher};
 
 use risingwave_pb::data::{Array as ProstArray, ArrayType};
 
-use super::{
-    Array, ArrayBuilder, ArrayError, ArrayIterator, ArrayMeta, ArrayResult, NULL_VAL_FOR_HASH,
-};
+use super::{Array, ArrayBuilder, ArrayIterator, ArrayMeta, ArrayResult, NULL_VAL_FOR_HASH};
 use crate::array::ArrayBuilderImpl;
 use crate::buffer::{Bitmap, BitmapBuilder};
 

--- a/src/common/src/array/column.rs
+++ b/src/common/src/array/column.rs
@@ -16,9 +16,8 @@ use std::sync::Arc;
 
 use risingwave_pb::data::Column as ProstColumn;
 
-use super::Array;
+use super::{Array, ArrayError, ArrayResult};
 use crate::array::{ArrayImpl, ArrayRef};
-use crate::error::Result;
 
 /// Column is owned by `DataChunk`. It consists of logic data type and physical array
 /// implementation.
@@ -37,7 +36,7 @@ impl Column {
         ProstColumn { array: Some(array) }
     }
 
-    pub fn from_protobuf(col: &ProstColumn, cardinality: usize) -> Result<Self> {
+    pub fn from_protobuf(col: &ProstColumn, cardinality: usize) -> ArrayResult<Self> {
         Ok(Column {
             array: Arc::new(ArrayImpl::from_protobuf(col.get_array()?, cardinality)?),
         })

--- a/src/common/src/array/column.rs
+++ b/src/common/src/array/column.rs
@@ -16,7 +16,7 @@ use std::sync::Arc;
 
 use risingwave_pb::data::Column as ProstColumn;
 
-use super::{Array, ArrayError, ArrayResult};
+use super::{Array, ArrayResult};
 use crate::array::{ArrayImpl, ArrayRef};
 
 /// Column is owned by `DataChunk`. It consists of logic data type and physical array

--- a/src/common/src/array/column_proto_readers.rs
+++ b/src/common/src/array/column_proto_readers.rs
@@ -99,21 +99,19 @@ fn read_naive_date_time(cursor: &mut Cursor<&[u8]>) -> ArrayResult<NaiveDateTime
     }
 }
 
-pub fn read_interval_unit(_cursor: &mut Cursor<&[u8]>) -> ArrayResult<IntervalUnit> {
-    // let iu = try {
-    //     let months = cursor.read_i32::<BigEndian>()?;
-    //     let days = cursor.read_i32::<BigEndian>()?;
-    //     let ms = cursor.read_i64::<BigEndian>()?;
+pub fn read_interval_unit(cursor: &mut Cursor<&[u8]>) -> ArrayResult<IntervalUnit> {
+    let mut read = || {
+        let months = cursor.read_i32::<BigEndian>()?;
+        let days = cursor.read_i32::<BigEndian>()?;
+        let ms = cursor.read_i64::<BigEndian>()?;
 
-    //     Ok::<_, std::io::Error>(IntervalUnit::new(months, days, ms))
-    // };
+        Ok::<_, std::io::Error>(IntervalUnit::new(months, days, ms))
+    };
 
-    // match iu {
-    //     Ok(i) => Ok(i),
-    //     Err(e) => bail_anyhow!("Failed to read IntervalUnit from buffer: {}", e),
-    // }
-
-    todo!()
+    match read() {
+        Ok(iu) => Ok(iu),
+        Err(e) => bail_anyhow!("Failed to read IntervalUnit from buffer: {}", e),
+    }
 }
 
 macro_rules! read_one_value_array {

--- a/src/common/src/array/column_proto_readers.rs
+++ b/src/common/src/array/column_proto_readers.rs
@@ -36,14 +36,14 @@ pub fn read_numeric_array<T: PrimitiveArrayItemType, R: PrimitiveValueReader<T>>
     array: &ProstArray,
     cardinality: usize,
 ) -> ArrayResult<ArrayImpl> {
-    ensure_anyhow!(
+    ensure!(
         array.get_values().len() == 1,
         "Must have only 1 buffer in a numeric array"
     );
 
     let buf = array.get_values()[0].get_body().as_slice();
     let value_size = std::mem::size_of::<T>();
-    ensure_anyhow!(
+    ensure!(
         buf.len() % value_size == 0,
         "Unexpected memory layout of numeric array"
     );
@@ -64,7 +64,7 @@ pub fn read_numeric_array<T: PrimitiveArrayItemType, R: PrimitiveValueReader<T>>
 }
 
 pub fn read_bool_array(array: &ProstArray, cardinality: usize) -> ArrayResult<ArrayImpl> {
-    ensure_anyhow!(
+    ensure!(
         array.get_values().len() == 1,
         "Must have only 1 buffer in a bool array"
     );
@@ -81,21 +81,21 @@ pub fn read_bool_array(array: &ProstArray, cardinality: usize) -> ArrayResult<Ar
 fn read_naive_date(cursor: &mut Cursor<&[u8]>) -> ArrayResult<NaiveDateWrapper> {
     match cursor.read_i32::<BigEndian>() {
         Ok(days) => NaiveDateWrapper::from_protobuf(days),
-        Err(e) => bail_anyhow!("Failed to read i32 from NaiveDate buffer: {}", e),
+        Err(e) => bail!("Failed to read i32 from NaiveDate buffer: {}", e),
     }
 }
 
 fn read_naive_time(cursor: &mut Cursor<&[u8]>) -> ArrayResult<NaiveTimeWrapper> {
     match cursor.read_i64::<BigEndian>() {
         Ok(t) => NaiveTimeWrapper::from_protobuf(t),
-        Err(e) => bail_anyhow!("Failed to read i64 from NaiveTime buffer: {}", e),
+        Err(e) => bail!("Failed to read i64 from NaiveTime buffer: {}", e),
     }
 }
 
 fn read_naive_date_time(cursor: &mut Cursor<&[u8]>) -> ArrayResult<NaiveDateTimeWrapper> {
     match cursor.read_i64::<BigEndian>() {
         Ok(t) => NaiveDateTimeWrapper::from_protobuf(t),
-        Err(e) => bail_anyhow!("Failed to read i64 from NaiveDateTime buffer: {}", e),
+        Err(e) => bail!("Failed to read i64 from NaiveDateTime buffer: {}", e),
     }
 }
 
@@ -110,7 +110,7 @@ pub fn read_interval_unit(cursor: &mut Cursor<&[u8]>) -> ArrayResult<IntervalUni
 
     match read() {
         Ok(iu) => Ok(iu),
-        Err(e) => bail_anyhow!("Failed to read IntervalUnit from buffer: {}", e),
+        Err(e) => bail!("Failed to read IntervalUnit from buffer: {}", e),
     }
 }
 
@@ -119,7 +119,7 @@ macro_rules! read_one_value_array {
         paste! {
             $(
             pub fn [<read_ $type:snake _array>](array: &ProstArray, cardinality: usize) -> ArrayResult<ArrayImpl> {
-                ensure_anyhow!(
+                ensure!(
                     array.get_values().len() == 1,
                     "Must have only 1 buffer in a {} array", stringify!($type)
                 );
@@ -154,7 +154,7 @@ read_one_value_array! {
 fn read_offset(offset_cursor: &mut Cursor<&[u8]>) -> ArrayResult<i64> {
     match offset_cursor.read_i64::<BigEndian>() {
         Ok(offset) => Ok(offset),
-        Err(e) => bail_anyhow!("failed to read i64 from offset buffer: {}", e),
+        Err(e) => bail!("failed to read i64 from offset buffer: {}", e),
     }
 }
 
@@ -162,7 +162,7 @@ pub fn read_string_array<B: ArrayBuilder, R: VarSizedValueReader<B>>(
     array: &ProstArray,
     cardinality: usize,
 ) -> ArrayResult<ArrayImpl> {
-    ensure_anyhow!(
+    ensure!(
         array.get_values().len() == 2,
         "Must have exactly 2 buffers in a string array"
     );

--- a/src/common/src/array/column_proto_readers.rs
+++ b/src/common/src/array/column_proto_readers.rs
@@ -12,21 +12,21 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use std::io::{self, Cursor, Read};
+use std::io::{Cursor, Read};
 
+use anyhow::anyhow;
 use byteorder::{BigEndian, ReadBytesExt};
 use paste::paste;
 use risingwave_pb::data::Array as ProstArray;
 
+use super::error::ArrayError;
 use crate::array::value_reader::{PrimitiveValueReader, VarSizedValueReader};
 use crate::array::{
-    Array, ArrayBuilder, ArrayImpl, ArrayMeta, BoolArray, IntervalArrayBuilder,
+    Array, ArrayBuilder, ArrayImpl, ArrayMeta, ArrayResult, BoolArray, IntervalArrayBuilder,
     NaiveDateArrayBuilder, NaiveDateTimeArrayBuilder, NaiveTimeArrayBuilder, PrimitiveArrayBuilder,
     PrimitiveArrayItemType,
 };
 use crate::buffer::Bitmap;
-use crate::error::ErrorCode::InternalError;
-use crate::error::{Result, RwError};
 use crate::types::interval::IntervalUnit;
 use crate::types::{NaiveDateTimeWrapper, NaiveDateWrapper, NaiveTimeWrapper};
 
@@ -36,15 +36,15 @@ use crate::types::{NaiveDateTimeWrapper, NaiveDateWrapper, NaiveTimeWrapper};
 pub fn read_numeric_array<T: PrimitiveArrayItemType, R: PrimitiveValueReader<T>>(
     array: &ProstArray,
     cardinality: usize,
-) -> Result<ArrayImpl> {
-    ensure!(
+) -> ArrayResult<ArrayImpl> {
+    ensure_anyhow!(
         array.get_values().len() == 1,
         "Must have only 1 buffer in a numeric array"
     );
 
     let buf = array.get_values()[0].get_body().as_slice();
     let value_size = std::mem::size_of::<T>();
-    ensure!(
+    ensure_anyhow!(
         buf.len() % value_size == 0,
         "Unexpected memory layout of numeric array"
     );
@@ -64,8 +64,8 @@ pub fn read_numeric_array<T: PrimitiveArrayItemType, R: PrimitiveValueReader<T>>
     Ok(arr.into())
 }
 
-pub fn read_bool_array(array: &ProstArray, cardinality: usize) -> Result<ArrayImpl> {
-    ensure!(
+pub fn read_bool_array(array: &ProstArray, cardinality: usize) -> ArrayResult<ArrayImpl> {
+    ensure_anyhow!(
         array.get_values().len() == 1,
         "Must have only 1 buffer in a bool array"
     );
@@ -79,58 +79,50 @@ pub fn read_bool_array(array: &ProstArray, cardinality: usize) -> Result<ArrayIm
     Ok(arr.into())
 }
 
-fn read_naive_date(cursor: &mut Cursor<&[u8]>) -> Result<NaiveDateWrapper> {
+fn read_naive_date(cursor: &mut Cursor<&[u8]>) -> ArrayResult<NaiveDateWrapper> {
     match cursor.read_i32::<BigEndian>() {
         Ok(days) => NaiveDateWrapper::from_protobuf(days),
-        Err(e) => Err(RwError::from(InternalError(format!(
-            "Failed to read i32 from NaiveDate buffer: {}",
-            e
-        )))),
+        Err(e) => bail_anyhow!("Failed to read i32 from NaiveDate buffer: {}", e),
     }
 }
 
-fn read_naive_time(cursor: &mut Cursor<&[u8]>) -> Result<NaiveTimeWrapper> {
+fn read_naive_time(cursor: &mut Cursor<&[u8]>) -> ArrayResult<NaiveTimeWrapper> {
     match cursor.read_i64::<BigEndian>() {
         Ok(t) => NaiveTimeWrapper::from_protobuf(t),
-        Err(e) => Err(RwError::from(InternalError(format!(
-            "Failed to read i64 from NaiveTime buffer: {}",
-            e
-        )))),
+        Err(e) => bail_anyhow!("Failed to read i64 from NaiveTime buffer: {}", e),
     }
 }
 
-fn read_naive_date_time(cursor: &mut Cursor<&[u8]>) -> Result<NaiveDateTimeWrapper> {
+fn read_naive_date_time(cursor: &mut Cursor<&[u8]>) -> ArrayResult<NaiveDateTimeWrapper> {
     match cursor.read_i64::<BigEndian>() {
         Ok(t) => NaiveDateTimeWrapper::from_protobuf(t),
-        Err(e) => Err(RwError::from(InternalError(format!(
-            "Failed to read i64 from NaiveDateTime buffer: {}",
-            e
-        )))),
+        Err(e) => bail_anyhow!("Failed to read i64 from NaiveDateTime buffer: {}", e),
     }
 }
 
-pub fn read_interval_unit(cursor: &mut Cursor<&[u8]>) -> Result<IntervalUnit> {
-    {
-        let months = cursor.read_i32::<BigEndian>()?;
-        let days = cursor.read_i32::<BigEndian>()?;
-        let ms = cursor.read_i64::<BigEndian>()?;
+pub fn read_interval_unit(cursor: &mut Cursor<&[u8]>) -> ArrayResult<IntervalUnit> {
+    // let iu = try {
+    //     let months = cursor.read_i32::<BigEndian>()?;
+    //     let days = cursor.read_i32::<BigEndian>()?;
+    //     let ms = cursor.read_i64::<BigEndian>()?;
 
-        Ok(IntervalUnit::new(months, days, ms))
-    }
-    .map_err(|e: io::Error| {
-        RwError::from(InternalError(format!(
-            "Failed to read IntervalUnit from buffer: {}",
-            e
-        )))
-    })
+    //     Ok::<_, std::io::Error>(IntervalUnit::new(months, days, ms))
+    // };
+
+    // match iu {
+    //     Ok(i) => Ok(i),
+    //     Err(e) => bail_anyhow!("Failed to read IntervalUnit from buffer: {}", e),
+    // }
+
+    todo!()
 }
 
 macro_rules! read_one_value_array {
     ($({ $type:ident, $builder:ty }),*) => {
         paste! {
             $(
-            pub fn [<read_ $type:snake _array>](array: &ProstArray, cardinality: usize) -> Result<ArrayImpl> {
-                ensure!(
+            pub fn [<read_ $type:snake _array>](array: &ProstArray, cardinality: usize) -> ArrayResult<ArrayImpl> {
+                ensure_anyhow!(
                     array.get_values().len() == 1,
                     "Must have only 1 buffer in a {} array", stringify!($type)
                 );
@@ -162,18 +154,18 @@ read_one_value_array! {
     { NaiveDateTime, NaiveDateTimeArrayBuilder }
 }
 
-fn read_offset(offset_cursor: &mut Cursor<&[u8]>) -> Result<i64> {
-    let offset = offset_cursor
-        .read_i64::<BigEndian>()
-        .map_err(|e| InternalError(format!("failed to read i64 from offset buffer: {}", e)))?;
-    Ok(offset)
+fn read_offset(offset_cursor: &mut Cursor<&[u8]>) -> ArrayResult<i64> {
+    match offset_cursor.read_i64::<BigEndian>() {
+        Ok(offset) => Ok(offset),
+        Err(e) => bail_anyhow!("failed to read i64 from offset buffer: {}", e),
+    }
 }
 
 pub fn read_string_array<B: ArrayBuilder, R: VarSizedValueReader<B>>(
     array: &ProstArray,
     cardinality: usize,
-) -> Result<ArrayImpl> {
-    ensure!(
+) -> ArrayResult<ArrayImpl> {
+    ensure_anyhow!(
         array.get_values().len() == 2,
         "Must have exactly 2 buffers in a string array"
     );
@@ -197,10 +189,12 @@ pub fn read_string_array<B: ArrayBuilder, R: VarSizedValueReader<B>>(
             prev_offset = offset;
             buf.resize(length, Default::default());
             data_cursor.read_exact(buf.as_mut_slice()).map_err(|e| {
-                InternalError(format!(
+                anyhow!(
                     "failed to read str from data buffer: {} [length={}, offset={}]",
-                    e, length, offset
-                ))
+                    e,
+                    length,
+                    offset
+                )
             })?;
             let v = R::read(buf.as_slice())?;
             builder.append(Some(v))?;

--- a/src/common/src/array/column_proto_readers.rs
+++ b/src/common/src/array/column_proto_readers.rs
@@ -19,7 +19,6 @@ use byteorder::{BigEndian, ReadBytesExt};
 use paste::paste;
 use risingwave_pb::data::Array as ProstArray;
 
-use super::error::ArrayError;
 use crate::array::value_reader::{PrimitiveValueReader, VarSizedValueReader};
 use crate::array::{
     Array, ArrayBuilder, ArrayImpl, ArrayMeta, ArrayResult, BoolArray, IntervalArrayBuilder,
@@ -100,7 +99,7 @@ fn read_naive_date_time(cursor: &mut Cursor<&[u8]>) -> ArrayResult<NaiveDateTime
     }
 }
 
-pub fn read_interval_unit(cursor: &mut Cursor<&[u8]>) -> ArrayResult<IntervalUnit> {
+pub fn read_interval_unit(_cursor: &mut Cursor<&[u8]>) -> ArrayResult<IntervalUnit> {
     // let iu = try {
     //     let months = cursor.read_i32::<BigEndian>()?;
     //     let days = cursor.read_i32::<BigEndian>()?;

--- a/src/common/src/array/data_chunk.rs
+++ b/src/common/src/array/data_chunk.rs
@@ -76,7 +76,7 @@ impl Vis {
         match self {
             Vis::Bitmap(b) => b.is_set(idx),
             Vis::Compact(c) => {
-                ensure_anyhow!(idx <= *c);
+                ensure!(idx <= *c);
                 Ok(true)
             }
         }

--- a/src/common/src/array/data_chunk.rs
+++ b/src/common/src/array/data_chunk.rs
@@ -21,7 +21,7 @@ use auto_enums::auto_enum;
 use itertools::Itertools;
 use risingwave_pb::data::DataChunk as ProstDataChunk;
 
-use super::{ArrayError, ArrayResult};
+use super::ArrayResult;
 use crate::array::column::Column;
 use crate::array::data_chunk_iter::{Row, RowRef};
 use crate::array::ArrayBuilderImpl;

--- a/src/common/src/array/data_chunk.rs
+++ b/src/common/src/array/data_chunk.rs
@@ -21,11 +21,11 @@ use auto_enums::auto_enum;
 use itertools::Itertools;
 use risingwave_pb::data::DataChunk as ProstDataChunk;
 
+use super::{ArrayError, ArrayResult};
 use crate::array::column::Column;
 use crate::array::data_chunk_iter::{Row, RowRef};
 use crate::array::ArrayBuilderImpl;
 use crate::buffer::{Bitmap, BitmapBuilder};
-use crate::error::{Result, RwError};
 use crate::hash::HashCode;
 use crate::types::{DataType, NaiveDateTimeWrapper, ToOwnedDatum};
 use crate::util::hash_util::finalize_hashers;
@@ -72,11 +72,11 @@ impl Vis {
         }
     }
 
-    pub fn is_set(&self, idx: usize) -> Result<bool> {
+    pub fn is_set(&self, idx: usize) -> ArrayResult<bool> {
         match self {
             Vis::Bitmap(b) => b.is_set(idx),
             Vis::Compact(c) => {
-                ensure!(idx <= *c);
+                ensure_anyhow!(idx <= *c);
                 Ok(true)
             }
         }
@@ -116,11 +116,11 @@ impl DataChunk {
     }
 
     /// Build a `DataChunk` with rows.
-    pub fn from_rows(rows: &[Row], data_types: &[DataType]) -> Result<Self> {
+    pub fn from_rows(rows: &[Row], data_types: &[DataType]) -> ArrayResult<Self> {
         let mut array_builders = data_types
             .iter()
             .map(|data_type| data_type.create_array_builder(1))
-            .collect::<Result<Vec<_>>>()?;
+            .collect::<ArrayResult<Vec<_>>>()?;
 
         for row in rows {
             for (datum, builder) in row.0.iter().zip_eq(array_builders.iter_mut()) {
@@ -131,7 +131,7 @@ impl DataChunk {
         let new_arrays = array_builders
             .into_iter()
             .map(|builder| builder.finish())
-            .collect::<Result<Vec<_>>>()?;
+            .collect::<ArrayResult<Vec<_>>>()?;
 
         let new_columns = new_arrays
             .into_iter()
@@ -232,7 +232,7 @@ impl DataChunk {
 
     /// `compact` will convert the chunk to compact format.
     /// Compact format means that `visibility == None`.
-    pub fn compact(self) -> Result<Self> {
+    pub fn compact(self) -> ArrayResult<Self> {
         match &self.vis2 {
             Vis::Compact(_) => Ok(self),
             Vis::Bitmap(visibility) => {
@@ -248,13 +248,13 @@ impl DataChunk {
                             .compact(visibility, cardinality)
                             .map(|array| Column::new(Arc::new(array)))
                     })
-                    .collect::<Result<Vec<_>>>()?;
+                    .collect::<ArrayResult<Vec<_>>>()?;
                 Ok(Self::new(columns, cardinality))
             }
         }
     }
 
-    pub fn from_protobuf(proto: &ProstDataChunk) -> Result<Self> {
+    pub fn from_protobuf(proto: &ProstDataChunk) -> ArrayResult<Self> {
         let mut columns = vec![];
         for any_col in proto.get_columns() {
             let cardinality = proto.get_cardinality() as usize;
@@ -271,7 +271,7 @@ impl DataChunk {
     ///
     /// Currently, `rechunk` would ignore visibility map. May or may not support it later depending
     /// on the demand
-    pub fn rechunk(chunks: &[DataChunk], each_size_limit: usize) -> Result<Vec<DataChunk>> {
+    pub fn rechunk(chunks: &[DataChunk], each_size_limit: usize) -> ArrayResult<Vec<DataChunk>> {
         assert!(each_size_limit > 0);
         // Corner case: one of the `chunks` may have 0 length
         // remove the chunks with zero physical length here,
@@ -334,10 +334,7 @@ impl DataChunk {
             if new_chunk_require == 0 {
                 let new_columns: Vec<Column> = array_builders
                     .drain(..)
-                    .map(|builder| {
-                        let array = builder.finish()?;
-                        Ok::<_, RwError>(Column::new(Arc::new(array)))
-                    })
+                    .map(|builder| builder.finish().map(Into::into))
                     .try_collect()?;
 
                 array_builders = new_columns
@@ -360,7 +357,7 @@ impl DataChunk {
         &self,
         column_idxes: &[usize],
         hasher_builder: H,
-    ) -> Result<Vec<HashCode>> {
+    ) -> ArrayResult<Vec<HashCode>> {
         let mut states = Vec::with_capacity(self.capacity());
         states.resize_with(self.capacity(), || hasher_builder.build_hasher());
         for column_idx in column_idxes {
@@ -378,7 +375,7 @@ impl DataChunk {
     /// * `pos` - Index of look up tuple
     /// * `RowRef` - Reference of data tuple
     /// * bool - whether this tuple is visible
-    pub fn row_at(&self, pos: usize) -> Result<(RowRef<'_>, bool)> {
+    pub fn row_at(&self, pos: usize) -> ArrayResult<(RowRef<'_>, bool)> {
         let row = self.row_at_unchecked_vis(pos);
         let vis = match &self.vis2 {
             Vis::Bitmap(bitmap) => bitmap.is_set(pos)?,
@@ -503,7 +500,7 @@ impl DataChunkTestExt for DataChunk {
                 _ => todo!("unsupported type: {c:?}"),
             })
             .map(|ty| ty.create_array_builder(1))
-            .collect::<Result<Vec<_>>>()
+            .collect::<ArrayResult<Vec<_>>>()
             .unwrap();
         let mut visibility = vec![];
         for mut line in lines {

--- a/src/common/src/array/data_chunk_iter.rs
+++ b/src/common/src/array/data_chunk_iter.rs
@@ -310,7 +310,7 @@ impl Row {
             let datum = self.0.get(*idx);
             match datum {
                 Some(datum) => datum.hash(&mut hasher),
-                None => bail_anyhow!("index {} out of row bound", idx),
+                None => bail!("index {} out of row bound", idx),
             }
         }
         Ok(HashCode(hasher.finish()))

--- a/src/common/src/array/data_chunk_iter.rs
+++ b/src/common/src/array/data_chunk_iter.rs
@@ -20,7 +20,7 @@ use itertools::Itertools;
 
 use super::column::Column;
 use crate::array::DataChunk;
-use crate::error::{ErrorCode, Result as RwResult};
+use crate::error::Result as RwResult;
 use crate::hash::HashCode;
 use crate::types::{
     deserialize_datum_from, deserialize_datum_not_null_from, serialize_datum_into,
@@ -297,7 +297,11 @@ impl Row {
     }
 
     /// Compute hash value of a row on corresponding indices.
-    pub fn hash_by_indices<H>(&self, hash_indices: &[usize], hash_builder: &H) -> RwResult<HashCode>
+    pub fn hash_by_indices<H>(
+        &self,
+        hash_indices: &[usize],
+        hash_builder: &H,
+    ) -> super::ArrayResult<HashCode>
     where
         H: BuildHasher,
     {
@@ -306,11 +310,7 @@ impl Row {
             let datum = self.0.get(*idx);
             match datum {
                 Some(datum) => datum.hash(&mut hasher),
-                None => {
-                    return Err(
-                        ErrorCode::InternalError(format!("index {} out of row bound", idx)).into(),
-                    )
-                }
+                None => bail_anyhow!("index {} out of row bound", idx),
             }
         }
         Ok(HashCode(hasher.finish()))

--- a/src/common/src/array/decimal_array.rs
+++ b/src/common/src/array/decimal_array.rs
@@ -19,7 +19,7 @@ use itertools::Itertools;
 use risingwave_pb::data::buffer::CompressionType;
 use risingwave_pb::data::{Array as ProstArray, ArrayType, Buffer};
 
-use super::{Array, ArrayBuilder, ArrayError, ArrayIterator, ArrayResult, NULL_VAL_FOR_HASH};
+use super::{Array, ArrayBuilder, ArrayIterator, ArrayResult, NULL_VAL_FOR_HASH};
 use crate::array::{ArrayBuilderImpl, ArrayMeta};
 use crate::buffer::{Bitmap, BitmapBuilder};
 use crate::types::Decimal;

--- a/src/common/src/array/decimal_array.rs
+++ b/src/common/src/array/decimal_array.rs
@@ -19,10 +19,9 @@ use itertools::Itertools;
 use risingwave_pb::data::buffer::CompressionType;
 use risingwave_pb::data::{Array as ProstArray, ArrayType, Buffer};
 
-use super::{Array, ArrayBuilder, ArrayIterator, NULL_VAL_FOR_HASH};
+use super::{Array, ArrayBuilder, ArrayError, ArrayIterator, ArrayResult, NULL_VAL_FOR_HASH};
 use crate::array::{ArrayBuilderImpl, ArrayMeta};
 use crate::buffer::{Bitmap, BitmapBuilder};
-use crate::error::Result;
 use crate::types::Decimal;
 
 #[derive(Debug)]
@@ -32,7 +31,7 @@ pub struct DecimalArray {
 }
 
 impl DecimalArray {
-    pub fn from_slice(data: &[Option<Decimal>]) -> Result<Self> {
+    pub fn from_slice(data: &[Option<Decimal>]) -> ArrayResult<Self> {
         let mut builder = <Self as Array>::Builder::new(data.len())?;
         for i in data {
             builder.append(*i)?;
@@ -123,7 +122,7 @@ impl Array for DecimalArray {
         }
     }
 
-    fn create_builder(&self, capacity: usize) -> Result<ArrayBuilderImpl> {
+    fn create_builder(&self, capacity: usize) -> ArrayResult<ArrayBuilderImpl> {
         let array_builder = DecimalArrayBuilder::new(capacity)?;
         Ok(ArrayBuilderImpl::Decimal(array_builder))
     }
@@ -139,14 +138,14 @@ pub struct DecimalArrayBuilder {
 impl ArrayBuilder for DecimalArrayBuilder {
     type ArrayType = DecimalArray;
 
-    fn with_meta(capacity: usize, _meta: ArrayMeta) -> Result<Self> {
+    fn with_meta(capacity: usize, _meta: ArrayMeta) -> ArrayResult<Self> {
         Ok(Self {
             bitmap: BitmapBuilder::with_capacity(capacity),
             data: Vec::with_capacity(capacity),
         })
     }
 
-    fn append(&mut self, value: Option<Decimal>) -> Result<()> {
+    fn append(&mut self, value: Option<Decimal>) -> ArrayResult<()> {
         match value {
             Some(x) => {
                 self.bitmap.append(true);
@@ -160,7 +159,7 @@ impl ArrayBuilder for DecimalArrayBuilder {
         Ok(())
     }
 
-    fn append_array(&mut self, other: &DecimalArray) -> Result<()> {
+    fn append_array(&mut self, other: &DecimalArray) -> ArrayResult<()> {
         for bit in other.bitmap.iter() {
             self.bitmap.append(bit);
         }
@@ -168,7 +167,7 @@ impl ArrayBuilder for DecimalArrayBuilder {
         Ok(())
     }
 
-    fn finish(self) -> Result<DecimalArray> {
+    fn finish(self) -> ArrayResult<DecimalArray> {
         Ok(DecimalArray {
             bitmap: self.bitmap.finish(),
             data: self.data,

--- a/src/common/src/array/error.rs
+++ b/src/common/src/array/error.rs
@@ -17,7 +17,6 @@ use risingwave_pb::ProstFieldNotFound;
 use thiserror::Error;
 
 use crate::error::{ErrorCode, RwError};
-use crate::types::DataType;
 
 #[derive(Error, Debug)]
 pub enum ArrayError {

--- a/src/common/src/array/error.rs
+++ b/src/common/src/array/error.rs
@@ -20,38 +20,12 @@ use crate::error::{ErrorCode, RwError};
 
 #[derive(Error, Debug)]
 pub enum ArrayError {
-    // #[error("Unsupported function: {0}")]
-    // UnsupportedFunction(String),
-
-    // #[error("Can't cast {0} to {1}")]
-    // Cast(&'static str, &'static str),
-
-    // // TODO: Unify Cast and Cast2.
-    // #[error("Can't cast {0:?} to {1:?}")]
-    // Cast2(DataType, DataType),
-
-    // #[error("Out of range")]
-    // NumericOutOfRange,
-
-    // #[error("Parse error: {0}")]
-    // Parse(&'static str),
-
-    // #[error("Invalid parameter {name}: {reason}")]
-    // InvalidParam { name: &'static str, reason: String },
-    #[error("Decode error: {0}")]
-    Decode(
-        #[backtrace]
-        #[source]
-        RwError,
-    ),
-
     #[error("Prost decode error: {0}")]
     ProstDecode(#[from] prost::DecodeError),
 
     #[error("Memcomparable error: {0}")]
     Memcomparable(#[from] memcomparable::Error),
 
-    // TODO: remove this
     #[error("I/O error: {0}")]
     Io(#[from] std::io::Error),
 
@@ -61,7 +35,7 @@ pub enum ArrayError {
 
 impl From<ArrayError> for RwError {
     fn from(s: ArrayError) -> Self {
-        ErrorCode::ArrayError(Box::new(s)).into()
+        ErrorCode::ArrayError(s).into()
     }
 }
 

--- a/src/common/src/array/error.rs
+++ b/src/common/src/array/error.rs
@@ -1,0 +1,73 @@
+// Copyright 2022 Singularity Data
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+pub use anyhow::anyhow;
+use risingwave_pb::ProstFieldNotFound;
+use thiserror::Error;
+
+use crate::error::{ErrorCode, RwError};
+use crate::types::DataType;
+
+#[derive(Error, Debug)]
+pub enum ArrayError {
+    // #[error("Unsupported function: {0}")]
+    // UnsupportedFunction(String),
+
+    // #[error("Can't cast {0} to {1}")]
+    // Cast(&'static str, &'static str),
+
+    // // TODO: Unify Cast and Cast2.
+    // #[error("Can't cast {0:?} to {1:?}")]
+    // Cast2(DataType, DataType),
+
+    // #[error("Out of range")]
+    // NumericOutOfRange,
+
+    // #[error("Parse error: {0}")]
+    // Parse(&'static str),
+
+    // #[error("Invalid parameter {name}: {reason}")]
+    // InvalidParam { name: &'static str, reason: String },
+    #[error("Decode error: {0}")]
+    Decode(
+        #[backtrace]
+        #[source]
+        RwError,
+    ),
+
+    #[error("Prost decode error: {0}")]
+    ProstDecode(#[from] prost::DecodeError),
+
+    #[error("Memcomparable error: {0}")]
+    Memcomparable(#[from] memcomparable::Error),
+
+    // TODO: remove this
+    #[error("I/O error: {0}")]
+    Io(#[from] std::io::Error),
+
+    #[error(transparent)]
+    Internal(#[from] anyhow::Error),
+}
+
+impl From<ArrayError> for RwError {
+    fn from(s: ArrayError) -> Self {
+        ErrorCode::ArrayError(Box::new(s)).into()
+    }
+}
+
+impl From<ProstFieldNotFound> for ArrayError {
+    fn from(err: ProstFieldNotFound) -> Self {
+        anyhow!("Failed to decode prost: field not found `{}`", err.0).into()
+    }
+}

--- a/src/common/src/array/list_array.rs
+++ b/src/common/src/array/list_array.rs
@@ -220,7 +220,7 @@ impl Array for ListArray {
 
 impl ListArray {
     pub fn from_protobuf(array: &ProstArray) -> ArrayResult<ArrayImpl> {
-        ensure_anyhow!(
+        ensure!(
             array.values.is_empty(),
             "Must have no buffer in a list array"
         );

--- a/src/common/src/array/list_array.rs
+++ b/src/common/src/array/list_array.rs
@@ -24,8 +24,8 @@ use risingwave_pb::data::{Array as ProstArray, ArrayType as ProstArrayType, List
 use risingwave_pb::expr::ListValue as ProstListValue;
 
 use super::{
-    Array, ArrayBuilder, ArrayBuilderImpl, ArrayError, ArrayImpl, ArrayIterator, ArrayMeta,
-    ArrayResult, RowRef, NULL_VAL_FOR_HASH,
+    Array, ArrayBuilder, ArrayBuilderImpl, ArrayImpl, ArrayIterator, ArrayMeta, ArrayResult,
+    RowRef, NULL_VAL_FOR_HASH,
 };
 use crate::buffer::{Bitmap, BitmapBuilder};
 use crate::types::{

--- a/src/common/src/array/list_array.rs
+++ b/src/common/src/array/list_array.rs
@@ -24,11 +24,10 @@ use risingwave_pb::data::{Array as ProstArray, ArrayType as ProstArrayType, List
 use risingwave_pb::expr::ListValue as ProstListValue;
 
 use super::{
-    Array, ArrayBuilder, ArrayBuilderImpl, ArrayImpl, ArrayIterator, ArrayMeta, RowRef,
-    NULL_VAL_FOR_HASH,
+    Array, ArrayBuilder, ArrayBuilderImpl, ArrayError, ArrayImpl, ArrayIterator, ArrayMeta,
+    ArrayResult, RowRef, NULL_VAL_FOR_HASH,
 };
 use crate::buffer::{Bitmap, BitmapBuilder};
-use crate::error::Result;
 use crate::types::{
     display_datum_ref, to_datum_ref, DataType, Datum, DatumRef, Scalar, ScalarRefImpl,
 };
@@ -48,12 +47,12 @@ impl ArrayBuilder for ListArrayBuilder {
     type ArrayType = ListArray;
 
     #[cfg(not(test))]
-    fn new(_capacity: usize) -> Result<Self> {
+    fn new(_capacity: usize) -> ArrayResult<Self> {
         panic!("Must use with_meta.")
     }
 
     #[cfg(test)]
-    fn new(capacity: usize) -> Result<Self> {
+    fn new(capacity: usize) -> ArrayResult<Self> {
         Self::with_meta(
             capacity,
             ArrayMeta::List {
@@ -63,7 +62,7 @@ impl ArrayBuilder for ListArrayBuilder {
         )
     }
 
-    fn with_meta(capacity: usize, meta: ArrayMeta) -> Result<Self> {
+    fn with_meta(capacity: usize, meta: ArrayMeta) -> ArrayResult<Self> {
         if let ArrayMeta::List { datatype } = meta {
             Ok(Self {
                 bitmap: BitmapBuilder::with_capacity(capacity),
@@ -77,7 +76,7 @@ impl ArrayBuilder for ListArrayBuilder {
         }
     }
 
-    fn append(&mut self, value: Option<ListRef<'_>>) -> Result<()> {
+    fn append(&mut self, value: Option<ListRef<'_>>) -> ArrayResult<()> {
         match value {
             None => {
                 self.bitmap.append(false);
@@ -98,7 +97,7 @@ impl ArrayBuilder for ListArrayBuilder {
         Ok(())
     }
 
-    fn append_array(&mut self, other: &ListArray) -> Result<()> {
+    fn append_array(&mut self, other: &ListArray) -> ArrayResult<()> {
         self.bitmap.append_bitmap(&other.bitmap);
         let last = *self.offsets.last().unwrap();
         self.offsets
@@ -108,7 +107,7 @@ impl ArrayBuilder for ListArrayBuilder {
         Ok(())
     }
 
-    fn finish(self) -> Result<ListArray> {
+    fn finish(self) -> ArrayResult<ListArray> {
         Ok(ListArray {
             bitmap: self.bitmap.finish(),
             offsets: self.offsets,
@@ -120,7 +119,7 @@ impl ArrayBuilder for ListArrayBuilder {
 }
 
 impl ListArrayBuilder {
-    pub fn append_row_ref(&mut self, row: RowRef) -> Result<()> {
+    pub fn append_row_ref(&mut self, row: RowRef) -> ArrayResult<()> {
         self.bitmap.append(true);
         let last = *self.offsets.last().unwrap();
         self.offsets.push(last + row.size());
@@ -202,7 +201,7 @@ impl Array for ListArray {
         }
     }
 
-    fn create_builder(&self, capacity: usize) -> Result<super::ArrayBuilderImpl> {
+    fn create_builder(&self, capacity: usize) -> ArrayResult<super::ArrayBuilderImpl> {
         let array_builder = ListArrayBuilder::with_meta(
             capacity,
             ArrayMeta::List {
@@ -220,8 +219,8 @@ impl Array for ListArray {
 }
 
 impl ListArray {
-    pub fn from_protobuf(array: &ProstArray) -> Result<ArrayImpl> {
-        ensure!(
+    pub fn from_protobuf(array: &ProstArray) -> ArrayResult<ArrayImpl> {
+        ensure_anyhow!(
             array.values.is_empty(),
             "Must have no buffer in a list array"
         );
@@ -244,7 +243,7 @@ impl ListArray {
         null_bitmap: &[bool],
         values: Vec<Option<ArrayImpl>>,
         value_type: DataType,
-    ) -> Result<ListArray> {
+    ) -> ArrayResult<ListArray> {
         let cardinality = null_bitmap.len();
         let bitmap = Bitmap::try_from(null_bitmap.to_vec())?;
         let mut offsets = vec![0];
@@ -355,7 +354,7 @@ impl<'a> ListRef<'a> {
         }
     }
 
-    pub fn value_at(&self, index: usize) -> Result<DatumRef<'a>> {
+    pub fn value_at(&self, index: usize) -> ArrayResult<DatumRef<'a>> {
         match self {
             ListRef::Indexed { arr, .. } => {
                 if index <= arr.value.len() {

--- a/src/common/src/array/mod.rs
+++ b/src/common/src/array/mod.rs
@@ -21,6 +21,7 @@ mod column_proto_readers;
 mod data_chunk;
 pub mod data_chunk_iter;
 mod decimal_array;
+pub mod error;
 pub mod interval_array;
 mod iterator;
 pub mod list_array;
@@ -55,11 +56,11 @@ pub use stream_chunk::{Op, StreamChunk, StreamChunkTestExt};
 pub use struct_array::{StructArray, StructArrayBuilder, StructRef, StructValue};
 pub use utf8_array::*;
 
+pub use self::error::ArrayError;
 use crate::array::iterator::ArrayImplIterator;
 use crate::buffer::Bitmap;
-use crate::error::ErrorCode::InternalError;
-use crate::error::{Result, RwError};
 use crate::types::*;
+pub type ArrayResult<T> = std::result::Result<T, ArrayError>;
 
 pub type I64Array = PrimitiveArray<i64>;
 pub type I32Array = PrimitiveArray<i32>;
@@ -91,33 +92,33 @@ pub trait ArrayBuilder: Send + Sync + Sized + 'static {
     type ArrayType: Array<Builder = Self>;
 
     /// Create a new builder with `capacity`.
-    fn new(capacity: usize) -> Result<Self> {
+    fn new(capacity: usize) -> ArrayResult<Self> {
         // No metadata by default.
         Self::with_meta(capacity, ArrayMeta::Simple)
     }
 
-    fn with_meta(capacity: usize, meta: ArrayMeta) -> Result<Self>;
+    fn with_meta(capacity: usize, meta: ArrayMeta) -> ArrayResult<Self>;
 
     /// Append a value to builder.
     fn append(
         &mut self,
         value: Option<<<Self as ArrayBuilder>::ArrayType as Array>::RefItem<'_>>,
-    ) -> Result<()>;
+    ) -> ArrayResult<()>;
 
-    fn append_null(&mut self) -> Result<()> {
+    fn append_null(&mut self) -> ArrayResult<()> {
         self.append(None)
     }
 
     /// Append an array to builder.
-    fn append_array(&mut self, other: &Self::ArrayType) -> Result<()>;
+    fn append_array(&mut self, other: &Self::ArrayType) -> ArrayResult<()>;
 
     /// Append an element in another array into builder.
-    fn append_array_element(&mut self, other: &Self::ArrayType, idx: usize) -> Result<()> {
+    fn append_array_element(&mut self, other: &Self::ArrayType, idx: usize) -> ArrayResult<()> {
         self.append(other.value_at(idx))
     }
 
     /// Finish build and return a new array.
-    fn finish(self) -> Result<Self::ArrayType>;
+    fn finish(self) -> ArrayResult<Self::ArrayType>;
 }
 
 /// A trait over all array.
@@ -201,7 +202,7 @@ pub trait Array: std::fmt::Debug + Send + Sync + Sized + 'static + Into<ArrayImp
         self.len() == 0
     }
 
-    fn create_builder(&self, capacity: usize) -> Result<ArrayBuilderImpl>;
+    fn create_builder(&self, capacity: usize) -> ArrayResult<ArrayBuilderImpl>;
 
     fn array_meta(&self) -> ArrayMeta {
         ArrayMeta::Simple
@@ -222,11 +223,11 @@ pub enum ArrayMeta {
 trait CompactableArray: Array {
     /// Select some elements from `Array` based on `visibility` bitmap.
     /// `cardinality` is only used to decide capacity of the new `Array`.
-    fn compact(&self, visibility: &Bitmap, cardinality: usize) -> Result<Self>;
+    fn compact(&self, visibility: &Bitmap, cardinality: usize) -> ArrayResult<Self>;
 }
 
 impl<A: Array> CompactableArray for A {
-    fn compact(&self, visibility: &Bitmap, cardinality: usize) -> Result<Self> {
+    fn compact(&self, visibility: &Bitmap, cardinality: usize) -> ArrayResult<Self> {
         use itertools::Itertools;
         let mut builder = A::Builder::with_meta(cardinality, self.array_meta())?;
         for (elem, visible) in self.iter().zip_eq(visibility.iter()) {
@@ -382,51 +383,51 @@ for_all_variants! { array_builder_impl_enum }
 macro_rules! impl_array_builder {
     ([], $({ $variant_name:ident, $suffix_name:ident, $array:ty, $builder:ty } ),*) => {
         impl ArrayBuilderImpl {
-            pub fn append_array(&mut self, other: &ArrayImpl) -> Result<()> {
+            pub fn append_array(&mut self, other: &ArrayImpl) -> ArrayResult<()> {
                 match self {
                     $( Self::$variant_name(inner) => inner.append_array(other.into()), )*
                 }
             }
 
-            pub fn append_null(&mut self) -> Result<()> {
+            pub fn append_null(&mut self) -> ArrayResult<()> {
                 match self {
                     $( Self::$variant_name(inner) => inner.append(None), )*
                 }
             }
 
             /// Append a datum, return error while type not match.
-            pub fn append_datum(&mut self, datum: &Datum) -> Result<()> {
+            pub fn append_datum(&mut self, datum: &Datum) -> ArrayResult<()> {
                 match datum {
                     None => self.append_null(),
                     Some(ref scalar) => match (self, scalar) {
                         $( (Self::$variant_name(inner), ScalarImpl::$variant_name(v)) => inner.append(Some(v.as_scalar_ref())), )*
-                        _ => Err(RwError::from(InternalError("Invalid datum type".to_string()))),
+                        _ => bail_anyhow!("Invalid datum type".to_string()),
                     },
                 }
             }
 
             /// Append a datum ref, return error while type not match.
-            pub fn append_datum_ref(&mut self, datum_ref: DatumRef<'_>) -> Result<()> {
+            pub fn append_datum_ref(&mut self, datum_ref: DatumRef<'_>) -> ArrayResult<()> {
                 match datum_ref {
                     None => self.append_null(),
                     Some(scalar_ref) => match (self, scalar_ref) {
                         $( (Self::$variant_name(inner), ScalarRefImpl::$variant_name(v)) => inner.append(Some(v)), )*
-                        (this_builder, this_scalar_ref) => Err(RwError::from(InternalError(format!(
+                        (this_builder, this_scalar_ref) => bail_anyhow!(
                             "Failed to append datum, array builder type: {}, scalar ref type: {}",
                             this_builder.get_ident(),
-                            this_scalar_ref.get_ident())
-                        ))),
+                            this_scalar_ref.get_ident()
+                        ),
                     },
                 }
             }
 
-            pub fn append_array_element(&mut self, other: &ArrayImpl, idx: usize) -> Result<()> {
+            pub fn append_array_element(&mut self, other: &ArrayImpl, idx: usize) -> ArrayResult<()> {
                 match self {
                     $( Self::$variant_name(inner) => inner.append_array_element(other.into(), idx), )*
                 }
             }
 
-            pub fn finish(self) -> Result<ArrayImpl> {
+            pub fn finish(self) -> ArrayResult<ArrayImpl> {
                 match self {
                     $( Self::$variant_name(inner) => Ok(inner.finish()?.into()), )*
                 }
@@ -484,7 +485,7 @@ macro_rules! impl_array {
             }
 
             /// Select some elements from `Array` based on `visibility` bitmap.
-            pub fn compact(&self, visibility: &Bitmap, cardinality: usize) -> Result<Self> {
+            pub fn compact(&self, visibility: &Bitmap, cardinality: usize) -> ArrayResult<Self> {
                 match self {
                     $( Self::$variant_name(inner) => Ok(inner.compact(visibility, cardinality)?.into()), )*
                 }
@@ -536,7 +537,7 @@ macro_rules! impl_array {
                 }
             }
 
-            pub fn create_builder(&self, capacity: usize) -> Result<ArrayBuilderImpl> {
+            pub fn create_builder(&self, capacity: usize) -> ArrayResult<ArrayBuilderImpl> {
                 match self {
                     $( Self::$variant_name(inner) => inner.create_builder(capacity), )*
                 }
@@ -552,7 +553,7 @@ impl ArrayImpl {
         ArrayImplIterator::new(self)
     }
 
-    pub fn from_protobuf(array: &ProstArray, cardinality: usize) -> Result<Self> {
+    pub fn from_protobuf(array: &ProstArray, cardinality: usize) -> ArrayResult<Self> {
         use self::column_proto_readers::*;
         use crate::array::value_reader::*;
         let array = match array.array_type() {
@@ -597,7 +598,7 @@ mod tests {
 
     use super::*;
 
-    fn filter<'a, A, F>(data: &'a A, pred: F) -> Result<A>
+    fn filter<'a, A, F>(data: &'a A, pred: F) -> ArrayResult<A>
     where
         A: Array + 'a,
         F: Fn(Option<A::RefItem<'a>>) -> bool,
@@ -627,7 +628,7 @@ mod tests {
     fn vec_add<T1, T2, T3>(
         a: &PrimitiveArray<T1>,
         b: &PrimitiveArray<T2>,
-    ) -> Result<PrimitiveArray<T3>>
+    ) -> ArrayResult<PrimitiveArray<T3>>
     where
         T1: PrimitiveArrayItemType + AsPrimitive<T3>,
         T2: PrimitiveArrayItemType + AsPrimitive<T3>,

--- a/src/common/src/array/mod.rs
+++ b/src/common/src/array/mod.rs
@@ -401,7 +401,7 @@ macro_rules! impl_array_builder {
                     None => self.append_null(),
                     Some(ref scalar) => match (self, scalar) {
                         $( (Self::$variant_name(inner), ScalarImpl::$variant_name(v)) => inner.append(Some(v.as_scalar_ref())), )*
-                        _ => bail_anyhow!("Invalid datum type".to_string()),
+                        _ => bail!("Invalid datum type".to_string()),
                     },
                 }
             }
@@ -412,7 +412,7 @@ macro_rules! impl_array_builder {
                     None => self.append_null(),
                     Some(scalar_ref) => match (self, scalar_ref) {
                         $( (Self::$variant_name(inner), ScalarRefImpl::$variant_name(v)) => inner.append(Some(v)), )*
-                        (this_builder, this_scalar_ref) => bail_anyhow!(
+                        (this_builder, this_scalar_ref) => bail!(
                             "Failed to append datum, array builder type: {}, scalar ref type: {}",
                             this_builder.get_ident(),
                             this_scalar_ref.get_ident()

--- a/src/common/src/array/primitive_array.rs
+++ b/src/common/src/array/primitive_array.rs
@@ -20,7 +20,7 @@ use std::mem::size_of;
 use risingwave_pb::data::buffer::CompressionType;
 use risingwave_pb::data::{Array as ProstArray, ArrayType, Buffer};
 
-use super::{Array, ArrayBuilder, ArrayError, ArrayIterator, ArrayResult, NULL_VAL_FOR_HASH};
+use super::{Array, ArrayBuilder, ArrayIterator, ArrayResult, NULL_VAL_FOR_HASH};
 use crate::array::{ArrayBuilderImpl, ArrayImpl, ArrayMeta};
 use crate::buffer::{Bitmap, BitmapBuilder};
 use crate::for_all_native_types;
@@ -93,7 +93,7 @@ macro_rules! impl_primitive_for_native_types {
                 impl_array_methods!($naive_type, $scalar_type, $scalar_type);
 
                 fn to_protobuf<T: Write>(self, output: &mut T) -> ArrayResult<usize> {
-                    NativeType::to_protobuf(self, output).map_err(ArrayError::Decode)
+                    NativeType::to_protobuf(self, output)
                 }
 
                 fn hash_wrapper<H: Hasher>(&self, state: &mut H) {

--- a/src/common/src/array/stream_chunk.rs
+++ b/src/common/src/array/stream_chunk.rs
@@ -20,10 +20,10 @@ use itertools::Itertools;
 use prost::DecodeError;
 use risingwave_pb::data::{Op as ProstOp, StreamChunk as ProstStreamChunk};
 
+use super::{ArrayError, ArrayResult};
 use crate::array::column::Column;
 use crate::array::{ArrayBuilderImpl, DataChunk, Row, Vis};
 use crate::buffer::Bitmap;
-use crate::error::{ErrorCode, Result, RwError};
 use crate::types::{DataType, NaiveDateTimeWrapper};
 use crate::util::hash_util::finalize_hashers;
 
@@ -51,17 +51,13 @@ impl Op {
         }
     }
 
-    pub fn from_protobuf(prost: &i32) -> Result<Op> {
+    pub fn from_protobuf(prost: &i32) -> ArrayResult<Op> {
         let op = match ProstOp::from_i32(*prost) {
             Some(ProstOp::Insert) => Op::Insert,
             Some(ProstOp::Delete) => Op::Delete,
             Some(ProstOp::UpdateInsert) => Op::UpdateInsert,
             Some(ProstOp::UpdateDelete) => Op::UpdateDelete,
-            None => {
-                return Err(RwError::from(ErrorCode::ProstError(DecodeError::new(
-                    "No such op type",
-                ))))
-            }
+            None => bail_anyhow!("No such op type"),
         };
         Ok(op)
     }
@@ -106,11 +102,11 @@ impl StreamChunk {
 
     /// Build a `StreamChunk` from rows.
     // TODO: introducing something like `StreamChunkBuilder` maybe better.
-    pub fn from_rows(rows: &[(Op, Row)], data_types: &[DataType]) -> Result<Self> {
+    pub fn from_rows(rows: &[(Op, Row)], data_types: &[DataType]) -> ArrayResult<Self> {
         let mut array_builders = data_types
             .iter()
             .map(|data_type| data_type.create_array_builder(rows.len()))
-            .collect::<Result<Vec<_>>>()?;
+            .collect::<ArrayResult<Vec<_>>>()?;
         let mut ops = vec![];
 
         for (op, row) in rows {
@@ -123,7 +119,7 @@ impl StreamChunk {
         let new_arrays = array_builders
             .into_iter()
             .map(|builder| builder.finish())
-            .collect::<Result<Vec<_>>>()?;
+            .collect::<ArrayResult<Vec<_>>>()?;
 
         let new_columns = new_arrays
             .into_iter()
@@ -151,7 +147,7 @@ impl StreamChunk {
     }
 
     /// compact the `StreamChunk` with its visibility map
-    pub fn compact(self) -> Result<Self> {
+    pub fn compact(self) -> ArrayResult<Self> {
         if self.visibility().is_none() {
             return Ok(self);
         }
@@ -170,7 +166,7 @@ impl StreamChunk {
                     .compact(&visibility, cardinality)
                     .map(|array| Column::new(Arc::new(array)))
             })
-            .collect::<Result<Vec<_>>>()?;
+            .collect::<ArrayResult<Vec<_>>>()?;
         let mut new_ops = Vec::with_capacity(cardinality);
         for (op, visible) in ops.into_iter().zip_eq(visibility.iter()) {
             if visible {
@@ -210,7 +206,7 @@ impl StreamChunk {
         }
     }
 
-    pub fn from_protobuf(prost: &ProstStreamChunk) -> Result<Self> {
+    pub fn from_protobuf(prost: &ProstStreamChunk) -> ArrayResult<Self> {
         let cardinality = prost.get_cardinality() as usize;
         let mut ops = Vec::with_capacity(cardinality);
         for op in prost.get_ops() {
@@ -235,7 +231,7 @@ impl StreamChunk {
         &self,
         keys: &[usize],
         hasher_builder: H,
-    ) -> Result<Vec<u64>> {
+    ) -> ArrayResult<Vec<u64>> {
         let mut states = vec![];
         states.resize_with(self.capacity(), || hasher_builder.build_hasher());
         for key in keys {
@@ -357,7 +353,7 @@ impl StreamChunkTestExt for StreamChunk {
                 _ => todo!("unsupported type: {c:?}"),
             })
             .map(|ty| ty.create_array_builder(1))
-            .collect::<Result<Vec<_>>>()
+            .collect::<ArrayResult<Vec<_>>>()
             .unwrap();
         let mut visibility = vec![];
         for mut line in lines {

--- a/src/common/src/array/stream_chunk.rs
+++ b/src/common/src/array/stream_chunk.rs
@@ -56,7 +56,7 @@ impl Op {
             Some(ProstOp::Delete) => Op::Delete,
             Some(ProstOp::UpdateInsert) => Op::UpdateInsert,
             Some(ProstOp::UpdateDelete) => Op::UpdateDelete,
-            None => bail_anyhow!("No such op type"),
+            None => bail!("No such op type"),
         };
         Ok(op)
     }

--- a/src/common/src/array/stream_chunk.rs
+++ b/src/common/src/array/stream_chunk.rs
@@ -17,10 +17,9 @@ use std::hash::BuildHasher;
 use std::sync::Arc;
 
 use itertools::Itertools;
-use prost::DecodeError;
 use risingwave_pb::data::{Op as ProstOp, StreamChunk as ProstStreamChunk};
 
-use super::{ArrayError, ArrayResult};
+use super::ArrayResult;
 use crate::array::column::Column;
 use crate::array::{ArrayBuilderImpl, DataChunk, Row, Vis};
 use crate::buffer::Bitmap;

--- a/src/common/src/array/struct_array.rs
+++ b/src/common/src/array/struct_array.rs
@@ -24,8 +24,8 @@ use risingwave_pb::data::{Array as ProstArray, ArrayType as ProstArrayType, Stru
 use risingwave_pb::expr::StructValue as ProstStructValue;
 
 use super::{
-    Array, ArrayBuilder, ArrayBuilderImpl, ArrayError, ArrayImpl, ArrayIterator, ArrayMeta,
-    ArrayResult, NULL_VAL_FOR_HASH,
+    Array, ArrayBuilder, ArrayBuilderImpl, ArrayImpl, ArrayIterator, ArrayMeta, ArrayResult,
+    NULL_VAL_FOR_HASH,
 };
 use crate::array::ArrayRef;
 use crate::buffer::{Bitmap, BitmapBuilder};

--- a/src/common/src/array/struct_array.rs
+++ b/src/common/src/array/struct_array.rs
@@ -24,11 +24,11 @@ use risingwave_pb::data::{Array as ProstArray, ArrayType as ProstArrayType, Stru
 use risingwave_pb::expr::StructValue as ProstStructValue;
 
 use super::{
-    Array, ArrayBuilder, ArrayBuilderImpl, ArrayImpl, ArrayIterator, ArrayMeta, NULL_VAL_FOR_HASH,
+    Array, ArrayBuilder, ArrayBuilderImpl, ArrayError, ArrayImpl, ArrayIterator, ArrayMeta,
+    ArrayResult, NULL_VAL_FOR_HASH,
 };
 use crate::array::ArrayRef;
 use crate::buffer::{Bitmap, BitmapBuilder};
-use crate::error::Result;
 use crate::types::{
     display_datum_ref, to_datum_ref, DataType, Datum, DatumRef, Scalar, ScalarRefImpl,
 };
@@ -45,12 +45,12 @@ impl ArrayBuilder for StructArrayBuilder {
     type ArrayType = StructArray;
 
     #[cfg(not(test))]
-    fn new(_capacity: usize) -> Result<Self> {
+    fn new(_capacity: usize) -> ArrayResult<Self> {
         panic!("Must use with_meta.")
     }
 
     #[cfg(test)]
-    fn new(capacity: usize) -> Result<Self> {
+    fn new(capacity: usize) -> ArrayResult<Self> {
         Self::with_meta(
             capacity,
             ArrayMeta::Struct {
@@ -59,7 +59,7 @@ impl ArrayBuilder for StructArrayBuilder {
         )
     }
 
-    fn with_meta(capacity: usize, meta: ArrayMeta) -> Result<Self> {
+    fn with_meta(capacity: usize, meta: ArrayMeta) -> ArrayResult<Self> {
         if let ArrayMeta::Struct { children } = meta {
             let children_array = children
                 .iter()
@@ -76,7 +76,7 @@ impl ArrayBuilder for StructArrayBuilder {
         }
     }
 
-    fn append(&mut self, value: Option<StructRef<'_>>) -> Result<()> {
+    fn append(&mut self, value: Option<StructRef<'_>>) -> ArrayResult<()> {
         match value {
             None => {
                 self.bitmap.append(false);
@@ -97,7 +97,7 @@ impl ArrayBuilder for StructArrayBuilder {
         Ok(())
     }
 
-    fn append_array(&mut self, other: &StructArray) -> Result<()> {
+    fn append_array(&mut self, other: &StructArray) -> ArrayResult<()> {
         self.bitmap.append_bitmap(&other.bitmap);
         self.children_array
             .iter_mut()
@@ -107,12 +107,12 @@ impl ArrayBuilder for StructArrayBuilder {
         Ok(())
     }
 
-    fn finish(self) -> Result<StructArray> {
+    fn finish(self) -> ArrayResult<StructArray> {
         let children = self
             .children_array
             .into_iter()
             .map(|b| Ok(Arc::new(b.finish()?)))
-            .collect::<Result<Vec<ArrayRef>>>()?;
+            .collect::<ArrayResult<Vec<ArrayRef>>>()?;
         Ok(StructArray {
             bitmap: self.bitmap.finish(),
             children,
@@ -191,7 +191,7 @@ impl Array for StructArray {
         }
     }
 
-    fn create_builder(&self, capacity: usize) -> Result<super::ArrayBuilderImpl> {
+    fn create_builder(&self, capacity: usize) -> ArrayResult<super::ArrayBuilderImpl> {
         let array_builder = StructArrayBuilder::with_meta(
             capacity,
             ArrayMeta::Struct {
@@ -209,8 +209,8 @@ impl Array for StructArray {
 }
 
 impl StructArray {
-    pub fn from_protobuf(array: &ProstArray) -> Result<ArrayImpl> {
-        ensure!(
+    pub fn from_protobuf(array: &ProstArray) -> ArrayResult<ArrayImpl> {
+        ensure_anyhow!(
             array.values.is_empty(),
             "Must have no buffer in a struct array"
         );
@@ -221,7 +221,7 @@ impl StructArray {
             .children_array
             .iter()
             .map(|child| Ok(Arc::new(ArrayImpl::from_protobuf(child, cardinality)?)))
-            .collect::<Result<Vec<ArrayRef>>>()?;
+            .collect::<ArrayResult<Vec<ArrayRef>>>()?;
         let children_type: Arc<[DataType]> = array_data
             .children_type
             .iter()
@@ -249,7 +249,7 @@ impl StructArray {
         null_bitmap: &[bool],
         children: Vec<ArrayImpl>,
         children_type: Vec<DataType>,
-    ) -> Result<StructArray> {
+    ) -> ArrayResult<StructArray> {
         let cardinality = null_bitmap.len();
         let bitmap = Bitmap::try_from(null_bitmap.to_vec())?;
         let children = children.into_iter().map(Arc::new).collect_vec();

--- a/src/common/src/array/struct_array.rs
+++ b/src/common/src/array/struct_array.rs
@@ -210,7 +210,7 @@ impl Array for StructArray {
 
 impl StructArray {
     pub fn from_protobuf(array: &ProstArray) -> ArrayResult<ArrayImpl> {
-        ensure_anyhow!(
+        ensure!(
             array.values.is_empty(),
             "Must have no buffer in a struct array"
         );

--- a/src/common/src/array/utf8_array.rs
+++ b/src/common/src/array/utf8_array.rs
@@ -20,9 +20,7 @@ use itertools::Itertools;
 use risingwave_pb::data::buffer::CompressionType;
 use risingwave_pb::data::{Array as ProstArray, ArrayType, Buffer};
 
-use super::{
-    Array, ArrayBuilder, ArrayError, ArrayIterator, ArrayMeta, ArrayResult, NULL_VAL_FOR_HASH,
-};
+use super::{Array, ArrayBuilder, ArrayIterator, ArrayMeta, ArrayResult, NULL_VAL_FOR_HASH};
 use crate::array::ArrayBuilderImpl;
 use crate::buffer::{Bitmap, BitmapBuilder};
 

--- a/src/common/src/array/utf8_array.rs
+++ b/src/common/src/array/utf8_array.rs
@@ -20,10 +20,11 @@ use itertools::Itertools;
 use risingwave_pb::data::buffer::CompressionType;
 use risingwave_pb::data::{Array as ProstArray, ArrayType, Buffer};
 
-use super::{Array, ArrayBuilder, ArrayIterator, ArrayMeta, NULL_VAL_FOR_HASH};
+use super::{
+    Array, ArrayBuilder, ArrayError, ArrayIterator, ArrayMeta, ArrayResult, NULL_VAL_FOR_HASH,
+};
 use crate::array::ArrayBuilderImpl;
 use crate::buffer::{Bitmap, BitmapBuilder};
-use crate::error::Result;
 
 /// `Utf8Array` is a collection of Rust Utf8 `String`s.
 #[derive(Debug)]
@@ -127,14 +128,14 @@ impl Array for Utf8Array {
         }
     }
 
-    fn create_builder(&self, capacity: usize) -> Result<ArrayBuilderImpl> {
+    fn create_builder(&self, capacity: usize) -> ArrayResult<ArrayBuilderImpl> {
         let array_builder = Utf8ArrayBuilder::new(capacity)?;
         Ok(ArrayBuilderImpl::Utf8(array_builder))
     }
 }
 
 impl Utf8Array {
-    pub fn from_slice(data: &[Option<&str>]) -> Result<Self> {
+    pub fn from_slice(data: &[Option<&str>]) -> ArrayResult<Self> {
         let mut builder = <Self as Array>::Builder::new(data.len())?;
         for i in data {
             builder.append(*i)?;
@@ -154,7 +155,7 @@ pub struct Utf8ArrayBuilder {
 impl ArrayBuilder for Utf8ArrayBuilder {
     type ArrayType = Utf8Array;
 
-    fn with_meta(capacity: usize, _meta: ArrayMeta) -> Result<Self> {
+    fn with_meta(capacity: usize, _meta: ArrayMeta) -> ArrayResult<Self> {
         let mut offset = Vec::with_capacity(capacity + 1);
         offset.push(0);
         Ok(Self {
@@ -164,7 +165,7 @@ impl ArrayBuilder for Utf8ArrayBuilder {
         })
     }
 
-    fn append<'a>(&'a mut self, value: Option<&'a str>) -> Result<()> {
+    fn append<'a>(&'a mut self, value: Option<&'a str>) -> ArrayResult<()> {
         match value {
             Some(x) => {
                 self.bitmap.append(true);
@@ -179,7 +180,7 @@ impl ArrayBuilder for Utf8ArrayBuilder {
         Ok(())
     }
 
-    fn append_array(&mut self, other: &Utf8Array) -> Result<()> {
+    fn append_array(&mut self, other: &Utf8Array) -> ArrayResult<()> {
         for bit in other.bitmap.iter() {
             self.bitmap.append(bit);
         }
@@ -191,7 +192,7 @@ impl ArrayBuilder for Utf8ArrayBuilder {
         Ok(())
     }
 
-    fn finish(self) -> Result<Utf8Array> {
+    fn finish(self) -> ArrayResult<Utf8Array> {
         Ok(Utf8Array {
             bitmap: (self.bitmap).finish(),
             data: self.data,
@@ -207,7 +208,7 @@ impl Utf8ArrayBuilder {
 
     /// `append_partial` will add a partial dirty data of the new record.
     /// The partial data will keep untracked until `finish_partial` was called.
-    unsafe fn append_partial(&mut self, x: &str) -> Result<()> {
+    unsafe fn append_partial(&mut self, x: &str) -> ArrayResult<()> {
         self.data.extend_from_slice(x.as_bytes());
         Ok(())
     }
@@ -215,7 +216,7 @@ impl Utf8ArrayBuilder {
     /// `finish_partial` will create a new record based on the current dirty data.
     /// `finish_partial` was safe even if we don't call `append_partial`, which
     /// is equivalent to appending an empty string.
-    fn finish_partial(&mut self) -> Result<()> {
+    fn finish_partial(&mut self) -> ArrayResult<()> {
         self.offset.push(self.data.len());
         self.bitmap.append(true);
         Ok(())
@@ -230,14 +231,14 @@ pub struct BytesWriter {
 impl BytesWriter {
     /// `write_ref` will consume `BytesWriter` and pass the ownership
     /// of `builder` to `BytesGuard`.
-    pub fn write_ref(mut self, value: &str) -> Result<BytesGuard> {
+    pub fn write_ref(mut self, value: &str) -> ArrayResult<BytesGuard> {
         self.builder.append(Some(value))?;
         Ok(BytesGuard {
             builder: self.builder,
         })
     }
 
-    pub fn write_from_char_iter(self, iter: impl Iterator<Item = char>) -> Result<BytesGuard> {
+    pub fn write_from_char_iter(self, iter: impl Iterator<Item = char>) -> ArrayResult<BytesGuard> {
         let mut writer = self.begin();
         for c in iter {
             let mut buf = [0; 4];
@@ -264,7 +265,7 @@ impl PartialBytesWriter {
     /// `write_ref` will append partial dirty data to `builder`.
     /// `PartialBytesWriter::write_ref` is different from `BytesWriter::write_ref`
     /// in that it allows us to call it multiple times.
-    pub fn write_ref(&mut self, value: &str) -> Result<()> {
+    pub fn write_ref(&mut self, value: &str) -> ArrayResult<()> {
         // SAFETY: The dirty `builder` is owned by `PartialBytesWriter`.
         // We can't access it until `finish` was called.
         unsafe { self.builder.append_partial(value) }
@@ -273,7 +274,7 @@ impl PartialBytesWriter {
     /// `finish` will be called while the entire record is written.
     /// Exactly one new record was appended and the `builder` can be safely used,
     /// so we move the builder to `BytesGuard`.
-    pub fn finish(mut self) -> Result<BytesGuard> {
+    pub fn finish(mut self) -> ArrayResult<BytesGuard> {
         self.builder.finish_partial()?;
         Ok(BytesGuard {
             builder: self.builder,

--- a/src/common/src/array/value_reader.rs
+++ b/src/common/src/array/value_reader.rs
@@ -40,7 +40,7 @@ macro_rules! impl_numeric_value_reader {
             fn read(cur: &mut Cursor<&[u8]>) -> ArrayResult<$value_type> {
                 match cur.$read_fn::<BigEndian>() {
                     Ok(v) => Ok(v.into()),
-                    Err(e) => bail_anyhow!("Failed to read value from buffer: {}", e),
+                    Err(e) => bail!("Failed to read value from buffer: {}", e),
                 }
             }
         }
@@ -63,7 +63,7 @@ impl VarSizedValueReader<Utf8ArrayBuilder> for Utf8ValueReader {
     fn read(buf: &[u8]) -> ArrayResult<&str> {
         match from_utf8(buf) {
             Ok(s) => Ok(s),
-            Err(e) => bail_anyhow!("failed to read utf8 string from bytes: {}", e),
+            Err(e) => bail!("failed to read utf8 string from bytes: {}", e),
         }
     }
 }
@@ -74,7 +74,7 @@ impl VarSizedValueReader<DecimalArrayBuilder> for DecimalValueReader {
     fn read(buf: &[u8]) -> ArrayResult<Decimal> {
         match Decimal::from_str(Utf8ValueReader::read(buf)?) {
             Ok(d) => Ok(d),
-            Err(e) => bail_anyhow!("failed to read decimal from string: {}", e),
+            Err(e) => bail!("failed to read decimal from string: {}", e),
         }
     }
 }

--- a/src/common/src/array/value_reader.rs
+++ b/src/common/src/array/value_reader.rs
@@ -17,16 +17,15 @@ use std::str::{from_utf8, FromStr};
 
 use byteorder::{BigEndian, ReadBytesExt};
 
+use super::ArrayResult;
 use crate::array::{
     Array, ArrayBuilder, DecimalArrayBuilder, PrimitiveArrayItemType, Utf8ArrayBuilder,
 };
-use crate::error::ErrorCode::InternalError;
-use crate::error::{ErrorCode, Result, RwError};
 use crate::types::{Decimal, OrderedF32, OrderedF64};
 
 /// Reads an encoded buffer into a value.
 pub trait PrimitiveValueReader<T: PrimitiveArrayItemType> {
-    fn read(cur: &mut Cursor<&[u8]>) -> Result<T>;
+    fn read(cur: &mut Cursor<&[u8]>) -> ArrayResult<T>;
 }
 
 pub struct I16ValueReader {}
@@ -38,13 +37,11 @@ pub struct F64ValueReader {}
 macro_rules! impl_numeric_value_reader {
     ($value_type:ty, $value_reader:ty, $read_fn:ident) => {
         impl PrimitiveValueReader<$value_type> for $value_reader {
-            fn read(cur: &mut Cursor<&[u8]>) -> Result<$value_type> {
-                cur.$read_fn::<BigEndian>().map(Into::into).map_err(|e| {
-                    RwError::from(ErrorCode::InternalError(format!(
-                        "Failed to read value from buffer: {}",
-                        e
-                    )))
-                })
+            fn read(cur: &mut Cursor<&[u8]>) -> ArrayResult<$value_type> {
+                match cur.$read_fn::<BigEndian>() {
+                    Ok(v) => Ok(v.into()),
+                    Err(e) => bail_anyhow!("Failed to read value from buffer: {}", e),
+                }
             }
         }
     };
@@ -57,31 +54,27 @@ impl_numeric_value_reader!(OrderedF32, F32ValueReader, read_f32);
 impl_numeric_value_reader!(OrderedF64, F64ValueReader, read_f64);
 
 pub trait VarSizedValueReader<AB: ArrayBuilder> {
-    fn read(buf: &[u8]) -> Result<<<AB as ArrayBuilder>::ArrayType as Array>::RefItem<'_>>;
+    fn read(buf: &[u8]) -> ArrayResult<<<AB as ArrayBuilder>::ArrayType as Array>::RefItem<'_>>;
 }
 
 pub struct Utf8ValueReader {}
 
 impl VarSizedValueReader<Utf8ArrayBuilder> for Utf8ValueReader {
-    fn read(buf: &[u8]) -> Result<&str> {
-        from_utf8(buf).map_err(|e| {
-            RwError::from(InternalError(format!(
-                "failed to read utf8 string from bytes: {}",
-                e
-            )))
-        })
+    fn read(buf: &[u8]) -> ArrayResult<&str> {
+        match from_utf8(buf) {
+            Ok(s) => Ok(s),
+            Err(e) => bail_anyhow!("failed to read utf8 string from bytes: {}", e),
+        }
     }
 }
 
 pub struct DecimalValueReader {}
 
 impl VarSizedValueReader<DecimalArrayBuilder> for DecimalValueReader {
-    fn read(buf: &[u8]) -> Result<Decimal> {
-        Decimal::from_str(Utf8ValueReader::read(buf)?).map_err(|e| {
-            RwError::from(InternalError(format!(
-                "failed to read decimal from string: {}",
-                e
-            )))
-        })
+    fn read(buf: &[u8]) -> ArrayResult<Decimal> {
+        match Decimal::from_str(Utf8ValueReader::read(buf)?) {
+            Ok(d) => Ok(d),
+            Err(e) => bail_anyhow!("failed to read decimal from string: {}", e),
+        }
     }
 }

--- a/src/common/src/buffer/bitmap.rs
+++ b/src/common/src/buffer/bitmap.rs
@@ -241,7 +241,7 @@ impl Bitmap {
     }
 
     fn check_idx(&self, idx: usize) -> ArrayResult<()> {
-        ensure_anyhow!(idx < self.len());
+        ensure!(idx < self.len());
         Ok(())
     }
 }

--- a/src/common/src/catalog/schema.rs
+++ b/src/common/src/catalog/schema.rs
@@ -122,7 +122,8 @@ impl Schema {
         self.fields
             .iter()
             .map(|field| field.data_type.create_array_builder(capacity))
-            .collect()
+            .try_collect()
+            .map_err(Into::into)
     }
 
     pub fn to_prost(&self) -> Vec<ProstField> {

--- a/src/common/src/error.rs
+++ b/src/common/src/error.rs
@@ -29,6 +29,7 @@ use tokio::task::JoinError;
 use tonic::metadata::{MetadataMap, MetadataValue};
 use tonic::Code;
 
+use crate::array::ArrayError;
 use crate::util::value_encoding::error::ValueEncodingError;
 
 /// Header used to store serialized [`RwError`] in grpc status.
@@ -98,17 +99,9 @@ pub enum ErrorCode {
         BoxedError,
     ),
     #[error("Expr error: {0:?}")]
-    ExprError(
-        #[backtrace]
-        #[source]
-        BoxedError,
-    ),
+    ExprError(BoxedError),
     #[error("Array error: {0:?}")]
-    ArrayError(
-        #[backtrace]
-        #[source]
-        BoxedError,
-    ),
+    ArrayError(ArrayError),
     #[error("Stream error: {0:?}")]
     StreamError(
         #[backtrace]

--- a/src/common/src/error.rs
+++ b/src/common/src/error.rs
@@ -29,7 +29,6 @@ use tokio::task::JoinError;
 use tonic::metadata::{MetadataMap, MetadataValue};
 use tonic::Code;
 
-use crate::array::ArrayError;
 use crate::util::value_encoding::error::ValueEncodingError;
 
 /// Header used to store serialized [`RwError`] in grpc status.

--- a/src/common/src/hash/key.rs
+++ b/src/common/src/hash/key.rs
@@ -126,9 +126,9 @@ pub trait HashKey: Clone + Debug + Hash + Eq + Sized + Send + Sync + 'static {
 
     #[inline(always)]
     fn deserialize<'a>(self, data_types: impl Iterator<Item = &'a DataType>) -> Result<Row> {
-        let mut builders = data_types
+        let mut builders: Vec<_> = data_types
             .map(|dt| dt.create_array_builder(1))
-            .collect::<Result<Vec<_>>>()?;
+            .try_collect()?;
 
         self.deserialize_to_builders(&mut builders)?;
         builders
@@ -647,7 +647,9 @@ impl HashKey for SerializedKey {
         array_builders
             .iter_mut()
             .zip_eq(self.key)
-            .try_for_each(|(array_builder, key)| array_builder.append_datum(&key))
+            .try_for_each(|(array_builder, key)| {
+                array_builder.append_datum(&key).map_err(Into::into)
+            })
     }
 
     fn has_null(&self) -> bool {

--- a/src/common/src/lib.rs
+++ b/src/common/src/lib.rs
@@ -36,6 +36,7 @@
 #![feature(test)]
 #![feature(trusted_len)]
 #![feature(allocator_api)]
+#![feature(try_blocks)]
 
 #[macro_use]
 pub mod error;

--- a/src/common/src/lib.rs
+++ b/src/common/src/lib.rs
@@ -36,7 +36,6 @@
 #![feature(test)]
 #![feature(trusted_len)]
 #![feature(allocator_api)]
-#![feature(try_blocks)]
 
 #[macro_use]
 pub mod error;

--- a/src/common/src/types/chrono_wrapper.rs
+++ b/src/common/src/types/chrono_wrapper.rs
@@ -20,6 +20,7 @@ use std::io::Write;
 use chrono::{Datelike, Duration, NaiveDate, NaiveDateTime, NaiveTime, Timelike};
 
 use super::{CheckedAdd, IntervalUnit};
+use crate::array::ArrayResult;
 use crate::error::ErrorCode::{InternalError, IoError};
 use crate::error::{Result, RwError};
 use crate::util::value_encoding::error::ValueEncodingError;
@@ -111,15 +112,14 @@ impl NaiveDateWrapper {
 
     /// Converted to the number of days since 1970.1.1 for compatibility with existing Java
     /// frontend. TODO: Save days directly when using Rust frontend.
-    pub fn to_protobuf<T: Write>(self, output: &mut T) -> Result<usize> {
+    pub fn to_protobuf<T: Write>(self, output: &mut T) -> ArrayResult<usize> {
         output
             .write(&(self.0.num_days_from_ce() - UNIX_EPOCH_DAYS).to_be_bytes())
-            .map_err(|e| RwError::from(IoError(e)))
+            .map_err(Into::into)
     }
 
-    pub fn from_protobuf(days: i32) -> Result<Self> {
-        Self::with_days(days + UNIX_EPOCH_DAYS)
-            .map_err(|e| RwError::from(InternalError(e.to_string())))
+    pub fn from_protobuf(days: i32) -> ArrayResult<Self> {
+        Self::with_days(days + UNIX_EPOCH_DAYS).map_err(Into::into)
     }
 }
 
@@ -140,20 +140,20 @@ impl NaiveTimeWrapper {
 
     /// Converted to microsecond timestamps for compatibility with existing Java frontend.
     /// TODO: Save nanoseconds directly when using Rust frontend.
-    pub fn to_protobuf<T: Write>(self, output: &mut T) -> Result<usize> {
+    pub fn to_protobuf<T: Write>(self, output: &mut T) -> ArrayResult<usize> {
         output
             .write(
                 &(self.0.num_seconds_from_midnight() as i64 * 1_000_000
                     + self.0.nanosecond() as i64 / 1000)
                     .to_be_bytes(),
             )
-            .map_err(|e| RwError::from(IoError(e)))
+            .map_err(Into::into)
     }
 
-    pub fn from_protobuf(timestamp_micro: i64) -> Result<Self> {
+    pub fn from_protobuf(timestamp_micro: i64) -> ArrayResult<Self> {
         let secs = (timestamp_micro / 1_000_000) as u32;
         let nano = (timestamp_micro % 1_000_000) as u32 * 1000;
-        Self::with_secs_nano(secs, nano).map_err(|e| RwError::from(InternalError(e.to_string())))
+        Self::with_secs_nano(secs, nano).map_err(Into::into)
     }
 }
 
@@ -178,16 +178,16 @@ impl NaiveDateTimeWrapper {
     /// Converted to microsecond timestamps for compatibility with existing Java frontend.
     /// TODO: Consider another way to save when using Rust frontend. Nanosecond timestamp can only
     /// represent about 584 years
-    pub fn to_protobuf<T: Write>(self, output: &mut T) -> Result<usize> {
+    pub fn to_protobuf<T: Write>(self, output: &mut T) -> ArrayResult<usize> {
         output
             .write(&(self.0.timestamp_nanos() / 1000).to_be_bytes())
-            .map_err(|e| RwError::from(IoError(e)))
+            .map_err(Into::into)
     }
 
-    pub fn from_protobuf(timestamp_micro: i64) -> Result<Self> {
+    pub fn from_protobuf(timestamp_micro: i64) -> ArrayResult<Self> {
         let secs = timestamp_micro / 1_000_000;
         let nsecs = (timestamp_micro % 1_000_000) as u32 * 1000;
-        Self::with_secs_nsecs(secs, nsecs).map_err(|e| RwError::from(InternalError(e.to_string())))
+        Self::with_secs_nsecs(secs, nsecs).map_err(Into::into)
     }
 }
 

--- a/src/common/src/types/chrono_wrapper.rs
+++ b/src/common/src/types/chrono_wrapper.rs
@@ -21,7 +21,6 @@ use chrono::{Datelike, Duration, NaiveDate, NaiveDateTime, NaiveTime, Timelike};
 
 use super::{CheckedAdd, IntervalUnit};
 use crate::array::ArrayResult;
-use crate::error::ErrorCode::{InternalError, IoError};
 use crate::error::{Result, RwError};
 use crate::util::value_encoding::error::ValueEncodingError;
 /// The same as `NaiveDate::from_ymd(1970, 1, 1).num_days_from_ce()`.

--- a/src/common/src/types/interval.rs
+++ b/src/common/src/types/interval.rs
@@ -25,7 +25,6 @@ use serde::{Deserialize, Serialize};
 use smallvec::SmallVec;
 
 use super::*;
-use crate::error::ErrorCode::IoError;
 
 /// Every interval can be represented by a `IntervalUnit`.
 /// Note that the difference between Interval and Instant.

--- a/src/common/src/types/interval.rs
+++ b/src/common/src/types/interval.rs
@@ -16,6 +16,7 @@ use std::fmt::{Display, Formatter};
 use std::io::Write;
 use std::ops::{Add, Sub};
 
+use anyhow::anyhow;
 use byteorder::{BigEndian, WriteBytesExt};
 use bytes::BytesMut;
 use num_traits::{CheckedAdd, CheckedSub};
@@ -66,23 +67,23 @@ impl IntervalUnit {
         self.ms
     }
 
-    pub fn from_protobuf_bytes(bytes: &[u8], ty: IntervalType) -> Result<Self> {
+    pub fn from_protobuf_bytes(bytes: &[u8], ty: IntervalType) -> ArrayResult<Self> {
         // TODO: remove IntervalType later.
         match ty {
             // the unit is months
             Year | YearToMonth | Month => {
-                let bytes = bytes.try_into().map_err(|e| {
-                    InternalError(format!("Failed to deserialize i32, reason: {:?}", e))
-                })?;
+                let bytes = bytes
+                    .try_into()
+                    .map_err(|e| anyhow!("Failed to deserialize i32: {:?}", e))?;
                 let mouths = i32::from_be_bytes(bytes);
                 Ok(IntervalUnit::from_month(mouths))
             }
             // the unit is ms
             Day | DayToHour | DayToMinute | DayToSecond | Hour | HourToMinute | HourToSecond
             | Minute | MinuteToSecond | Second => {
-                let bytes = bytes.try_into().map_err(|e| {
-                    InternalError(format!("Failed to deserialize i64, reason: {:?}", e))
-                })?;
+                let bytes = bytes
+                    .try_into()
+                    .map_err(|e| anyhow!("Failed to deserialize i64: {:?}", e))?;
                 let ms = i64::from_be_bytes(bytes);
                 Ok(IntervalUnit::from_millis(ms))
             }
@@ -151,14 +152,11 @@ impl IntervalUnit {
         writer.into_inner().to_vec()
     }
 
-    pub fn to_protobuf<T: Write>(self, output: &mut T) -> Result<usize> {
-        {
-            output.write_i32::<BigEndian>(self.months)?;
-            output.write_i32::<BigEndian>(self.days)?;
-            output.write_i64::<BigEndian>(self.ms)?;
-            Ok(16)
-        }
-        .map_err(|e| RwError::from(IoError(e)))
+    pub fn to_protobuf<T: Write>(self, output: &mut T) -> ArrayResult<usize> {
+        output.write_i32::<BigEndian>(self.months)?;
+        output.write_i32::<BigEndian>(self.days)?;
+        output.write_i64::<BigEndian>(self.ms)?;
+        Ok(16)
     }
 
     /// Multiple [`IntervalUnit`] by an integer with overflow check.

--- a/src/common/src/types/mod.rs
+++ b/src/common/src/types/mod.rs
@@ -465,7 +465,7 @@ macro_rules! impl_convert {
                 fn try_from(val: ScalarImpl) -> ArrayResult<Self> {
                     match val {
                         ScalarImpl::$variant_name(scalar) => Ok(scalar),
-                        other_scalar => bail_anyhow!("cannot convert ScalarImpl::{} to concrete type", other_scalar.get_ident()),
+                        other_scalar => bail!("cannot convert ScalarImpl::{} to concrete type", other_scalar.get_ident()),
                     }
                 }
             }
@@ -482,7 +482,7 @@ macro_rules! impl_convert {
                 fn try_from(val: ScalarRefImpl<'scalar>) -> ArrayResult<Self> {
                     match val {
                         ScalarRefImpl::$variant_name(scalar_ref) => Ok(scalar_ref),
-                        other_scalar => bail_anyhow!("cannot convert ScalarRefImpl::{} to concrete type {}", other_scalar.get_ident(), stringify!($variant_name)),
+                        other_scalar => bail!("cannot convert ScalarRefImpl::{} to concrete type {}", other_scalar.get_ident(), stringify!($variant_name)),
                     }
                 }
             }
@@ -817,7 +817,7 @@ impl ScalarImpl {
                     .collect::<ArrayResult<Vec<Datum>>>()?;
                 ScalarImpl::List(ListValue::new(fields))
             }
-            _ => bail_anyhow!("Unrecognized type name: {:?}", data_type.get_type_name()),
+            _ => bail!("Unrecognized type name: {:?}", data_type.get_type_name()),
         };
         Ok(value)
     }

--- a/src/common/src/types/mod.rs
+++ b/src/common/src/types/mod.rs
@@ -56,7 +56,6 @@ use crate::array::{
     read_interval_unit, ArrayBuilderImpl, ListRef, ListValue, PrimitiveArrayItemType, StructRef,
     StructValue,
 };
-use crate::error::ErrorCode::InternalError;
 
 pub type OrderedF32 = ordered_float::OrderedFloat<f32>;
 pub type OrderedF64 = ordered_float::OrderedFloat<f64>;

--- a/src/common/src/types/mod.rs
+++ b/src/common/src/types/mod.rs
@@ -15,11 +15,12 @@
 use std::convert::TryFrom;
 use std::sync::Arc;
 
+use anyhow::anyhow;
 use bytes::{Buf, BufMut};
 use risingwave_pb::data::DataType as ProstDataType;
 use serde::{Deserialize, Serialize};
 
-use crate::error::{ErrorCode, Result, RwError};
+use crate::array::{ArrayError, ArrayResult};
 mod native_type;
 mod ops;
 mod scalar_impl;
@@ -121,7 +122,7 @@ impl From<&ProstDataType> for DataType {
 }
 
 impl DataType {
-    pub fn create_array_builder(&self, capacity: usize) -> Result<ArrayBuilderImpl> {
+    pub fn create_array_builder(&self, capacity: usize) -> ArrayResult<ArrayBuilderImpl> {
         use crate::array::*;
         Ok(match self {
             DataType::Boolean => BoolArrayBuilder::new(capacity)?.into(),
@@ -246,7 +247,7 @@ pub trait Scalar:
     + 'static
     + Clone
     + std::fmt::Debug
-    + TryFrom<ScalarImpl, Error = RwError>
+    + TryFrom<ScalarImpl, Error = ArrayError>
     + Into<ScalarImpl>
 {
     /// Type for reference of `Scalar`
@@ -276,7 +277,11 @@ pub fn option_to_owned_scalar<S: Scalar>(scalar: &Option<S::ScalarRefType<'_>>) 
 /// `ScalarRef` is reciprocal to `Scalar`. Use `to_owned_scalar` to get an
 /// owned scalar.
 pub trait ScalarRef<'a>:
-    Copy + std::fmt::Debug + 'a + TryFrom<ScalarRefImpl<'a>, Error = RwError> + Into<ScalarRefImpl<'a>>
+    Copy
+    + std::fmt::Debug
+    + 'a
+    + TryFrom<ScalarRefImpl<'a>, Error = ArrayError>
+    + Into<ScalarRefImpl<'a>>
 {
     /// `ScalarType` is the owned type of current `ScalarRef`.
     type ScalarType: Scalar<ScalarRefType<'a> = Self>;
@@ -456,14 +461,12 @@ macro_rules! impl_convert {
             }
 
             impl TryFrom<ScalarImpl> for $scalar {
-                type Error = RwError;
+                type Error = ArrayError;
 
-                fn try_from(val: ScalarImpl) -> Result<Self> {
+                fn try_from(val: ScalarImpl) -> ArrayResult<Self> {
                     match val {
                         ScalarImpl::$variant_name(scalar) => Ok(scalar),
-                        other_scalar => Err(ErrorCode::InternalError(
-                            format!("cannot convert ScalarImpl::{} to concrete type", other_scalar.get_ident())
-                        ).into())
+                        other_scalar => bail_anyhow!("cannot convert ScalarImpl::{} to concrete type", other_scalar.get_ident()),
                     }
                 }
             }
@@ -475,14 +478,12 @@ macro_rules! impl_convert {
             }
 
             impl <'scalar> TryFrom<ScalarRefImpl<'scalar>> for $scalar_ref {
-                type Error = RwError;
+                type Error = ArrayError;
 
-                fn try_from(val: ScalarRefImpl<'scalar>) -> Result<Self> {
+                fn try_from(val: ScalarRefImpl<'scalar>) -> ArrayResult<Self> {
                     match val {
                         ScalarRefImpl::$variant_name(scalar_ref) => Ok(scalar_ref),
-                        other_scalar => Err(ErrorCode::InternalError(
-                            format!("cannot convert ScalarRefImpl::{} to concrete type {}", other_scalar.get_ident(), stringify!($variant_name))
-                        ).into())
+                        other_scalar => bail_anyhow!("cannot convert ScalarRefImpl::{} to concrete type {}", other_scalar.get_ident(), stringify!($variant_name)),
                     }
                 }
             }
@@ -732,52 +733,55 @@ impl ScalarImpl {
         body
     }
 
-    pub fn bytes_to_scalar(b: &Vec<u8>, data_type: &ProstDataType) -> Result<Self> {
+    pub fn bytes_to_scalar(b: &Vec<u8>, data_type: &ProstDataType) -> ArrayResult<Self> {
         let value = match data_type.get_type_name()? {
             TypeName::Boolean => ScalarImpl::Bool(
-                i8::from_be_bytes(b.as_slice().try_into().map_err(|e| {
-                    InternalError(format!("Failed to deserialize bool, reason: {:?}", e))
-                })?) == 1,
+                i8::from_be_bytes(
+                    b.as_slice()
+                        .try_into()
+                        .map_err(|e| anyhow!("Failed to deserialize bool, reason: {:?}", e))?,
+                ) == 1,
             ),
-            TypeName::Int16 => {
-                ScalarImpl::Int16(i16::from_be_bytes(b.as_slice().try_into().map_err(
-                    |e| InternalError(format!("Failed to deserialize i16, reason: {:?}", e)),
-                )?))
-            }
-            TypeName::Int32 => {
-                ScalarImpl::Int32(i32::from_be_bytes(b.as_slice().try_into().map_err(
-                    |e| InternalError(format!("Failed to deserialize i32, reason: {:?}", e)),
-                )?))
-            }
-            TypeName::Int64 => {
-                ScalarImpl::Int64(i64::from_be_bytes(b.as_slice().try_into().map_err(
-                    |e| InternalError(format!("Failed to deserialize i64, reason: {:?}", e)),
-                )?))
-            }
+            TypeName::Int16 => ScalarImpl::Int16(i16::from_be_bytes(
+                b.as_slice()
+                    .try_into()
+                    .map_err(|e| anyhow!("Failed to deserialize i16, reason: {:?}", e))?,
+            )),
+            TypeName::Int32 => ScalarImpl::Int32(i32::from_be_bytes(
+                b.as_slice()
+                    .try_into()
+                    .map_err(|e| anyhow!("Failed to deserialize i32, reason: {:?}", e))?,
+            )),
+            TypeName::Int64 => ScalarImpl::Int64(i64::from_be_bytes(
+                b.as_slice()
+                    .try_into()
+                    .map_err(|e| anyhow!("Failed to deserialize i64, reason: {:?}", e))?,
+            )),
             TypeName::Float => ScalarImpl::Float32(
-                f32::from_be_bytes(b.as_slice().try_into().map_err(|e| {
-                    InternalError(format!("Failed to deserialize f32, reason: {:?}", e))
-                })?)
+                f32::from_be_bytes(
+                    b.as_slice()
+                        .try_into()
+                        .map_err(|e| anyhow!("Failed to deserialize f32, reason: {:?}", e))?,
+                )
                 .into(),
             ),
             TypeName::Double => ScalarImpl::Float64(
-                f64::from_be_bytes(b.as_slice().try_into().map_err(|e| {
-                    InternalError(format!("Failed to deserialize f64, reason: {:?}", e))
-                })?)
+                f64::from_be_bytes(
+                    b.as_slice()
+                        .try_into()
+                        .map_err(|e| anyhow!("Failed to deserialize f64, reason: {:?}", e))?,
+                )
                 .into(),
             ),
             TypeName::Varchar => ScalarImpl::Utf8(
                 std::str::from_utf8(b)
-                    .map_err(|e| {
-                        InternalError(format!("Failed to deserialize varchar, reason: {:?}", e))
-                    })?
+                    .map_err(|e| anyhow!("Failed to deserialize varchar, reason: {:?}", e))?
                     .to_string(),
             ),
-            TypeName::Decimal => {
-                ScalarImpl::Decimal(Decimal::from_str(std::str::from_utf8(b).unwrap()).map_err(
-                    |e| InternalError(format!("Failed to deserialize decimal, reason: {:?}", e)),
-                )?)
-            }
+            TypeName::Decimal => ScalarImpl::Decimal(
+                Decimal::from_str(std::str::from_utf8(b).unwrap())
+                    .map_err(|e| anyhow!("Failed to deserialize decimal, reason: {:?}", e))?,
+            ),
             TypeName::Interval => ScalarImpl::Interval(IntervalUnit::from_protobuf_bytes(
                 b,
                 data_type.get_interval_type()?,
@@ -795,7 +799,7 @@ impl ScalarImpl {
                             Ok(Some(ScalarImpl::bytes_to_scalar(b, d)?))
                         }
                     })
-                    .collect::<Result<Vec<Datum>>>()?;
+                    .collect::<ArrayResult<Vec<Datum>>>()?;
                 ScalarImpl::Struct(StructValue::new(fields))
             }
             TypeName::List => {
@@ -811,16 +815,10 @@ impl ScalarImpl {
                             Ok(Some(ScalarImpl::bytes_to_scalar(b, d)?))
                         }
                     })
-                    .collect::<Result<Vec<Datum>>>()?;
+                    .collect::<ArrayResult<Vec<Datum>>>()?;
                 ScalarImpl::List(ListValue::new(fields))
             }
-            _ => {
-                return Err(InternalError(format!(
-                    "Unrecognized type name: {:?}",
-                    data_type.get_type_name()
-                ))
-                .into());
-            }
+            _ => bail_anyhow!("Unrecognized type name: {:?}", data_type.get_type_name()),
         };
         Ok(value)
     }

--- a/src/common/src/types/native_type.rs
+++ b/src/common/src/types/native_type.rs
@@ -17,21 +17,18 @@ use std::hash::{Hash, Hasher};
 use std::io::Write;
 
 use super::{OrderedF32, OrderedF64};
-use crate::error::ErrorCode::IoError;
-use crate::error::{Result, RwError};
+use crate::array::ArrayResult;
 
 pub trait NativeType:
     PartialOrd + PartialEq + Debug + Copy + Send + Sync + Sized + Default + 'static
 {
-    fn to_protobuf<T: Write>(self, output: &mut T) -> Result<usize>;
+    fn to_protobuf<T: Write>(self, output: &mut T) -> ArrayResult<usize>;
     fn hash_wrapper<H: Hasher>(&self, state: &mut H);
 }
 
 impl NativeType for i16 {
-    fn to_protobuf<T: Write>(self, output: &mut T) -> Result<usize> {
-        output
-            .write(&self.to_be_bytes())
-            .map_err(|e| RwError::from(IoError(e)))
+    fn to_protobuf<T: Write>(self, output: &mut T) -> ArrayResult<usize> {
+        output.write(&self.to_be_bytes()).map_err(Into::into)
     }
 
     fn hash_wrapper<H: Hasher>(&self, state: &mut H) {
@@ -40,10 +37,8 @@ impl NativeType for i16 {
 }
 
 impl NativeType for i32 {
-    fn to_protobuf<T: Write>(self, output: &mut T) -> Result<usize> {
-        output
-            .write(&self.to_be_bytes())
-            .map_err(|e| RwError::from(IoError(e)))
+    fn to_protobuf<T: Write>(self, output: &mut T) -> ArrayResult<usize> {
+        output.write(&self.to_be_bytes()).map_err(Into::into)
     }
 
     fn hash_wrapper<H: Hasher>(&self, state: &mut H) {
@@ -52,10 +47,8 @@ impl NativeType for i32 {
 }
 
 impl NativeType for i64 {
-    fn to_protobuf<T: Write>(self, output: &mut T) -> Result<usize> {
-        output
-            .write(&self.to_be_bytes())
-            .map_err(|e| RwError::from(IoError(e)))
+    fn to_protobuf<T: Write>(self, output: &mut T) -> ArrayResult<usize> {
+        output.write(&self.to_be_bytes()).map_err(Into::into)
     }
 
     fn hash_wrapper<H: Hasher>(&self, state: &mut H) {
@@ -64,10 +57,8 @@ impl NativeType for i64 {
 }
 
 impl NativeType for OrderedF32 {
-    fn to_protobuf<T: Write>(self, output: &mut T) -> Result<usize> {
-        output
-            .write(&self.to_be_bytes())
-            .map_err(|e| RwError::from(IoError(e)))
+    fn to_protobuf<T: Write>(self, output: &mut T) -> ArrayResult<usize> {
+        output.write(&self.to_be_bytes()).map_err(Into::into)
     }
 
     fn hash_wrapper<H: Hasher>(&self, state: &mut H) {
@@ -76,10 +67,8 @@ impl NativeType for OrderedF32 {
 }
 
 impl NativeType for OrderedF64 {
-    fn to_protobuf<T: Write>(self, output: &mut T) -> Result<usize> {
-        output
-            .write(&self.to_be_bytes())
-            .map_err(|e| RwError::from(IoError(e)))
+    fn to_protobuf<T: Write>(self, output: &mut T) -> ArrayResult<usize> {
+        output.write(&self.to_be_bytes()).map_err(Into::into)
     }
 
     fn hash_wrapper<H: Hasher>(&self, state: &mut H) {
@@ -88,10 +77,8 @@ impl NativeType for OrderedF64 {
 }
 
 impl NativeType for u8 {
-    fn to_protobuf<T: Write>(self, output: &mut T) -> Result<usize> {
-        output
-            .write(&self.to_be_bytes())
-            .map_err(|e| RwError::from(IoError(e)))
+    fn to_protobuf<T: Write>(self, output: &mut T) -> ArrayResult<usize> {
+        output.write(&self.to_be_bytes()).map_err(Into::into)
     }
 
     fn hash_wrapper<H: Hasher>(&self, state: &mut H) {
@@ -100,10 +87,8 @@ impl NativeType for u8 {
 }
 
 impl NativeType for u16 {
-    fn to_protobuf<T: Write>(self, output: &mut T) -> Result<usize> {
-        output
-            .write(&self.to_be_bytes())
-            .map_err(|e| RwError::from(IoError(e)))
+    fn to_protobuf<T: Write>(self, output: &mut T) -> ArrayResult<usize> {
+        output.write(&self.to_be_bytes()).map_err(Into::into)
     }
 
     fn hash_wrapper<H: Hasher>(&self, state: &mut H) {
@@ -112,10 +97,8 @@ impl NativeType for u16 {
 }
 
 impl NativeType for u32 {
-    fn to_protobuf<T: Write>(self, output: &mut T) -> Result<usize> {
-        output
-            .write(&self.to_be_bytes())
-            .map_err(|e| RwError::from(IoError(e)))
+    fn to_protobuf<T: Write>(self, output: &mut T) -> ArrayResult<usize> {
+        output.write(&self.to_be_bytes()).map_err(Into::into)
     }
 
     fn hash_wrapper<H: Hasher>(&self, state: &mut H) {
@@ -124,10 +107,8 @@ impl NativeType for u32 {
 }
 
 impl NativeType for u64 {
-    fn to_protobuf<T: Write>(self, output: &mut T) -> Result<usize> {
-        output
-            .write(&self.to_be_bytes())
-            .map_err(|e| RwError::from(IoError(e)))
+    fn to_protobuf<T: Write>(self, output: &mut T) -> ArrayResult<usize> {
+        output.write(&self.to_be_bytes()).map_err(Into::into)
     }
 
     fn hash_wrapper<H: Hasher>(&self, state: &mut H) {

--- a/src/common/src/util/chunk_coalesce.rs
+++ b/src/common/src/util/chunk_coalesce.rs
@@ -18,8 +18,7 @@ use std::sync::Arc;
 use itertools::Itertools;
 
 use crate::array::column::Column;
-use crate::array::{ArrayBuilderImpl, DataChunk, RowRef};
-use crate::error::Result;
+use crate::array::{ArrayBuilderImpl, ArrayError, ArrayResult, DataChunk, RowRef};
 use crate::types::{DataType, Datum, DatumRef};
 
 pub const DEFAULT_CHUNK_BUFFER_SIZE: usize = 2048;
@@ -61,15 +60,15 @@ impl DataChunkBuilder {
         self.batch_size - self.buffered_count
     }
 
-    fn ensure_builders(&mut self) -> Result<()> {
+    fn ensure_builders(&mut self) -> ArrayResult<()> {
         if self.array_builders.len() != self.data_types.len() {
             self.array_builders = self
                 .data_types
                 .iter()
                 .map(|data_type| data_type.create_array_builder(self.batch_size))
-                .collect::<Result<Vec<ArrayBuilderImpl>>>()?;
+                .collect::<ArrayResult<Vec<ArrayBuilderImpl>>>()?;
 
-            ensure!(self.buffered_count == 0);
+            ensure_anyhow!(self.buffered_count == 0);
         }
 
         Ok(())
@@ -86,7 +85,7 @@ impl DataChunkBuilder {
     pub fn append_chunk(
         &mut self,
         input_chunk: SlicedDataChunk,
-    ) -> Result<(Option<SlicedDataChunk>, Option<DataChunk>)> {
+    ) -> ArrayResult<(Option<SlicedDataChunk>, Option<DataChunk>)> {
         self.ensure_builders()?;
 
         let mut new_return_offset = input_chunk.offset;
@@ -117,7 +116,7 @@ impl DataChunkBuilder {
             }
         }
 
-        ensure!(self.buffered_count <= self.batch_size);
+        ensure_anyhow!(self.buffered_count <= self.batch_size);
 
         let returned_input_chunk = if input_chunk.data_chunk.capacity() > new_return_offset {
             Some(input_chunk.with_new_offset_checked(new_return_offset)?)
@@ -137,7 +136,7 @@ impl DataChunkBuilder {
     /// Returns all data in current buffer.
     ///
     /// If `buffered_count` is 0, `None` is returned.
-    pub fn consume_all(&mut self) -> Result<Option<DataChunk>> {
+    pub fn consume_all(&mut self) -> ArrayResult<Option<DataChunk>> {
         if self.buffered_count > 0 {
             self.build_data_chunk().map(Some)
         } else {
@@ -145,14 +144,18 @@ impl DataChunkBuilder {
         }
     }
 
-    fn append_one_row_internal(&mut self, data_chunk: &DataChunk, row_idx: usize) -> Result<()> {
+    fn append_one_row_internal(
+        &mut self,
+        data_chunk: &DataChunk,
+        row_idx: usize,
+    ) -> ArrayResult<()> {
         self.do_append_one_row_from_datum_refs(data_chunk.row_at(row_idx)?.0.values())
     }
 
     fn do_append_one_row_from_datum_refs<'a>(
         &mut self,
         datum_refs: impl Iterator<Item = DatumRef<'a>>,
-    ) -> Result<()> {
+    ) -> ArrayResult<()> {
         self.array_builders
             .iter_mut()
             .zip_eq(datum_refs)
@@ -164,7 +167,7 @@ impl DataChunkBuilder {
     fn do_append_one_row_from_datums<'a>(
         &mut self,
         datums: impl Iterator<Item = &'a Datum>,
-    ) -> Result<()> {
+    ) -> ArrayResult<()> {
         self.array_builders
             .iter_mut()
             .zip_eq(datums)
@@ -178,8 +181,8 @@ impl DataChunkBuilder {
     pub fn append_one_row_from_datum_refs<'a>(
         &mut self,
         datum_refs: impl Iterator<Item = DatumRef<'a>>,
-    ) -> Result<Option<DataChunk>> {
-        ensure!(self.buffered_count < self.batch_size);
+    ) -> ArrayResult<Option<DataChunk>> {
+        ensure_anyhow!(self.buffered_count < self.batch_size);
         self.ensure_builders()?;
 
         self.do_append_one_row_from_datum_refs(datum_refs)?;
@@ -192,7 +195,7 @@ impl DataChunkBuilder {
 
     /// Append one row from the given `row_ref`.
     /// Return a data chunk if the buffer is full after append one row. Otherwise `None`.
-    pub fn append_one_row_ref(&mut self, row_ref: RowRef<'_>) -> Result<Option<DataChunk>> {
+    pub fn append_one_row_ref(&mut self, row_ref: RowRef<'_>) -> ArrayResult<Option<DataChunk>> {
         self.append_one_row_from_datum_refs(row_ref.values())
     }
 
@@ -201,8 +204,8 @@ impl DataChunkBuilder {
     pub fn append_one_row_from_datums<'a>(
         &mut self,
         datums: impl Iterator<Item = &'a Datum>,
-    ) -> Result<Option<DataChunk>> {
-        ensure!(self.buffered_count < self.batch_size);
+    ) -> ArrayResult<Option<DataChunk>> {
+        ensure_anyhow!(self.buffered_count < self.batch_size);
         self.ensure_builders()?;
 
         self.do_append_one_row_from_datums(datums)?;
@@ -213,7 +216,7 @@ impl DataChunkBuilder {
         }
     }
 
-    fn build_data_chunk(&mut self) -> Result<DataChunk> {
+    fn build_data_chunk(&mut self) -> ArrayResult<DataChunk> {
         let mut new_array_builders = vec![];
         swap(&mut new_array_builders, &mut self.array_builders);
         let cardinality = self.buffered_count;
@@ -221,7 +224,7 @@ impl DataChunkBuilder {
 
         let columns = new_array_builders.into_iter().try_fold(
             Vec::with_capacity(self.data_types.len()),
-            |mut vec, array_builder| -> Result<Vec<Column>> {
+            |mut vec, array_builder| -> ArrayResult<Vec<Column>> {
                 let array = array_builder.finish()?;
                 let column = Column::new(Arc::new(array));
                 vec.push(column);
@@ -237,16 +240,16 @@ impl DataChunkBuilder {
 }
 
 impl SlicedDataChunk {
-    pub fn new_checked(data_chunk: DataChunk) -> Result<Self> {
+    pub fn new_checked(data_chunk: DataChunk) -> ArrayResult<Self> {
         SlicedDataChunk::with_offset_checked(data_chunk, 0)
     }
 
-    pub fn with_offset_checked(data_chunk: DataChunk, offset: usize) -> Result<Self> {
-        ensure!(offset < data_chunk.capacity());
+    pub fn with_offset_checked(data_chunk: DataChunk, offset: usize) -> ArrayResult<Self> {
+        ensure_anyhow!(offset < data_chunk.capacity());
         Ok(Self { data_chunk, offset })
     }
 
-    pub fn with_new_offset_checked(self, new_offset: usize) -> Result<Self> {
+    pub fn with_new_offset_checked(self, new_offset: usize) -> ArrayResult<Self> {
         SlicedDataChunk::with_offset_checked(self.data_chunk, new_offset)
     }
 

--- a/src/common/src/util/chunk_coalesce.rs
+++ b/src/common/src/util/chunk_coalesce.rs
@@ -68,7 +68,7 @@ impl DataChunkBuilder {
                 .map(|data_type| data_type.create_array_builder(self.batch_size))
                 .collect::<ArrayResult<Vec<ArrayBuilderImpl>>>()?;
 
-            ensure_anyhow!(self.buffered_count == 0);
+            ensure!(self.buffered_count == 0);
         }
 
         Ok(())
@@ -116,7 +116,7 @@ impl DataChunkBuilder {
             }
         }
 
-        ensure_anyhow!(self.buffered_count <= self.batch_size);
+        ensure!(self.buffered_count <= self.batch_size);
 
         let returned_input_chunk = if input_chunk.data_chunk.capacity() > new_return_offset {
             Some(input_chunk.with_new_offset_checked(new_return_offset)?)
@@ -182,7 +182,7 @@ impl DataChunkBuilder {
         &mut self,
         datum_refs: impl Iterator<Item = DatumRef<'a>>,
     ) -> ArrayResult<Option<DataChunk>> {
-        ensure_anyhow!(self.buffered_count < self.batch_size);
+        ensure!(self.buffered_count < self.batch_size);
         self.ensure_builders()?;
 
         self.do_append_one_row_from_datum_refs(datum_refs)?;
@@ -205,7 +205,7 @@ impl DataChunkBuilder {
         &mut self,
         datums: impl Iterator<Item = &'a Datum>,
     ) -> ArrayResult<Option<DataChunk>> {
-        ensure_anyhow!(self.buffered_count < self.batch_size);
+        ensure!(self.buffered_count < self.batch_size);
         self.ensure_builders()?;
 
         self.do_append_one_row_from_datums(datums)?;
@@ -245,7 +245,7 @@ impl SlicedDataChunk {
     }
 
     pub fn with_offset_checked(data_chunk: DataChunk, offset: usize) -> ArrayResult<Self> {
-        ensure_anyhow!(offset < data_chunk.capacity());
+        ensure!(offset < data_chunk.capacity());
         Ok(Self { data_chunk, offset })
     }
 

--- a/src/common/src/util/chunk_coalesce.rs
+++ b/src/common/src/util/chunk_coalesce.rs
@@ -18,7 +18,7 @@ use std::sync::Arc;
 use itertools::Itertools;
 
 use crate::array::column::Column;
-use crate::array::{ArrayBuilderImpl, ArrayError, ArrayResult, DataChunk, RowRef};
+use crate::array::{ArrayBuilderImpl, ArrayResult, DataChunk, RowRef};
 use crate::types::{DataType, Datum, DatumRef};
 
 pub const DEFAULT_CHUNK_BUFFER_SIZE: usize = 2048;

--- a/src/common/src/util/value_encoding/mod.rs
+++ b/src/common/src/util/value_encoding/mod.rs
@@ -156,7 +156,7 @@ fn deserialize_struct_or_list(data_type: &DataType, mut data: impl Buf) -> Resul
     let len = data.get_u32_le();
     let mut bytes = vec![0; len as usize];
     data.copy_to_slice(&mut bytes);
-    ScalarImpl::bytes_to_scalar(&bytes, &data_type.to_protobuf())
+    ScalarImpl::bytes_to_scalar(&bytes, &data_type.to_protobuf()).map_err(Into::into)
 }
 
 fn deserialize_str(mut data: impl Buf) -> Result<String> {

--- a/src/expr/src/expr/expr_array.rs
+++ b/src/expr/src/expr/expr_array.rs
@@ -55,16 +55,14 @@ impl Expression for ArrayExpression {
             ArrayMeta::List {
                 datatype: self.element_type.clone(),
             },
-        )
-        .map_err(ExprError::Array)?;
+        )?;
         chunk
             .rows()
-            .try_for_each(|row| builder.append_row_ref(row))
-            .map_err(ExprError::Array)?;
+            .try_for_each(|row| builder.append_row_ref(row))?;
         builder
             .finish()
             .map(|a| Arc::new(ArrayImpl::List(a)))
-            .map_err(ExprError::Array)
+            .map_err(Into::into)
     }
 
     fn eval_row(&self, input: &Row) -> Result<Datum> {

--- a/src/expr/src/expr/expr_case.rs
+++ b/src/expr/src/expr/expr_case.rs
@@ -17,7 +17,7 @@ use risingwave_common::array::{ArrayRef, DataChunk, Row};
 use risingwave_common::types::{DataType, Datum, ScalarImpl, ScalarRefImpl, ToOwnedDatum};
 
 use crate::expr::{BoxedExpression, Expression};
-use crate::{ExprError, Result};
+use crate::Result;
 
 #[derive(Debug)]
 pub struct WhenClause {

--- a/src/expr/src/expr/expr_case.rs
+++ b/src/expr/src/expr/expr_case.rs
@@ -59,7 +59,7 @@ impl Expression for CaseExpression {
 
     fn eval(&self, input: &DataChunk) -> Result<ArrayRef> {
         // TODO: we can avoid the compact here.
-        let input = input.clone().compact().map_err(ExprError::Array)?;
+        let input = input.clone().compact()?;
         let mut els = self
             .else_clause
             .as_deref()
@@ -74,10 +74,7 @@ impl Expression for CaseExpression {
                 )
             })
             .collect_vec();
-        let mut output_array = self
-            .return_type()
-            .create_array_builder(input.capacity())
-            .map_err(ExprError::Array)?;
+        let mut output_array = self.return_type().create_array_builder(input.capacity())?;
         for idx in 0..input.capacity() {
             if let Some((_, t)) = when_thens
                 .iter()
@@ -88,17 +85,15 @@ impl Expression for CaseExpression {
                         .as_bool()
                 })
             {
-                output_array
-                    .append_datum(&t.to_owned_datum())
-                    .map_err(ExprError::Array)?;
+                output_array.append_datum(&t.to_owned_datum())?;
             } else if let Some(els) = els.as_mut() {
                 let t = els.datum_at(idx);
-                output_array.append_datum(&t).map_err(ExprError::Array)?;
+                output_array.append_datum(&t)?;
             } else {
-                output_array.append_null().map_err(ExprError::Array)?;
+                output_array.append_null()?;
             };
         }
-        let output_array = output_array.finish().map_err(ExprError::Array)?.into();
+        let output_array = output_array.finish()?.into();
         Ok(output_array)
     }
 

--- a/src/expr/src/expr/expr_coalesce.rs
+++ b/src/expr/src/expr/expr_coalesce.rs
@@ -40,10 +40,7 @@ impl Expression for CoalesceExpression {
             .iter()
             .map(|c| c.eval(input))
             .collect::<Result<Vec<_>>>()?;
-        let mut builder = self
-            .return_type
-            .create_array_builder(input.cardinality())
-            .map_err(ExprError::Array)?;
+        let mut builder = self.return_type.create_array_builder(input.cardinality())?;
 
         let len = children_array[0].len();
         for i in 0..len {
@@ -55,9 +52,9 @@ impl Expression for CoalesceExpression {
                     break;
                 }
             }
-            builder.append_datum(&data).map_err(ExprError::Array)?;
+            builder.append_datum(&data)?;
         }
-        Ok(Arc::new(builder.finish().map_err(ExprError::Array)?))
+        Ok(Arc::new(builder.finish()?))
     }
 
     fn eval_row(&self, input: &Row) -> Result<Datum> {

--- a/src/expr/src/expr/expr_concat_ws.rs
+++ b/src/expr/src/expr/expr_concat_ws.rs
@@ -52,13 +52,13 @@ impl Expression for ConcatWsExpression {
             .collect::<Vec<_>>();
 
         let row_len = input.cardinality();
-        let mut builder = Utf8ArrayBuilder::new(row_len).map_err(ExprError::Array)?;
+        let mut builder = Utf8ArrayBuilder::new(row_len)?;
 
         for row_idx in 0..row_len {
             let sep = match sep_column.value_at(row_idx) {
                 Some(sep) => sep,
                 None => {
-                    builder.append(None).map_err(ExprError::Array)?;
+                    builder.append(None)?;
                     continue;
                 }
             };
@@ -68,23 +68,21 @@ impl Expression for ConcatWsExpression {
             let mut string_columns = string_columns_ref.iter();
             for string_column in string_columns.by_ref() {
                 if let Some(string) = string_column.value_at(row_idx) {
-                    writer.write_ref(string).map_err(ExprError::Array)?;
+                    writer.write_ref(string)?;
                     break;
                 }
             }
 
             for string_column in string_columns {
                 if let Some(string) = string_column.value_at(row_idx) {
-                    writer.write_ref(sep).map_err(ExprError::Array)?;
-                    writer.write_ref(string).map_err(ExprError::Array)?;
+                    writer.write_ref(sep)?;
+                    writer.write_ref(string)?;
                 }
             }
 
-            builder = writer.finish().map_err(ExprError::Array)?.into_inner();
+            builder = writer.finish()?.into_inner();
         }
-        Ok(Arc::new(ArrayImpl::from(
-            builder.finish().map_err(ExprError::Array)?,
-        )))
+        Ok(Arc::new(ArrayImpl::from(builder.finish()?)))
     }
 
     fn eval_row(&self, input: &Row) -> Result<Datum> {

--- a/src/expr/src/expr/expr_in.rs
+++ b/src/expr/src/expr/expr_in.rs
@@ -20,7 +20,7 @@ use risingwave_common::array::{ArrayBuilder, ArrayRef, BoolArrayBuilder, DataChu
 use risingwave_common::types::{DataType, Datum, Scalar, ToOwnedDatum};
 
 use crate::expr::{BoxedExpression, Expression};
-use crate::{ExprError, Result};
+use crate::Result;
 
 #[derive(Debug)]
 pub(crate) struct InExpression {

--- a/src/expr/src/expr/expr_in.rs
+++ b/src/expr/src/expr/expr_in.rs
@@ -58,15 +58,12 @@ impl Expression for InExpression {
 
     fn eval(&self, input: &DataChunk) -> Result<ArrayRef> {
         let input_array = self.left.eval(input)?;
-        let mut output_array =
-            BoolArrayBuilder::new(input_array.len()).map_err(ExprError::Array)?;
+        let mut output_array = BoolArrayBuilder::new(input_array.len())?;
         for data in input_array.iter() {
             let ret = self.exists(&data.to_owned_datum());
-            output_array.append(Some(ret)).map_err(ExprError::Array)?;
+            output_array.append(Some(ret))?;
         }
-        Ok(Arc::new(
-            output_array.finish().map_err(ExprError::Array)?.into(),
-        ))
+        Ok(Arc::new(output_array.finish()?.into()))
     }
 
     fn eval_row(&self, input: &Row) -> Result<Datum> {

--- a/src/expr/src/expr/expr_input_ref.rs
+++ b/src/expr/src/expr/expr_input_ref.rs
@@ -45,11 +45,7 @@ impl Expression for InputRefExpression {
         match bitmap {
             Some(bitmap) => {
                 if input.cardinality() != input.capacity() {
-                    Ok(Arc::new(
-                        array
-                            .compact(bitmap, cardinality)
-                            .map_err(ExprError::Array)?,
-                    ))
+                    Ok(Arc::new(array.compact(bitmap, cardinality)?))
                 } else {
                     Ok(array)
                 }

--- a/src/expr/src/expr/expr_is_null.rs
+++ b/src/expr/src/expr/expr_is_null.rs
@@ -20,7 +20,7 @@ use risingwave_common::array::{
 use risingwave_common::types::{DataType, Datum, Scalar};
 
 use crate::expr::{BoxedExpression, Expression};
-use crate::{ExprError, Result};
+use crate::Result;
 
 #[derive(Debug)]
 pub struct IsNullExpression {

--- a/src/expr/src/expr/expr_is_null.rs
+++ b/src/expr/src/expr/expr_is_null.rs
@@ -58,17 +58,14 @@ impl Expression for IsNullExpression {
     }
 
     fn eval(&self, input: &DataChunk) -> Result<ArrayRef> {
-        let mut builder = BoolArrayBuilder::new(input.cardinality()).map_err(ExprError::Array)?;
+        let mut builder = BoolArrayBuilder::new(input.cardinality())?;
         self.child
             .eval(input)?
             .null_bitmap()
             .iter()
-            .try_for_each(|b| builder.append(Some(!b)))
-            .map_err(ExprError::Array)?;
+            .try_for_each(|b| builder.append(Some(!b)))?;
 
-        Ok(Arc::new(ArrayImpl::Bool(
-            builder.finish().map_err(ExprError::Array)?,
-        )))
+        Ok(Arc::new(ArrayImpl::Bool(builder.finish()?)))
     }
 
     fn eval_row(&self, input: &Row) -> Result<Datum> {
@@ -84,17 +81,14 @@ impl Expression for IsNotNullExpression {
     }
 
     fn eval(&self, input: &DataChunk) -> Result<ArrayRef> {
-        let mut builder = BoolArrayBuilder::new(input.cardinality()).map_err(ExprError::Array)?;
+        let mut builder = BoolArrayBuilder::new(input.cardinality())?;
         self.child
             .eval(input)?
             .null_bitmap()
             .iter()
-            .try_for_each(|b| builder.append(Some(b)))
-            .map_err(ExprError::Array)?;
+            .try_for_each(|b| builder.append(Some(b)))?;
 
-        Ok(Arc::new(ArrayImpl::Bool(
-            builder.finish().map_err(ExprError::Array)?,
-        )))
+        Ok(Arc::new(ArrayImpl::Bool(builder.finish()?)))
     }
 
     fn eval_row(&self, input: &Row) -> Result<Datum> {

--- a/src/expr/src/expr/mod.rs
+++ b/src/expr/src/expr/mod.rs
@@ -127,8 +127,7 @@ impl RowExpression {
     }
 
     pub fn eval(&mut self, row: &Row, data_types: &[DataType]) -> Result<ArrayRef> {
-        let input =
-            DataChunk::from_rows(slice::from_ref(row), data_types).map_err(ExprError::Array)?;
+        let input = DataChunk::from_rows(slice::from_ref(row), data_types)?;
         self.expr.eval(&input)
     }
 

--- a/src/expr/src/lib.rs
+++ b/src/expr/src/lib.rs
@@ -38,5 +38,5 @@ pub mod expr;
 pub mod vector_op;
 
 pub use error::ExprError;
-pub use risingwave_common::{bail_anyhow as bail, ensure_anyhow as ensure};
+pub use risingwave_common::{bail, ensure};
 pub type Result<T> = std::result::Result<T, ExprError>;

--- a/src/expr/src/lib.rs
+++ b/src/expr/src/lib.rs
@@ -38,4 +38,5 @@ pub mod expr;
 pub mod vector_op;
 
 pub use error::ExprError;
+pub use risingwave_common::{bail_anyhow as bail, ensure_anyhow as ensure};
 pub type Result<T> = std::result::Result<T, ExprError>;

--- a/src/expr/src/vector_op/agg/approx_count_distinct.rs
+++ b/src/expr/src/vector_op/agg/approx_count_distinct.rs
@@ -137,7 +137,7 @@ impl Aggregator for ApproxCountDistinct {
     fn output(&self, builder: &mut ArrayBuilderImpl) -> Result<()> {
         let result = self.calculate_result();
         match builder {
-            ArrayBuilderImpl::Int64(b) => b.append(Some(result)),
+            ArrayBuilderImpl::Int64(b) => b.append(Some(result)).map_err(Into::into),
             _ => Err(ErrorCode::InternalError("Unexpected builder for count(*).".into()).into()),
         }
     }

--- a/src/expr/src/vector_op/agg/count_star.rs
+++ b/src/expr/src/vector_op/agg/count_star.rs
@@ -47,7 +47,7 @@ impl Aggregator for CountStar {
 
     fn output(&self, builder: &mut ArrayBuilderImpl) -> Result<()> {
         match builder {
-            ArrayBuilderImpl::Int64(b) => b.append(Some(self.result as i64)),
+            ArrayBuilderImpl::Int64(b) => b.append(Some(self.result as i64)).map_err(Into::into),
             _ => Err(ErrorCode::InternalError("Unexpected builder for count(*).".into()).into()),
         }
     }

--- a/src/expr/src/vector_op/agg/general_agg.rs
+++ b/src/expr/src/vector_op/agg/general_agg.rs
@@ -78,7 +78,9 @@ where
     }
 
     pub(super) fn output_concrete(&self, builder: &mut R::Builder) -> Result<()> {
-        builder.append(self.result.as_ref().map(|x| x.as_scalar_ref()))
+        builder
+            .append(self.result.as_ref().map(|x| x.as_scalar_ref()))
+            .map_err(Into::into)
     }
 
     pub(super) fn update_and_output_with_sorted_groups_concrete(
@@ -241,7 +243,7 @@ mod tests {
         let mut agg_state = create_agg_state_unary(input_type, 0, agg_type, return_type, false)?;
         agg_state.update(&input_chunk)?;
         agg_state.output(&mut builder)?;
-        builder.finish()
+        builder.finish().map_err(Into::into)
     }
 
     #[test]

--- a/src/expr/src/vector_op/agg/general_distinct_agg.rs
+++ b/src/expr/src/vector_op/agg/general_distinct_agg.rs
@@ -91,7 +91,9 @@ where
     }
 
     fn output_concrete(&self, builder: &mut R::Builder) -> Result<()> {
-        builder.append(self.result.as_ref().map(|x| x.as_scalar_ref()))
+        builder
+            .append(self.result.as_ref().map(|x| x.as_scalar_ref()))
+            .map_err(Into::into)
     }
 
     fn update_and_output_with_sorted_groups_concrete(
@@ -257,7 +259,7 @@ mod tests {
         let mut agg_state = create_agg_state_unary(input_type, 0, agg_type, return_type, true)?;
         agg_state.update(&input_chunk)?;
         agg_state.output(&mut builder)?;
-        builder.finish()
+        builder.finish().map_err(Into::into)
     }
 
     #[test]

--- a/src/expr/src/vector_op/agg/general_sorted_grouper.rs
+++ b/src/expr/src/vector_op/agg/general_sorted_grouper.rs
@@ -243,7 +243,9 @@ where
     }
 
     pub fn output_concrete(&self, builder: &mut T::Builder) -> Result<()> {
-        builder.append(self.group_value.as_ref().map(|x| x.as_scalar_ref()))
+        builder
+            .append(self.group_value.as_ref().map(|x| x.as_scalar_ref()))
+            .map_err(Into::into)
     }
 }
 

--- a/src/expr/src/vector_op/array_access.rs
+++ b/src/expr/src/vector_op/array_access.rs
@@ -22,9 +22,9 @@ pub fn array_access<T: Scalar>(l: Option<ListRef>, r: Option<i32>) -> Result<Opt
     match (l, r) {
         // index must be greater than 0 following a one-based numbering convention for arrays
         (Some(list), Some(index)) if index > 0 => {
-            let datumref = list.value_at(index as usize).map_err(ExprError::Array)?;
+            let datumref = list.value_at(index as usize)?;
             if let Some(scalar) = datumref.to_owned_datum() {
-                Ok(Some(scalar.try_into().map_err(ExprError::Array)?))
+                Ok(Some(scalar.try_into()?))
             } else {
                 Ok(None)
             }

--- a/src/expr/src/vector_op/array_access.rs
+++ b/src/expr/src/vector_op/array_access.rs
@@ -15,7 +15,7 @@
 use risingwave_common::array::ListRef;
 use risingwave_common::types::{Scalar, ToOwnedDatum};
 
-use crate::{ExprError, Result};
+use crate::Result;
 
 #[inline(always)]
 pub fn array_access<T: Scalar>(l: Option<ListRef>, r: Option<i32>) -> Result<Option<T>> {

--- a/src/expr/src/vector_op/lower.rs
+++ b/src/expr/src/vector_op/lower.rs
@@ -14,7 +14,7 @@
 
 use risingwave_common::array::{BytesGuard, BytesWriter};
 
-use crate::{ExprError, Result};
+use crate::Result;
 
 #[inline(always)]
 pub fn lower(s: &str, writer: BytesWriter) -> Result<BytesGuard> {

--- a/src/expr/src/vector_op/lower.rs
+++ b/src/expr/src/vector_op/lower.rs
@@ -18,9 +18,7 @@ use crate::{ExprError, Result};
 
 #[inline(always)]
 pub fn lower(s: &str, writer: BytesWriter) -> Result<BytesGuard> {
-    writer
-        .write_ref(&s.to_lowercase())
-        .map_err(ExprError::Array)
+    writer.write_ref(&s.to_lowercase()).map_err(Into::into)
 }
 
 #[cfg(test)]

--- a/src/expr/src/vector_op/ltrim.rs
+++ b/src/expr/src/vector_op/ltrim.rs
@@ -21,7 +21,7 @@ use crate::{ExprError, Result};
 /// Since we would like to simplify the implementation, currently we omit this case.
 #[inline(always)]
 pub fn ltrim(s: &str, writer: BytesWriter) -> Result<BytesGuard> {
-    writer.write_ref(s.trim_start()).map_err(ExprError::Array)
+    writer.write_ref(s.trim_start()).map_err(Into::into)
 }
 
 #[cfg(test)]

--- a/src/expr/src/vector_op/ltrim.rs
+++ b/src/expr/src/vector_op/ltrim.rs
@@ -14,7 +14,7 @@
 
 use risingwave_common::array::{BytesGuard, BytesWriter};
 
-use crate::{ExprError, Result};
+use crate::Result;
 
 /// Note: the behavior of `ltrim` in `PostgreSQL` and `trim_start` (or `trim_left`) in Rust
 /// are actually different when the string is in right-to-left languages like Arabic or Hebrew.

--- a/src/expr/src/vector_op/md5.rs
+++ b/src/expr/src/vector_op/md5.rs
@@ -21,7 +21,7 @@ use crate::{ExprError, Result};
 pub fn md5(s: &str, writer: BytesWriter) -> Result<BytesGuard> {
     writer
         .write_ref(&format!("{:x}", lib_md5::compute(s)))
-        .map_err(ExprError::Array)
+        .map_err(Into::into)
 }
 
 #[cfg(test)]

--- a/src/expr/src/vector_op/md5.rs
+++ b/src/expr/src/vector_op/md5.rs
@@ -15,7 +15,7 @@
 use md5 as lib_md5;
 use risingwave_common::array::{BytesGuard, BytesWriter};
 
-use crate::{ExprError, Result};
+use crate::Result;
 
 #[inline(always)]
 pub fn md5(s: &str, writer: BytesWriter) -> Result<BytesGuard> {

--- a/src/expr/src/vector_op/replace.rs
+++ b/src/expr/src/vector_op/replace.rs
@@ -19,20 +19,18 @@ use crate::{ExprError, Result};
 #[inline(always)]
 pub fn replace(s: &str, from_str: &str, to_str: &str, writer: BytesWriter) -> Result<BytesGuard> {
     if from_str.is_empty() {
-        return writer.write_ref(s).map_err(ExprError::Array);
+        return writer.write_ref(s).map_err(Into::into);
     }
     let mut last = 0;
     let mut writer = writer.begin();
     while let Some(mut start) = s[last..].find(from_str) {
         start += last;
-        writer
-            .write_ref(&s[last..start])
-            .map_err(ExprError::Array)?;
-        writer.write_ref(to_str).map_err(ExprError::Array)?;
+        writer.write_ref(&s[last..start])?;
+        writer.write_ref(to_str)?;
         last = start + from_str.len();
     }
-    writer.write_ref(&s[last..]).map_err(ExprError::Array)?;
-    writer.finish().map_err(ExprError::Array)
+    writer.write_ref(&s[last..])?;
+    writer.finish().map_err(Into::into)
 }
 
 #[cfg(test)]

--- a/src/expr/src/vector_op/replace.rs
+++ b/src/expr/src/vector_op/replace.rs
@@ -14,7 +14,7 @@
 
 use risingwave_common::array::{BytesGuard, BytesWriter};
 
-use crate::{ExprError, Result};
+use crate::Result;
 
 #[inline(always)]
 pub fn replace(s: &str, from_str: &str, to_str: &str, writer: BytesWriter) -> Result<BytesGuard> {

--- a/src/expr/src/vector_op/rtrim.rs
+++ b/src/expr/src/vector_op/rtrim.rs
@@ -14,7 +14,7 @@
 
 use risingwave_common::array::{BytesGuard, BytesWriter};
 
-use crate::{ExprError, Result};
+use crate::Result;
 
 /// Note: the behavior of `rtrim` in `PostgreSQL` and `trim_end` (or `trim_right`) in Rust
 /// are actually different when the string is in right-to-left languages like Arabic or Hebrew.

--- a/src/expr/src/vector_op/rtrim.rs
+++ b/src/expr/src/vector_op/rtrim.rs
@@ -21,7 +21,7 @@ use crate::{ExprError, Result};
 /// Since we would like to simplify the implementation, currently we omit this case.
 #[inline(always)]
 pub fn rtrim(s: &str, writer: BytesWriter) -> Result<BytesGuard> {
-    writer.write_ref(s.trim_end()).map_err(ExprError::Array)
+    writer.write_ref(s.trim_end()).map_err(Into::into)
 }
 
 #[cfg(test)]

--- a/src/expr/src/vector_op/split_part.rs
+++ b/src/expr/src/vector_op/split_part.rs
@@ -62,7 +62,7 @@ pub fn split_part(
         }
     };
 
-    writer.write_ref(nth_val).map_err(ExprError::Array)
+    writer.write_ref(nth_val).map_err(Into::into)
 }
 
 #[cfg(test)]

--- a/src/expr/src/vector_op/substr.rs
+++ b/src/expr/src/vector_op/substr.rs
@@ -21,13 +21,13 @@ use crate::{bail, ExprError, Result};
 #[inline(always)]
 pub fn substr_start(s: &str, start: i32, writer: BytesWriter) -> Result<BytesGuard> {
     let start = min(max(start - 1, 0) as usize, s.len());
-    writer.write_ref(&s[start..]).map_err(ExprError::Array)
+    writer.write_ref(&s[start..]).map_err(Into::into)
 }
 
 #[inline(always)]
 pub fn substr_for(s: &str, count: i32, writer: BytesWriter) -> Result<BytesGuard> {
     let end = min(count as usize, s.len());
-    writer.write_ref(&s[..end]).map_err(ExprError::Array)
+    writer.write_ref(&s[..end]).map_err(Into::into)
 }
 
 #[inline(always)]
@@ -42,7 +42,7 @@ pub fn substr_start_for(
     }
     let begin = max(start - 1, 0) as usize;
     let end = min(max(start - 1 + count, 0) as usize, s.len());
-    writer.write_ref(&s[begin..end]).map_err(ExprError::Array)
+    writer.write_ref(&s[begin..end]).map_err(Into::into)
 }
 
 #[cfg(test)]

--- a/src/expr/src/vector_op/substr.rs
+++ b/src/expr/src/vector_op/substr.rs
@@ -16,7 +16,7 @@ use std::cmp::{max, min};
 
 use risingwave_common::array::{BytesGuard, BytesWriter};
 
-use crate::{bail, ExprError, Result};
+use crate::{bail, Result};
 
 #[inline(always)]
 pub fn substr_start(s: &str, start: i32, writer: BytesWriter) -> Result<BytesGuard> {

--- a/src/expr/src/vector_op/to_char.rs
+++ b/src/expr/src/vector_op/to_char.rs
@@ -16,7 +16,7 @@ use aho_corasick::AhoCorasickBuilder;
 use risingwave_common::array::{BytesGuard, BytesWriter};
 use risingwave_common::types::NaiveDateTimeWrapper;
 
-use crate::{ExprError, Result};
+use crate::Result;
 
 /// Compile the pg pattern to chrono pattern.
 // TODO: Chrono can not fully support the pg format, so consider using other implementations later.

--- a/src/expr/src/vector_op/to_char.rs
+++ b/src/expr/src/vector_op/to_char.rs
@@ -51,5 +51,5 @@ pub fn to_char_timestamp(
 ) -> Result<BytesGuard> {
     let chrono_tmpl = compile_pattern_to_chrono(tmpl);
     let res = data.0.format(&chrono_tmpl).to_string();
-    dst.write_ref(&res).map_err(ExprError::Array)
+    dst.write_ref(&res).map_err(Into::into)
 }

--- a/src/expr/src/vector_op/translate.rs
+++ b/src/expr/src/vector_op/translate.rs
@@ -16,7 +16,7 @@ use std::collections::HashMap;
 
 use risingwave_common::array::{BytesGuard, BytesWriter};
 
-use crate::{ExprError, Result};
+use crate::Result;
 
 #[inline(always)]
 pub fn translate(

--- a/src/expr/src/vector_op/translate.rs
+++ b/src/expr/src/vector_op/translate.rs
@@ -45,7 +45,7 @@ pub fn translate(
         None => Some(c),
     });
 
-    writer.write_from_char_iter(iter).map_err(ExprError::Array)
+    writer.write_from_char_iter(iter).map_err(Into::into)
 }
 
 #[cfg(test)]

--- a/src/expr/src/vector_op/trim.rs
+++ b/src/expr/src/vector_op/trim.rs
@@ -14,7 +14,7 @@
 
 use risingwave_common::array::{BytesGuard, BytesWriter};
 
-use crate::{ExprError, Result};
+use crate::Result;
 
 #[inline(always)]
 pub fn trim(s: &str, writer: BytesWriter) -> Result<BytesGuard> {

--- a/src/expr/src/vector_op/trim.rs
+++ b/src/expr/src/vector_op/trim.rs
@@ -18,7 +18,7 @@ use crate::{ExprError, Result};
 
 #[inline(always)]
 pub fn trim(s: &str, writer: BytesWriter) -> Result<BytesGuard> {
-    writer.write_ref(s.trim()).map_err(ExprError::Array)
+    writer.write_ref(s.trim()).map_err(Into::into)
 }
 
 #[cfg(test)]

--- a/src/expr/src/vector_op/upper.rs
+++ b/src/expr/src/vector_op/upper.rs
@@ -14,7 +14,7 @@
 
 use risingwave_common::array::{BytesGuard, BytesWriter};
 
-use crate::{ExprError, Result};
+use crate::Result;
 
 #[inline(always)]
 pub fn upper(s: &str, writer: BytesWriter) -> Result<BytesGuard> {

--- a/src/expr/src/vector_op/upper.rs
+++ b/src/expr/src/vector_op/upper.rs
@@ -18,9 +18,7 @@ use crate::{ExprError, Result};
 
 #[inline(always)]
 pub fn upper(s: &str, writer: BytesWriter) -> Result<BytesGuard> {
-    writer
-        .write_ref(&s.to_uppercase())
-        .map_err(ExprError::Array)
+    writer.write_ref(&s.to_uppercase()).map_err(Into::into)
 }
 
 #[cfg(test)]

--- a/src/source/src/common.rs
+++ b/src/source/src/common.rs
@@ -16,7 +16,7 @@ use std::sync::Arc;
 
 use itertools::Itertools;
 use risingwave_common::array::column::Column;
-use risingwave_common::array::{ArrayBuilderImpl, DataChunk};
+use risingwave_common::array::DataChunk;
 use risingwave_common::error::Result;
 use risingwave_common::types::Datum;
 use risingwave_common::util::chunk_coalesce::DEFAULT_CHUNK_BUFFER_SIZE;

--- a/src/stream/src/common/builder.rs
+++ b/src/stream/src/common/builder.rs
@@ -76,7 +76,7 @@ impl StreamChunkBuilder {
         let column_builders = data_types
             .iter()
             .map(|datatype| datatype.create_array_builder(reduced_capacity))
-            .collect::<Result<Vec<_>>>()?;
+            .try_collect()?;
         Ok(Self {
             ops,
             column_builders,

--- a/src/stream/src/executor/aggregation/row_count.rs
+++ b/src/stream/src/executor/aggregation/row_count.rs
@@ -54,7 +54,9 @@ impl StreamingRowCountAgg {
     }
 
     pub fn create_array_builder(capacity: usize) -> Result<ArrayBuilderImpl> {
-        I64ArrayBuilder::new(capacity).map(|builder| builder.into())
+        I64ArrayBuilder::new(capacity)
+            .map(|builder| builder.into())
+            .map_err(Into::into)
     }
 
     pub fn return_type() -> DataType {

--- a/src/stream/src/executor/managed_state/join/mod.rs
+++ b/src/stream/src/executor/managed_state/join/mod.rs
@@ -194,7 +194,7 @@ impl<K: HashKey, S: StateStore> JoinHashMap<K, S> {
     /// Returns a mutable reference to the value of the key in the memory, if does not exist, look
     /// up in remote storage and return, if still not exist, return None.
     #[allow(dead_code)]
-    pub async fn get(&mut self, key: &K) -> Option<&HashValueType<S>> {
+    pub async fn get<'a>(&'a mut self, key: &K) -> Option<&'a HashValueType<S>> {
         let state = self.inner.get(key);
         // TODO: we should probably implement a entry function for `LruCache`
         match state {


### PR DESCRIPTION
## What's changed and what's your intention?

This PR introduces `ArrayError`, and unifies the `ensure` macro by using `anyhow!` everywhere so that it can work under any context including `RwError`, `ArrayError`, and `ExprError`.

## Checklist

- [x] I have written necessary docs and comments
- [x] I have added necessary unit tests and integration tests
- [x] All checks passed in `./risedev check` (or alias, `./risedev c`)

## Refer to a related PR or issue link (optional)
- Close #3089 
- #3081