### PR TITLE
fix: fix in-correct unittest (pk infer)

### DIFF
--- a/src/stream/src/executor/global_simple_agg.rs
+++ b/src/stream/src/executor/global_simple_agg.rs
@@ -383,7 +383,7 @@ mod tests {
         ];
 
         let simple_agg = Box::new(
-            SimpleAggExecutor::new(Box::new(source), agg_calls, keyspace, vec![], 1, vec![])
+            SimpleAggExecutor::new(Box::new(source), agg_calls, keyspace, vec![2], 1, vec![])
                 .unwrap(),
         );
         let mut simple_agg = simple_agg.execute();

--- a/src/stream/src/executor/hash_agg.rs
+++ b/src/stream/src/executor/hash_agg.rs
@@ -768,7 +768,7 @@ mod tests {
         ];
 
         let hash_agg =
-            new_boxed_hash_agg_executor(Box::new(source), agg_calls, keys, keyspace, vec![], 1);
+            new_boxed_hash_agg_executor(Box::new(source), agg_calls, keys, keyspace, vec![2], 1);
         let mut hash_agg = hash_agg.execute();
 
         // Consume the init barrier
@@ -855,7 +855,7 @@ mod tests {
         ];
 
         let hash_agg =
-            new_boxed_hash_agg_executor(Box::new(source), agg_calls, keys, keyspace, vec![], 1);
+            new_boxed_hash_agg_executor(Box::new(source), agg_calls, keys, keyspace, vec![2], 1);
         let mut hash_agg = hash_agg.execute();
 
         // Consume the init barrier


### PR DESCRIPTION
## What's changed and what's your intention?

The source has pk vec![2]. So the agg should accept pk_indices as vec![2].

The unitest is wrong-written.

## Checklist

- [x] I have written necessary docs and comments
- [x] I have added necessary unit tests and integration tests
- [x] All checks passed in `./risedev check` (or alias, `./risedev c`)

## Refer to a related PR or issue link (optional)
