### PR TITLE
refactor: cleanup dead code that casts between same type

### DIFF
--- a/src/expr/src/expr/expr_unary.rs
+++ b/src/expr/src/expr/expr_unary.rs
@@ -73,20 +73,6 @@ macro_rules! gen_cast {
         gen_cast_impl! {
             [$($x),*],
 
-            // We do not always expect the frontend to do constant folding
-            // to eliminate the unnecessary cast.
-            { int16, int16, |x| Ok(x) },
-            { int32, int32, |x| Ok(x) },
-            { int64, int64, |x| Ok(x) },
-            { float64, float64, |x| Ok(x) },
-            { float32, float32, |x| Ok(x) },
-            { decimal, decimal, |x| Ok(x) },
-            { date, date, |x| Ok(x) },
-            { timestamp, timestamp, |x| Ok(x) },
-            { time, time, |x| Ok(x) },
-            { boolean, boolean, |x| Ok(x) },
-            { varchar, varchar, |x| Ok(x.into()) },
-
             { varchar, date, str_to_date },
             { varchar, time, str_to_time },
             { varchar, timestamp, str_to_timestamp },
@@ -366,19 +352,15 @@ pub fn new_rtrim_expr(expr_ia1: BoxedExpression, return_type: DataType) -> Boxed
 mod tests {
     use chrono::NaiveDate;
     use itertools::Itertools;
-    use num_traits::FromPrimitive;
     use risingwave_common::array::column::Column;
     use risingwave_common::array::*;
-    use risingwave_common::types::{
-        Decimal, NaiveDateTimeWrapper, NaiveDateWrapper, NaiveTimeWrapper, Scalar, ScalarImpl,
-    };
+    use risingwave_common::types::{NaiveDateWrapper, Scalar};
     use risingwave_pb::data::data_type::TypeName;
     use risingwave_pb::data::DataType;
     use risingwave_pb::expr::expr_node::{RexNode, Type};
     use risingwave_pb::expr::FunctionCall;
 
     use super::super::*;
-    use super::new_unary_expr;
     use crate::expr::test_utils::{make_expression, make_input_ref};
     use crate::vector_op::cast::{date_to_timestamp, str_parse};
 
@@ -625,38 +607,5 @@ mod tests {
             let expected = target[i].as_ref().cloned().map(|x| x.to_scalar_value());
             assert_eq!(result, expected);
         }
-    }
-
-    #[test]
-    fn test_same_type_cast() {
-        use risingwave_common::types::DataType;
-        use risingwave_pb::expr::expr_node::Type as ExprType;
-
-        fn assert_castible<T: Into<ScalarImpl>>(t: DataType, v: T) {
-            let expr = new_unary_expr(
-                ExprType::Cast,
-                t.clone(),
-                Box::new(LiteralExpression::new(t, Some(v.into()))) as BoxedExpression,
-            )
-            .unwrap();
-            expr.eval(&DataChunk::new_dummy(1)).unwrap();
-        }
-        assert_castible(DataType::Int16, 1_i16);
-        assert_castible(DataType::Int32, 1_i32);
-        assert_castible(DataType::Int64, 1_i64);
-        assert_castible(DataType::Boolean, true);
-        assert_castible(DataType::Float32, 3.0_f32);
-        assert_castible(DataType::Float64, 3.0_f64);
-        assert_castible(DataType::Decimal, Decimal::from_f32(3.15_f32).unwrap());
-        assert_castible(DataType::Varchar, "abc".to_string());
-        assert_castible(DataType::Date, NaiveDateWrapper::with_days(100).unwrap());
-        assert_castible(
-            DataType::Time,
-            NaiveTimeWrapper::with_secs_nano(1, 1).unwrap(),
-        );
-        assert_castible(
-            DataType::Timestamp,
-            NaiveDateTimeWrapper::with_secs_nsecs(1, 1).unwrap(),
-        );
     }
 }

--- a/src/expr/src/vector_op/cast.rs
+++ b/src/expr/src/vector_op/cast.rs
@@ -36,27 +36,6 @@ const PARSE_ERROR_STR_TO_TIME: &str =
 const PARSE_ERROR_STR_TO_DATE: &str = "Can't cast string to date (expected format is YYYY-MM-DD)";
 
 #[inline(always)]
-pub fn num_up<T, R>(n: T) -> Result<R>
-where
-    T: Into<R>,
-{
-    Ok(n.into())
-}
-
-#[inline(always)]
-pub fn float_up(n: OrderedF32) -> Result<OrderedF64> {
-    Ok((n.0 as f64).into())
-}
-
-/// Cast between different precision/length.
-/// Eg. Char(5) -> Char(10)
-/// Currently no-op. TODO: implement padding and overflow check (#2137)
-#[inline(always)]
-pub fn str_to_str(n: &str) -> Result<String> {
-    Ok(n.into())
-}
-
-#[inline(always)]
 pub fn str_to_date(elem: &str) -> Result<NaiveDateWrapper> {
     Ok(NaiveDateWrapper::new(
         NaiveDate::parse_from_str(elem, "%Y-%m-%d")

--- a/src/frontend/src/expr/type_inference.rs
+++ b/src/frontend/src/expr/type_inference.rs
@@ -449,18 +449,6 @@ fn build_cast_map() -> HashMap<(DataTypeName, DataTypeName), CastContext> {
     );
     insert_cast_seq(&mut m, &[T::Date, T::Timestamp, T::Timestampz]);
     insert_cast_seq(&mut m, &[T::Time, T::Interval]);
-    // Allow explicit cast operation between the same type, for types not included above.
-    // Ideally we should remove all such useless casts. But for now we just forbid them in contexts
-    // that only allow implicit or assign cast operations, and the user can still write them
-    // explicitly.
-    //
-    // Note this is different in PG, where same type cast is used for sizing (e.g. `NUMERIC(18,3)`
-    // to `NUMERIC(20,4)`). Sizing casts are only available for `numeric`, `timestamp`,
-    // `timestamptz`, `time`, `interval` and these are implicit. https://www.postgresql.org/docs/current/typeconv-query.html
-    //
-    // As we do not support size parameters in types, there are no sizing casts.
-    m.insert((T::Boolean, T::Boolean), CastContext::Explicit);
-    m.insert((T::Varchar, T::Varchar), CastContext::Explicit);
 
     // Casting to and from string type.
     for t in [
@@ -504,8 +492,11 @@ fn insert_cast_seq(
         for (target_index, target_type) in types.iter().enumerate() {
             let cast_context = match source_index.cmp(&target_index) {
                 std::cmp::Ordering::Less => CastContext::Implicit,
-                // See comments in `build_cast_map` for why same type cast is marked as explicit.
-                std::cmp::Ordering::Equal => CastContext::Explicit,
+                // Unnecessary cast between the same type should have been removed.
+                // Note that sizing cast between `NUMERIC(18, 3)` and `NUMERIC(20, 4)` or between
+                // `int` and `int not null` may still be necessary. But we do not have such types
+                // yet.
+                std::cmp::Ordering::Equal => continue,
                 std::cmp::Ordering::Greater => CastContext::Assign,
             };
             m.insert((*source_type, *target_type), cast_context);
@@ -737,19 +728,19 @@ mod tests {
         assert_eq!(
             actual,
             vec![
-                "T T    T     ", // bool
-                " TTTTTTT     ",
-                "TTTTTTTT     ",
-                " TTTTTTT     ",
-                " TTTTTTT     ",
-                " TTTTTTT     ",
-                " TTTTTTT     ",
-                "TTTTTTTTTTTTT", // varchar
-                "       TTTT  ",
-                "       TTTTT ",
-                "       TTTTT ",
-                "       T   TT",
-                "       T   TT",
+                "  T    T     ", // bool
+                "  TTTTTT     ",
+                "TT TTTTT     ",
+                " TT TTTT     ",
+                " TTT TTT     ",
+                " TTTT TT     ",
+                " TTTTT T     ",
+                "TTTTTTT TTTTT", // varchar
+                "       T TT  ",
+                "       TT TT ",
+                "       TTT T ",
+                "       T    T",
+                "       T   T ",
             ]
         );
     }


### PR DESCRIPTION
## What's changed and what's your intention?

The frontend binder is already removing unnecessary cast between same type.

## Checklist

- [x] I have written necessary docs and comments
- [x] I have added necessary unit tests and integration tests
- [x] All checks passed in `./risedev check` (or alias, `./risedev c`)

## Refer to a related PR or issue link (optional)
