### PR TITLE
fix(connector): support deterministic datagen for random int/float

### DIFF
--- a/src/connector/src/datagen/source/field_generator/mod.rs
+++ b/src/connector/src/datagen/source/field_generator/mod.rs
@@ -42,7 +42,7 @@ pub trait NumericFieldRandomGenerator {
     where
         Self: Sized;
 
-    fn generate(&mut self) -> Value;
+    fn generate(&mut self, offset: u64) -> Value;
 }
 
 /// fields that can be continuously generated impl this trait
@@ -156,18 +156,18 @@ impl FieldGeneratorImpl {
         }
     }
 
-    pub fn generate(&mut self) -> Value {
+    pub fn generate(&mut self, offset: u64) -> Value {
         match self {
             FieldGeneratorImpl::I16Sequence(f) => f.generate(),
             FieldGeneratorImpl::I32Sequence(f) => f.generate(),
             FieldGeneratorImpl::I64Sequence(f) => f.generate(),
             FieldGeneratorImpl::F32Sequence(f) => f.generate(),
             FieldGeneratorImpl::F64Sequence(f) => f.generate(),
-            FieldGeneratorImpl::I16Random(f) => f.generate(),
-            FieldGeneratorImpl::I32Random(f) => f.generate(),
-            FieldGeneratorImpl::I64Random(f) => f.generate(),
-            FieldGeneratorImpl::F32Random(f) => f.generate(),
-            FieldGeneratorImpl::F64Random(f) => f.generate(),
+            FieldGeneratorImpl::I16Random(f) => f.generate(offset),
+            FieldGeneratorImpl::I32Random(f) => f.generate(offset),
+            FieldGeneratorImpl::I64Random(f) => f.generate(offset),
+            FieldGeneratorImpl::F32Random(f) => f.generate(offset),
+            FieldGeneratorImpl::F64Random(f) => f.generate(offset),
             FieldGeneratorImpl::Varchar(f) => f.generate(),
             FieldGeneratorImpl::Timestamp(f) => f.generate(),
         }
@@ -197,7 +197,7 @@ mod tests {
 
         for step in 0..5 {
             for (index, i32_field) in i32_fields.iter_mut().enumerate() {
-                let value = i32_field.generate();
+                let value = i32_field.generate(0);
                 assert!(value.is_number());
                 let num = value.as_u64();
                 let expected_num = split_num * step + 1 + index as u64;

--- a/src/connector/src/datagen/source/generator.rs
+++ b/src/connector/src/datagen/source/generator.rs
@@ -62,16 +62,17 @@ impl DatagenEventGenerator {
             if now.elapsed().as_millis() >= DEFUALT_DATAGEN_INTERVAL {
                 break;
             }
+            let offset = self.events_so_far + i;
             let map: Map<String, Value> = self
                 .fields_map
                 .iter_mut()
-                .map(|(name, field_generator)| (name.to_string(), field_generator.generate()))
+                .map(|(name, field_generator)| (name.to_string(), field_generator.generate(offset)))
                 .collect();
 
             let value = Value::Object(map);
             let msg = SourceMessage {
                 payload: Some(Bytes::from(value.to_string())),
-                offset: (self.events_so_far + i).to_string(),
+                offset: offset.to_string(),
                 split_id: self.split_id.clone(),
             };
             generated_count += 1;

--- a/src/connector/src/datagen/source/reader.rs
+++ b/src/connector/src/datagen/source/reader.rs
@@ -52,7 +52,9 @@ impl SplitReader for DatagenSplitReader {
                 split_id = split.id();
                 if let SplitImpl::Datagen(n) = split {
                     if let Some(s) = n.start_offset {
-                        events_so_far = s;
+                        // start_offset in `SplitImpl` indicates the latest successfully generated
+                        // index, so here we use start_offset+1
+                        events_so_far = s + 1;
                     };
                     assigned_split = n;
                     break;
@@ -253,6 +255,45 @@ mod tests {
                 .as_ref()
         );
 
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn test_random_deterministic() -> Result<()> {
+        let mock_datum = vec![
+            Column {
+                name: "_".to_string(),
+                data_type: DataType::Int64,
+            },
+            Column {
+                name: "random_int".to_string(),
+                data_type: DataType::Int32,
+            },
+        ];
+        let state = Some(vec![SplitImpl::Datagen(DatagenSplit {
+            split_index: 0,
+            split_num: 1,
+            start_offset: None,
+        })]);
+        let properties = DatagenProperties {
+            split_num: None,
+            rows_per_second: "10".to_string(),
+            fields: HashMap::new(),
+        };
+        let mut reader =
+            DatagenSplitReader::new(properties.clone(), state, Some(mock_datum.clone())).await?;
+        let _ = reader.next().await;
+        let v1 = reader.next().await?.unwrap();
+
+        let state = Some(vec![SplitImpl::Datagen(DatagenSplit {
+            split_index: 0,
+            split_num: 1,
+            start_offset: Some(9),
+        })]);
+        let mut reader = DatagenSplitReader::new(properties, state, Some(mock_datum)).await?;
+        let v2 = reader.next().await?.unwrap();
+
+        assert_eq!(v1, v2);
         Ok(())
     }
 }


### PR DESCRIPTION
Signed-off-by: tabVersion <tabvision@bupt.icu>

## What's changed and what's your intention?

***PLEASE DO NOT LEAVE THIS EMPTY !!!***

Please explain **IN DETAIL** what the changes are in this PR and why they are needed:

int and float generation supports deterministic results with given seed and offset (we xor seed and offset as new seed). 

the prev impl gen a certain sequence with the given seed, but if we rebuild the source, datagen will output the sequence from the beginning rather than at the specific offset. 

- Summarize your change (**mandatory**)
- How does this PR work? Need a brief introduction for the changed logic (optional)
- Describe clearly one logical change and avoid lazy messages (optional)
- Describe any limitations of the current code (optional)
  - varchar and timestamp datagen does not support deterministic gen
- Add the 'user-facing changes' label if your PR contains changes that are visible to users (optional)

## Checklist

- [x] I have written necessary docs and comments
- [x] I have added necessary unit tests and integration tests
- [x] All checks passed in `./risedev check` (or alias, `./risedev c`)

## Refer to a related PR or issue link (optional)

helps #3039 