### PR TITLE
feat(hummock): remove combine group for compaction

### DIFF
--- a/proto/hummock.proto
+++ b/proto/hummock.proto
@@ -21,6 +21,7 @@ message SstableInfo {
   KeyRange key_range = 2;
   uint64 file_size = 3;
   repeated common.VNodeBitmap vnode_bitmaps = 4;
+  uint64 unit_id = 5;
 }
 
 enum LevelType {

--- a/src/meta/src/hummock/compaction/tier_compaction_picker.rs
+++ b/src/meta/src/hummock/compaction/tier_compaction_picker.rs
@@ -380,6 +380,7 @@ pub mod tests {
             }),
             file_size: (right - left + 1) as u64,
             vnode_bitmaps: vec![],
+            unit_id: u64::MAX,
         }
     }
 

--- a/src/meta/src/hummock/test_utils.rs
+++ b/src/meta/src/hummock/test_utils.rs
@@ -109,6 +109,7 @@ pub fn generate_test_tables(epoch: u64, sst_ids: Vec<HummockSSTableId>) -> Vec<S
                     bitmap: vec![],
                 },
             ],
+            unit_id: 0,
         });
     }
     sst_info

--- a/src/storage/src/hummock/compactor.rs
+++ b/src/storage/src/hummock/compactor.rs
@@ -35,11 +35,11 @@ use risingwave_rpc_client::HummockMetaClient;
 use tokio::sync::oneshot::Sender;
 use tokio::task::JoinHandle;
 
-use super::group_builder::KeyValueGroupingImpl::VirtualNode;
 use super::group_builder::{GroupedSstableBuilder, VirtualNodeGrouping};
 use super::iterator::{BoxedForwardHummockIterator, ConcatIterator, MergeIterator};
 use super::{HummockResult, SSTableBuilder, SSTableIterator, SSTableIteratorType, Sstable};
 use crate::hummock::compaction_executor::CompactionExecutor;
+use crate::hummock::group_builder::KeyValueGrouping;
 use crate::hummock::iterator::ReadOptions;
 use crate::hummock::multi_builder::SealedSstableBuilder;
 use crate::hummock::shared_buffer::shared_buffer_uploader::UploadTaskPayload;
@@ -136,7 +136,7 @@ pub struct Compactor {
     compact_task: CompactTask,
 }
 
