### PR TITLE
feat(storage): simply support trigger manual compaction and risectl

### DIFF
--- a/proto/hummock.proto
+++ b/proto/hummock.proto
@@ -225,6 +225,14 @@ message GetCompactionGroupsResponse {
   repeated CompactionGroup compaction_groups = 2;
 }
 
+message TriggerManualCompactionRequest {
+  uint64 compaction_group_id = 1;
+}
+
+message TriggerManualCompactionResponse {
+  common.Status status = 1;
+}
+
 service HummockManagerService {
   rpc PinVersion(PinVersionRequest) returns (PinVersionResponse);
   rpc UnpinVersion(UnpinVersionRequest) returns (UnpinVersionResponse);
@@ -236,6 +244,7 @@ service HummockManagerService {
   rpc SubscribeCompactTasks(SubscribeCompactTasksRequest) returns (stream SubscribeCompactTasksResponse);
   rpc ReportVacuumTask(ReportVacuumTaskRequest) returns (ReportVacuumTaskResponse);
   rpc GetCompactionGroups(GetCompactionGroupsRequest) returns (GetCompactionGroupsResponse);
+  rpc TriggerManualCompaction(TriggerManualCompactionRequest) returns (TriggerManualCompactionResponse);
 }
 
 service CompactorService {}

--- a/src/ctl/src/cmd_impl/hummock/trigger_manual_compaction.rs
+++ b/src/ctl/src/cmd_impl/hummock/trigger_manual_compaction.rs
@@ -21,7 +21,7 @@ pub async fn trigger_manual_compaction(compaction_group_id: u64) -> anyhow::Resu
     let meta_client = meta_opts.create_meta_client().await?;
     let result = meta_client
         .trigger_manual_compaction(compaction_group_id)
-        .await?;
+        .await;
     println!("{:#?}", result);
     Ok(())
 }

--- a/src/ctl/src/cmd_impl/hummock/trigger_manual_compaction.rs
+++ b/src/ctl/src/cmd_impl/hummock/trigger_manual_compaction.rs
@@ -12,9 +12,16 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-mod list_version;
-pub use list_version::*;
-mod list_kv;
-pub use list_kv::*;
-mod trigger_manual_compaction;
-pub use trigger_manual_compaction::*;
+use risingwave_rpc_client::HummockMetaClient;
+
+use crate::common::MetaServiceOpts;
+
+pub async fn trigger_manual_compaction(compaction_group_id: u64) -> anyhow::Result<()> {
+    let meta_opts = MetaServiceOpts::from_env()?;
+    let meta_client = meta_opts.create_meta_client().await?;
+    let result = meta_client
+        .trigger_manual_compaction(compaction_group_id)
+        .await?;
+    println!("{:#?}", result);
+    Ok(())
+}

--- a/src/ctl/src/lib.rs
+++ b/src/ctl/src/lib.rs
@@ -45,6 +45,10 @@ enum HummockCommands {
         #[clap(short, long = "table-id", default_value_t = u32::MAX)]
         tableid: u32,
     },
+    TriggerManualCompaction {
+        #[clap(short, long = "compaction_group_id", default_value_t = u64::MAX)]
+        compaction_group_id: u64,
+    },
 }
 
 pub async fn start(opts: CliOpts) {
@@ -55,5 +59,10 @@ pub async fn start(opts: CliOpts) {
         Commands::Hummock(HummockCommands::ListKv { epoch, tableid }) => {
             cmd_impl::hummock::list_kv(*epoch, *tableid).await.unwrap()
         }
+        Commands::Hummock(HummockCommands::TriggerManualCompaction {
+            compaction_group_id,
+        }) => cmd_impl::hummock::trigger_manual_compaction(*compaction_group_id)
+            .await
+            .unwrap(),
     }
 }

--- a/src/ctl/src/lib.rs
+++ b/src/ctl/src/lib.rs
@@ -46,7 +46,7 @@ enum HummockCommands {
         tableid: u32,
     },
     TriggerManualCompaction {
-        #[clap(short, long = "compaction_group_id", default_value_t = u64::MAX)]
+        #[clap(short, long = "compaction-group-id", default_value_t = 2)]
         compaction_group_id: u64,
     },
 }

