### PR TITLE
chore: remove all tracing logs relates to pin/unpin

### DIFF
--- a/src/frontend/src/scheduler/hummock_snapshot_manager.rs
+++ b/src/frontend/src/scheduler/hummock_snapshot_manager.rs
@@ -49,7 +49,6 @@ impl HummockSnapshotManager {
             core_guard.epoch_to_query_ids.insert(epoch, HashSet::new());
         }
         let last_pinned = core_guard.last_pinned;
-        tracing::info!("Pin epoch {} for query {:?}", last_pinned, &query_id);
         core_guard
             .epoch_to_query_ids
             .get_mut(&last_pinned)
@@ -59,7 +58,6 @@ impl HummockSnapshotManager {
     }
 
     pub async fn unpin_snapshot(&self, epoch: u64, query_id: &QueryId) -> Result<()> {
-        tracing::info!("Unpin epoch {} for query {:?}", epoch, &query_id);
         let min_epoch = async {
             // Decrease the ref count of corresponding epoch. If all last pinned epoch is dropped,
             // mark as outdated.

--- a/src/meta/src/hummock/hummock_manager.rs
+++ b/src/meta/src/hummock/hummock_manager.rs
@@ -518,9 +518,6 @@ where
             .collect_vec();
         // Unpin the snapshots pinned by meta but frontend doesn't know. Also equal to unpin all
         // epochs below specific watermark.
-        // let mut snapshots_change = !to_unpin.is_empty();
-        tracing::info!("Unpin epochs {:?}", to_unpin);
-
         for epoch in &to_unpin {
             context_pinned_snapshot.unpin_snapshot(*epoch);
         }


### PR DESCRIPTION
## What's changed and what's your intention?

We should consider visualize the info in Grafana/Dashboard to help debug instead of directly tracing it. 
Otherwise the log size may be huge.

## Checklist

- [x] I have written necessary docs and comments
- [x] I have added necessary unit tests and integration tests
- [x] All checks passed in `./risedev check` (or alias, `./risedev c`)

## Refer to a related PR or issue link (optional)
