### PR TITLE
feat(streaming): integrate append-only executors to stream graph

### DIFF
--- a/proto/stream_plan.proto
+++ b/proto/stream_plan.proto
@@ -56,14 +56,18 @@ message SimpleAggNode {
   repeated expr.AggCall agg_calls = 1;
   repeated uint32 distribution_keys = 2;
   repeated uint32 table_ids = 3;
-  bool append_only = 4;
+  // Whether to optimize for append only stream.
+  // It is true when the input is append-only
+  bool is_append_only = 4;
 }
 
 message HashAggNode {
   repeated uint32 distribution_keys = 1;
   repeated expr.AggCall agg_calls = 2;
   repeated uint32 table_ids = 3;
-  bool append_only = 4;
+  // Whether to optimize for append only stream.
+  // It is true when the input is append-only
+  bool is_append_only = 4;
 }
 
 message TopNNode {
@@ -90,6 +94,9 @@ message HashJoinNode {
   uint32 left_table_id = 7;
   // Used for internal table states. Id of the right table.
   uint32 right_table_id = 8;
+  // Whether to optimize for append only stream.
+  // It is true when the input is append-only
+  bool is_append_only = 9;
 }
 
 // Delta join with two indexes. This is a pseudo plan node generated on frontend. On meta

--- a/src/frontend/src/optimizer/plan_node/stream_exchange.rs
+++ b/src/frontend/src/optimizer/plan_node/stream_exchange.rs
@@ -47,11 +47,9 @@ impl StreamExchange {
 impl fmt::Display for StreamExchange {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         let mut builder = f.debug_struct("StreamExchange");
-        builder.field("dist", &format_args!("{:?}", self.base.dist));
-        if self.append_only() {
-            builder.field("append_only", &format_args!("{}", true));
-        }
-        builder.finish()
+        builder
+            .field("dist", &format_args!("{:?}", self.base.dist))
+            .finish()
     }
 }
 

--- a/src/frontend/src/optimizer/plan_node/stream_hash_agg.rs
+++ b/src/frontend/src/optimizer/plan_node/stream_hash_agg.rs
@@ -57,7 +57,11 @@ impl StreamHashAgg {
 
 impl fmt::Display for StreamHashAgg {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        let mut builder = f.debug_struct("StreamHashAgg");
+        let mut builder = if self.input().append_only() {
+            f.debug_struct("StreamAppendOnlyHashAgg")
+        } else {
+            f.debug_struct("StreamHashAgg")
+        };
         builder
             .field(
                 "group_keys",
@@ -70,7 +74,7 @@ impl fmt::Display for StreamHashAgg {
             )
             .field("aggs", &self.agg_calls());
 
-        if self.base.append_only {
+        if self.append_only() {
             builder.field("append_only", &format_args!("{}", true));
         }
         builder.finish()
@@ -104,7 +108,7 @@ impl ToStreamProst for StreamHashAgg {
                 .map(PlanAggCall::to_protobuf)
                 .collect_vec(),
             table_ids: vec![],
-            append_only: self.append_only(),
+            is_append_only: self.input().append_only(),
         })
     }
 }

--- a/src/frontend/src/optimizer/plan_node/stream_hash_agg.rs
+++ b/src/frontend/src/optimizer/plan_node/stream_hash_agg.rs
@@ -72,12 +72,8 @@ impl fmt::Display for StreamHashAgg {
                     .map(InputRefDisplay)
                     .collect_vec(),
             )
-            .field("aggs", &self.agg_calls());
-
-        if self.append_only() {
-            builder.field("append_only", &format_args!("{}", true));
-        }
-        builder.finish()
+            .field("aggs", &self.agg_calls())
+            .finish()
     }
 }
 

