### PR TITLE
fix(batch scheduler): intermediate stage may have single distribution

### DIFF
--- a/e2e_test/batch/tpch.slt
+++ b/e2e_test/batch/tpch.slt
@@ -26,12 +26,13 @@ include ./tpch/q11.slt.part
 include ./tpch/q12.slt.part
 include ./tpch/q13.slt.part
 include ./tpch/q14.slt.part
-#include ./tpch/q15.slt.part
+include ./tpch/q15.slt.part
 include ./tpch/q16.slt.part
 include ./tpch/q17.slt.part
 include ./tpch/q18.slt.part
 include ./tpch/q19.slt.part
 include ./tpch/q20.slt.part
 include ./tpch/q21.slt.part
+include ./tpch/q22.slt.part
 
 include ../tpch/drop_tables.slt.part

--- a/src/frontend/src/scheduler/plan_fragmenter.rs
+++ b/src/frontend/src/scheduler/plan_fragmenter.rs
@@ -299,7 +299,7 @@ impl StageGraphBuilder {
 impl BatchPlanFragmenter {
     /// Split the plan node into each stages, based on exchange node.
     pub fn split(mut self, batch_node: PlanRef) -> Result<Query> {
-        let root_stage = self.new_stage(batch_node.clone(), None);
+        let root_stage = self.new_stage(batch_node.clone(), Distribution::Single.to_prost(1));
         let stage_graph = self.stage_graph_builder.build(root_stage.id);
         Ok(Query {
             stage_graph,
@@ -307,18 +307,12 @@ impl BatchPlanFragmenter {
         })
     }
 
-    fn new_stage(&mut self, root: PlanRef, exchange_info: Option<ExchangeInfo>) -> QueryStageRef {
+    fn new_stage(&mut self, root: PlanRef, exchange_info: ExchangeInfo) -> QueryStageRef {
         let next_stage_id = self.next_stage_id;
         self.next_stage_id += 1;
         let parallelism = match root.distribution() {
             Distribution::Single => 1,
             _ => self.worker_node_manager.worker_node_count(),
-        };
-
-        let exchange_info = match exchange_info {
-            Some(info) => info,
-            // Root stage, the exchange info should always be Single
-            None => Distribution::Single.to_prost(1),
         };
 
         let mut builder = QueryStageBuilder::new(
@@ -368,7 +362,7 @@ impl BatchPlanFragmenter {
         parent_exec_node: Option<&mut ExecutionPlanNode>,
     ) {
         let mut execution_plan_node = ExecutionPlanNode::from(node.clone());
-        let child_exchange_info = Some(node.distribution().to_prost(builder.parallelism));
+        let child_exchange_info = node.distribution().to_prost(builder.parallelism);
         let child_stage = self.new_stage(node.inputs()[0].clone(), child_exchange_info);
         execution_plan_node.stage_id = Some(child_stage.id);
 

--- a/src/frontend/src/scheduler/plan_fragmenter.rs
+++ b/src/frontend/src/scheduler/plan_fragmenter.rs
@@ -310,16 +310,14 @@ impl BatchPlanFragmenter {
     fn new_stage(
         &mut self,
         root: PlanRef,
-        parent_parallelism: Option<u32>,
+        _parent_parallelism: Option<u32>,
         exchange_info: Option<ExchangeInfo>,
     ) -> QueryStageRef {
         let next_stage_id = self.next_stage_id;
         self.next_stage_id += 1;
-        let parallelism = match parent_parallelism {
-            // Non-root node
-            Some(_) => self.worker_node_manager.worker_node_count(),
-            // Root node.
-            None => 1,
+        let parallelism = match root.distribution() {
+            Distribution::Single => 1,
+            _ => self.worker_node_manager.worker_node_count(),
         };
 
         let exchange_info = match exchange_info {

--- a/src/frontend/test_runner/tests/testdata/tpch.yaml
+++ b/src/frontend/test_runner/tests/testdata/tpch.yaml
@@ -1218,6 +1218,18 @@
   before:
     - create_tables
   sql: |
+    with revenue0 (supplier_no, total_revenue) as (
+      select
+        l_suppkey,
+        sum(l_extendedprice * (1 - l_discount))
+      from
+        lineitem
+      where
+        l_shipdate >= date '1993-01-01'
+        and l_shipdate < date '1993-01-01' + interval '3' month
+      group by
+        l_suppkey
+    )
     select
       s_suppkey,
       s_name,
@@ -1226,36 +1238,14 @@
       total_revenue
     from
       supplier,
-      (
-        select
-        l_suppkey,
-        sum(l_extendedprice * (1 - l_discount)) as total_revenue
-      from
-        lineitem
-      where
-        l_shipdate >= date '1993-01-01'
-        and l_shipdate < date '1993-01-01' + interval '3' month
-      group by
-        l_suppkey
-      ) as revenue0 (supplier_no, total_revenue)
+      revenue0
     where
       s_suppkey = supplier_no
       and total_revenue = (
         select
-          max(total_revenue) as max_revenue
+          max(total_revenue)
         from
-          (
-            select
-            l_suppkey,
-            sum(l_extendedprice * (1 - l_discount)) as total_revenue
-          from
-            lineitem
-          where
-            l_shipdate >= date '1993-01-01'
-            and l_shipdate < date '1993-01-01' + interval '3' month
-          group by
-            l_suppkey
-          ) as revenue0 (supplier_no, total_revenue)
+          revenue0
       )
     order by
       s_suppkey;


### PR DESCRIPTION
## What's changed and what's your intention?

This PR fixes #2490 and enables TPC-H Q15 & Q22 for e2e batch.

The root cause is that we have SimpleAgg as intermediate node in the plan, which can only output in Single distribution. However, the scheduler expects all non-root stages to run in multiple tasks, thus schedules upper stages to read from non-existent output_id.

## Checklist

- [x] I have written necessary docs and comments
- [x] I have added necessary unit tests and integration tests
- [x] All checks passed in `./risedev check` (or alias, `./risedev c`)

## Refer to a related PR or issue link (optional)
