### PR TITLE
feat(storage): add StateStoreProxy trait

### DIFF
--- a/src/batch/src/executor/row_seq_scan.rs
+++ b/src/batch/src/executor/row_seq_scan.rs
@@ -25,6 +25,7 @@ use risingwave_common::util::sort_util::OrderType;
 use risingwave_expr::expr::LiteralExpression;
 use risingwave_pb::batch_plan::plan_node::NodeBody;
 use risingwave_pb::batch_plan::{scan_range, ScanRange};
+use risingwave_storage::store::StateStoreProxy;
 use risingwave_storage::table::cell_based_table::{
     CellBasedTable, CellBasedTableRowIter, CellTableChunkIter, DedupPkCellBasedTableRowIter,
 };

--- a/src/batch/src/task/env.rs
+++ b/src/batch/src/task/env.rs
@@ -83,9 +83,7 @@ impl BatchEnvironment {
             source_manager: std::sync::Arc::new(MemSourceManager::default()),
             config: Arc::new(BatchConfig::default()),
             worker_id: WorkerNodeId::default(),
-            state_store: StateStoreImpl::shared_in_memory_store(Arc::new(
-                StateStoreMetrics::unused(),
-            )),
+            state_store: StateStoreImpl::shared_in_memory_store(),
             stats: Arc::new(BatchMetrics::unused()),
         }
     }

--- a/src/bench/ss_bench/main.rs
+++ b/src/bench/ss_bench/main.rs
@@ -180,7 +180,7 @@ async fn main() {
             Arc::new(CompactorContext {
                 options: config.clone(),
                 hummock_meta_client: mock_hummock_meta_client.clone(),
-                sstable_store: hummock.inner().sstable_store(),
+                sstable_store: hummock.sstable_store(),
                 stats: state_store_stats.clone(),
                 is_share_buffer_compact: false,
                 sstable_id_generator: get_remote_sstable_id_generator(
@@ -190,7 +190,7 @@ async fn main() {
                     config.share_buffer_compaction_worker_threads_number as usize,
                 )))),
             }),
-            hummock.inner().local_version_manager().clone(),
+            hummock.local_version_manager().clone(),
         ));
     }
 

--- a/src/bench/ss_bench/operations/mod.rs
+++ b/src/bench/ss_bench/operations/mod.rs
@@ -21,6 +21,7 @@ use rand::SeedableRng;
 use risingwave_meta::hummock::MockHummockMetaClient;
 use risingwave_storage::hummock::compactor::CompactorContext;
 use risingwave_storage::hummock::local_version_manager::LocalVersionManager;
+use risingwave_storage::store::StateStoreProxy;
 use risingwave_storage::StateStore;
 
 use crate::utils::display_stats::*;