--- a/src/frontend/src/optimizer/plan_node/stream_hash_join.rs
+++ b/src/frontend/src/optimizer/plan_node/stream_hash_join.rs
@@ -122,12 +122,10 @@ impl fmt::Display for StreamHashJoin {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         let mut builder = if self.is_delta {
             f.debug_struct("StreamDeltaHashJoin")
+        } else if self.is_append_only {
+            f.debug_struct("StreamAppendOnlyHashJoin")
         } else {
-            if self.is_append_only {
-                f.debug_struct("StreamAppendOnlyHashJoin")
-            } else {
-                f.debug_struct("StreamHashJoin")
-            }
+            f.debug_struct("StreamHashJoin")
         };
         builder
             .field("type", &format_args!("{:?}", self.logical.join_type()))

--- a/src/frontend/src/optimizer/plan_node/stream_hash_join.rs
+++ b/src/frontend/src/optimizer/plan_node/stream_hash_join.rs
@@ -129,12 +129,8 @@ impl fmt::Display for StreamHashJoin {
         };
         builder
             .field("type", &format_args!("{:?}", self.logical.join_type()))
-            .field("predicate", &format_args!("{}", self.eq_join_predicate()));
-
-        if self.append_only() {
-            builder.field("append_only", &format_args!("{}", true));
-        }
-        builder.finish()
+            .field("predicate", &format_args!("{}", self.eq_join_predicate()))
+            .finish()
     }
 }
 

--- a/src/frontend/src/optimizer/plan_node/stream_materialize.rs
+++ b/src/frontend/src/optimizer/plan_node/stream_materialize.rs
@@ -215,10 +215,6 @@ impl fmt::Display for StreamMaterialize {
         if pk_column_names != order_descs {
             builder.field("order_descs", &format_args!("[{}]", order_descs));
         }
-
-        if self.append_only() {
-            builder.field("append_only", &format_args!("{}", true));
-        }
         builder.finish()
     }
 }

--- a/src/frontend/src/optimizer/plan_node/stream_project.rs
+++ b/src/frontend/src/optimizer/plan_node/stream_project.rs
@@ -31,11 +31,7 @@ pub struct StreamProject {
 impl fmt::Display for StreamProject {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         let mut builder = f.debug_struct("StreamProject");
-        builder.field("exprs", self.logical.exprs());
-        if self.append_only() {
-            builder.field("appendonly", &format_args!("{}", true));
-        }
-        builder.finish()
+        builder.field("exprs", self.logical.exprs()).finish()
     }
 }
 

--- a/src/frontend/src/optimizer/plan_node/stream_simple_agg.rs
+++ b/src/frontend/src/optimizer/plan_node/stream_simple_agg.rs
@@ -50,9 +50,13 @@ impl StreamSimpleAgg {
 
 impl fmt::Display for StreamSimpleAgg {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        f.debug_struct("StreamSimpleAgg")
-            .field("aggs", &self.agg_calls())
-            .finish()
+        let mut builder = if self.input().append_only() {
+            f.debug_struct("StreamAppendOnlySimpleAgg")
+        } else {
+            f.debug_struct("StreamSimpleAgg")
+        };
+        builder.field("aggs", &self.agg_calls());
+        builder.finish()
     }
 }
 
@@ -86,7 +90,7 @@ impl ToStreamProst for StreamSimpleAgg {
                 .map(|idx| *idx as u32)
                 .collect_vec(),
             table_ids: vec![],
-            append_only: self.append_only(),
+            is_append_only: self.input().append_only(),
         })
     }
 }

--- a/src/frontend/src/optimizer/plan_node/stream_source.rs
+++ b/src/frontend/src/optimizer/plan_node/stream_source.rs
@@ -59,12 +59,8 @@ impl fmt::Display for StreamSource {
             .field(
                 "columns",
                 &format_args!("[{}]", &self.column_names().join(", ")),
-            );
-
-        if self.append_only() {
-            builder.field("append_only", &format_args!("{}", true));
-        }
-        builder.finish()
+            )
+            .finish()
     }
 }
 

