### PR TITLE
chore: introduce rpc error

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4385,6 +4385,7 @@ dependencies = [
 name = "risingwave_rpc_client"
 version = "0.1.9"
 dependencies = [
+ "anyhow",
  "async-trait",
  "futures",
  "log",
@@ -4396,6 +4397,7 @@ dependencies = [
  "risingwave_common",
  "risingwave_hummock_sdk",
  "risingwave_pb",
+ "thiserror",
  "tokio-retry",
  "tracing",
  "workspace-hack",

--- a/src/batch/src/execution/grpc_exchange.rs
+++ b/src/batch/src/execution/grpc_exchange.rs
@@ -74,7 +74,7 @@ impl ExchangeSource for GrpcExchangeSource {
             None => return Ok(None),
             Some(r) => r,
         };
-        let task_data = res.to_rw_result()?;
+        let task_data = res?;
         let data = DataChunk::from_protobuf(task_data.get_record_batch()?)?.compact()?;
         trace!(
             "Receiver taskOutput = {:?}, data = {:?}",

--- a/src/batch/src/execution/grpc_exchange.rs
+++ b/src/batch/src/execution/grpc_exchange.rs
@@ -16,7 +16,7 @@ use std::fmt::{Debug, Formatter};
 
 use futures::StreamExt;
 use risingwave_common::array::DataChunk;
-use risingwave_common::error::{Result, ToRwResult};
+use risingwave_common::error::Result;
 use risingwave_pb::batch_plan::exchange_source::LocalExecutePlan::Plan;
 use risingwave_pb::batch_plan::{ExchangeSource as ProstExchangeSource, TaskOutputId};
 use risingwave_pb::task_service::{ExecuteRequest, GetDataResponse};

--- a/src/frontend/src/handler/dml.rs
+++ b/src/frontend/src/handler/dml.rs
@@ -84,10 +84,11 @@ async fn flush_for_write(session: &SessionImpl, stmt_type: StatementType) -> Res
     match stmt_type {
         StatementType::INSERT | StatementType::DELETE | StatementType::UPDATE => {
             let client = session.env().meta_client();
-            client.flush().await
+            client.flush().await?;
         }
-        _ => Ok(()),
+        _ => {}
     }
+    Ok(())
 }
 
 fn to_statement_type(stmt: &Statement) -> StatementType {

--- a/src/frontend/src/meta_client.rs
+++ b/src/frontend/src/meta_client.rs
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use risingwave_common::error::Result;
+use risingwave_rpc_client::error::Result;
 use risingwave_rpc_client::{HummockMetaClient, MetaClient};
 
 /// A wrapper around the `MetaClient` that only provides a minor set of meta rpc.

--- a/src/frontend/src/scheduler/distributed/query_manager.rs
+++ b/src/frontend/src/scheduler/distributed/query_manager.rs
@@ -14,12 +14,11 @@
 
 use std::fmt::{Debug, Formatter};
 
-use anyhow::anyhow;
 use futures::StreamExt;
 use futures_async_stream::try_stream;
 use log::debug;
 use risingwave_common::array::DataChunk;
-use risingwave_common::error::{RwError, ToErrorStr};
+use risingwave_common::error::{RwError, ToRwResult};
 use risingwave_pb::batch_plan::{PlanNode as BatchPlanProst, TaskId, TaskOutputId};
 use risingwave_pb::common::HostAddress;
 use risingwave_rpc_client::ComputeClientPoolRef;
@@ -28,7 +27,6 @@ use uuid::Uuid;
 use super::QueryExecution;
 use crate::scheduler::plan_fragmenter::{Query, QueryId};
 use crate::scheduler::worker_node_manager::WorkerNodeManagerRef;
-use crate::scheduler::SchedulerError::RpcError;
 use crate::scheduler::{
     DataChunkStream, ExecutionContextRef, HummockSnapshotManagerRef, SchedulerResult,
 };
@@ -76,8 +74,7 @@ impl QueryManager {
         let compute_client = self
             .compute_client_pool
             .get_client_for_addr((&worker_node_addr).into())
-            .await
-            .map_err(|e| anyhow!(e.to_string()))?;
+            .await?;
 
         let query_id = QueryId {
             id: Uuid::new_v4().to_string(),
@@ -105,7 +102,7 @@ impl QueryManager {
         self.hummock_snapshot_manager
             .unpin_snapshot(epoch, &query_id)
             .await?;
-        creat_task_resp.map_err(|e| RpcError(e.to_string()))?;
+        creat_task_resp?;
 
         let query_result_fetcher = QueryResultFetcher::new(
             epoch,
@@ -181,11 +178,7 @@ impl QueryResultFetcher {
             .await?;
         let mut stream = compute_client.get_data(self.task_output_id.clone()).await?;
         while let Some(response) = stream.next().await {
-            yield DataChunk::from_protobuf(
-                response
-                    .map_err(|e| RpcError(e.to_error_str()))?
-                    .get_record_batch()?,
-            )?;
+            yield DataChunk::from_protobuf(response?.get_record_batch()?)?;
         }
     }
 }

--- a/src/frontend/src/scheduler/distributed/query_manager.rs
+++ b/src/frontend/src/scheduler/distributed/query_manager.rs
@@ -18,7 +18,7 @@ use futures::StreamExt;
 use futures_async_stream::try_stream;
 use log::debug;
 use risingwave_common::array::DataChunk;
-use risingwave_common::error::{RwError, ToRwResult};
+use risingwave_common::error::RwError;
 use risingwave_pb::batch_plan::{PlanNode as BatchPlanProst, TaskId, TaskOutputId};
 use risingwave_pb::common::HostAddress;
 use risingwave_rpc_client::ComputeClientPoolRef;

--- a/src/frontend/src/test_utils.rs
+++ b/src/frontend/src/test_utils.rs
@@ -30,6 +30,7 @@ use risingwave_pb::catalog::{
 };
 use risingwave_pb::stream_plan::StreamFragmentGraph;
 use risingwave_pb::user::{GrantPrivilege, UserInfo};
+use risingwave_rpc_client::error::Result as RpcResult;
 use risingwave_sqlparser::ast::Statement;
 use risingwave_sqlparser::parser::Parser;
 use tempfile::{Builder, NamedTempFile};
@@ -387,19 +388,19 @@ pub struct MockFrontendMetaClient {}
 
 #[async_trait::async_trait]
 impl FrontendMetaClient for MockFrontendMetaClient {
-    async fn pin_snapshot(&self, _epoch: u64) -> Result<u64> {
+    async fn pin_snapshot(&self, _epoch: u64) -> RpcResult<u64> {
         Ok(0)
     }
 
-    async fn flush(&self) -> Result<()> {
+    async fn flush(&self) -> RpcResult<()> {
         Ok(())
     }
 
-    async fn unpin_snapshot(&self, _epoch: u64) -> Result<()> {
+    async fn unpin_snapshot(&self, _epoch: u64) -> RpcResult<()> {
         Ok(())
     }
 
-    async fn unpin_snapshot_before(&self, _epoch: u64) -> Result<()> {
+    async fn unpin_snapshot_before(&self, _epoch: u64) -> RpcResult<()> {
         Ok(())
     }
 }

--- a/src/meta/src/barrier/command.rs
+++ b/src/meta/src/barrier/command.rs
@@ -16,7 +16,7 @@ use std::collections::{HashMap, HashSet};
 
 use futures::future::try_join_all;
 use risingwave_common::catalog::TableId;
-use risingwave_common::error::{Result, RwError, ToRwResult};
+use risingwave_common::error::{Result, RwError};
 use risingwave_common::util::epoch::Epoch;
 use risingwave_connector::SplitImpl;
 use risingwave_pb::common::ActorInfo;

--- a/src/meta/src/barrier/command.rs
+++ b/src/meta/src/barrier/command.rs
@@ -203,7 +203,7 @@ where
                             request_id,
                             actor_ids: actors.to_owned(),
                         };
-                        client.drop_actors(request).await.to_rw_result()?;
+                        client.drop_actors(request).await?;
 
                         Ok::<_, RwError>(())
                     }

--- a/src/meta/src/barrier/mod.rs
+++ b/src/meta/src/barrier/mod.rs
@@ -395,7 +395,7 @@ where
                         .inject_barrier(request)
                         .await
                         .map(tonic::Response::<_>::into_inner)
-                        .to_rw_result()
+                        .map_err(Into::into)
                 }
                 .into()
             }

--- a/src/meta/src/barrier/mod.rs
+++ b/src/meta/src/barrier/mod.rs
@@ -20,7 +20,7 @@ use std::time::Duration;
 use futures::future::try_join_all;
 use itertools::Itertools;
 use risingwave_common::catalog::TableId;
-use risingwave_common::error::{ErrorCode, Result, RwError, ToRwResult};
+use risingwave_common::error::{ErrorCode, Result, RwError};
 use risingwave_common::util::epoch::INVALID_EPOCH;
 use risingwave_hummock_sdk::HummockEpoch;
 use risingwave_pb::common::worker_node::State::Running;

--- a/src/meta/src/barrier/recovery.rs
+++ b/src/meta/src/barrier/recovery.rs
@@ -18,7 +18,7 @@ use std::time::Duration;
 
 use futures::future::try_join_all;
 use log::{debug, error};
-use risingwave_common::error::{ErrorCode, Result, RwError, ToRwResult};
+use risingwave_common::error::{ErrorCode, Result, RwError};
 use risingwave_common::util::epoch::Epoch;
 use risingwave_pb::common::ActorInfo;
 use risingwave_pb::data::Epoch as ProstEpoch;

--- a/src/meta/src/barrier/recovery.rs
+++ b/src/meta/src/barrier/recovery.rs
@@ -138,11 +138,7 @@ where
             };
             async move {
                 let client = &self.env.stream_client_pool().get(node).await?;
-                client
-                    .to_owned()
-                    .sync_sources(request)
-                    .await
-                    .to_rw_result()?;
+                client.to_owned().sync_sources(request).await?;
 
                 Ok::<_, RwError>(())
             }
@@ -183,8 +179,7 @@ where
                 .broadcast_actor_info_table(BroadcastActorInfoTableRequest {
                     info: actor_infos.clone(),
                 })
-                .await
-                .to_rw_result_with(|| format!("failed to connect to {}", node_id))?;
+                .await?;
 
             let request_id = Uuid::new_v4().to_string();
             tracing::debug!(request_id = request_id.as_str(), actors = ?actors, "update actors");
@@ -195,8 +190,7 @@ where
                     actors: node_actors.get(node_id).cloned().unwrap_or_default(),
                     ..Default::default()
                 })
-                .await
-                .to_rw_result_with(|| format!("failed to connect to {}", node_id))?;
+                .await?;
         }
 
         Ok(())
@@ -216,8 +210,7 @@ where
                     request_id,
                     actor_id: actors.to_owned(),
                 })
-                .await
-                .to_rw_result_with(|| format!("failed to connect to {}", node_id))?;
+                .await?;
         }
 
         Ok(())
