### PR TITLE
feat(binder): allow CTE as time window table function's input

### DIFF
--- a/src/frontend/src/binder/relation/window_table_function.rs
+++ b/src/frontend/src/binder/relation/window_table_function.rs
@@ -117,7 +117,7 @@ impl Binder {
             ).collect::<Result<Vec<_>>>()?;
 
         let (_, table_name) = Self::resolve_table_name(table_name)?;
-        self.bind_context(columns, table_name.clone(), alias)?;
+        self.bind_context(columns, table_name, alias)?;
 
         let exprs: Vec<_> = args
             .map(|arg| self.bind_function_arg(arg))

--- a/src/frontend/src/binder/relation/window_table_function.rs
+++ b/src/frontend/src/binder/relation/window_table_function.rs
@@ -76,9 +76,8 @@ impl Binder {
             )
             .into()),
         }?;
-        let (schema_name, table_name) = Self::resolve_table_name(table_name)?;
 
-        let base = self.bind_table_or_source(&schema_name, &table_name, None)?;
+        let base = self.bind_relation_by_name(table_name.clone(), None)?;
 
         let Some(time_col_arg) = args.next() else {
             return Err(ErrorCode::BindError(
@@ -117,6 +116,7 @@ impl Binder {
                 .into_iter(),
             ).collect::<Result<Vec<_>>>()?;
 
+        let (_, table_name) = Self::resolve_table_name(table_name)?;
         self.bind_context(columns, table_name.clone(), alias)?;
 
         let exprs: Vec<_> = args

--- a/src/frontend/src/optimizer/plan_node/logical_hop_window.rs
+++ b/src/frontend/src/optimizer/plan_node/logical_hop_window.rs
@@ -172,7 +172,7 @@ impl LogicalHopWindow {
     pub fn fmt_with_name(&self, f: &mut fmt::Formatter, name: &str) -> fmt::Result {
         write!(
             f,
-            "{} {{ time_col: {} slide: {} size: {} output_indices: {} }}",
+            "{} {{ time_col: {}, slide: {}, size: {}, output_indices: {} }}",
             name,
             InputRefDisplay(self.time_col.index),
             self.window_slide,

--- a/src/frontend/test_runner/tests/testdata/column_pruning.yaml
+++ b/src/frontend/test_runner/tests/testdata/column_pruning.yaml
@@ -127,16 +127,16 @@
     select a, window_end from hop(t1, created_at, interval '15' minute, interval '30' minute)
   logical_plan: |
     LogicalProject { exprs: [$1, $5] }
-      LogicalHopWindow { time_col: $3 slide: 00:15:00 size: 00:30:00 output_indices: all }
+      LogicalHopWindow { time_col: $3, slide: 00:15:00, size: 00:30:00, output_indices: all }
         LogicalScan { table: t1, columns: [_row_id, a, b, created_at] }
   optimized_logical_plan: |
-    LogicalHopWindow { time_col: $1 slide: 00:15:00 size: 00:30:00 output_indices: [0, 3] }
+    LogicalHopWindow { time_col: $1, slide: 00:15:00, size: 00:30:00, output_indices: [0, 3] }
       LogicalScan { table: t1, columns: [a, created_at] }
   batch_plan: |
-    BatchHopWindow { time_col: $1 slide: 00:15:00 size: 00:30:00 output_indices: [0, 3] }
+    BatchHopWindow { time_col: $1, slide: 00:15:00, size: 00:30:00, output_indices: [0, 3] }
       BatchExchange { order: [], dist: Single }
         BatchScan { table: t1, columns: [a, created_at] }
   stream_plan: |
     StreamMaterialize { columns: [a, window_end, _row_id(hidden)], pk_columns: [_row_id, window_end] }
-      StreamHopWindow { time_col: $1 slide: 00:15:00 size: 00:30:00 output_indices: [0, 4, 2] }
+      StreamHopWindow { time_col: $1, slide: 00:15:00, size: 00:30:00, output_indices: [0, 4, 2] }
         StreamTableScan { table: t1, columns: [a, created_at, _row_id], pk_indices: [2] }

--- a/src/frontend/test_runner/tests/testdata/nexmark.yaml
+++ b/src/frontend/test_runner/tests/testdata/nexmark.yaml
@@ -168,14 +168,14 @@
                 BatchHashAgg { group_keys: [$0, $1], aggs: [count] }
                   BatchExchange { order: [], dist: HashShard([0, 1]) }
                     BatchProject { exprs: [$1, $0] }
-                      BatchHopWindow { time_col: $1 slide: 00:00:02 size: 00:00:10 output_indices: [0, 2] }
+                      BatchHopWindow { time_col: $1, slide: 00:00:02, size: 00:00:10, output_indices: [0, 2] }
                         BatchScan { table: bid, columns: [auction, dateTime] }
             BatchProject { exprs: [$1, $0] }
               BatchHashAgg { group_keys: [$0], aggs: [max($1)] }
                 BatchExchange { order: [], dist: HashShard([0]) }
                   BatchProject { exprs: [$1, $2] }
                     BatchHashAgg { group_keys: [$0, $1], aggs: [count] }
-                      BatchHopWindow { time_col: $1 slide: 00:00:02 size: 00:00:10 output_indices: [0, 2] }
+                      BatchHopWindow { time_col: $1, slide: 00:00:02, size: 00:00:10, output_indices: [0, 2] }
                         BatchExchange { order: [], dist: HashShard([0]) }
                           BatchScan { table: bid, columns: [auction, dateTime] }
   stream_plan: |
@@ -188,7 +188,7 @@
                 StreamHashAgg { group_keys: [$0, $1], aggs: [count, count] }
                   StreamExchange { dist: HashShard([0, 1]) }
                     StreamProject { exprs: [$1, $0, $2] }
-                      StreamHopWindow { time_col: $1 slide: 00:00:02 size: 00:00:10 output_indices: [0, 3, 2] }
+                      StreamHopWindow { time_col: $1, slide: 00:00:02, size: 00:00:10, output_indices: [0, 3, 2] }
                         StreamTableScan { table: bid, columns: [auction, dateTime, _row_id], pk_indices: [2] }
             StreamProject { exprs: [$2, $0] }
               StreamHashAgg { group_keys: [$0], aggs: [count, max($1)] }
@@ -196,7 +196,7 @@
                   StreamProject { exprs: [$1, $3, $0] }
                     StreamHashAgg { group_keys: [$0, $1], aggs: [count, count] }
                       StreamExchange { dist: HashShard([0, 1]) }
-                        StreamHopWindow { time_col: $1 slide: 00:00:02 size: 00:00:10 output_indices: [0, 3, 2] }
+                        StreamHopWindow { time_col: $1, slide: 00:00:02, size: 00:00:10, output_indices: [0, 3, 2] }
                           StreamTableScan { table: bid, columns: [auction, dateTime, _row_id], pk_indices: [2] }
 - id: nexmark_q6
   before:

--- a/src/frontend/test_runner/tests/testdata/time_window.yaml
+++ b/src/frontend/test_runner/tests/testdata/time_window.yaml
@@ -41,63 +41,63 @@
     select * from hop(t1, created_at, interval '1' day, interval '3' day);
   logical_plan: |
     LogicalProject { exprs: [$1, $2, $3, $4] }
-      LogicalHopWindow { time_col: $2 slide: 1 day 00:00:00 size: 3 days 00:00:00 output_indices: all }
+      LogicalHopWindow { time_col: $2, slide: 1 day 00:00:00, size: 3 days 00:00:00, output_indices: all }
         LogicalScan { table: t1, columns: [_row_id, id, created_at] }
   stream_plan: |
     StreamMaterialize { columns: [id, created_at, window_start, window_end, _row_id(hidden)], pk_columns: [_row_id, window_start] }
-      StreamHopWindow { time_col: $1 slide: 1 day 00:00:00 size: 3 days 00:00:00 output_indices: [0, 1, 3, 4, 2] }
+      StreamHopWindow { time_col: $1, slide: 1 day 00:00:00, size: 3 days 00:00:00, output_indices: [0, 1, 3, 4, 2] }
         StreamTableScan { table: t1, columns: [id, created_at, _row_id], pk_indices: [2] }
 - sql: |
     create table t1 (id int, created_at date);
     select id, created_at, window_start from hop(t1, created_at, interval '1' day, interval '3' day);
   logical_plan: |
     LogicalProject { exprs: [$1, $2, $3] }
-      LogicalHopWindow { time_col: $2 slide: 1 day 00:00:00 size: 3 days 00:00:00 output_indices: all }
+      LogicalHopWindow { time_col: $2, slide: 1 day 00:00:00, size: 3 days 00:00:00, output_indices: all }
         LogicalScan { table: t1, columns: [_row_id, id, created_at] }
   stream_plan: |
     StreamMaterialize { columns: [id, created_at, window_start, _row_id(hidden)], pk_columns: [_row_id, window_start] }
-      StreamHopWindow { time_col: $1 slide: 1 day 00:00:00 size: 3 days 00:00:00 output_indices: [0, 1, 3, 2] }
+      StreamHopWindow { time_col: $1, slide: 1 day 00:00:00, size: 3 days 00:00:00, output_indices: [0, 1, 3, 2] }
         StreamTableScan { table: t1, columns: [id, created_at, _row_id], pk_indices: [2] }
 - sql: |
     create table t1 (id int, created_at date);
     select id, created_at, window_end from hop(t1, created_at, interval '1' day, interval '3' day);
   logical_plan: |
     LogicalProject { exprs: [$1, $2, $4] }
-      LogicalHopWindow { time_col: $2 slide: 1 day 00:00:00 size: 3 days 00:00:00 output_indices: all }
+      LogicalHopWindow { time_col: $2, slide: 1 day 00:00:00, size: 3 days 00:00:00, output_indices: all }
         LogicalScan { table: t1, columns: [_row_id, id, created_at] }
   stream_plan: |
     StreamMaterialize { columns: [id, created_at, window_end, _row_id(hidden)], pk_columns: [_row_id, window_end] }
-      StreamHopWindow { time_col: $1 slide: 1 day 00:00:00 size: 3 days 00:00:00 output_indices: [0, 1, 4, 2] }
+      StreamHopWindow { time_col: $1, slide: 1 day 00:00:00, size: 3 days 00:00:00, output_indices: [0, 1, 4, 2] }
         StreamTableScan { table: t1, columns: [id, created_at, _row_id], pk_indices: [2] }
 - sql: |
     create table t1 (id int, created_at date);
     select id, created_at from hop(t1, created_at, interval '1' day, interval '3' day);
   logical_plan: |
     LogicalProject { exprs: [$1, $2] }
-      LogicalHopWindow { time_col: $2 slide: 1 day 00:00:00 size: 3 days 00:00:00 output_indices: all }
+      LogicalHopWindow { time_col: $2, slide: 1 day 00:00:00, size: 3 days 00:00:00, output_indices: all }
         LogicalScan { table: t1, columns: [_row_id, id, created_at] }
   batch_plan: |
-    BatchHopWindow { time_col: $1 slide: 1 day 00:00:00 size: 3 days 00:00:00 output_indices: [0, 1] }
+    BatchHopWindow { time_col: $1, slide: 1 day 00:00:00, size: 3 days 00:00:00, output_indices: [0, 1] }
       BatchExchange { order: [], dist: Single }
         BatchScan { table: t1, columns: [id, created_at] }
   stream_plan: |
     StreamMaterialize { columns: [id, created_at, window_start(hidden), _row_id(hidden)], pk_columns: [_row_id, window_start] }
-      StreamHopWindow { time_col: $1 slide: 1 day 00:00:00 size: 3 days 00:00:00 output_indices: [0, 1, 3, 2] }
+      StreamHopWindow { time_col: $1, slide: 1 day 00:00:00, size: 3 days 00:00:00, output_indices: [0, 1, 3, 2] }
         StreamTableScan { table: t1, columns: [id, created_at, _row_id], pk_indices: [2] }
 - sql: |
     create table t1 (id int, created_at date);
     select t_hop.id, t_hop.created_at from hop(t1, created_at, interval '1' day, interval '3' day) as t_hop;
   logical_plan: |
     LogicalProject { exprs: [$1, $2] }
-      LogicalHopWindow { time_col: $2 slide: 1 day 00:00:00 size: 3 days 00:00:00 output_indices: all }
+      LogicalHopWindow { time_col: $2, slide: 1 day 00:00:00, size: 3 days 00:00:00, output_indices: all }
         LogicalScan { table: t1, columns: [_row_id, id, created_at] }
   batch_plan: |
-    BatchHopWindow { time_col: $1 slide: 1 day 00:00:00 size: 3 days 00:00:00 output_indices: [0, 1] }
+    BatchHopWindow { time_col: $1, slide: 1 day 00:00:00, size: 3 days 00:00:00, output_indices: [0, 1] }
       BatchExchange { order: [], dist: Single }
         BatchScan { table: t1, columns: [id, created_at] }
   stream_plan: |
     StreamMaterialize { columns: [id, created_at, window_start(hidden), _row_id(hidden)], pk_columns: [_row_id, window_start] }
-      StreamHopWindow { time_col: $1 slide: 1 day 00:00:00 size: 3 days 00:00:00 output_indices: [0, 1, 3, 2] }
+      StreamHopWindow { time_col: $1, slide: 1 day 00:00:00, size: 3 days 00:00:00, output_indices: [0, 1, 3, 2] }
         StreamTableScan { table: t1, columns: [id, created_at, _row_id], pk_indices: [2] }
 - sql: |
     create table t (v1 varchar, v2 timestamp, v3 float);
@@ -106,7 +106,7 @@
     LogicalProject { exprs: [$0, $1, ($2 / $3)] }
       LogicalAgg { group_keys: [0, 1], agg_calls: [sum($2), count($2)] }
         LogicalProject { exprs: [$1, $5, $3] }
-          LogicalHopWindow { time_col: $2 slide: 00:01:00 size: 00:10:00 output_indices: all }
+          LogicalHopWindow { time_col: $2, slide: 00:01:00, size: 00:10:00, output_indices: all }
             LogicalScan { table: t, columns: [_row_id, v1, v2, v3] }
   batch_plan: |
     BatchExchange { order: [], dist: Single }
@@ -114,7 +114,7 @@
         BatchHashAgg { group_keys: [$0, $1], aggs: [sum($2), count($2)] }
           BatchExchange { order: [], dist: HashShard([0, 1]) }
             BatchProject { exprs: [$0, $2, $1] }
-              BatchHopWindow { time_col: $1 slide: 00:01:00 size: 00:10:00 output_indices: [0, 2, 4] }
+              BatchHopWindow { time_col: $1, slide: 00:01:00, size: 00:10:00, output_indices: [0, 2, 4] }
                 BatchScan { table: t, columns: [v1, v2, v3] }
   stream_plan: |
     StreamMaterialize { columns: [v1, window_end, avg], pk_columns: [v1, window_end] }
@@ -122,5 +122,25 @@
         StreamHashAgg { group_keys: [$0, $1], aggs: [count, sum($2), count($2)] }
           StreamExchange { dist: HashShard([0, 1]) }
             StreamProject { exprs: [$0, $2, $1, $3] }
-              StreamHopWindow { time_col: $1 slide: 00:01:00 size: 00:10:00 output_indices: [0, 2, 5, 3] }
+              StreamHopWindow { time_col: $1, slide: 00:01:00, size: 00:10:00, output_indices: [0, 2, 5, 3] }
                 StreamTableScan { table: t, columns: [v1, v2, v3, _row_id], pk_indices: [3] }
+- sql: |
+    create table t1 (id int, v1 int, created_at date);
+    with t2 as (select * from t1 where v1 >= 10)
+    select * from hop(t2, created_at, interval '1' day, interval '3' day);
+  logical_plan: |
+    LogicalProject { exprs: [$0, $1, $2, $3, $4] }
+      LogicalHopWindow { time_col: $2, slide: 1 day 00:00:00, size: 3 days 00:00:00, output_indices: all }
+        LogicalProject { exprs: [$1, $2, $3] }
+          LogicalFilter { predicate: ($2 >= 10:Int32) }
+            LogicalScan { table: t1, columns: [_row_id, id, v1, created_at] }
+  batch_plan: |
+    BatchHopWindow { time_col: $2, slide: 1 day 00:00:00, size: 3 days 00:00:00, output_indices: all }
+      BatchExchange { order: [], dist: Single }
+        BatchFilter { predicate: ($1 >= 10:Int32) }
+          BatchScan { table: t1, columns: [id, v1, created_at] }
+  stream_plan: |
+    StreamMaterialize { columns: [id, v1, created_at, window_start, window_end, _row_id(hidden)], pk_columns: [_row_id, window_start] }
+      StreamHopWindow { time_col: $2, slide: 1 day 00:00:00, size: 3 days 00:00:00, output_indices: [0, 1, 2, 4, 5, 3] }
+        StreamFilter { predicate: ($1 >= 10:Int32) }
+          StreamTableScan { table: t1, columns: [id, v1, created_at, _row_id], pk_indices: [3] }

--- a/src/frontend/test_runner/tests/testdata/time_window.yaml
+++ b/src/frontend/test_runner/tests/testdata/time_window.yaml
@@ -127,6 +127,22 @@
 - sql: |
     create table t1 (id int, v1 int, created_at date);
     with t2 as (select * from t1 where v1 >= 10)
+    select * from tumble(t1, created_at, interval '3' day);
+  logical_plan: |
+    LogicalProject { exprs: [$1, $2, $3, $4, $5] }
+      LogicalProject { exprs: [$0, $1, $2, $3, TumbleStart($3, '3 days 00:00:00':Interval), (TumbleStart($3, '3 days 00:00:00':Interval) + '3 days 00:00:00':Interval)] }
+        LogicalScan { table: t1, columns: [_row_id, id, v1, created_at] }
+  batch_plan: |
+    BatchExchange { order: [], dist: Single }
+      BatchProject { exprs: [$0, $1, $2, TumbleStart($2, '3 days 00:00:00':Interval), (TumbleStart($2, '3 days 00:00:00':Interval) + '3 days 00:00:00':Interval)] }
+        BatchScan { table: t1, columns: [id, v1, created_at] }
+  stream_plan: |
+    StreamMaterialize { columns: [id, v1, created_at, window_start, window_end, _row_id(hidden)], pk_columns: [_row_id] }
+      StreamProject { exprs: [$0, $1, $2, TumbleStart($2, '3 days 00:00:00':Interval), (TumbleStart($2, '3 days 00:00:00':Interval) + '3 days 00:00:00':Interval), $3] }
+        StreamTableScan { table: t1, columns: [id, v1, created_at, _row_id], pk_indices: [3] }
+- sql: |
+    create table t1 (id int, v1 int, created_at date);
+    with t2 as (select * from t1 where v1 >= 10)
     select * from hop(t2, created_at, interval '1' day, interval '3' day);
   logical_plan: |
     LogicalProject { exprs: [$0, $1, $2, $3, $4] }


### PR DESCRIPTION
Signed-off-by: TennyZhuang <zty0826@gmail.com>

## What's changed and what's your intention?

***PLEASE DO NOT LEAVE THIS EMPTY !!!***

It's a little hard in parser to support a subquery as the table function's input, but we can achieve the same ability by accepting CTE here.

## Checklist

- [x] I have written necessary docs and comments
- [x] I have added necessary unit tests and integration tests
- [x] All checks passed in `./risedev check` (or alias, `./risedev c`)

## Refer to a related PR or issue link (optional)

Close #2733 