--- a/src/frontend/src/optimizer/plan_node/stream_table_scan.rs
+++ b/src/frontend/src/optimizer/plan_node/stream_table_scan.rs
@@ -77,12 +77,8 @@ impl fmt::Display for StreamTableScan {
                 "columns",
                 &format_args!("[{}]", self.logical.column_names().join(", ")),
             )
-            .field("pk_indices", &format_args!("{:?}", self.base.pk_indices));
-
-        if self.append_only() {
-            builder.field("append_only", &format_args!("{}", true));
-        }
-        builder.finish()
+            .field("pk_indices", &format_args!("{:?}", self.base.pk_indices))
+            .finish()
     }
 }
 

--- a/src/frontend/src/optimizer/plan_node/stream_topn.rs
+++ b/src/frontend/src/optimizer/plan_node/stream_topn.rs
@@ -55,15 +55,11 @@ impl fmt::Display for StreamTopN {
             f.debug_struct("StreamTopN")
         };
 
-        builder.field("order", &format_args!("{}", self.logical.topn_order()));
-        builder.field("limit", &format_args!("{}", self.logical.limit()));
-        builder.field("offset", &format_args!("{}", self.logical.offset()));
-
-        if self.append_only() {
-            builder.field("append_only", &format_args!("{}", true));
-        }
-
-        builder.finish()
+        builder
+            .field("order", &format_args!("{}", self.logical.topn_order()))
+            .field("limit", &format_args!("{}", self.logical.limit()))
+            .field("offset", &format_args!("{}", self.logical.offset()))
+            .finish()
     }
 }
 

--- a/src/frontend/src/optimizer/plan_node/stream_topn.rs
+++ b/src/frontend/src/optimizer/plan_node/stream_topn.rs
@@ -55,7 +55,7 @@ impl fmt::Display for StreamTopN {
             f.debug_struct("StreamTopN")
         };
 
-        builder.field("order", self.logical.topn_order());
+        builder.field("order", &format_args!("{}", self.logical.topn_order()));
         builder.field("limit", &format_args!("{}", self.logical.limit()));
         builder.field("offset", &format_args!("{}", self.logical.offset()));
 

--- a/src/frontend/test_runner/tests/testdata/append_only.yaml
+++ b/src/frontend/test_runner/tests/testdata/append_only.yaml
@@ -25,7 +25,7 @@
     select v1 from t1 order by v1 limit 3 offset 3;
   stream_plan: |
     StreamMaterialize { columns: [v1, _row_id(hidden)], pk_columns: [_row_id], order_descs: [v1, _row_id] }
-      StreamAppendOnlyTopN { order: Order { field_order: [$0 ASC] }, limit: 3, offset: 3 }
+      StreamAppendOnlyTopN { order: [$0 ASC], limit: 3, offset: 3 }
         StreamExchange { dist: Single, append_only: true }
           StreamTableScan { table: t1, columns: [v1, _row_id], pk_indices: [1], append_only: true }
 - sql: |

