### PR TITLE
fix(storage): re-enable compaction filter

### DIFF
--- a/Makefile.toml
+++ b/Makefile.toml
@@ -105,7 +105,7 @@ do
   fi
 done
 
-if (( "$(du -sk ${PREFIX_LOG} | cut -f1)" > 2000 )) ; then
+if (( "$(du -sk ${PREFIX_LOG} | cut -f1)" > 5000 )) ; then
     echo "$(tput setaf 3)log size is significantly large ($(du -sh ${PREFIX_LOG} | cut -f1)).$(tput sgr0) Please disable unnecessary logs."
     exit 1
 fi

--- a/Makefile.toml
+++ b/Makefile.toml
@@ -105,7 +105,7 @@ do
   fi
 done
 
-if (( "$(du -sk ${PREFIX_LOG} | cut -f1)" > 5000 )) ; then
+if (( "$(du -sk ${PREFIX_LOG} | cut -f1)" > 2000 )) ; then
     echo "$(tput setaf 3)log size is significantly large ($(du -sh ${PREFIX_LOG} | cut -f1)).$(tput sgr0) Please disable unnecessary logs."
     exit 1
 fi

--- a/src/meta/src/hummock/compaction_group/manager.rs
+++ b/src/meta/src/hummock/compaction_group/manager.rs
@@ -78,7 +78,10 @@ impl<S: MetaStore> CompactionGroupManager<S> {
         // internal_table_id (stateful executor)
         pairs.push((
             Prefix::from(table_fragments.table_id().table_id),
-            CompactionGroupId::from(StaticCompactionGroupId::MaterializedView),
+            // TODO: before compaction group write path is finished, all SSTs belongs to
+            // `StateDefault`.
+            CompactionGroupId::from(StaticCompactionGroupId::StateDefault),
+            // CompactionGroupId::from(StaticCompactionGroupId::MaterializedView),
         ));
         // internal states
         for table_id in table_fragments.internal_table_ids() {

--- a/src/storage/src/hummock/compactor.rs
+++ b/src/storage/src/hummock/compactor.rs
@@ -98,7 +98,6 @@ trait CompactionFilter {
     }
 }
 
-#[derive(Default, Clone)]
 pub struct DummyCompactionFilter;
 impl CompactionFilter for DummyCompactionFilter {}
 
@@ -108,7 +107,6 @@ pub struct StateCleanUpCompactionFilter {
 }
 
 impl StateCleanUpCompactionFilter {
-    #[allow(unused)]
     fn new(table_id_set: HashSet<u32>) -> Self {
         StateCleanUpCompactionFilter {
             existing_table_ids: table_id_set,
@@ -383,11 +381,8 @@ impl Compactor {
             );
         }
 
-        // TODO: Temporarily disable StateCleanUpCompactionFilter, because meta is not providing the
-        // correct `existing_table_ids` in 9a34de40.
-        let compaction_filter = DummyCompactionFilter::default();
-        // let compaction_filter =
-        // StateCleanUpCompactionFilter::new(HashSet::from_iter(compact_task.existing_table_ids));
+        let compaction_filter =
+            StateCleanUpCompactionFilter::new(HashSet::from_iter(compact_task.existing_table_ids));
 
         for (split_index, _) in compact_task.splits.iter().enumerate() {
             let compactor = compactor.clone();

--- a/src/storage/src/hummock/compactor_tests.rs
+++ b/src/storage/src/hummock/compactor_tests.rs
@@ -168,9 +168,7 @@ mod tests {
         assert!(compact_task.is_none());
     }
 
-    // TODO: enable after fix incorrect existing_table_id
     #[tokio::test]
-    #[ignore]
     async fn test_compaction_drop_all_key() {
         let (_env, hummock_manager_ref, _cluster_manager_ref, worker_node) =
             setup_compute_env(8080).await;
@@ -248,9 +246,7 @@ mod tests {
         assert!(compact_task.is_none());
     }
 
-    // TODO: enable after fix incorrect existing_table_id
     #[tokio::test]
-    #[ignore]
     async fn test_compaction_drop_key_by_existing_table_id() {
         let (_env, hummock_manager_ref, _cluster_manager_ref, worker_node) =
             setup_compute_env(8080).await;


### PR DESCRIPTION
## What's changed and what's your intention?

Workaround compaction filter failure due to unfinished compaction group feature.
Re-enable compaction filter.

## Checklist

- [x] I have written necessary docs and comments
- [x] All checks passed in `./risedev check` (or alias, `./risedev c`)

## Refer to a related PR or issue link (optional)