@@ -247,7 +240,7 @@ where
                             }),
                         })
                         .await
-                        .to_rw_result()
+                        .map_err(RwError::from)
                 })
                 .await
                 .expect("Force stop actors until success");

--- a/src/meta/src/hummock/mock_hummock_meta_client.rs
+++ b/src/meta/src/hummock/mock_hummock_meta_client.rs
@@ -14,14 +14,15 @@
 
 use std::sync::Arc;
 
+use anyhow::anyhow;
 use async_trait::async_trait;
-use risingwave_common::error::{ErrorCode, Result};
 use risingwave_hummock_sdk::compaction_group::StaticCompactionGroupId;
 use risingwave_hummock_sdk::{HummockContextId, HummockEpoch, HummockSSTableId, HummockVersionId};
 use risingwave_pb::hummock::{
     CompactTask, CompactionGroup, HummockSnapshot, HummockVersion, SstableInfo,
     SubscribeCompactTasksResponse, VacuumTask,
 };
+use risingwave_rpc_client::error::{Result, RpcError};
 use risingwave_rpc_client::HummockMetaClient;
 use tonic::Streaming;
 
@@ -52,20 +53,24 @@ impl MockHummockMetaClient {
     }
 }
 
+fn mock_err(error: super::error::Error) -> RpcError {
+    anyhow!("mock error: {}", error).into()
+}
+
 #[async_trait]
 impl HummockMetaClient for MockHummockMetaClient {
     async fn pin_version(&self, last_pinned: HummockVersionId) -> Result<HummockVersion> {
         self.hummock_manager
             .pin_version(self.context_id, last_pinned)
             .await
-            .map_err(|e| e.into())
+            .map_err(mock_err)
     }
 
     async fn unpin_version(&self, pinned_version_id: &[HummockVersionId]) -> Result<()> {
         self.hummock_manager
             .unpin_version(self.context_id, pinned_version_id)
             .await
-            .map_err(|e| e.into())
+            .map_err(mock_err)
     }
 
     async fn pin_snapshot(&self, last_pinned: HummockEpoch) -> Result<HummockEpoch> {
@@ -73,7 +78,7 @@ impl HummockMetaClient for MockHummockMetaClient {
             .pin_snapshot(self.context_id, last_pinned)
             .await
             .map(|e| e.epoch)
-            .map_err(|e| e.into())
+            .map_err(mock_err)
     }
 
     async fn unpin_snapshot(&self, pinned_epochs: &[HummockEpoch]) -> Result<()> {
@@ -86,7 +91,7 @@ impl HummockMetaClient for MockHummockMetaClient {
         self.hummock_manager
             .unpin_snapshot(self.context_id, snapshots)
             .await
-            .map_err(|e| e.into())
+            .map_err(mock_err)
     }
 
     async fn unpin_snapshot_before(&self, pinned_epochs: HummockEpoch) -> Result<()> {
@@ -98,14 +103,14 @@ impl HummockMetaClient for MockHummockMetaClient {
                 },
             )
             .await
-            .map_err(|e| e.into())
+            .map_err(mock_err)
     }
 
     async fn get_new_table_id(&self) -> Result<HummockSSTableId> {
         self.hummock_manager
             .get_new_table_id()
             .await
-            .map_err(|e| e.into())
+            .map_err(mock_err)
     }
 
     async fn report_compaction_task(&self, compact_task: CompactTask) -> Result<()> {
@@ -113,22 +118,18 @@ impl HummockMetaClient for MockHummockMetaClient {
             .report_compact_task(&compact_task)
             .await
             .map(|_| ())
-            .map_err(|e| e.into())
+            .map_err(mock_err)
     }
 
     async fn commit_epoch(&self, epoch: HummockEpoch, sstables: Vec<SstableInfo>) -> Result<()> {
         self.hummock_manager
             .commit_epoch(epoch, sstables)
             .await
-            .map_err(|e| e.into())
+            .map_err(mock_err)
     }
 
     async fn subscribe_compact_tasks(&self) -> Result<Streaming<SubscribeCompactTasksResponse>> {
-        Err(ErrorCode::NotImplemented(
-            "MockHummockMetaClient::subscribe_compact_tasks".to_owned(),
-            None.into(),
-        )
-        .into())
+        unimplemented!()
     }
 
     async fn report_vacuum_task(&self, _vacuum_task: VacuumTask) -> Result<()> {

--- a/src/meta/src/stream/source_manager.rs
+++ b/src/meta/src/stream/source_manager.rs
@@ -21,7 +21,7 @@ use std::time::Duration;
 use futures::future::try_join_all;
 use itertools::Itertools;
 use risingwave_common::catalog::TableId;
-use risingwave_common::error::{internal_error, Result, ToRwResult};
+use risingwave_common::error::{internal_error, Result, RwError, ToRwResult};
 use risingwave_common::try_match_expand;
 use risingwave_connector::{ConnectorProperties, SplitEnumeratorImpl, SplitImpl};
 use risingwave_pb::catalog::source::Info;
@@ -580,7 +580,7 @@ where
                 let request = ComputeNodeCreateSourceRequest {
                     source: Some(source.clone()),
                 };
-                async move { client.create_source(request).await.to_rw_result() }
+                async move { client.create_source(request).await.map_err(RwError::from) }
             });
 
         // ignore response body, always none
@@ -629,7 +629,7 @@ where
             .into_iter()
             .map(|mut client| {
                 let request = ComputeNodeDropSourceRequest { source_id };
-                async move { client.drop_source(request).await.to_rw_result() }
+                async move { client.drop_source(request).await.map_err(RwError::from) }
             });
         let _responses: Vec<_> = try_join_all(futures).await?;
 

--- a/src/meta/src/stream/stream_manager.rs
+++ b/src/meta/src/stream/stream_manager.rs
@@ -492,8 +492,7 @@ where
                 .broadcast_actor_info_table(BroadcastActorInfoTableRequest {
                     info: actor_infos_to_broadcast.clone(),
                 })
-                .await
-                .to_rw_result_with(|| format!("failed to connect to {}", node_id))?;
+                .await?;
 
             let stream_actors = actors
                 .iter()
@@ -509,8 +508,7 @@ where
                     actors: stream_actors.clone(),
                     hanging_channels: node_hanging_channels.remove(node_id).unwrap_or_default(),
                 })