@@ -50,7 +51,7 @@ pub(crate) struct PerfMetrics {
 impl Operations {
     /// Run operations in the `--benchmarks` option
     pub(crate) async fn run(
-        store: impl StateStore,
+        store: impl StateStoreProxy,
         meta_service: Arc<MockHummockMetaClient>,
         context: Option<(Arc<CompactorContext>, Arc<LocalVersionManager>)>,
         opts: &Opts,

--- a/src/bench/ss_bench/operations/prefix_scan_random.rs
+++ b/src/bench/ss_bench/operations/prefix_scan_random.rs
@@ -19,6 +19,7 @@ use itertools::Itertools;
 use rand::distributions::Uniform;
 use rand::prelude::Distribution;
 use risingwave_hummock_sdk::key::next_key;
+use risingwave_storage::store::StateStoreProxy;
 use risingwave_storage::StateStore;
 
 use super::Operations;
@@ -27,7 +28,7 @@ use crate::utils::workload::Workload;
 use crate::Opts;
 
 impl Operations {
-    pub(crate) async fn prefix_scan_random(&mut self, store: &impl StateStore, opts: &Opts) {
+    pub(crate) async fn prefix_scan_random(&mut self, store: &impl StateStoreProxy, opts: &Opts) {
         // generate queried prefixes
         let mut scan_prefixes = match self.prefixes.is_empty() {
             true => Workload::new_random_prefixes(opts, opts.scans as u64, &mut self.rng),
@@ -60,6 +61,7 @@ impl Operations {
                 for prefix in prefixes {
                     let start = Instant::now();
                     let kv_pairs = store
+                        .state(Default::default())
                         .scan(
                             prefix.chunk().to_vec()..next_key(prefix.chunk()),
                             None,

--- a/src/bench/ss_bench/operations/write_batch.rs
+++ b/src/bench/ss_bench/operations/write_batch.rs
@@ -24,6 +24,7 @@ use risingwave_rpc_client::HummockMetaClient;
 use risingwave_storage::hummock::compactor::{Compactor, CompactorContext};
 use risingwave_storage::hummock::local_version_manager::LocalVersionManager;
 use risingwave_storage::storage_value::StorageValue;
+use risingwave_storage::store::StateStoreProxy;
 use risingwave_storage::StateStore;
 
 use super::{Batch, Operations, PerfMetrics};
@@ -80,7 +81,7 @@ impl BatchTaskContext {
 impl Operations {
     pub(crate) async fn write_batch(
         &mut self,
-        store: &impl StateStore,
+        store: &impl StateStoreProxy,
         opts: &Opts,
         context: Option<(Arc<CompactorContext>, Arc<LocalVersionManager>)>,
     ) {
@@ -120,7 +121,7 @@ impl Operations {
         );
     }
 
-    pub(crate) async fn delete_random(&mut self, store: &impl StateStore, opts: &Opts) {
+    pub(crate) async fn delete_random(&mut self, store: &impl StateStoreProxy, opts: &Opts) {
         let delete_keys = match self.keys.is_empty() {
             true => Workload::new_random_keys(opts, opts.deletes as u64, &mut self.rng).1,
             false => {
@@ -150,7 +151,7 @@ impl Operations {
 
     async fn run_batches(
         &mut self,
-        store: &impl StateStore,
+        store: &impl StateStoreProxy,
         opts: &Opts,
         mut batches: Vec<Batch>,
     ) -> PerfMetrics {
@@ -189,7 +190,11 @@ impl Operations {
                         .map(|(k, v)| (k, StorageValue::new(Default::default(), v)))
                         .collect_vec();
                     let epoch = ctx.epoch.load(Ordering::Acquire);
-                    store.ingest_batch(batch, epoch).await.unwrap();
+                    store
+                        .state(Default::default())
+                        .ingest_batch(batch, epoch)
+                        .await
+                        .unwrap();
                     let last_batch = i + 1 == l;
                     if ctx.epoch_barrier_finish(last_batch) {
                         store.sync(Some(epoch)).await.unwrap();
@@ -200,7 +205,11 @@ impl Operations {
                             .unwrap();
                         ctx.epoch.fetch_add(1, Ordering::SeqCst);
                     }
-                    store.wait_epoch(epoch).await.unwrap();
+                    store
+                        .state(Default::default())
+                        .wait_epoch(epoch)
+                        .await
+                        .unwrap();
                     let time_nano = start.elapsed().as_nanos();
                     latencies.push(time_nano);
                 }

--- a/src/compute/src/server.rs
+++ b/src/compute/src/server.rs
@@ -118,13 +118,13 @@ pub async fn compute_node_serve(
             let (handle, shutdown_sender) = Compactor::start_compactor(
                 storage_config,
                 hummock_meta_client,
-                storage.inner().sstable_store(),
+                storage.sstable_store(),
                 state_store_metrics.clone(),
                 Some(Arc::new(CompactionExecutor::new(Some(1)))),
             );
             sub_tasks.push((handle, shutdown_sender));
         }
-        monitor_cache(storage.inner().sstable_store(), &registry).unwrap();
+        monitor_cache(storage.sstable_store(), &registry).unwrap();
     }
 
     // Initialize the managers.

--- a/src/ctl/src/common/hummock_service.rs
+++ b/src/ctl/src/common/hummock_service.rs
@@ -54,7 +54,7 @@ impl HummockServiceOpts {
         })
     }
 
-    pub async fn create_hummock_store(&self) -> Result<MonitoredStateStore<HummockStorage>> {
+    pub async fn create_hummock_store(&self) -> Result<HummockStorage> {
         let meta_client = self.meta_opts.create_meta_client().await?;
 
         // FIXME: allow specify custom config

--- a/src/meta/src/hummock/compactor_manager.rs
+++ b/src/meta/src/hummock/compactor_manager.rs
@@ -172,7 +172,7 @@ mod tests {
             }),
             task_status: false,
             vnode_mappings: vec![],
-            compaction_group_id: StaticCompactionGroupId::SharedBuffer.into(),
+            compaction_group_id: StaticCompactionGroupId::StateDefault.into(),
             existing_table_ids: vec![],
         }
     }

--- a/src/storage/hummock_sdk/src/compaction_group/mod.rs
+++ b/src/storage/hummock_sdk/src/compaction_group/mod.rs
@@ -66,8 +66,6 @@ impl From<&Prefix> for Vec<u8> {
 /// A compaction task's `StaticCompactionGroupId` indicates the compaction group that all its input
 /// SSTs belong to.
 pub enum StaticCompactionGroupId {
-    /// All shared buffer local compaction task goes to here.
-    SharedBuffer = 1,
     /// All states goes to here by default.
     StateDefault = 2,
     /// All MVs goes to here.

--- a/src/storage/src/hummock/mod.rs
+++ b/src/storage/src/hummock/mod.rs
@@ -170,6 +170,10 @@ impl HummockStorage {
     pub fn local_version_manager(&self) -> &Arc<LocalVersionManager> {
         &self.local_version_manager
     }
+
+    pub fn stats(&self) -> Arc<StateStoreMetrics> {
+        self.stats.clone()
+    }
 }
 
 impl fmt::Debug for HummockStorage {

--- a/src/storage/src/panic_store.rs
+++ b/src/storage/src/panic_store.rs
@@ -14,10 +14,13 @@
 
 use std::future::Future;
 use std::ops::RangeBounds;
+use std::sync::Arc;
 
 use bytes::Bytes;
+use risingwave_common::catalog::TableId;
 use risingwave_common::consistent_hash::VNodeBitmap;
 
+use crate::monitor::StateStoreMetrics;
 use crate::storage_value::StorageValue;
 use crate::store::*;
 use crate::{define_state_store_associated_type, StateStore, StateStoreIter};
@@ -130,11 +133,25 @@ impl StateStore for PanicStateStore {
             panic!("should not wait epoch from the panic state store!");
         }
     }
+}
+
+impl StateStoreProxy for PanicStateStore {
+    type Output = PanicStateStore;
+
+    type SyncFuture<'a> = impl EmptyFutureTrait<'a>;
 
     fn sync(&self, _epoch: Option<u64>) -> Self::SyncFuture<'_> {
         async move {
             panic!("should not sync from the panic state store!");
         }
+    }
+
+    fn state(&self, _table_id: TableId) -> Self::Output {
+        panic!("should not build the panic state store!");
+    }
+
+    fn stats(&self) -> Arc<StateStoreMetrics> {
+        panic!("should not get stats from the panic state store!");
     }
 }
 

--- a/src/stream/src/from_proto/batch_query.rs
+++ b/src/stream/src/from_proto/batch_query.rs
@@ -20,8 +20,9 @@ use risingwave_common::catalog::ColumnDesc;
 use risingwave_common::consistent_hash::VIRTUAL_NODE_COUNT;
 use risingwave_pb::common::ParallelUnitMapping;
 use risingwave_storage::monitor::StateStoreMetrics;
+use risingwave_storage::store::StateStoreProxy;
 use risingwave_storage::table::cell_based_table::CellBasedTable;
-use risingwave_storage::{Keyspace, StateStore};
+use risingwave_storage::Keyspace;
 
 use super::*;
 use crate::executor::BatchQueryExecutor;
@@ -29,10 +30,10 @@ use crate::executor::BatchQueryExecutor;
 pub struct BatchQueryExecutorBuilder;
 
 impl ExecutorBuilder for BatchQueryExecutorBuilder {
-    fn new_boxed_executor(
+    fn new_boxed_executor<S: StateStoreProxy>(
         params: ExecutorParams,
         node: &StreamNode,
-        state_store: impl StateStore,
+        state_store: S,
         _stream: &mut LocalStreamManagerCore,
     ) -> Result<BoxedExecutor> {
         let node = try_match_expand!(node.get_node_body().unwrap(), NodeBody::BatchPlan)?;

--- a/src/stream/src/from_proto/chain.rs
+++ b/src/stream/src/from_proto/chain.rs
@@ -18,10 +18,10 @@ use crate::executor::{ChainExecutor, RearrangedChainExecutor};
 pub struct ChainExecutorBuilder;
 
 impl ExecutorBuilder for ChainExecutorBuilder {
-    fn new_boxed_executor(
+    fn new_boxed_executor<S: StateStoreProxy>(
         mut params: ExecutorParams,
         node: &StreamNode,
-        _store: impl StateStore,
+        _store: S,
         stream: &mut LocalStreamManagerCore,
     ) -> Result<BoxedExecutor> {
         let node = try_match_expand!(node.get_node_body().unwrap(), NodeBody::Chain)?;

--- a/src/stream/src/from_proto/filter.rs
+++ b/src/stream/src/from_proto/filter.rs
@@ -20,10 +20,10 @@ use crate::executor::FilterExecutor;
 pub struct FilterExecutorBuilder;
 
 impl ExecutorBuilder for FilterExecutorBuilder {
-    fn new_boxed_executor(
+    fn new_boxed_executor<S: StateStoreProxy>(
         mut params: ExecutorParams,
         node: &StreamNode,
-        _store: impl StateStore,
+        _store: S,
         _stream: &mut LocalStreamManagerCore,
     ) -> Result<BoxedExecutor> {
         let node = try_match_expand!(node.get_node_body().unwrap(), NodeBody::Filter)?;

--- a/src/stream/src/from_proto/global_simple_agg.rs
+++ b/src/stream/src/from_proto/global_simple_agg.rs
@@ -23,10 +23,10 @@ use crate::executor::SimpleAggExecutor;
 pub struct SimpleAggExecutorBuilder;
 
 impl ExecutorBuilder for SimpleAggExecutorBuilder {
-    fn new_boxed_executor(
+    fn new_boxed_executor<S: StateStoreProxy>(
         mut params: ExecutorParams,
         node: &StreamNode,
-        store: impl StateStore,
+        store: S,
         _stream: &mut LocalStreamManagerCore,
     ) -> Result<BoxedExecutor> {
         let node = try_match_expand!(node.get_node_body().unwrap(), NodeBody::GlobalSimpleAgg)?;

--- a/src/stream/src/from_proto/hash_agg.rs
+++ b/src/stream/src/from_proto/hash_agg.rs
@@ -54,10 +54,10 @@ impl<S: StateStore> HashKeyDispatcher for HashAggExecutorDispatcher<S> {
 pub struct HashAggExecutorBuilder;
 
 impl ExecutorBuilder for HashAggExecutorBuilder {
-    fn new_boxed_executor(
+    fn new_boxed_executor<S: StateStoreProxy>(
         mut params: ExecutorParams,
         node: &StreamNode,
-        store: impl StateStore,
+        store: S,
         _stream: &mut LocalStreamManagerCore,
     ) -> Result<BoxedExecutor> {
         let node = try_match_expand!(node.get_node_body().unwrap(), NodeBody::HashAgg)?;

--- a/src/stream/src/from_proto/hash_join.rs
+++ b/src/stream/src/from_proto/hash_join.rs
@@ -26,10 +26,10 @@ use crate::executor::PkIndices;
 pub struct HashJoinExecutorBuilder;
 
 impl ExecutorBuilder for HashJoinExecutorBuilder {
-    fn new_boxed_executor(
+    fn new_boxed_executor<S: StateStoreProxy>(
         mut params: ExecutorParams,
         node: &StreamNode,
-        store: impl StateStore,
+        store: S,
         _stream: &mut LocalStreamManagerCore,
     ) -> Result<BoxedExecutor> {
         // Get table id and used as keyspace prefix.

--- a/src/stream/src/from_proto/hop_window.rs
+++ b/src/stream/src/from_proto/hop_window.rs
@@ -22,10 +22,10 @@ use crate::executor::HopWindowExecutor;
 pub struct HopWindowExecutorBuilder;
 
 impl ExecutorBuilder for HopWindowExecutorBuilder {
-    fn new_boxed_executor(
+    fn new_boxed_executor<S: StateStoreProxy>(
         params: ExecutorParams,
         node: &StreamNode,
-        _store: impl StateStore,
+        _store: S,
         _stream: &mut LocalStreamManagerCore,
     ) -> Result<BoxedExecutor> {
         let ExecutorParams {

--- a/src/stream/src/from_proto/local_simple_agg.rs
+++ b/src/stream/src/from_proto/local_simple_agg.rs
@@ -24,10 +24,10 @@ use crate::executor::LocalSimpleAggExecutor;
 pub struct LocalSimpleAggExecutorBuilder;
 
 impl ExecutorBuilder for LocalSimpleAggExecutorBuilder {
-    fn new_boxed_executor(
+    fn new_boxed_executor<S: StateStoreProxy>(
         mut params: ExecutorParams,
         node: &StreamNode,
-        _store: impl StateStore,
+        _store: S,
         _stream: &mut LocalStreamManagerCore,
     ) -> Result<BoxedExecutor> {
         let node = try_match_expand!(node.get_node_body().unwrap(), NodeBody::LocalSimpleAgg)?;

--- a/src/stream/src/from_proto/lookup.rs
+++ b/src/stream/src/from_proto/lookup.rs
@@ -22,10 +22,10 @@ use crate::executor::{LookupExecutor, LookupExecutorParams};
 pub struct LookupExecutorBuilder;
 
 impl ExecutorBuilder for LookupExecutorBuilder {
-    fn new_boxed_executor(
+    fn new_boxed_executor<S: StateStoreProxy>(
         mut params: ExecutorParams,
         node: &StreamNode,
-        store: impl StateStore,
+        store: S,
         _stream: &mut LocalStreamManagerCore,
     ) -> Result<BoxedExecutor> {
         let lookup = try_match_expand!(node.get_node_body().unwrap(), NodeBody::Lookup)?;

--- a/src/stream/src/from_proto/lookup_union.rs
+++ b/src/stream/src/from_proto/lookup_union.rs
@@ -18,10 +18,10 @@ use crate::executor::LookupUnionExecutor;
 pub struct LookupUnionExecutorBuilder;
 
 impl ExecutorBuilder for LookupUnionExecutorBuilder {
-    fn new_boxed_executor(
+    fn new_boxed_executor<S: StateStoreProxy>(
         params: ExecutorParams,
         node: &StreamNode,
-        _store: impl StateStore,
+        _store: S,
         _stream: &mut LocalStreamManagerCore,
     ) -> Result<BoxedExecutor> {
         let lookup_union = try_match_expand!(node.get_node_body().unwrap(), NodeBody::LookupUnion)?;

--- a/src/stream/src/from_proto/merge.rs
+++ b/src/stream/src/from_proto/merge.rs
@@ -21,10 +21,10 @@ use crate::executor::MergeExecutor;
 pub struct MergeExecutorBuilder;
 
 impl ExecutorBuilder for MergeExecutorBuilder {
-    fn new_boxed_executor(
+    fn new_boxed_executor<S: StateStoreProxy>(
         params: ExecutorParams,
         x_node: &StreamNode,
-        _store: impl StateStore,
+        _store: S,
         stream: &mut LocalStreamManagerCore,
     ) -> Result<BoxedExecutor> {
         let node = try_match_expand!(x_node.get_node_body().unwrap(), NodeBody::Merge)?;

--- a/src/stream/src/from_proto/mod.rs
+++ b/src/stream/src/from_proto/mod.rs
@@ -38,6 +38,7 @@ use risingwave_common::error::{ErrorCode, Result, RwError};
 use risingwave_common::try_match_expand;
 use risingwave_pb::stream_plan::stream_node::NodeBody;
 use risingwave_pb::stream_plan::StreamNode;
+use risingwave_storage::store::StateStoreProxy;
 use risingwave_storage::{Keyspace, StateStore};
 
 use self::batch_query::*;
@@ -62,10 +63,10 @@ use crate::task::{ExecutorParams, LocalStreamManagerCore};
 
 trait ExecutorBuilder {
     /// Create a [`BoxedExecutor`] from [`StreamNode`].
-    fn new_boxed_executor(
+    fn new_boxed_executor<S: StateStoreProxy>(
         params: ExecutorParams,
         node: &StreamNode,
-        store: impl StateStore,
+        store: S,
         stream: &mut LocalStreamManagerCore,
     ) -> Result<BoxedExecutor>;
 }
@@ -89,11 +90,11 @@ macro_rules! build_executor {
 }
 
 /// Create an executor from protobuf [`StreamNode`].
-pub fn create_executor(
+pub fn create_executor<S: StateStoreProxy>(
     params: ExecutorParams,
     stream: &mut LocalStreamManagerCore,
     node: &StreamNode,
-    store: impl StateStore,
+    store: S,
 ) -> Result<BoxedExecutor> {
     build_executor! {
         params,

--- a/src/stream/src/from_proto/mview.rs
+++ b/src/stream/src/from_proto/mview.rs
@@ -21,10 +21,10 @@ use crate::executor::MaterializeExecutor;
 pub struct MaterializeExecutorBuilder;
 
 impl ExecutorBuilder for MaterializeExecutorBuilder {
-    fn new_boxed_executor(
+    fn new_boxed_executor<S: StateStoreProxy>(
         mut params: ExecutorParams,
         node: &StreamNode,
-        store: impl StateStore,
+        store: S,
         _stream: &mut LocalStreamManagerCore,
     ) -> Result<BoxedExecutor> {
         let node = try_match_expand!(node.get_node_body().unwrap(), NodeBody::Materialize)?;
@@ -66,10 +66,10 @@ impl ExecutorBuilder for MaterializeExecutorBuilder {
 pub struct ArrangeExecutorBuilder;
 
 impl ExecutorBuilder for ArrangeExecutorBuilder {
-    fn new_boxed_executor(
+    fn new_boxed_executor<S: StateStoreProxy>(
         mut params: ExecutorParams,
         node: &StreamNode,
-        store: impl StateStore,
+        store: S,
         _stream: &mut LocalStreamManagerCore,
     ) -> Result<BoxedExecutor> {
         let arrange_node = try_match_expand!(node.get_node_body().unwrap(), NodeBody::Arrange)?;

--- a/src/stream/src/from_proto/project.rs
+++ b/src/stream/src/from_proto/project.rs
@@ -20,10 +20,10 @@ use crate::executor::ProjectExecutor;
 pub struct ProjectExecutorBuilder;
 
 impl ExecutorBuilder for ProjectExecutorBuilder {
-    fn new_boxed_executor(
+    fn new_boxed_executor<S: StateStoreProxy>(
         mut params: ExecutorParams,
         node: &StreamNode,
-        _store: impl StateStore,
+        _store: S,
         _stream: &mut LocalStreamManagerCore,
     ) -> Result<BoxedExecutor> {
         let node = try_match_expand!(node.get_node_body().unwrap(), NodeBody::Project)?;

--- a/src/stream/src/from_proto/source.rs
+++ b/src/stream/src/from_proto/source.rs
@@ -21,10 +21,10 @@ use crate::executor::SourceExecutor;
 pub struct SourceExecutorBuilder;
 
 impl ExecutorBuilder for SourceExecutorBuilder {
-    fn new_boxed_executor(
+    fn new_boxed_executor<S: StateStoreProxy>(
         params: ExecutorParams,
         node: &StreamNode,
-        store: impl StateStore,
+        store: S,
         stream: &mut LocalStreamManagerCore,
     ) -> Result<BoxedExecutor> {
         let node = try_match_expand!(node.get_node_body().unwrap(), NodeBody::Source)?;

--- a/src/stream/src/from_proto/top_n.rs
+++ b/src/stream/src/from_proto/top_n.rs
@@ -21,10 +21,10 @@ use crate::executor::TopNExecutor;
 pub struct TopNExecutorBuilder;
 
 impl ExecutorBuilder for TopNExecutorBuilder {
-    fn new_boxed_executor(
+    fn new_boxed_executor<S: StateStoreProxy>(
         mut params: ExecutorParams,
         node: &StreamNode,
-        store: impl StateStore,
+        store: S,
         _stream: &mut LocalStreamManagerCore,
     ) -> Result<BoxedExecutor> {
         let node = try_match_expand!(node.get_node_body().unwrap(), NodeBody::TopN)?;

--- a/src/stream/src/from_proto/top_n_appendonly.rs
+++ b/src/stream/src/from_proto/top_n_appendonly.rs
@@ -21,10 +21,10 @@ use crate::executor::AppendOnlyTopNExecutor;
 pub struct AppendOnlyTopNExecutorBuilder;
 
 impl ExecutorBuilder for AppendOnlyTopNExecutorBuilder {
-    fn new_boxed_executor(
+    fn new_boxed_executor<S: StateStoreProxy>(
         mut params: ExecutorParams,
         node: &StreamNode,
-        store: impl StateStore,
+        store: S,
         _stream: &mut LocalStreamManagerCore,
     ) -> Result<BoxedExecutor> {
         let node = try_match_expand!(node.get_node_body().unwrap(), NodeBody::AppendOnlyTopN)?;

--- a/src/stream/src/from_proto/union.rs
+++ b/src/stream/src/from_proto/union.rs
@@ -18,10 +18,10 @@ use crate::executor::UnionExecutor;
 pub struct UnionExecutorBuilder;
 
 impl ExecutorBuilder for UnionExecutorBuilder {
-    fn new_boxed_executor(
+    fn new_boxed_executor<S: StateStoreProxy>(
         params: ExecutorParams,
         node: &StreamNode,
-        _store: impl StateStore,
+        _store: S,
         _stream: &mut LocalStreamManagerCore,
     ) -> Result<BoxedExecutor> {
         try_match_expand!(node.get_node_body().unwrap(), NodeBody::Union)?;

--- a/src/stream/src/task/env.rs
+++ b/src/stream/src/task/env.rs
@@ -69,9 +69,7 @@ impl StreamEnvironment {
             source_manager: Arc::new(MemSourceManager::default()),
             config: Arc::new(StreamingConfig::default()),
             worker_id: WorkerNodeId::default(),
-            state_store: StateStoreImpl::shared_in_memory_store(Arc::new(
-                StateStoreMetrics::unused(),
-            )),
+            state_store: StateStoreImpl::shared_in_memory_store(),
         }
     }
 


### PR DESCRIPTION
## What's changed and what's your intention?

**WIP. Please don't review.**

Now that we will support compaction group soon, we need to StateStore's read/write be aware of compaction group id.
This PR refactors the single state store into multiple ones, as following:
![d drawio](https://user-images.githubusercontent.com/70626450/173490179-1b935325-aa2e-44b8-8342-46340373b92f.png)

Compared with directly passing compaction group id(or table id) to StateStore's read/write interfaces, this PR tries to make each StateStore explicitly handle only one specific compaction group id(or table id).

## Checklist

- [ ] I have written necessary docs and comments
- [ ] I have added necessary unit tests and integration tests
- [ ] All checks passed in `./risedev check` (or alias, `./risedev c`)

## Refer to a related PR or issue link (optional)
https://github.com/singularity-data/risingwave/issues/2065