### PR TITLE
fix(binder): bind CTE only when schema_name is empty

### DIFF
--- a/e2e_test/batch/cte.slt
+++ b/e2e_test/batch/cte.slt
@@ -37,6 +37,16 @@ with cte1 as (select v3, v4 from t2), cte2 as (select v3 from cte1) select v3 fr
 3
 1
 
+query II
+with t1 as (values(100, 200)) select * from t1;
+----
+100 200
+
+query II
+with t1 as (values(100, 200)) select * from public.t1;
+----
+1 2
+
 statement ok
 drop table t1;
 

--- a/src/frontend/src/binder/relation/mod.rs
+++ b/src/frontend/src/binder/relation/mod.rs
@@ -176,8 +176,11 @@ impl Binder {
         match table_factor {
             TableFactor::Table { name, alias, args } => {
                 if args.is_empty() {
+                    let has_schema_name = name.0.len() > 1;
                     let (schema_name, table_name) = Self::resolve_table_name(name)?;
-                    if let Some(bound_query) = self.cte_to_relation.get(&table_name) {
+                    if !has_schema_name
+                        && let Some(bound_query) = self.cte_to_relation.get(&table_name)
+                    {
                         let (query, alias) = bound_query.clone();
                         self.bind_context(
                             query


### PR DESCRIPTION
Signed-off-by: TennyZhuang <zty0826@gmail.com>

## What's changed and what's your intention?

***PLEASE DO NOT LEAVE THIS EMPTY !!!***

See the related issue

## Checklist

- [x] I have written necessary docs and comments
- [x] I have added necessary unit tests and integration tests
- [x] All checks passed in `./risedev check` (or alias, `./risedev c`)

## Refer to a related PR or issue link (optional)

Fixes #3155 