-                .await
-                .to_rw_result_with(|| format!("failed to connect to {}", node_id))?;
+                .await?;
         }
 
         for (node_id, hanging_channels) in node_hanging_channels {
@@ -526,8 +524,7 @@ where
                     actors: vec![],
                     hanging_channels,
                 })
-                .await
-                .to_rw_result_with(|| format!("failed to connect to {}", node_id))?;
+                .await?;
         }
 
         // In the second stage, each [`WorkerNode`] builds local actors and connect them with
@@ -545,8 +542,7 @@ where
                     request_id,
                     actor_id: actors,
                 })
-                .await
-                .to_rw_result_with(|| format!("failed to connect to {}", node_id))?;
+                .await?;
         }
 
         let mut source_fragments = HashMap::new();

--- a/src/meta/src/stream/stream_manager.rs
+++ b/src/meta/src/stream/stream_manager.rs
@@ -20,7 +20,7 @@ use itertools::Itertools;
 use log::{debug, info};
 use risingwave_common::catalog::TableId;
 use risingwave_common::consistent_hash::VIRTUAL_NODE_COUNT;
-use risingwave_common::error::{internal_error, Result, ToRwResult};
+use risingwave_common::error::{internal_error, Result};
 use risingwave_pb::catalog::Source;
 use risingwave_pb::common::{ActorInfo, ParallelUnitMapping, WorkerType};
 use risingwave_pb::meta::table_fragments::{ActorState, ActorStatus};