-pub type CompactOutput = (usize, Vec<(Sstable, Vec<VNodeBitmap>)>);
+pub type CompactOutput = (usize, Vec<(Sstable, u64, Vec<VNodeBitmap>)>);
 
 impl Compactor {
     /// Create a new compactor.
@@ -151,7 +151,7 @@ impl Compactor {
     pub async fn compact_shared_buffer(
         context: Arc<CompactorContext>,
         payload: &UploadTaskPayload,
-    ) -> HummockResult<Vec<(Sstable, Vec<VNodeBitmap>)>> {
+    ) -> HummockResult<Vec<(Sstable, u64, Vec<VNodeBitmap>)>> {
         let mut start_user_keys = payload
             .iter()
             .flat_map(|data_list| data_list.iter().map(UncommittedData::start_user_key))
@@ -253,7 +253,7 @@ impl Compactor {
             let mut level0 = Vec::with_capacity(parallelism);
 
             for (_, sst) in output_ssts {
-                for (table, _) in &sst {
+                for (table, _, _) in &sst {
                     compactor
                         .context
                         .stats
@@ -444,7 +444,7 @@ impl Compactor {
             .reserve(self.compact_task.splits.len());
         let mut compaction_write_bytes = 0;
         for (_, ssts) in output_ssts {
-            for (sst, vnode_bitmaps) in ssts {
+            for (sst, unit_id, vnode_bitmaps) in ssts {
                 let sst_info = SstableInfo {
                     id: sst.id,
                     key_range: Some(risingwave_pb::hummock::KeyRange {
@@ -454,6 +454,7 @@ impl Compactor {
                     }),
                     file_size: sst.meta.estimated_size as u64,
                     vnode_bitmaps,
+                    unit_id,
                 };
                 compaction_write_bytes += sst_info.file_size;
                 self.compact_task.sorted_output_ssts.push(sst_info);
@@ -507,11 +508,11 @@ impl Compactor {
                 let timer = Instant::now();
                 let table_id = (self.context.sstable_id_generator)().await?;
                 let cost = (timer.elapsed().as_secs_f64() * 1000000.0).round() as u64;
-                let builder = SSTableBuilder::new(self.context.options.as_ref().into());
+                let builder = SSTableBuilder::new(table_id, self.context.options.as_ref().into());
                 get_id_time.fetch_add(cost, Ordering::Relaxed);
-                Ok((table_id, builder))
+                Ok(builder)
             },
-            VirtualNode(VirtualNodeGrouping::new(vnode2unit)),
+            VirtualNodeGrouping::new(vnode2unit),
             self.context.sstable_store.clone(),
         );
 
@@ -543,11 +544,12 @@ impl Compactor {
             vnode_bitmaps,
             upload_join_handle,
             data_len,
+            unit_id,
         } in sealed_builders
         {
             let sst = Sstable { id: table_id, meta };
             let len = data_len;
-            ssts.push((sst.clone(), vnode_bitmaps));
+            ssts.push((sst.clone(), unit_id, vnode_bitmaps));
             upload_join_handles.push(upload_join_handle);
 
             if self.context.is_share_buffer_compact {
@@ -779,8 +781,8 @@ impl Compactor {
         (join_handle, shutdown_tx)
     }
 
-    async fn compact_and_build_sst<B, F>(
-        sst_builder: &mut GroupedSstableBuilder<B>,
+    async fn compact_and_build_sst<B, G, F>(
+        sst_builder: &mut GroupedSstableBuilder<B, G>,
         kr: KeyRange,
         mut iter: BoxedForwardHummockIterator,
         has_user_key_overlap: bool,
@@ -789,7 +791,8 @@ impl Compactor {
     ) -> HummockResult<()>
     where
         B: Clone + Fn() -> F,
-        F: Future<Output = HummockResult<(u64, SSTableBuilder)>>,
+        G: KeyValueGrouping,
+        F: Future<Output = HummockResult<SSTableBuilder>>,
     {
         if !kr.left.is_empty() {
             iter.seek(&kr.left).await?;

--- a/src/storage/src/hummock/shared_buffer/shared_buffer_uploader.rs
+++ b/src/storage/src/hummock/shared_buffer/shared_buffer_uploader.rs
@@ -203,7 +203,7 @@ impl SharedBufferUploader {
 
         let uploaded_sst_info: Vec<SstableInfo> = tables
             .into_iter()
-            .map(|(sst, vnode_bitmaps)| SstableInfo {
+            .map(|(sst, unit_id, vnode_bitmaps)| SstableInfo {
                 id: sst.id,
                 key_range: Some(risingwave_pb::hummock::KeyRange {
                     left: sst.meta.smallest_key.clone(),
@@ -212,6 +212,7 @@ impl SharedBufferUploader {
                 }),
                 file_size: sst.meta.estimated_size as u64,
                 vnode_bitmaps,
+                unit_id,
             })
             .collect();
 

--- a/src/storage/src/hummock/sstable/builder.rs
+++ b/src/storage/src/hummock/sstable/builder.rs
@@ -86,10 +86,11 @@ pub struct SSTableBuilder {
     /// Last added full key.
     last_full_key: Bytes,
     key_count: usize,
+    sstable_id: u64,
 }
 
 impl SSTableBuilder {
-    pub fn new(options: SSTableBuilderOptions) -> Self {
+    pub fn new(sstable_id: u64, options: SSTableBuilderOptions) -> Self {
         Self {
             options: options.clone(),
             buf: BytesMut::with_capacity(options.capacity),
@@ -99,6 +100,7 @@ impl SSTableBuilder {
             user_key_hashes: Vec::with_capacity(options.capacity / DEFAULT_ENTRY_SIZE + 1),
             last_full_key: Bytes::default(),
             key_count: 0,
+            sstable_id,
         }
     }
 
@@ -148,6 +150,10 @@ impl SSTableBuilder {
             self.build_block();
         }
         self.key_count += 1;
+    }
+
+    pub fn get_sstable_id(&self) -> u64 {
+        self.sstable_id
     }
 
     /// Finish building sst.
@@ -248,14 +254,14 @@ pub(super) mod tests {
             compression_algorithm: CompressionAlgorithm::None,
         };
 
-        let b = SSTableBuilder::new(opt);
+        let b = SSTableBuilder::new(0, opt);
 
         b.finish();
     }
 
     #[test]
     fn test_smallest_key_and_largest_key() {
-        let mut b = SSTableBuilder::new(default_builder_opt_for_test());
+        let mut b = SSTableBuilder::new(0, default_builder_opt_for_test());
 
         for i in 0..TEST_KEYS_COUNT {
             b.add(&test_key_of(i), HummockValue::put(&test_value_of(i)));

--- a/src/storage/src/hummock/sstable/builder.rs
+++ b/src/storage/src/hummock/sstable/builder.rs
@@ -152,10 +152,6 @@ impl SSTableBuilder {
         self.key_count += 1;
     }
 
-    pub fn get_sstable_id(&self) -> u64 {
-        self.sstable_id
-    }
-
     /// Finish building sst.
     ///
     /// Unlike most LSM-Tree implementations, sstable meta and data are encoded separately.
@@ -168,7 +164,7 @@ impl SSTableBuilder {
     /// ```plain
     /// | Block 0 | ... | Block N-1 | N (4B) |
     /// ```
-    pub fn finish(mut self) -> (Bytes, SstableMeta, Vec<VNodeBitmap>) {
+    pub fn finish(mut self) -> (u64, Bytes, SstableMeta, Vec<VNodeBitmap>) {
         let smallest_key = self.block_metas[0].smallest_key.clone();
         let largest_key = self.last_full_key.to_vec();
         self.build_block();
@@ -193,6 +189,7 @@ impl SSTableBuilder {
         };
 
         (
+            self.sstable_id,
             self.buf.freeze(),
             meta,
             self.vnode_bitmaps
@@ -267,7 +264,7 @@ pub(super) mod tests {
             b.add(&test_key_of(i), HummockValue::put(&test_value_of(i)));
         }
 
-        let (_, meta, _) = b.finish();
+        let (_, _, meta, _) = b.finish();
 
         assert_eq!(test_key_of(0), meta.smallest_key);
         assert_eq!(test_key_of(TEST_KEYS_COUNT - 1), meta.largest_key);

--- a/src/storage/src/hummock/sstable/group_builder.rs
+++ b/src/storage/src/hummock/sstable/group_builder.rs
@@ -14,33 +14,29 @@
 
 use std::collections::HashMap;
 use std::future::Future;
-use std::mem::size_of;
 use std::sync::Arc;
 
 use itertools::Itertools;
 use risingwave_hummock_sdk::compaction_group::Prefix;
 use risingwave_hummock_sdk::key::{get_table_id, FullKey};
-use risingwave_hummock_sdk::{CompactionGroupId, HummockSSTableId};
+use risingwave_hummock_sdk::CompactionGroupId;
 
 use crate::hummock::multi_builder::{CapacitySplitTableBuilder, SealedSstableBuilder};
 use crate::hummock::sstable_store::SstableStoreRef;
 use crate::hummock::value::HummockValue;
 use crate::hummock::{HummockResult, SSTableBuilder};
 
-pub type KeyValueGroupId = Vec<u8>;
+pub type KeyValueGroupId = u64;
 
 /// [`KeyValueGroupingImpl`] defines strategies to group key values
 #[derive(Clone)]
 pub enum KeyValueGroupingImpl {
     VirtualNode(VirtualNodeGrouping),
     CompactionGroup(CompactionGroupGrouping),
-    Combined(CombinedGrouping),
 }
 
-trait KeyValueGrouping {
+pub trait KeyValueGrouping {
     fn group(&self, full_key: &FullKey<&[u8]>, value: &HummockValue<&[u8]>) -> KeyValueGroupId;
-
-    fn group_key_len(&self) -> usize;
 }
 
 impl KeyValueGrouping for KeyValueGroupingImpl {
@@ -48,15 +44,6 @@ impl KeyValueGrouping for KeyValueGroupingImpl {
         match self {
             KeyValueGroupingImpl::VirtualNode(grouping) => grouping.group(full_key, value),
             KeyValueGroupingImpl::CompactionGroup(grouping) => grouping.group(full_key, value),
-            KeyValueGroupingImpl::Combined(grouping) => grouping.group(full_key, value),
-        }
-    }
-
-    fn group_key_len(&self) -> usize {
-        match self {
-            KeyValueGroupingImpl::VirtualNode(grouping) => grouping.group_key_len(),
-            KeyValueGroupingImpl::CompactionGroup(grouping) => grouping.group_key_len(),
-            KeyValueGroupingImpl::Combined(grouping) => grouping.group_key_len(),
         }
     }
 }
@@ -80,15 +67,8 @@ impl KeyValueGrouping for CompactionGroupGrouping {
             .prefixes
             .get(&prefix.into())
             .cloned()
-            .unwrap_or(CompactionGroupId::MAX)
-            .to_be_bytes()
-            .to_vec();
-        debug_assert_eq!(group_key.len(), self.group_key_len());
+            .unwrap_or(CompactionGroupId::MAX);
         group_key
-    }
-
-    fn group_key_len(&self) -> usize {
-        size_of::<CompactionGroupId>()
     }
 }
 
@@ -112,68 +92,33 @@ impl KeyValueGrouping for VirtualNodeGrouping {
                     HummockValue::Put(meta, _) => meta.vnode,
                     HummockValue::Delete(meta) => meta.vnode,
                 };
-                mapping[idx as usize]
+                mapping[idx as usize] as u64
             })
         } else {
             None
         };
-        let group_key = group.unwrap_or(u32::MAX).to_be_bytes().to_vec();
-        debug_assert_eq!(group_key.len(), self.group_key_len());
+        let group_key = group.unwrap_or(u64::MAX);
         group_key
-    }
-
-    fn group_key_len(&self) -> usize {
-        size_of::<u32>()
-    }
-}
-
-#[derive(Clone)]
-pub struct CombinedGrouping {
-    group_impls: Vec<KeyValueGroupingImpl>,
-}
-
-impl CombinedGrouping {
-    pub fn new(group_impls: Vec<KeyValueGroupingImpl>) -> Self {
-        Self { group_impls }
-    }
-}
-
-impl KeyValueGrouping for CombinedGrouping {
-    fn group(&self, full_key: &FullKey<&[u8]>, value: &HummockValue<&[u8]>) -> KeyValueGroupId {
-        let group_key = self
-            .group_impls
-            .iter()
-            .flat_map(|g| g.group(full_key, value))
-            .collect_vec();
-        debug_assert_eq!(group_key.len(), self.group_key_len());
-        group_key
-    }
-
-    fn group_key_len(&self) -> usize {
-        self.group_impls.iter().map(|g| g.group_key_len()).sum()
     }
 }
 
 /// A wrapper for [`CapacitySplitTableBuilder`] which automatically split key-value pairs into
 /// multiple `SSTables`, based on [`KeyValueGroupingImpl`].
-pub struct GroupedSstableBuilder<B> {
+pub struct GroupedSstableBuilder<B, G: KeyValueGrouping> {
     /// See [`CapacitySplitTableBuilder`]
     get_id_and_builder: B,
-    grouping: KeyValueGroupingImpl,
+    grouping: G,
     builders: HashMap<KeyValueGroupId, CapacitySplitTableBuilder<B>>,
     sstable_store: SstableStoreRef,
 }
 
-impl<B, F> GroupedSstableBuilder<B>
+impl<B, G, F> GroupedSstableBuilder<B, G>
 where
     B: Clone + Fn() -> F,
-    F: Future<Output = HummockResult<(HummockSSTableId, SSTableBuilder)>>,
+    G: KeyValueGrouping,
+    F: Future<Output = HummockResult<SSTableBuilder>>,
 {
-    pub fn new(
-        get_id_and_builder: B,
-        grouping: KeyValueGroupingImpl,
-        sstable_store: SstableStoreRef,
-    ) -> Self {
+    pub fn new(get_id_and_builder: B, grouping: G, sstable_store: SstableStoreRef) -> Self {
         Self {
             get_id_and_builder,
             grouping,
@@ -216,7 +161,12 @@ where
         self.seal_current();
         self.builders
             .into_iter()
-            .flat_map(|(_k, v)| v.finish())
+            .flat_map(|(k, v)| {
+                v.finish().into_iter().map(move |mut builder| {
+                    builder.unit_id = k.clone();
+                    builder
+                })
+            })
             .collect_vec()
     }
 }
@@ -243,13 +193,16 @@ mod tests {
         let get_id_and_builder = || async {
             Ok((
                 next_id.fetch_add(1, SeqCst),
-                SSTableBuilder::new(SSTableBuilderOptions {
-                    capacity: table_capacity,
-                    block_capacity: block_size,
-                    restart_interval: DEFAULT_RESTART_INTERVAL,
-                    bloom_false_positive: 0.1,
-                    compression_algorithm: CompressionAlgorithm::None,
-                }),
+                SSTableBuilder::new(
+                    0,
+                    SSTableBuilderOptions {
+                        capacity: table_capacity,
+                        block_capacity: block_size,
+                        restart_interval: DEFAULT_RESTART_INTERVAL,
+                        bloom_false_positive: 0.1,
+                        compression_algorithm: CompressionAlgorithm::None,
+                    },
+                ),
             ))
         };
         let prefix = b"\x01\x02\x03\x04".as_slice().get_u32();
@@ -300,13 +253,16 @@ mod tests {
         let get_id_and_builder = || async {
             Ok((
                 next_id.fetch_add(1, SeqCst),
-                SSTableBuilder::new(SSTableBuilderOptions {
-                    capacity: table_capacity,
-                    block_capacity: block_size,
-                    restart_interval: DEFAULT_RESTART_INTERVAL,
-                    bloom_false_positive: 0.1,
-                    compression_algorithm: CompressionAlgorithm::None,
-                }),
+                SSTableBuilder::new(
+                    0,
+                    SSTableBuilderOptions {
+                        capacity: table_capacity,
+                        block_capacity: block_size,
+                        restart_interval: DEFAULT_RESTART_INTERVAL,
+                        bloom_false_positive: 0.1,
+                        compression_algorithm: CompressionAlgorithm::None,
+                    },
+                ),
             ))
         };
         let table_id = 1u32;
@@ -392,59 +348,5 @@ mod tests {
         builder.seal_current();
         let results = builder.finish();
         assert_eq!(results.len(), 1usize);
-    }
-
-    #[tokio::test]
-    async fn test_combined_grouping() {
-        let next_id = AtomicU64::new(1001);
-        let block_size = 1 << 10;
-        let table_capacity = 4 * block_size;
-        let get_id_and_builder = || async {
-            Ok((
-                next_id.fetch_add(1, SeqCst),
-                SSTableBuilder::new(SSTableBuilderOptions {
-                    capacity: table_capacity,
-                    block_capacity: block_size,
-                    restart_interval: DEFAULT_RESTART_INTERVAL,
-                    bloom_false_positive: 0.1,
-                    compression_algorithm: CompressionAlgorithm::None,
-                }),
-            ))
-        };
-
-        let compaction_group_grouping =
-            KeyValueGroupingImpl::CompactionGroup(CompactionGroupGrouping::new(HashMap::from([
-                (0u32.into(), 1 as CompactionGroupId),
-                (1u32.into(), 2 as CompactionGroupId),
-            ])));
-        let magic_prefix = b't';
-        let vnode2unit = Arc::new(HashMap::from([(0u32, vec![0, 1]), (1u32, vec![0, 1])]));
-        let virtual_node_grouping =
-            KeyValueGroupingImpl::VirtualNode(VirtualNodeGrouping::new(vnode2unit));
-        let grouping = KeyValueGroupingImpl::Combined(CombinedGrouping::new(vec![
-            compaction_group_grouping,
-            virtual_node_grouping,
-        ]));
-        let mut builder =
-            GroupedSstableBuilder::new(get_id_and_builder, grouping, mock_sstable_store());
-        for i in 0..4 {
-            builder
-                .add_full_key(
-                    FullKey::from_user_key(
-                        [&[magic_prefix], ((i % 2) as u32).to_be_bytes().as_slice()]
-                            .concat()
-                            .to_vec(),
-                        (table_capacity - i) as u64,
-                    )
-                    .as_slice(),
-                    HummockValue::Put(ValueMeta::with_vnode((i / 2) as VirtualNode), b"value"),
-                    false,
-                )
-                .await
-                .unwrap();
-        }
-        builder.seal_current();
-        let results = builder.finish();
-        assert_eq!(results.len(), 4usize);
     }
 }

--- a/src/storage/src/hummock/sstable/group_builder.rs
+++ b/src/storage/src/hummock/sstable/group_builder.rs
@@ -97,8 +97,7 @@ impl KeyValueGrouping for VirtualNodeGrouping {
         } else {
             None
         };
-        let group_key = group.unwrap_or(u64::MAX);
-        group_key
+        group.unwrap_or(u64::MAX)
     }
 }
 
@@ -163,7 +162,7 @@ where
             .into_iter()
             .flat_map(|(k, v)| {
                 v.finish().into_iter().map(move |mut builder| {
-                    builder.unit_id = k.clone();
+                    builder.unit_id = k;
                     builder
                 })
             })
@@ -191,18 +190,15 @@ mod tests {
         let block_size = 1 << 10;
         let table_capacity = 4 * block_size;
         let get_id_and_builder = || async {
-            Ok((
+            Ok(SSTableBuilder::new(
                 next_id.fetch_add(1, SeqCst),
-                SSTableBuilder::new(
-                    0,
-                    SSTableBuilderOptions {
-                        capacity: table_capacity,
-                        block_capacity: block_size,
-                        restart_interval: DEFAULT_RESTART_INTERVAL,
-                        bloom_false_positive: 0.1,
-                        compression_algorithm: CompressionAlgorithm::None,
-                    },
-                ),
+                SSTableBuilderOptions {
+                    capacity: table_capacity,
+                    block_capacity: block_size,
+                    restart_interval: DEFAULT_RESTART_INTERVAL,
+                    bloom_false_positive: 0.1,
+                    compression_algorithm: CompressionAlgorithm::None,
+                },
             ))
         };
         let prefix = b"\x01\x02\x03\x04".as_slice().get_u32();
@@ -251,18 +247,15 @@ mod tests {
         let block_size = 1 << 10;
         let table_capacity = 4 * block_size;
         let get_id_and_builder = || async {
-            Ok((
+            Ok(SSTableBuilder::new(
                 next_id.fetch_add(1, SeqCst),
-                SSTableBuilder::new(
-                    0,
-                    SSTableBuilderOptions {
-                        capacity: table_capacity,
-                        block_capacity: block_size,
-                        restart_interval: DEFAULT_RESTART_INTERVAL,
-                        bloom_false_positive: 0.1,
-                        compression_algorithm: CompressionAlgorithm::None,
-                    },
-                ),
+                SSTableBuilderOptions {
+                    capacity: table_capacity,
+                    block_capacity: block_size,
+                    restart_interval: DEFAULT_RESTART_INTERVAL,
+                    bloom_false_positive: 0.1,
+                    compression_algorithm: CompressionAlgorithm::None,
+                },
             ))
         };
         let table_id = 1u32;

--- a/src/storage/src/hummock/sstable/mod.rs
+++ b/src/storage/src/hummock/sstable/mod.rs
@@ -31,6 +31,7 @@ pub use forward_sstable_iterator::*;
 mod backward_sstable_iterator;
 pub use backward_sstable_iterator::*;
 use risingwave_hummock_sdk::HummockSSTableId;
+#[cfg(test)]
 use risingwave_pb::hummock::{KeyRange, SstableInfo};
 
 pub mod group_builder;
@@ -85,6 +86,7 @@ impl Sstable {
         8 /* id */ + self.meta.encoded_size()
     }
 
+    #[cfg(test)]
     pub fn get_sstable_info(&self) -> SstableInfo {
         SstableInfo {
             id: self.id,
@@ -95,6 +97,7 @@ impl Sstable {
             }),
             file_size: self.meta.estimated_size as u64,
             vnode_bitmaps: vec![],
+            unit_id: 0,
         }
     }
 }

--- a/src/storage/src/hummock/sstable/multi_builder.rs
+++ b/src/storage/src/hummock/sstable/multi_builder.rs
@@ -125,8 +125,7 @@ where
     /// will be no-op.
     pub fn seal_current(&mut self) {
         if let Some(builder) = self.current_builder.take() {
-            let table_id = builder.get_sstable_id();
-            let (data, meta, vnode_bitmap) = builder.finish();
+            let (table_id, data, meta, vnode_bitmap) = builder.finish();
             let len = data.len();
             let sstable_store = self.sstable_store.clone();
             let meta_clone = meta.clone();
@@ -179,18 +178,15 @@ mod tests {
         let block_size = 1 << 10;
         let table_capacity = 4 * block_size;
         let get_id_and_builder = || async {
-            Ok((
+            Ok(SSTableBuilder::new(
                 next_id.fetch_add(1, SeqCst),
-                SSTableBuilder::new(
-                    0,
-                    SSTableBuilderOptions {
-                        capacity: table_capacity,
-                        block_capacity: block_size,
-                        restart_interval: DEFAULT_RESTART_INTERVAL,
-                        bloom_false_positive: 0.1,
-                        compression_algorithm: CompressionAlgorithm::None,
-                    },
-                ),
+                SSTableBuilderOptions {
+                    capacity: table_capacity,
+                    block_capacity: block_size,
+                    restart_interval: DEFAULT_RESTART_INTERVAL,
+                    bloom_false_positive: 0.1,
+                    compression_algorithm: CompressionAlgorithm::None,
+                },
             ))
         };
         let builder = CapacitySplitTableBuilder::new(get_id_and_builder, mock_sstable_store());
@@ -205,18 +201,15 @@ mod tests {
         let block_size = 1 << 10;
         let table_capacity = 4 * block_size;
         let get_id_and_builder = || async {
-            Ok((
+            Ok(SSTableBuilder::new(
                 next_id.fetch_add(1, SeqCst),
-                SSTableBuilder::new(
-                    0,
-                    SSTableBuilderOptions {
-                        capacity: table_capacity,
-                        block_capacity: block_size,
-                        restart_interval: DEFAULT_RESTART_INTERVAL,
-                        bloom_false_positive: 0.1,
-                        compression_algorithm: CompressionAlgorithm::None,
-                    },
-                ),
+                SSTableBuilderOptions {
+                    capacity: table_capacity,
+                    block_capacity: block_size,
+                    restart_interval: DEFAULT_RESTART_INTERVAL,
+                    bloom_false_positive: 0.1,
+                    compression_algorithm: CompressionAlgorithm::None,
+                },
             ))
         };
         let mut builder = CapacitySplitTableBuilder::new(get_id_and_builder, mock_sstable_store());
@@ -242,9 +235,9 @@ mod tests {
         let next_id = AtomicU64::new(1001);
         let mut builder = CapacitySplitTableBuilder::new(
             || async {
-                Ok((
+                Ok(SSTableBuilder::new(
                     next_id.fetch_add(1, SeqCst),
-                    SSTableBuilder::new(0, default_builder_opt_for_test()),
+                    default_builder_opt_for_test(),
                 ))
             },
             mock_sstable_store(),
@@ -286,9 +279,9 @@ mod tests {
         let next_id = AtomicU64::new(1001);
         let mut builder = CapacitySplitTableBuilder::new(
             || async {
-                Ok((
+                Ok(SSTableBuilder::new(
                     next_id.fetch_add(1, SeqCst),
-                    SSTableBuilder::new(0, default_builder_opt_for_test()),
+                    default_builder_opt_for_test(),
                 ))
             },
             mock_sstable_store(),

--- a/src/storage/src/hummock/test_utils.rs
+++ b/src/storage/src/hummock/test_utils.rs
@@ -123,7 +123,7 @@ pub fn gen_test_sstable_data(
     opts: SSTableBuilderOptions,
     kv_iter: impl Iterator<Item = (Vec<u8>, HummockValue<Vec<u8>>)>,
 ) -> (Bytes, SstableMeta, Vec<VNodeBitmap>) {
-    let mut b = SSTableBuilder::new(opts);
+    let mut b = SSTableBuilder::new(0, opts);
     for (key, value) in kv_iter {
         b.add(&key, value.as_slice())
     }

--- a/src/storage/src/hummock/test_utils.rs
+++ b/src/storage/src/hummock/test_utils.rs
@@ -84,6 +84,7 @@ pub fn gen_dummy_sst_info(id: HummockSSTableId, batches: Vec<SharedBufferBatch>)
         }),
         file_size: batches.len() as u64,
         vnode_bitmaps: vec![],
+        unit_id: u64::MAX,
     }
 }
 
@@ -127,7 +128,8 @@ pub fn gen_test_sstable_data(
     for (key, value) in kv_iter {
         b.add(&key, value.as_slice())
     }
-    b.finish()
+    let (_, data, meta, vnodes) = b.finish();
+    (data, meta, vnodes)
 }
 
 /// Generates a test table from the given `kv_iter` and put the kv value to `sstable_store`


### PR DESCRIPTION
Signed-off-by: Little-Wallace <bupt2013211450@gmail.com>

## What's changed and what's your intention?

- remove `CombinedGrouping`. I have talked with @zwang28. We will split all get/write/flush operations for different group. Of course, the sst files of different group will be also splitted.
- add unit id for sstableinfo for unit aware compaction. See more details in https://github.com/singularity-data/risingwave/pull/3111

## Checklist

- [x] I have added necessary unit tests and integration tests
- [x] All checks passed in `./risedev check` (or alias, `./risedev c`)

## Refer to a related PR or issue link (optional)
