### PR TITLE
refactor(streaming): remove redundant hash_mapping in batch node

### DIFF
--- a/proto/stream_plan.proto
+++ b/proto/stream_plan.proto
@@ -2,7 +2,6 @@ syntax = "proto3";
 
 package stream_plan;
 
-import "common.proto";
 import "data.proto";
 import "expr.proto";
 import "plan_common.proto";
@@ -154,8 +153,6 @@ message BatchPlanNode {
   plan_common.CellBasedTableDesc table_desc = 1;
   repeated plan_common.ColumnDesc column_descs = 2;
   repeated uint32 distribution_keys = 3;
-  common.ParallelUnitMapping hash_mapping = 4;
-  uint32 parallel_unit_id = 5;
 }
 
 message ArrangementInfo {

--- a/src/frontend/src/optimizer/plan_node/stream_index_scan.rs
+++ b/src/frontend/src/optimizer/plan_node/stream_index_scan.rs
@@ -118,9 +118,6 @@ impl StreamIndexScan {
                 .iter()
                 .map(|k| *k as u32)
                 .collect_vec(),
-            // Will fill when resolving chain node.
-            hash_mapping: None,
-            parallel_unit_id: 0,
         };
 
         let pk_indices = self.base.pk_indices.iter().map(|x| *x as u32).collect_vec();

--- a/src/frontend/src/optimizer/plan_node/stream_table_scan.rs
+++ b/src/frontend/src/optimizer/plan_node/stream_table_scan.rs
@@ -129,9 +129,6 @@ impl StreamTableScan {
                 .iter()
                 .map(|k| *k as u32)
                 .collect_vec(),
-            // Will fill when resolving chain node.
-            hash_mapping: None,
-            parallel_unit_id: 0,
         };
 
         let pk_indices = self.base.pk_indices.iter().map(|x| *x as u32).collect_vec();

--- a/src/meta/src/stream/stream_manager.rs
+++ b/src/meta/src/stream/stream_manager.rs
@@ -21,7 +21,6 @@ use log::{debug, info};
 use risingwave_common::catalog::TableId;
 use risingwave_common::consistent_hash::VIRTUAL_NODE_COUNT;
 use risingwave_common::error::{internal_error, Result, ToRwResult};
-use risingwave_common::util::compress::compress_data;
 use risingwave_pb::catalog::Source;
 use risingwave_pb::common::{ActorInfo, ParallelUnitMapping, WorkerType};
 use risingwave_pb::meta::table_fragments::{ActorState, ActorStatus};
@@ -77,7 +76,7 @@ pub struct GlobalStreamManager<S: MetaStore> {
     source_manager: SourceManagerRef<S>,
 
     /// Maintains vnode mapping of all fragments and state tables.
-    hash_mapping_manager: HashMappingManagerRef,
+    _hash_mapping_manager: HashMappingManagerRef,
 
     /// Schedules streaming actors into compute nodes
     scheduler: Scheduler<S>,
@@ -103,7 +102,7 @@ where
             barrier_manager,
             cluster_manager,
             source_manager,
-            hash_mapping_manager: env.hash_mapping_manager_ref(),
+            _hash_mapping_manager: env.hash_mapping_manager_ref(),
             client_pool: env.stream_client_pool_ref(),
         })
     }
@@ -118,7 +117,6 @@ where
     ) -> Result<()> {
         // The closure environment. Used to simulate recursive closure.
         struct Env<'a> {
-            hash_mapping_manager: &'a HashMappingManagerRef,
             /// Records what's the correspoding actor of each parallel unit of one table.
             upstream_parallel_unit_info: &'a HashMap<TableId, BTreeMap<ParallelUnitId, ActorId>>,
             /// Records what's the actors on each worker of one table.
@@ -148,28 +146,16 @@ where
 
                 // get upstream table id
                 let table_id = TableId::from(&chain.table_ref_id);
-                let hash_mapping = self
-                    .hash_mapping_manager
-                    .get_table_hash_mapping(&table_id.table_id)
-                    .unwrap_or_else(|| {
-                        panic!("table {} should have a vnode mapping", table_id.table_id)
-                    });
 
-                let (upstream_actor_id, parallel_unit_id) = {
+                let upstream_actor_id = {
                     // 1. use table id to get upstream parallel_unit -> actor_id mapping
                     let upstream_parallel_actor_mapping =
-                        self.upstream_parallel_unit_info.get(&table_id).unwrap();
+                        &self.upstream_parallel_unit_info[&table_id];
                     // 2. use our actor id to get parallel unit id of the chain actor
-                    let parallel_unit_id =
-                        self.locations.actor_locations.get(&actor_id).unwrap().id;
+                    let parallel_unit_id = self.locations.actor_locations[&actor_id].id;
                     // 3. and use chain actor's parallel unit id to get the corresponding upstream
                     // actor id
-                    (
-                        *upstream_parallel_actor_mapping
-                            .get(&parallel_unit_id)
-                            .unwrap(),
-                        parallel_unit_id,
-                    )
+                    upstream_parallel_actor_mapping[&parallel_unit_id]
                 };
 
                 // The current implementation already ensures chain and upstream are on the same
@@ -219,18 +205,10 @@ where
                     unreachable!("chain's input[0] should always be merge");
                 }
                 let batch_stream_node = &mut stream_node.input[1];
-                if let Some(NodeBody::BatchPlan(ref mut batch_query)) = batch_stream_node.node_body
-                {
-                    let (original_indices, data) = compress_data(&hash_mapping);
-                    batch_query.hash_mapping = Some(ParallelUnitMapping {
-                        table_id: Default::default(),
-                        original_indices,
-                        data,
-                    });
-                    batch_query.parallel_unit_id = parallel_unit_id;
-                } else {
-                    unreachable!("chain's input[1] should always be batch query");
-                }
+                assert!(
+                    matches!(batch_stream_node.node_body, Some(NodeBody::BatchPlan(_))),
+                    "chain's input[1] should always be batch query"
+                );
 
                 // finally, we should also build dispatcher infos here.
                 self.dispatches
@@ -253,7 +231,6 @@ where
             .await?;
 
         let mut env = Env {
-            hash_mapping_manager: &self.hash_mapping_manager,
             upstream_parallel_unit_info,
             tables_node_actors,
             locations,


### PR DESCRIPTION
## What's changed and what's your intention?

Use `ExecutorParams.vnode_bitmap` instead

## Checklist

- ~~[ ] I have written necessary docs and comments~~
- ~~[ ] I have added necessary unit tests and integration tests~~
- [x] All checks passed in `./risedev check` (or alias, `./risedev c`)

## Refer to a related PR or issue link (optional)