--- a/src/rpc_client/Cargo.toml
+++ b/src/rpc_client/Cargo.toml
@@ -4,6 +4,7 @@ version = "0.1.9"
 edition = "2021"
 
 [dependencies]
+anyhow = "1"
 async-trait = "0.1"
 futures = { version = "0.3", default-features = false, features = ["alloc"] }
 log = "0.4"
@@ -13,6 +14,7 @@ paste = "1"
 risingwave_common = { path = "../common" }
 risingwave_hummock_sdk = { path = "../storage/hummock_sdk" }
 risingwave_pb = { path = "../prost" }
+thiserror = "1"
 tokio = { version = "=0.2.0-alpha.3", package = "madsim-tokio", features = [
     "rt",
     "rt-multi-thread",

--- a/src/rpc_client/src/compute_client.rs
+++ b/src/rpc_client/src/compute_client.rs
@@ -16,7 +16,6 @@ use std::fmt::Debug;
 use std::time::Duration;
 
 use risingwave_common::array::DataChunk;
-use risingwave_common::error::ErrorCode::InternalError;
 use risingwave_common::util::addr::HostAddr;
 use risingwave_pb::batch_plan::exchange_info::DistributionMode;
 use risingwave_pb::batch_plan::{ExchangeInfo, PlanFragment, PlanNode, TaskId, TaskOutputId};
@@ -29,7 +28,7 @@ use risingwave_pb::task_service::{
 use tonic::transport::{Channel, Endpoint};
 use tonic::Streaming;
 
-use crate::error::{Result, RpcError};
+use crate::error::Result;
 
 #[derive(Clone)]
 pub struct ComputeClient {

--- a/src/rpc_client/src/compute_client_pool.rs
+++ b/src/rpc_client/src/compute_client_pool.rs
@@ -14,10 +14,11 @@
 
 use std::sync::Arc;
 
+use anyhow::anyhow;
 use moka::future::Cache;
-use risingwave_common::error::Result;
 use risingwave_common::util::addr::HostAddr;
 
+use crate::error::Result;
 use crate::ComputeClient;
 
 #[derive(Clone)]
@@ -37,10 +38,7 @@ impl ComputeClientPool {
         self.cache
             .try_get_with(addr.clone(), async { ComputeClient::new(addr).await })
             .await
-            .map_err(|e| {
-                // TODO: change this to error when we completed failover and error handling
-                panic!("failed to create compute client: {:?}", e)
-            })
+            .map_err(|e| anyhow!("failed to create compute client: {:?}", e).into())
     }
 }
 

--- a/src/rpc_client/src/hummock_meta_client.rs
+++ b/src/rpc_client/src/hummock_meta_client.rs
@@ -13,13 +13,14 @@
 // limitations under the License.
 
 use async_trait::async_trait;
-use risingwave_common::error::Result;
 use risingwave_hummock_sdk::{HummockEpoch, HummockSSTableId, HummockVersionId};
 use risingwave_pb::hummock::{
     CompactTask, CompactionGroup, HummockVersion, SstableInfo, SubscribeCompactTasksResponse,
     VacuumTask,
 };
 use tonic::Streaming;
+
+use crate::error::Result;
 
 #[async_trait]
 pub trait HummockMetaClient: Send + Sync + 'static {

--- a/src/rpc_client/src/lib.rs
+++ b/src/rpc_client/src/lib.rs
@@ -26,6 +26,7 @@
 #![feature(trait_alias)]
 #![feature(generic_associated_types)]
 #![feature(binary_heap_drain_sorted)]
+#![feature(result_option_inspect)]
 
 mod meta_client;
 pub use meta_client::{GrpcMetaClient, MetaClient, NotificationStream};
@@ -37,3 +38,5 @@ mod hummock_meta_client;
 pub use hummock_meta_client::HummockMetaClient;
 mod stream_client_pool;
 pub use stream_client_pool::{StreamClient, StreamClientPool, StreamClientPoolRef};
+
+pub mod error;

--- a/src/rpc_client/src/meta_client.rs
+++ b/src/rpc_client/src/meta_client.rs
@@ -519,8 +519,7 @@ macro_rules! grpc_meta_client_impl {
                         .to_owned()
                         .$fn_name(request)
                         .await?
-                        .into_inner()
-                        .into())
+                        .into_inner())
                 }
             }
         })*