--- a/src/frontend/test_runner/tests/testdata/append_only.yaml
+++ b/src/frontend/test_runner/tests/testdata/append_only.yaml
@@ -4,7 +4,7 @@
     select v1, max(v2) as mx2 from t1 group by v1;
   stream_plan: |
     StreamMaterialize { columns: [v1, agg#0(hidden), mx2], pk_columns: [v1] }
-      StreamHashAgg { group_keys: [$0], aggs: [count, max($1)] }
+      StreamAppendOnlyHashAgg { group_keys: [$0], aggs: [count, max($1)] }
         StreamExchange { dist: HashShard([0]), append_only: true }
           StreamTableScan { table: t1, columns: [v1, v2, _row_id], pk_indices: [2], append_only: true }
 - sql: |
@@ -15,8 +15,24 @@
     StreamMaterialize { columns: [id, v2, v3, _row_id(hidden), _row_id#1(hidden)], pk_columns: [_row_id, _row_id#1], append_only: true }
       StreamExchange { dist: HashShard([3, 4]), append_only: true }
         StreamProject { exprs: [$0, $1, $4, $2, $5], appendonly: true }
-          StreamHashJoin { type: Inner, predicate: $0 = $3, append_only: true }
+          StreamAppendOnlyHashJoin { type: Inner, predicate: $0 = $3, append_only: true }
             StreamExchange { dist: HashShard([0]), append_only: true }
               StreamTableScan { table: t1, columns: [v1, v2, _row_id], pk_indices: [2], append_only: true }
             StreamExchange { dist: HashShard([0]), append_only: true }
               StreamTableScan { table: t2, columns: [v1, v3, _row_id], pk_indices: [2], append_only: true }
+- sql: |
+    create table t1 (v1 int, v2 int) with ('appendonly' = true);
+    select v1 from t1 order by v1 limit 3 offset 3;
+  stream_plan: |
+    StreamMaterialize { columns: [v1, _row_id(hidden)], pk_columns: [_row_id], order_descs: [v1, _row_id] }
+      StreamAppendOnlyTopN { order: Order { field_order: [$0 ASC] }, limit: 3, offset: 3 }
+        StreamExchange { dist: Single, append_only: true }
+          StreamTableScan { table: t1, columns: [v1, _row_id], pk_indices: [1], append_only: true }
+- sql: |
+    create table t1 (v1 int, v2 int) with ('appendonly' = true);
+    select max(v1) as max_v1 from t1;
+  stream_plan: |
+    StreamMaterialize { columns: [agg#0(hidden), max_v1], pk_columns: [] }
+      StreamAppendOnlySimpleAgg { aggs: [count, max($0)] }
+        StreamExchange { dist: Single, append_only: true }
+          StreamTableScan { table: t1, columns: [v1, _row_id], pk_indices: [1], append_only: true }

--- a/src/frontend/test_runner/tests/testdata/append_only.yaml
+++ b/src/frontend/test_runner/tests/testdata/append_only.yaml
@@ -5,34 +5,34 @@
   stream_plan: |
     StreamMaterialize { columns: [v1, agg#0(hidden), mx2], pk_columns: [v1] }
       StreamAppendOnlyHashAgg { group_keys: [$0], aggs: [count, max($1)] }
-        StreamExchange { dist: HashShard([0]), append_only: true }
-          StreamTableScan { table: t1, columns: [v1, v2, _row_id], pk_indices: [2], append_only: true }
+        StreamExchange { dist: HashShard([0]) }
+          StreamTableScan { table: t1, columns: [v1, v2, _row_id], pk_indices: [2] }
 - sql: |
     create table t1 (v1 int, v2 int) with ('appendonly' = true);
     create table t2 (v1 int, v3 int) with ('appendonly' = true);
     select t1.v1 as id, v2, v3 from t1 join t2 on t1.v1=t2.v1;
   stream_plan: |
-    StreamMaterialize { columns: [id, v2, v3, _row_id(hidden), _row_id#1(hidden)], pk_columns: [_row_id, _row_id#1], append_only: true }
-      StreamExchange { dist: HashShard([3, 4]), append_only: true }
-        StreamProject { exprs: [$0, $1, $4, $2, $5], appendonly: true }
-          StreamAppendOnlyHashJoin { type: Inner, predicate: $0 = $3, append_only: true }
-            StreamExchange { dist: HashShard([0]), append_only: true }
-              StreamTableScan { table: t1, columns: [v1, v2, _row_id], pk_indices: [2], append_only: true }
-            StreamExchange { dist: HashShard([0]), append_only: true }
-              StreamTableScan { table: t2, columns: [v1, v3, _row_id], pk_indices: [2], append_only: true }
+    StreamMaterialize { columns: [id, v2, v3, _row_id(hidden), _row_id#1(hidden)], pk_columns: [_row_id, _row_id#1] }
+      StreamExchange { dist: HashShard([3, 4]) }
+        StreamProject { exprs: [$0, $1, $4, $2, $5] }
+          StreamAppendOnlyHashJoin { type: Inner, predicate: $0 = $3 }
+            StreamExchange { dist: HashShard([0]) }
+              StreamTableScan { table: t1, columns: [v1, v2, _row_id], pk_indices: [2] }
+            StreamExchange { dist: HashShard([0]) }
+              StreamTableScan { table: t2, columns: [v1, v3, _row_id], pk_indices: [2] }
 - sql: |
     create table t1 (v1 int, v2 int) with ('appendonly' = true);
     select v1 from t1 order by v1 limit 3 offset 3;
   stream_plan: |
     StreamMaterialize { columns: [v1, _row_id(hidden)], pk_columns: [_row_id], order_descs: [v1, _row_id] }
       StreamAppendOnlyTopN { order: [$0 ASC], limit: 3, offset: 3 }
-        StreamExchange { dist: Single, append_only: true }
-          StreamTableScan { table: t1, columns: [v1, _row_id], pk_indices: [1], append_only: true }
+        StreamExchange { dist: Single }
+          StreamTableScan { table: t1, columns: [v1, _row_id], pk_indices: [1] }
 - sql: |
     create table t1 (v1 int, v2 int) with ('appendonly' = true);
     select max(v1) as max_v1 from t1;
   stream_plan: |
     StreamMaterialize { columns: [agg#0(hidden), max_v1], pk_columns: [] }
       StreamAppendOnlySimpleAgg { aggs: [count, max($0)] }
-        StreamExchange { dist: Single, append_only: true }
-          StreamTableScan { table: t1, columns: [v1, _row_id], pk_indices: [1], append_only: true }
+        StreamExchange { dist: Single }
+          StreamTableScan { table: t1, columns: [v1, _row_id], pk_indices: [1] }

--- a/src/meta/src/stream/test_fragmenter.rs
+++ b/src/meta/src/stream/test_fragmenter.rs
@@ -166,7 +166,7 @@ fn make_stream_node() -> StreamNode {
             agg_calls: vec![make_sum_aggcall(0), make_sum_aggcall(1)],
             distribution_keys: Default::default(),
             table_ids: vec![],
-            append_only: false,
+            is_append_only: false,
         })),
         input: vec![filter_node],
         fields: vec![], // TODO: fill this later
@@ -198,7 +198,7 @@ fn make_stream_node() -> StreamNode {
             agg_calls: vec![make_sum_aggcall(0), make_sum_aggcall(1)],
             distribution_keys: Default::default(),
             table_ids: vec![],
-            append_only: false,
+            is_append_only: false,
         })),
         fields: vec![], // TODO: fill this later
         input: vec![exchange_node_1],

--- a/src/stream/src/executor/hash_join.rs
+++ b/src/stream/src/executor/hash_join.rs
@@ -363,7 +363,7 @@ impl<K: HashKey, S: StateStore, const T: JoinTypePrimitive> HashJoinExecutor<K, 
         key_indices: Vec<usize>,
         ks_l: Keyspace<S>,
         ks_r: Keyspace<S>,
-        append_only: bool,
+        is_append_only: bool,
     ) -> Self {
         let side_l_column_n = input_l.schema().len();
 
@@ -398,7 +398,7 @@ impl<K: HashKey, S: StateStore, const T: JoinTypePrimitive> HashJoinExecutor<K, 
         let pk_indices_r = input_r.pk_indices().to_vec();
 
         // check whether join key contains pk in both side
-        let append_only_optimize = if append_only {
+        let append_only_optimize = if is_append_only {
             let join_key_l = HashSet::<usize>::from_iter(params_l.key_indices.clone());
             let join_key_r = HashSet::<usize>::from_iter(params_r.key_indices.clone());
             let pk_contained_l = pk_indices_l.len()

--- a/src/stream/src/from_proto/global_simple_agg.rs
+++ b/src/stream/src/from_proto/global_simple_agg.rs
@@ -33,7 +33,7 @@ impl ExecutorBuilder for SimpleAggExecutorBuilder {
         let agg_calls: Vec<AggCall> = node
             .get_agg_calls()
             .iter()
-            .map(|agg_call| build_agg_call_from_prost(node.append_only, agg_call))
+            .map(|agg_call| build_agg_call_from_prost(node.is_append_only, agg_call))
             .try_collect()?;
         // Build vector of keyspace via table ids.
         // One keyspace for one agg call.

--- a/src/stream/src/from_proto/hash_agg.rs
+++ b/src/stream/src/from_proto/hash_agg.rs
@@ -69,7 +69,7 @@ impl ExecutorBuilder for HashAggExecutorBuilder {
         let agg_calls: Vec<AggCall> = node
             .get_agg_calls()
             .iter()
-            .map(|agg_call| build_agg_call_from_prost(node.append_only, agg_call))
+            .map(|agg_call| build_agg_call_from_prost(node.is_append_only, agg_call))
             .try_collect()?;
         // Build vector of keyspace via table ids.
         // One keyspace for one agg call.

--- a/src/stream/src/from_proto/hash_join.rs
+++ b/src/stream/src/from_proto/hash_join.rs
@@ -33,8 +33,8 @@ impl ExecutorBuilder for HashJoinExecutorBuilder {
         _stream: &mut LocalStreamManagerCore,
     ) -> Result<BoxedExecutor> {
         // Get table id and used as keyspace prefix.
-        let append_only = node.get_append_only();
         let node = try_match_expand!(node.get_node_body().unwrap(), NodeBody::HashJoin)?;
+        let is_append_only = node.is_append_only;
         let source_r = params.input.remove(1);
         let source_l = params.input.remove(0);
         let params_l = JoinParams::new(
@@ -114,7 +114,7 @@ impl ExecutorBuilder for HashJoinExecutorBuilder {
             key_indices,
             keyspace_l: Keyspace::table_root(store.clone(), &left_table_id),
             keyspace_r: Keyspace::table_root(store, &right_table_id),
-            append_only,
+            is_append_only,
         };
 
         for_all_join_types! { impl_create_hash_join_executor };
@@ -137,7 +137,7 @@ struct HashJoinExecutorDispatcherArgs<S: StateStore> {
     key_indices: Vec<usize>,
     keyspace_l: Keyspace<S>,
     keyspace_r: Keyspace<S>,
-    append_only: bool,
+    is_append_only: bool,
 }
 
 impl<S: StateStore, const T: JoinTypePrimitive> HashKeyDispatcher
@@ -159,7 +159,7 @@ impl<S: StateStore, const T: JoinTypePrimitive> HashKeyDispatcher
             args.key_indices,
             args.keyspace_l,
             args.keyspace_r,
-            args.append_only,
+            args.is_append_only,
         )))
     }
 }

--- a/src/stream/src/from_proto/local_simple_agg.rs
+++ b/src/stream/src/from_proto/local_simple_agg.rs
@@ -34,7 +34,7 @@ impl ExecutorBuilder for LocalSimpleAggExecutorBuilder {
         let agg_calls: Vec<AggCall> = node
             .get_agg_calls()
             .iter()
-            .map(|agg_call| build_agg_call_from_prost(node.append_only, agg_call))
+            .map(|agg_call| build_agg_call_from_prost(node.is_append_only, agg_call))
             .try_collect()?;
 
         Ok(LocalSimpleAggExecutor::new(


### PR DESCRIPTION
## What's changed and what's your intention?

Integrate append-only version executors (TopN, HashAgg, HashJoin, SimpleAgg) to the stream graph.

## Checklist

- [x] I have written necessary docs and comments
- [x] I have added necessary unit tests and integration tests
- [x] All checks passed in `./risedev check` (or alias, `./risedev c`)

## Refer to a related PR or issue link (optional)
close #2407
close #1550 