--- a/src/meta/src/hummock/compaction/level_selector.rs
+++ b/src/meta/src/hummock/compaction/level_selector.rs
@@ -227,7 +227,6 @@ impl LevelSelector for DynamicLevelSelector {
         level_handlers: &mut [LevelHandler],
     ) -> Option<SearchResult> {
         let ctx = self.get_priority_levels(levels, level_handlers);
-        println!("ctx.score_levels {:?}", ctx.score_levels);
         for (score, select_level, target_level) in ctx.score_levels {
             if score <= SCORE_BASE {
                 return None;

--- a/src/meta/src/hummock/compaction/level_selector.rs
+++ b/src/meta/src/hummock/compaction/level_selector.rs
@@ -143,6 +143,14 @@ impl DynamicLevelSelector {
         for _ in first_non_empty_level..self.config.max_level as usize {
             cur_level_size /= self.config.max_bytes_for_level_multiplier;
         }
+        println!(
+            "before first_non_empty_level {} cur_level_size {} range {} {} max_level_size {}",
+            first_non_empty_level,
+            cur_level_size,
+            first_non_empty_level,
+            self.config.max_level,
+            max_level_size
+        );
 
         let base_level_size = if cur_level_size <= base_bytes_min {
             // Case 1. If we make target size of last level to be max_level_size,
@@ -159,6 +167,8 @@ impl DynamicLevelSelector {
             std::cmp::min(base_bytes_max, cur_level_size)
         };
 
+        println!("first_non_empty_level {} max_level_size {} l0_size {} base_bytes_max {} base_bytes_min {} cur_level_size {} base_level_size {} ctx.base_level {}", first_non_empty_level, max_level_size, l0_size, base_bytes_max, base_bytes_min, cur_level_size, base_level_size, ctx.base_level);
+
         let level_multiplier = self.config.max_bytes_for_level_multiplier as f64;
         let mut level_size = base_level_size;
         for i in ctx.base_level..=self.config.max_level as usize {
@@ -166,6 +176,11 @@ impl DynamicLevelSelector {
             // assume an hourglass shape where L1+ sizes are smaller than L0. This
             // causes compaction scoring, which depends on level sizes, to favor L1+
             // at the expense of L0, which may fill up and stall.
+
+            println!(
+                "level {} level_size {} base_bytes_max {}",
+                i, level_size, base_bytes_max
+            );
             ctx.level_max_bytes[i] = std::cmp::max(level_size, base_bytes_max);
             level_size = (level_size as f64 * level_multiplier) as u64;
         }
@@ -207,6 +222,7 @@ impl DynamicLevelSelector {
 
         // sort reverse to pick the largest one.
         ctx.score_levels.sort_by(|a, b| b.0.cmp(&a.0));
+        println!("ctx.score_levels {:?}", ctx.score_levels);
         ctx
     }
 }
@@ -226,14 +242,25 @@ impl LevelSelector for DynamicLevelSelector {
         levels: &[Level],
         level_handlers: &mut [LevelHandler],
     ) -> Option<SearchResult> {
+        println!("pick_compaction {}", task_id);
+
         let ctx = self.get_priority_levels(levels, level_handlers);
         for (score, select_level, target_level) in ctx.score_levels {
+            println!(
+                "score {} select_level {} target_level {} SCORE_BASE {}",
+                score, select_level, target_level, SCORE_BASE
+            );
             if score <= SCORE_BASE {
                 return None;
             }
             let picker = self.create_compaction_picker(select_level, target_level, task_id);
             if let Some(ret) = picker.pick_compaction(levels, level_handlers) {
                 return Some(ret);
+            } else {
+                println!(
+                    "create_compaction_picker {} {} fail",
+                    select_level, target_level
+                );
             }
         }
         None

--- a/src/meta/src/hummock/compaction/tier_compaction_picker.rs
+++ b/src/meta/src/hummock/compaction/tier_compaction_picker.rs
@@ -165,6 +165,7 @@ impl CompactionPicker for LevelCompactionPicker {
         let next_task_id = self.compact_task_id;
 
         if levels[select_level].table_infos.is_empty() {
+            println!("levels[select_level] {} table empty", select_level);
             return None;
         }
 
@@ -175,6 +176,7 @@ impl CompactionPicker for LevelCompactionPicker {
             &level_handlers[target_level],
         );
         if select_level_inputs.is_empty() {
+            println!("select_level_inputs empty");
             return None;
         }
 

--- a/src/meta/src/hummock/compaction/tier_compaction_picker.rs
+++ b/src/meta/src/hummock/compaction/tier_compaction_picker.rs
@@ -165,7 +165,6 @@ impl CompactionPicker for LevelCompactionPicker {
         let next_task_id = self.compact_task_id;
 
         if levels[select_level].table_infos.is_empty() {
-            println!("levels[select_level] {} table empty", select_level);
             return None;
         }
 
@@ -176,7 +175,6 @@ impl CompactionPicker for LevelCompactionPicker {
             &level_handlers[target_level],
         );
         if select_level_inputs.is_empty() {
-            println!("select_level_inputs empty");
             return None;
         }
 

--- a/src/meta/src/hummock/compactor_manager.rs
+++ b/src/meta/src/hummock/compactor_manager.rs
@@ -36,15 +36,13 @@ impl Compactor {
         vacuum_task: Option<VacuumTask>,
     ) -> Result<()> {
         // TODO: compactor node backpressure
-        let result = self
-            .sender
+        self.sender
             .send(Ok(SubscribeCompactTasksResponse {
                 compact_task,
                 vacuum_task,
             }))
             .await
-            .map_err(|e| ErrorCode::InternalError(e.to_error_str()).into());
-        result
+            .map_err(|e| ErrorCode::InternalError(e.to_error_str()).into())
     }
 
     pub fn context_id(&self) -> HummockContextId {

--- a/src/meta/src/hummock/compactor_manager.rs
+++ b/src/meta/src/hummock/compactor_manager.rs
@@ -14,6 +14,7 @@
 
 use std::sync::Arc;
 
+use rand::Rng;
 use risingwave_common::error::{ErrorCode, Result, ToErrorStr};
 use risingwave_hummock_sdk::HummockContextId;
 use risingwave_pb::hummock::{CompactTask, SubscribeCompactTasksResponse, VacuumTask};
@@ -35,13 +36,15 @@ impl Compactor {
         vacuum_task: Option<VacuumTask>,
     ) -> Result<()> {
         // TODO: compactor node backpressure
-        self.sender
+        let result = self
+            .sender
             .send(Ok(SubscribeCompactTasksResponse {
                 compact_task,
                 vacuum_task,
             }))
             .await
-            .map_err(|e| ErrorCode::InternalError(e.to_error_str()).into())
+            .map_err(|e| ErrorCode::InternalError(e.to_error_str()).into());
+        result
     }
 
     pub fn context_id(&self) -> HummockContextId {
@@ -102,6 +105,17 @@ impl CompactorManager {
         let compactor_index = guard.next_compactor % guard.compactors.len();
         let compactor = guard.compactors[compactor_index].clone();
         guard.next_compactor += 1;
+        Some(compactor)
+    }
+
+    pub fn random_compactor(&self) -> Option<Arc<Compactor>> {
+        let guard = self.inner.read();
+        if guard.compactors.is_empty() {
+            return None;
+        }
+
+        let compactor_index = rand::thread_rng().gen::<usize>() % guard.compactors.len();
+        let compactor = guard.compactors[compactor_index].clone();
         Some(compactor)
     }
 

--- a/src/meta/src/hummock/hummock_manager.rs
+++ b/src/meta/src/hummock/hummock_manager.rs
@@ -1343,7 +1343,7 @@ where
     }
 
     /// Sends a compaction request to compaction scheduler.
-    fn try_send_compaction_request(&self, compaction_group: CompactionGroupId) -> bool {
+    pub fn try_send_compaction_request(&self, compaction_group: CompactionGroupId) -> bool {
         if let Some(sender) = self.compaction_scheduler.read().as_ref() {
             return sender.try_send(compaction_group);
         }

--- a/src/meta/src/hummock/hummock_manager.rs
+++ b/src/meta/src/hummock/hummock_manager.rs
@@ -1430,7 +1430,7 @@ where
             }
         }
 
-        tracing::trace!(
+        tracing::info!(
             "Trigger manual compaction task. {}. cost time: {:?}",
             compact_task_to_string(&compact_task),
             start_time.elapsed(),

--- a/src/meta/src/hummock/hummock_manager.rs
+++ b/src/meta/src/hummock/hummock_manager.rs
@@ -48,6 +48,7 @@ use crate::hummock::model::{
     sstable_id_info, CurrentHummockVersionId, HummockPinnedSnapshotExt, HummockPinnedVersionExt,
     INVALID_TIMESTAMP,
 };
+use crate::hummock::CompactorManagerRef;
 use crate::manager::{IdCategory, MetaSrvEnv};
 use crate::model::{MetadataModel, ValTransaction, VarTransaction};
 use crate::rpc::metrics::MetaMetrics;
@@ -72,6 +73,8 @@ pub struct HummockManager<S: MetaStore> {
 
     // `compaction_scheduler` is used to schedule a compaction for specified CompactionGroupId
     compaction_scheduler: parking_lot::RwLock<Option<CompactionRequestChannelRef>>,
+
+    compactor_manager: CompactorManagerRef,
 }
 
 pub type HummockManagerRef<S> = Arc<HummockManager<S>>;
@@ -160,6 +163,7 @@ where
         cluster_manager: ClusterManagerRef<S>,
         metrics: Arc<MetaMetrics>,
         compaction_group_manager: CompactionGroupManagerRef<S>,
+        compactor_manager: CompactorManagerRef,
     ) -> Result<HummockManager<S>> {
         let instance = HummockManager {
             env,
@@ -169,6 +173,7 @@ where
             cluster_manager,
             compaction_group_manager,
             compaction_scheduler: parking_lot::RwLock::new(None),
+            compactor_manager,
         };
 
         instance.load_meta_store_state().await?;
@@ -587,13 +592,15 @@ where
             task_id as HummockCompactionTaskId,
             compaction_group_id,
         );
-        let existing_table_ids_from_meta = self
-            .compaction_group_manager
-            .internal_table_ids_by_compation_group_id(compaction_group_id)
-            .await?;
+
         let ret = match compact_task {
             None => Ok(None),
             Some(mut compact_task) => {
+                let existing_table_ids_from_meta = self
+                    .compaction_group_manager
+                    .internal_table_ids_by_compation_group_id(compaction_group_id)
+                    .await?;
+
                 compact_task.watermark = {
                     let versioning_guard = self.versioning.read().await;
                     let current_version_id = versioning_guard.current_version_id.id();
@@ -1348,5 +1355,81 @@ where
             return sender.try_send(compaction_group);
         }
         false
+    }
+
+    pub async fn trigger_manual_compaction(
+        &self,
+        compaction_group: CompactionGroupId,
+    ) -> Result<()> {
+        let start_time = Instant::now();
+
+        // 1. select_compactor
+        let compactor = self.compactor_manager.random_compactor();
+        let compactor = match compactor {
+            None => {
+                tracing::warn!("trigger_manual_compaction No compactor is available.");
+                return Err(Error::InternalError(format!(
+                    "trigger_manual_compaction No compactor is available. compaction_group {}",
+                    compaction_group
+                )));
+            }
+
+            Some(compactor) => compactor,
+        };
+
+        // 2. compact_task
+        let compact_task = self.get_compact_task(compaction_group).await;
+        let compact_task = match compact_task {
+            Ok(Some(compact_task)) => compact_task,
+            Ok(None) => {
+                // No compaction task available.
+                return Err(Error::InternalError(format!(
+                    "trigger_manual_compaction No compaction_task is available. compaction_group {}",
+                    compaction_group
+                )));
+            }
+            Err(err) => {
+                tracing::warn!("Failed to get compaction task: {:#?}.", err);
+                return Err(Error::InternalError(format!(
+                    "Failed to get compaction task: {:#?} compaction_group {}",
+                    err, compaction_group
+                )));
+            }
+        };
+
+        let send_task = async {
+            tokio::time::timeout(Duration::from_secs(3), async {
+                compactor
+                    .send_task(Some(compact_task.clone()), None)
+                    .await
+                    .is_ok()
+            })
+            .await
+            .unwrap_or(false)
+        };
+
+        self.assign_compaction_task(&compact_task, compactor.context_id(), send_task)
+            .await?;
+
+        tracing::trace!(
+            "Trigger manual compaction task. {}. cost time: {:?}",
+            compact_task_to_string(&compact_task),
+            start_time.elapsed(),
+        );
+
+        Ok(())
+    }
+
+    pub fn compactor_manager_ref_for_test(&self) -> CompactorManagerRef {
+        self.compactor_manager.clone()
+    }
+
+    pub async fn compaction_task_from_assignment_for_test(
+        &self,
+        task_id: u64,
+    ) -> Option<CompactTaskAssignment> {
+        let compaction_guard = self.compaction.read().await;
+        let assignment_ref = &compaction_guard.compact_task_assignment;
+        assignment_ref.get(&task_id).cloned()
     }
 }

--- a/src/meta/src/hummock/hummock_manager_tests.rs
+++ b/src/meta/src/hummock/hummock_manager_tests.rs
@@ -980,7 +980,7 @@ async fn test_trigger_manual_compaction() {
         let result = hummock_manager
             .trigger_manual_compaction(StaticCompactionGroupId::StateDefault.into())
             .await;
-        assert_eq!((), result.unwrap());
+        assert!(result.is_ok());
     }
 
     let task_id: u64 = 2;

--- a/src/meta/src/hummock/hummock_manager_tests.rs
+++ b/src/meta/src/hummock/hummock_manager_tests.rs
@@ -915,3 +915,80 @@ async fn test_mark_orphan_ssts() {
         .unwrap_err();
     assert!(matches!(error, Error::InternalError(_)));
 }
+
+#[tokio::test]
+async fn test_trigger_manual_compaction() {
+    let (env, hummock_manager, cluster_manager, worker_node) = setup_compute_env(80).await;
+    let context_id = worker_node.id;
+    let sst_num = 2usize;
+
+    // Construct vnode mappings for generating compaction tasks.
+    let parallel_units = cluster_manager
+        .list_parallel_units(Some(ParallelUnitType::Hash))
+        .await;
+    env.hash_mapping_manager()
+        .build_fragment_hash_mapping(1, &parallel_units);
+    for table_id in 1..sst_num + 2 {
+        env.hash_mapping_manager()
+            .set_fragment_state_table(1, table_id as u32);
+    }
+
+    {
+        // to check no compactor
+        let result = hummock_manager
+            .trigger_manual_compaction(StaticCompactionGroupId::StateDefault.into())
+            .await;
+
+        assert_eq!(
+            "internal error: trigger_manual_compaction No compactor is available. compaction_group 2",
+            result.err().unwrap().to_string()
+        );
+    }
+
+    // No compaction task available.
+    let compactor_manager_ref = hummock_manager.compactor_manager_ref_for_test();
+    let _receiver = compactor_manager_ref.add_compactor(context_id);
+    {
+        let result = hummock_manager
+            .trigger_manual_compaction(StaticCompactionGroupId::StateDefault.into())
+            .await;
+        assert_eq!("internal error: trigger_manual_compaction No compaction_task is available. compaction_group 2", result.err().unwrap().to_string());
+    }
+
+    // Add some sstables and commit.
+    let epoch: u64 = 1;
+    let original_tables = generate_test_tables(epoch, get_sst_ids(&hummock_manager, sst_num).await);
+    hummock_manager
+        .commit_epoch(epoch, original_tables.clone())
+        .await
+        .unwrap();
+
+    // check safe epoch in hummock version
+    let version_id1 = CurrentHummockVersionId::get(env.meta_store())
+        .await
+        .unwrap()
+        .unwrap();
+    let hummock_version1 = HummockVersion::select(env.meta_store(), &version_id1.id())
+        .await
+        .unwrap()
+        .unwrap();
+
+    // safe epoch should be INVALID before success compaction
+    assert_eq!(INVALID_EPOCH, hummock_version1.safe_epoch);
+
+    {
+        let result = hummock_manager
+            .trigger_manual_compaction(StaticCompactionGroupId::StateDefault.into())
+            .await;
+        assert_eq!((), result.unwrap());
+    }
+
+    let task_id: u64 = 2;
+    let compact_task = hummock_manager
+        .compaction_task_from_assignment_for_test(task_id)
+        .await
+        .unwrap()
+        .compact_task
+        .unwrap();
+    assert_eq!(task_id, compact_task.task_id);
+}

--- a/src/meta/src/hummock/hummock_manager_tests.rs
+++ b/src/meta/src/hummock/hummock_manager_tests.rs
@@ -947,7 +947,7 @@ async fn test_trigger_manual_compaction() {
 
     // No compaction task available.
     let compactor_manager_ref = hummock_manager.compactor_manager_ref_for_test();
-    let _receiver = compactor_manager_ref.add_compactor(context_id);
+    let receiver = compactor_manager_ref.add_compactor(context_id);
     {
         let result = hummock_manager
             .trigger_manual_compaction(StaticCompactionGroupId::StateDefault.into())
@@ -978,7 +978,7 @@ async fn test_trigger_manual_compaction() {
 
     {
         // to check compactor send task fail
-        drop(_receiver);
+        drop(receiver);
         {
             let result = hummock_manager
                 .trigger_manual_compaction(StaticCompactionGroupId::StateDefault.into())

--- a/src/meta/src/hummock/level_handler.rs
+++ b/src/meta/src/hummock/level_handler.rs
@@ -63,6 +63,7 @@ impl LevelHandler {
             total_file_size += sst.file_size;
             table_ids.push(sst.id);
         }
+
         self.pending_tasks
             .push((task_id, total_file_size, table_ids));
     }

--- a/src/meta/src/hummock/mock_hummock_meta_client.rs
+++ b/src/meta/src/hummock/mock_hummock_meta_client.rs
@@ -139,6 +139,10 @@ impl HummockMetaClient for MockHummockMetaClient {
     async fn get_compaction_groups(&self) -> Result<Vec<CompactionGroup>> {
         todo!()
     }
+
+    async fn trigger_manual_compaction(&self, _compaction_group_id: u64) -> Result<()> {
+        todo!()
+    }
 }
 
 impl MockHummockMetaClient {

--- a/src/meta/src/hummock/test_utils.rs
+++ b/src/meta/src/hummock/test_utils.rs
@@ -25,7 +25,7 @@ use risingwave_pb::hummock::{HummockVersion, KeyRange, SstableInfo};
 use crate::cluster::{ClusterManager, ClusterManagerRef};
 use crate::hummock::compaction::compaction_config::CompactionConfigBuilder;
 use crate::hummock::compaction_group::manager::CompactionGroupManager;
-use crate::hummock::{HummockManager, HummockManagerRef};
+use crate::hummock::{CompactorManager, HummockManager, HummockManagerRef};
 use crate::manager::MetaSrvEnv;
 use crate::rpc::metrics::MetaMetrics;
 use crate::storage::{MemStore, MetaStore};
@@ -169,12 +169,15 @@ pub async fn setup_compute_env(
             .unwrap(),
     );
 
+    let compactor_manager = Arc::new(CompactorManager::new());
+
     let hummock_manager = Arc::new(
         HummockManager::new(
             env.clone(),
             cluster_manager.clone(),
             Arc::new(MetaMetrics::new()),
             compaction_group_manager,
+            compactor_manager,
         )
         .await
         .unwrap(),

--- a/src/meta/src/rpc/server.rs
+++ b/src/meta/src/rpc/server.rs
@@ -300,6 +300,7 @@ pub async fn rpc_serve_with_store<S: MetaStore>(
             cluster_manager.clone(),
             meta_metrics.clone(),
             compaction_group_manager.clone(),
+            compactor_manager.clone(),
         )
         .await
         .unwrap(),

--- a/src/meta/src/rpc/service/hummock_service.rs
+++ b/src/meta/src/rpc/service/hummock_service.rs
@@ -225,4 +225,29 @@ where
         };
         Ok(Response::new(resp))
     }
+
+    async fn trigger_manual_compaction(
+        &self,
+        request: Request<TriggerManualCompactionRequest>,
+    ) -> Result<Response<TriggerManualCompactionResponse>, Status> {
+        let compaction_group_id = request.into_inner().compaction_group_id;
+        let result_state = match self
+            .hummock_manager
+            .try_send_compaction_request(compaction_group_id)
+        {
+            true => None,
+
+            false => {
+                return Err(tonic_err(ErrorCode::InternalError(format!(
+                    "try_send_compaction_request error compaction_group_id {}",
+                    compaction_group_id
+                ))));
+            }
+        };
+
+        let resp = TriggerManualCompactionResponse {
+            status: result_state,
+        };
+        Ok(Response::new(resp))
+    }
 }

--- a/src/meta/src/rpc/service/hummock_service.rs
+++ b/src/meta/src/rpc/service/hummock_service.rs
@@ -233,15 +233,13 @@ where
         let compaction_group_id = request.into_inner().compaction_group_id;
         let result_state = match self
             .hummock_manager
-            .try_send_compaction_request(compaction_group_id)
+            .trigger_manual_compaction(compaction_group_id)
+            .await
         {
-            true => None,
+            Ok(_) => None,
 
-            false => {
-                return Err(tonic_err(ErrorCode::InternalError(format!(
-                    "try_send_compaction_request error compaction_group_id {}",
-                    compaction_group_id
-                ))));
+            Err(error) => {
+                return Err(tonic_err(error));
             }
         };
 

--- a/src/meta/src/stream/stream_manager.rs
+++ b/src/meta/src/stream/stream_manager.rs
@@ -660,7 +660,7 @@ mod tests {
     use crate::barrier::GlobalBarrierManager;
     use crate::cluster::ClusterManager;
     use crate::hummock::compaction_group::manager::CompactionGroupManager;
-    use crate::hummock::HummockManager;
+    use crate::hummock::{CompactorManager, HummockManager};
     use crate::manager::{CatalogManager, MetaSrvEnv};
     use crate::model::ActorId;
     use crate::rpc::metrics::MetaMetrics;
@@ -820,15 +820,19 @@ mod tests {
             let meta_metrics = Arc::new(MetaMetrics::new());
             let compaction_group_manager =
                 Arc::new(CompactionGroupManager::new(env.clone()).await.unwrap());
+            let compactor_manager = Arc::new(CompactorManager::new());
+
             let hummock_manager = Arc::new(
                 HummockManager::new(
                     env.clone(),
                     cluster_manager.clone(),
                     meta_metrics.clone(),
                     compaction_group_manager.clone(),
+                    compactor_manager.clone(),
                 )
                 .await?,
             );
+
             let barrier_manager = Arc::new(GlobalBarrierManager::new(
                 env.clone(),
                 cluster_manager.clone(),

--- a/src/rpc_client/src/hummock_meta_client.rs
+++ b/src/rpc_client/src/hummock_meta_client.rs
@@ -36,4 +36,5 @@ pub trait HummockMetaClient: Send + Sync + 'static {
     async fn subscribe_compact_tasks(&self) -> Result<Streaming<SubscribeCompactTasksResponse>>;
     async fn report_vacuum_task(&self, vacuum_task: VacuumTask) -> Result<()>;
     async fn get_compaction_groups(&self) -> Result<Vec<CompactionGroup>>;
+    async fn trigger_manual_compaction(&self, compaction_group_id: u64) -> Result<()>;
 }

--- a/src/rpc_client/src/meta_client.rs
+++ b/src/rpc_client/src/meta_client.rs
@@ -39,9 +39,9 @@ use risingwave_pb::hummock::{
     PinSnapshotRequest, PinSnapshotResponse, PinVersionRequest, PinVersionResponse,
     ReportCompactionTasksRequest, ReportCompactionTasksResponse, ReportVacuumTaskRequest,
     ReportVacuumTaskResponse, SstableInfo, SubscribeCompactTasksRequest,
-    SubscribeCompactTasksResponse, UnpinSnapshotBeforeRequest, UnpinSnapshotBeforeResponse,
-    UnpinSnapshotRequest, UnpinSnapshotResponse, UnpinVersionRequest, UnpinVersionResponse,
-    VacuumTask,
+    SubscribeCompactTasksResponse, TriggerManualCompactionRequest, TriggerManualCompactionResponse,
+    UnpinSnapshotBeforeRequest, UnpinSnapshotBeforeResponse, UnpinSnapshotRequest,
+    UnpinSnapshotResponse, UnpinVersionRequest, UnpinVersionResponse, VacuumTask,
 };
 use risingwave_pb::meta::cluster_service_client::ClusterServiceClient;
 use risingwave_pb::meta::heartbeat_service_client::HeartbeatServiceClient;
@@ -448,6 +448,15 @@ impl HummockMetaClient for MetaClient {
         let resp = self.inner.get_compaction_groups(req).await?;
         Ok(resp.compaction_groups)
     }
+
+    async fn trigger_manual_compaction(&self, compaction_group_id: u64) -> Result<()> {
+        let req = TriggerManualCompactionRequest {
+            compaction_group_id,
+        };
+
+        self.inner.trigger_manual_compaction(req).await?;
+        Ok(())
+    }
 }
 
 /// Client to meta server. Cloning the instance is lightweight.
@@ -556,6 +565,7 @@ macro_rules! for_all_meta_rpc {
             ,{ hummock_client, subscribe_compact_tasks, SubscribeCompactTasksRequest, Streaming<SubscribeCompactTasksResponse> }
             ,{ hummock_client, report_vacuum_task, ReportVacuumTaskRequest, ReportVacuumTaskResponse }
             ,{ hummock_client, get_compaction_groups, GetCompactionGroupsRequest, GetCompactionGroupsResponse }
+            ,{ hummock_client, trigger_manual_compaction, TriggerManualCompactionRequest, TriggerManualCompactionResponse }
             ,{ user_client, create_user, CreateUserRequest, CreateUserResponse }
             ,{ user_client, drop_user, DropUserRequest, DropUserResponse }
             ,{ user_client, grant_privilege, GrantPrivilegeRequest, GrantPrivilegeResponse }

--- a/src/storage/src/hummock/hummock_meta_client.rs
+++ b/src/storage/src/hummock/hummock_meta_client.rs
@@ -107,4 +107,10 @@ impl HummockMetaClient for MonitoredHummockMetaClient {
     async fn get_compaction_groups(&self) -> Result<Vec<CompactionGroup>> {
         self.meta_client.get_compaction_groups().await
     }
+
+    async fn trigger_manual_compaction(&self, compaction_group_id: u64) -> Result<()> {
+        self.meta_client
+            .trigger_manual_compaction(compaction_group_id)
+            .await
+    }
 }


### PR DESCRIPTION
## What's changed and what's your intention?

simply support trigger manual compaction

Please explain **IN DETAIL** what the changes are in this PR and why they are needed:

- simply support trigger manual compaction in hummock_manager
- add trigger manual compaction rpc
- support  trigger manual compaction for risectl

## Checklist

- [x] I have written necessary docs and comments
- [x] I have added necessary unit tests and integration tests
## Refer to a related PR or issue link (optional)
- https://github.com/singularity-data/risingwave/issues/3097