--- a/src/rpc_client/src/meta_client.rs
+++ b/src/rpc_client/src/meta_client.rs
@@ -17,9 +17,6 @@ use std::time::Duration;
 use async_trait::async_trait;
 use paste::paste;
 use risingwave_common::catalog::{CatalogVersion, TableId};
-use risingwave_common::error::ErrorCode::{self, InternalError};
-use risingwave_common::error::{Result, ToRwResult};
-use risingwave_common::try_match_expand;
 use risingwave_common::util::addr::HostAddr;
 use risingwave_hummock_sdk::{HummockEpoch, HummockSSTableId, HummockVersionId};
 use risingwave_pb::catalog::{
@@ -70,6 +67,7 @@ use tokio_retry::strategy::{jitter, ExponentialBackoff};
 use tonic::transport::{Channel, Endpoint};
 use tonic::{Status, Streaming};
 
+use crate::error::Result;
 use crate::hummock_meta_client::HummockMetaClient;
 
 type DatabaseId = u32;
@@ -119,8 +117,7 @@ impl MetaClient {
             host: Some(addr.to_protobuf()),
         };
         let resp = self.inner.add_worker_node(request).await?;
-        let worker_node =
-            try_match_expand!(resp.node, Some, "AddWorkerNodeResponse::node is empty")?;
+        let worker_node = resp.node.expect("AddWorkerNodeResponse::node is empty");
         self.set_worker_id(worker_node.id);
         Ok(worker_node.id)
     }
