### PR TITLE
fix: the agg value should be put behind pk

### DIFF
--- a/src/stream/src/executor/managed_state/aggregation/value.rs
+++ b/src/stream/src/executor/managed_state/aggregation/value.rs
@@ -114,8 +114,9 @@ impl ManagedValueState {
 
         // Persist value into relational table. The inserted row should concat with pk (pk is in
         // front of value). In this case, the pk is just group key.
-        let mut v = vec![self.state.get_output()?];
-        v.extend(self.pk.as_ref().unwrap_or(&Row(vec![])).0.iter().cloned());
+        let mut v = vec![];
+        v.extend_from_slice(&self.pk.as_ref().unwrap_or(&Row(vec![])).0);
+        v.push(self.state.get_output()?);
         state_table.insert(self.pk.as_ref().unwrap_or(&Row(vec![])), Row::new(v))?;
 
         self.is_dirty = false;


### PR DESCRIPTION
## What's changed and what's your intention?

value (agg call value) should always be the last part of a row. 

## Checklist

- [x] I have written necessary docs and comments
- [x] I have added necessary unit tests and integration tests
- [x] All checks passed in `./risedev check` (or alias, `./risedev c`)

## Refer to a related PR or issue link (optional)
