### PR TITLE
feat(pgwire): add infer_return_type interface in session trait

### DIFF
--- a/src/frontend/src/session.rs
+++ b/src/frontend/src/session.rs
@@ -22,6 +22,7 @@ use std::sync::Arc;
 use std::time::Duration;
 
 use parking_lot::RwLock;
+use pgwire::pg_field_descriptor::PgFieldDescriptor;
 use pgwire::pg_response::PgResponse;
 use pgwire::pg_server::{BoxedError, Session, SessionManager, UserAuthenticator};
 use rand::RngCore;
@@ -549,6 +550,13 @@ impl Session for SessionImpl {
             e
         })?;
         Ok(rsp)
+    }
+
+    async fn infer_return_type(
+        self: Arc<Self>,
+        _sql: &str,
+    ) -> std::result::Result<Vec<PgFieldDescriptor>, BoxedError> {
+        unimplemented!()
     }
 
     fn user_authenticator(&self) -> &UserAuthenticator {

--- a/src/utils/pgwire/src/pg_protocol.rs
+++ b/src/utils/pgwire/src/pg_protocol.rs
@@ -14,7 +14,6 @@
 
 use std::collections::HashMap;
 use std::io::{Error as IoError, ErrorKind, Result};
-use std::ops::Sub;
 use std::str;
 use std::sync::Arc;
 
@@ -23,7 +22,7 @@ use tokio::io::{AsyncRead, AsyncWrite, AsyncWriteExt};
 
 use crate::error::PsqlError;
 use crate::pg_extended::{PgPortal, PgStatement};
-use crate::pg_field_descriptor::{PgFieldDescriptor, TypeOid};
+use crate::pg_field_descriptor::TypeOid;
 use crate::pg_message::{
     BeCommandCompleteMessage, BeMessage, BeParameterStatusMessage, FeMessage, FePasswordMessage,
     FeStartupMessage,
@@ -173,29 +172,16 @@ where
                     .collect();
 
                 // 2. Create the row description.
-                let rows: Vec<PgFieldDescriptor> = query
-                    .split(&[' ', ',', ';'])
-                    .skip(1)
-                    .into_iter()
-                    .map(|x| {
-                        if let Some(str) = x.strip_prefix('$') {
-                            if let Ok(i) = str.parse() {
-                                i
-                            } else {
-                                -1
-                            }
-                        } else {
-                            -1
-                        }
-                    })
-                    .take_while(|x: &i32| x.is_positive())
-                    .map(|x| {
-                        // NOTE Make sure the type_description include all generic parametre
-                        // description we needed.
-                        assert!((x.sub(1) as usize) < types.len());
-                        PgFieldDescriptor::new(String::new(), types[x.sub(1) as usize].to_owned())
-                    })
-                    .collect();
+                let session = self.session.clone().unwrap();
+                let rows_res = session.infer_return_type(query).await;
+                let rows = match rows_res {
+                    Ok(r) => r,
+                    Err(e) => {
+                        self.write_message_no_flush(&BeMessage::ErrorResponse(e))?;
+                        // TODO: Error handle needed modified later.
+                        unimplemented!();
+                    }
+                };
 
                 // 3. Create the statement.
                 let statement = PgStatement::new(

--- a/src/utils/pgwire/src/pg_server.rs
+++ b/src/utils/pgwire/src/pg_server.rs
@@ -337,30 +337,13 @@ mod tests {
             let value: &str = rows[0].get(1);
             assert_eq!(value, "AA");
         }
-    }
-
-    #[tokio::test]
-    async fn test_psql_extended_mode_no_param() {
-        let session_mgr = Arc::new(MockSessionManager {});
-        tokio::spawn(async move { pg_serve("127.0.0.1:10000", session_mgr).await });
-
-        // Connect to the database.
-        let (client, connection) = tokio_postgres::connect("host=localhost port=10000", NoTls)
-            .await
-            .unwrap();
-
-        // The connection object performs the actual communication with the database,
-        // so spawn it off to run on its own.
-        tokio::spawn(async move {
-            if let Err(e) = connection.await {
-                eprintln!("connection error: {}", e);
-            }
-        });
-
-        let rows = client.query("SELECT 'AA','BB';", &[]).await.unwrap();
-        let value: &str = rows[0].get(0);
-        assert_eq!(value, "AA");
-        let value: &str = rows[0].get(1);
-        assert_eq!(value, "BB");
+        // no params
+        {
+            let rows = client.query("SELECT 'AA','BB';", &[]).await.unwrap();
+            let value: &str = rows[0].get(0);
+            assert_eq!(value, "AA");
+            let value: &str = rows[0].get(1);
+            assert_eq!(value, "BB");
+        }
     }
 }

--- a/src/utils/pgwire/src/pg_server.rs
+++ b/src/utils/pgwire/src/pg_server.rs
@@ -338,4 +338,29 @@ mod tests {
             assert_eq!(value, "AA");
         }
     }
+
+    #[tokio::test]
+    async fn test_psql_extended_mode_no_param() {
+        let session_mgr = Arc::new(MockSessionManager {});
+        tokio::spawn(async move { pg_serve("127.0.0.1:10000", session_mgr).await });
+
+        // Connect to the database.
+        let (client, connection) = tokio_postgres::connect("host=localhost port=10000", NoTls)
+            .await
+            .unwrap();
+
+        // The connection object performs the actual communication with the database,
+        // so spawn it off to run on its own.
+        tokio::spawn(async move {
+            if let Err(e) = connection.await {
+                eprintln!("connection error: {}", e);
+            }
+        });
+
+        let rows = client.query("SELECT 'AA','BB';", &[]).await.unwrap();
+        let value: &str = rows[0].get(0);
+        assert_eq!(value, "AA");
+        let value: &str = rows[0].get(1);
+        assert_eq!(value, "BB");
+    }
 }


### PR DESCRIPTION
## What's changed and what's your intention?
- Add the infer_return_type interface in the session trait.
- Use the infer_return_type interface in pgwire to get the row_description.
- To test the modification of pgwire, add the implementation of infer_return_type  in mock_session and pass the original unit test.
- add simple infer_return_type implementation in frontend session to support no param SQL.

## Checklist

- [x] I have written necessary docs and comments
- [x] I have added necessary unit tests and integration tests
- [x] All checks passed in `./risedev check` (or alias, `./risedev c`)

## Refer to a related PR or issue link (optional)
#3131 