@@ -339,10 +336,7 @@ impl MetaClient {
                     Ok(Ok(_)) => {}
                     Ok(Err(err)) => {
                         tracing::warn!("Failed to send_heartbeat: error {}", err);
-                        if err
-                            .to_string()
-                            .contains(&ErrorCode::UnknownWorker.to_string())
-                        {
+                        if err.to_string().contains("unknown worker") {
                             panic!("Already removed by the meta node. Need to restart the worker");
                         }
                     }
@@ -431,7 +425,7 @@ impl HummockMetaClient for MetaClient {
     }
 
     async fn commit_epoch(&self, _epoch: HummockEpoch, _sstables: Vec<SstableInfo>) -> Result<()> {
-        unimplemented!("Only meta service can commit_epoch in production.")
+        panic!("Only meta service can commit_epoch in production.")
     }
 
     async fn subscribe_compact_tasks(&self) -> Result<Streaming<SubscribeCompactTasksResponse>> {
@@ -476,8 +470,7 @@ impl GrpcMetaClient {
 
     /// Connect to the meta server `addr`.
     pub async fn new(addr: &str) -> Result<Self> {
-        let endpoint =
-            Endpoint::from_shared(addr.to_string()).map_err(|e| InternalError(format!("{}", e)))?;
+        let endpoint = Endpoint::from_shared(addr.to_string())?;
         let retry_strategy = ExponentialBackoff::from_millis(Self::CONN_RETRY_BASE_INTERVAL_MS)
             .max_delay(Duration::from_millis(Self::CONN_RETRY_MAX_INTERVAL_MS))
             .map(jitter);
@@ -487,15 +480,15 @@ impl GrpcMetaClient {
                 .connect_timeout(Duration::from_secs(5))
                 .connect()
                 .await
-                .map_err(|_e| {
+                .inspect_err(|e| {
                     tracing::warn!(
-                        "Failed to connect to meta server: {}, wait for online.",
-                        addr
+                        "Failed to connect to meta server {}, wait for online: {}",
+                        addr,
+                        e
                     );
                 })
         })
-        .await
-        .expect("Retry connecting to meta server");
+        .await?;
 
         let cluster_client = ClusterServiceClient::new(channel.clone());
         let heartbeat_client = HeartbeatServiceClient::new(channel.clone());
@@ -525,9 +518,9 @@ macro_rules! grpc_meta_client_impl {
                         .$client
                         .to_owned()
                         .$fn_name(request)
-                        .await
-                        .to_rw_result()?
-                        .into_inner())
+                        .await?
+                        .into_inner()
+                        .into())
                 }
             }
         })*
@@ -575,8 +568,6 @@ macro_rules! for_all_meta_rpc {
 for_all_meta_rpc! { grpc_meta_client_impl }
 
 impl GrpcMetaClient {
-    // TODO(TaoWu): Use macro to refactor the following methods.
-
     pub async fn subscribe(
         &self,
         request: SubscribeRequest,
@@ -585,8 +576,7 @@ impl GrpcMetaClient {
             self.notification_client
                 .to_owned()
                 .subscribe(request)
-                .await
-                .to_rw_result()?
+                .await?
                 .into_inner(),
         ))
     }
@@ -603,17 +593,13 @@ pub trait NotificationStream: Send {
 #[async_trait::async_trait]
 impl NotificationStream for Streaming<SubscribeResponse> {
     async fn next(&mut self) -> Result<Option<SubscribeResponse>> {
-        self.message().await.to_rw_result()
+        self.message().await.map_err(Into::into)
     }
 }
 
 #[async_trait::async_trait]
 impl NotificationStream for Receiver<std::result::Result<SubscribeResponse, Status>> {
     async fn next(&mut self) -> Result<Option<SubscribeResponse>> {
-        match self.recv().await {
-            Some(Ok(x)) => Ok(Some(x)),
-            Some(Err(e)) => Err(e).to_rw_result(),
-            None => Ok(None),
-        }
+        self.recv().await.transpose().map_err(Into::into)
     }
 }

--- a/src/rpc_client/src/stream_client_pool.rs
+++ b/src/rpc_client/src/stream_client_pool.rs
@@ -15,13 +15,15 @@
 use std::sync::Arc;
 use std::time::Duration;
 
+use anyhow::anyhow;
 use moka::future::Cache;
 use risingwave_common::error::ErrorCode::{self, InternalError};
-use risingwave_common::error::{Result, RwError, ToRwResult};
 use risingwave_common::util::addr::HostAddr;
 use risingwave_pb::common::WorkerNode;
 use risingwave_pb::stream_service::stream_service_client::StreamServiceClient;
 use tonic::transport::{Channel, Endpoint};
+
+use crate::error::{Result, RpcError};
 
 pub type StreamClient = StreamServiceClient<Channel>;
 
@@ -51,22 +53,18 @@ impl StreamClientPool {
     pub async fn get(&self, node: &WorkerNode) -> Result<StreamServiceClient<Channel>> {
         self.clients
             .try_get_with(node.id, async {
-                let addr: HostAddr = node.get_host()?.into();
-                let endpoint = Endpoint::from_shared(format!("http://{}", addr));
+                let addr: HostAddr = node.get_host().unwrap().into();
+                let endpoint = Endpoint::from_shared(format!("http://{}", addr))?;
                 let client = StreamServiceClient::new(
                     endpoint
-                        .map_err(|e| InternalError(e.to_string()))?
                         .connect_timeout(Duration::from_secs(5))
                         .connect()
-                        .await
-                        .to_rw_result_with(|| format!("failed to connect to {}", node.get_id()))?,
+                        .await?,
                 );
-                Ok::<_, RwError>(client)
+                Ok::<_, RpcError>(client)
             })
             .await
-            .map_err(|e| {
-                ErrorCode::InternalError(format!("failed to create compute client: {:?}", e)).into()
-            })
+            .map_err(|e| anyhow!("failed to create compute client: {:?}", e).into())
     }
 }
 

--- a/src/rpc_client/src/stream_client_pool.rs
+++ b/src/rpc_client/src/stream_client_pool.rs
@@ -17,7 +17,6 @@ use std::time::Duration;
 
 use anyhow::anyhow;
 use moka::future::Cache;
-use risingwave_common::error::ErrorCode::{self, InternalError};
 use risingwave_common::util::addr::HostAddr;
 use risingwave_pb::common::WorkerNode;
 use risingwave_pb::stream_service::stream_service_client::StreamServiceClient;

--- a/src/storage/src/hummock/hummock_meta_client.rs
+++ b/src/storage/src/hummock/hummock_meta_client.rs
@@ -15,11 +15,11 @@
 use std::sync::Arc;
 
 use async_trait::async_trait;
-use risingwave_common::error::{ErrorCode, Result};
 use risingwave_pb::hummock::{
     CompactTask, CompactionGroup, HummockVersion, SstableInfo, SubscribeCompactTasksResponse,
     VacuumTask,
 };
+use risingwave_rpc_client::error::Result;
 use risingwave_rpc_client::{HummockMetaClient, MetaClient};
 use tonic::Streaming;
 
@@ -93,7 +93,7 @@ impl HummockMetaClient for MonitoredHummockMetaClient {
     }
 
     async fn commit_epoch(&self, _epoch: HummockEpoch, _sstables: Vec<SstableInfo>) -> Result<()> {
-        Err(ErrorCode::NotImplemented("commit_epoch unsupported".to_string(), None.into()).into())
+        panic!("Only meta service can commit_epoch in production.")
     }
 
     async fn subscribe_compact_tasks(&self) -> Result<Streaming<SubscribeCompactTasksResponse>> {


### PR DESCRIPTION
## What's changed and what's your intention?

As title.

We should always use the wrapper functions in `rpc_client` crate in the future. We may store some info about the worker nodes there and refine the error messages.

## Checklist

- [x] I have written necessary docs and comments
- [x] I have added necessary unit tests and integration tests
- [x] All checks passed in `./risedev check` (or alias, `./risedev c`)

## Refer to a related PR or issue link (optional)
- #3156 