### PR TITLE
fix(storage): avoid endless loop when flush share buffer

### DIFF
--- a/src/storage/src/hummock/local_version_manager.rs
+++ b/src/storage/src/hummock/local_version_manager.rs
@@ -232,7 +232,10 @@ impl LocalVersionManager {
         let batch_size = SharedBufferBatch::measure_batch_size(&sorted_items);
         while !self.buffer_tracker.can_write() {
             // TODO: may apply high-low memory threshold here to avoid always await here.
-            self.flush_shared_buffer().await?;
+            if !self.flush_shared_buffer().await? {
+                // The flush has no effect. yield to avoid occupying the execution endlessly.
+                tokio::task::yield_now().await;
+            }
         }
 
         let batch = SharedBufferBatch::new_with_size(
@@ -266,7 +269,7 @@ impl LocalVersionManager {
         Ok(batch_size)
     }
 
-    pub async fn flush_shared_buffer(&self) -> HummockResult<()> {
+    pub async fn flush_shared_buffer(&self) -> HummockResult<bool> {
         // The current implementation is a trivial one, which issue only one flush task and wait for
         // the task to finish.
         //
@@ -283,7 +286,7 @@ impl LocalVersionManager {
         }
         let task = match task {
             Some(task) => task,
-            None => return Ok(()),
+            None => return Ok(false),
         };
 
         let epoch = task.epoch;
@@ -308,7 +311,7 @@ impl LocalVersionManager {
         match task_result {
             Ok(ssts) => {
                 shared_buffer_guard.succeed_upload_task(order_index, ssts);
-                Ok(())
+                Ok(true)
             }
             Err(e) => {
                 shared_buffer_guard.fail_upload_task(order_index);


### PR DESCRIPTION
## What's changed and what's your intention?

Currently, in `write_shared_buffer`, we will wait in a while loop until the total memory usage of shared buffer batch reduce to below a threshold. However, while we wait in the while loop, there is no await point that takes effect and yields the execution to tokio runtime, and therefore the tokio worker thread will keep being occupied until the memory usage goes below the threshold.

With the behavior of shared buffer described above, the system might get dead locked under the following case. Assume our tokio runtime has only one worker thread and the current memory usage is beyond the threshold. Executor1 write shared buffer, and trigger a flush task. Executor2 write shared buffer, and there is no flush task to issue, and it keep waiting in a while loop and occupy the worker thread. Since the only worker thread is occupied by executor2, the flush task cannot make progress, and the memory usage cannot decrease, and executor2 cannot make progress because the memory usage is still beyond the threshold, and this is a deadlock.

The deadlock described above can be reproduced when we manually set the capacity of `BufferTracker` to a very small value (in my experiment, 200B) and run `./risedev test`.

In this PR, we fix this bug by adding a `yield_now` in the while loop when no task is issued in the `flush_shared_buffer` call.

## Checklist

- [x] I have written necessary docs and comments
- [x] I have added necessary unit tests and integration tests
- [x] All checks passed in `./risedev check` (or alias, `./risedev c`)

## Refer to a related PR or issue link (optional)
