### PR TITLE
refactor(cell_based_table): rename iter_with_pk to dedup_pk_iter

### DIFF
--- a/src/batch/src/executor/row_seq_scan.rs
+++ b/src/batch/src/executor/row_seq_scan.rs
@@ -168,7 +168,7 @@ impl BoxedExecutorBuilder for RowSeqScanExecutorBuilder {
             );
 
             let scan_type = if pk_prefix_value.size() == 0 && is_full_range(&next_col_bounds) {
-                let iter = table.iter_with_pk(source.epoch, &pk_descs).await?;
+                let iter = table.dedup_pk_iter(source.epoch, &pk_descs).await?;
                 ScanType::TableScan(iter)
             } else if pk_prefix_value.size() == pk_descs.len() {
                 keyspace.state_store().wait_epoch(source.epoch).await?;

--- a/src/compute/tests/integration_tests.rs
+++ b/src/compute/tests/integration_tests.rs
@@ -219,7 +219,7 @@ async fn test_table_v2_materialize() -> Result<()> {
 
     let scan = Box::new(RowSeqScanExecutor::new(
         table.schema().clone(),
-        ScanType::TableScan(table.iter_with_pk(u64::MAX, &ordered_column_descs).await?),
+        ScanType::TableScan(table.dedup_pk_iter(u64::MAX, &ordered_column_descs).await?),
         1024,
         true,
         "RowSeqExecutor2".to_string(),
@@ -278,7 +278,7 @@ async fn test_table_v2_materialize() -> Result<()> {
     // Scan the table again, we are able to get the data now!
     let scan = Box::new(RowSeqScanExecutor::new(
         table.schema().clone(),
-        ScanType::TableScan(table.iter_with_pk(u64::MAX, &ordered_column_descs).await?),
+        ScanType::TableScan(table.dedup_pk_iter(u64::MAX, &ordered_column_descs).await?),
         1024,
         true,
         "RowSeqScanExecutor2".to_string(),
@@ -346,7 +346,7 @@ async fn test_table_v2_materialize() -> Result<()> {
     // Scan the table again, we are able to see the deletion now!
     let scan = Box::new(RowSeqScanExecutor::new(
         table.schema().clone(),
-        ScanType::TableScan(table.iter_with_pk(u64::MAX, &ordered_column_descs).await?),
+        ScanType::TableScan(table.dedup_pk_iter(u64::MAX, &ordered_column_descs).await?),
         1024,
         true,
         "RowSeqScanExecutor2".to_string(),
@@ -429,7 +429,7 @@ async fn test_row_seq_scan() -> Result<()> {
 
     let executor = Box::new(RowSeqScanExecutor::new(
         table.schema().clone(),
-        ScanType::TableScan(table.iter_with_pk(u64::MAX, &pk_descs).await.unwrap()),
+        ScanType::TableScan(table.dedup_pk_iter(u64::MAX, &pk_descs).await.unwrap()),
         1,
         true,
         "RowSeqScanExecutor2".to_string(),

--- a/src/storage/src/table/cell_based_table.rs
+++ b/src/storage/src/table/cell_based_table.rs
@@ -334,7 +334,7 @@ impl<S: StateStore> CellBasedTable<S> {
 
     /// `dedup_pk_iter` should be used when pk is not persisted as value in storage.
     /// It will attempt to decode pk from key instead of cell value.
-    /// Tracking issue: https://github.com/singularity-data/risingwave/issues/588
+    /// Tracking issue: <https://github.com/singularity-data/risingwave/issues/588>
     pub async fn dedup_pk_iter(
         &self,
         epoch: u64,

--- a/src/storage/src/table/cell_based_table.rs
+++ b/src/storage/src/table/cell_based_table.rs
@@ -332,8 +332,7 @@ impl<S: StateStore> CellBasedTable<S> {
         CellBasedTableRowIter::new(&self.keyspace, self.mapping.clone(), epoch).await
     }
 
-    // TODO: give a more meaningful name to this function
-    pub async fn iter_with_pk(
+    pub async fn dedup_pk_iter(
         &self,
         epoch: u64,
         // TODO: remove this parameter: https://github.com/singularity-data/risingwave/issues/3203

--- a/src/storage/src/table/cell_based_table.rs
+++ b/src/storage/src/table/cell_based_table.rs
@@ -332,6 +332,9 @@ impl<S: StateStore> CellBasedTable<S> {
         CellBasedTableRowIter::new(&self.keyspace, self.mapping.clone(), epoch).await
     }
 
+    /// `dedup_pk_iter` should be used when pk is not persisted as value in storage.
+    /// It will attempt to decode pk from key instead of cell value.
+    /// Tracking issue: https://github.com/singularity-data/risingwave/issues/588
     pub async fn dedup_pk_iter(
         &self,
         epoch: u64,

--- a/src/storage/src/table/test_relational_table.rs
+++ b/src/storage/src/table/test_relational_table.rs
@@ -1491,7 +1491,7 @@ async fn test_dedup_cell_based_table_iter_with(
     let mut actual_rows = vec![];
 
     // ---------- Init reader
-    let mut iter = table.iter_with_pk(epoch, &pk_ordered_descs).await.unwrap();
+    let mut iter = table.dedup_pk_iter(epoch, &pk_ordered_descs).await.unwrap();
     for _ in 0..rows.len() {
         // ---------- Read + Deserialize from storage
         let actual = iter.next().await.unwrap();

--- a/src/stream/src/executor/batch_query.rs
+++ b/src/stream/src/executor/batch_query.rs
@@ -72,7 +72,7 @@ where
 
     #[try_stream(ok = Message, error = StreamExecutorError)]
     async fn execute_inner(self, epoch: u64) {
-        let mut iter = self.table.iter_with_pk(epoch, &self.pk_descs).await?;
+        let mut iter = self.table.dedup_pk_iter(epoch, &self.pk_descs).await?;
 
         while let Some(data_chunk) = iter
             .collect_data_chunk(self.schema(), Some(self.batch_size))


### PR DESCRIPTION
## What's changed and what's your intention?

See: https://github.com/singularity-data/risingwave/issues/3203#issuecomment-1154806210

Please explain **IN DETAIL** what the changes are in this PR and why they are needed:

- Summarize your change (**mandatory**)
- How does this PR work? Need a brief introduction for the changed logic (optional)
- Describe clearly one logical change and avoid lazy messages (optional)
- Describe any limitations of the current code (optional)
- Add the 'user-facing changes' label if your PR contains changes that are visible to users (optional)

## Checklist

- [x] I have written necessary docs and comments
- [x] I have added necessary unit tests and integration tests
- [x] All checks passed in `./risedev check` (or alias, `./risedev c`)

## Refer to a related PR or issue link (optional)

related #3203 