### PR TITLE
refactor(storage): remove new_adhoc from CellBasedTable

### DIFF
--- a/src/compute/tests/integration_tests.rs
+++ b/src/compute/tests/integration_tests.rs
@@ -202,10 +202,12 @@ async fn test_table_v2_materialize() -> Result<()> {
 
     // Since we have not polled `Materialize`, we cannot scan anything from this table
     let keyspace = Keyspace::table_root(memory_state_store, &source_table_id);
-    let table = CellBasedTable::new_adhoc(
+    let table = CellBasedTable::new(
         keyspace,
         column_descs.clone(),
+        None,
         Arc::new(StateStoreMetrics::unused()),
+        None,
     );
 
     let ordered_column_descs: Vec<OrderedColumnDesc> = column_descs
@@ -388,10 +390,12 @@ async fn test_row_seq_scan() -> Result<()> {
         None,
         vec![0_usize],
     );
-    let table = CellBasedTable::new_adhoc(
+    let table = CellBasedTable::new(
         keyspace,
         column_descs.clone(),
+        None,
         Arc::new(StateStoreMetrics::unused()),
+        None,
     );
 
     let epoch: u64 = 0;

--- a/src/storage/src/table/cell_based_table.rs
+++ b/src/storage/src/table/cell_based_table.rs
@@ -132,15 +132,6 @@ impl<S: StateStore> CellBasedTable<S> {
         )
     }
 
-    /// Creates an "adhoc" [`CellBasedTable`] with specified columns.
-    pub fn new_adhoc(
-        keyspace: Keyspace<S>,
-        column_descs: Vec<ColumnDesc>,
-        stats: Arc<StateStoreMetrics>,
-    ) -> Self {
-        Self::new(keyspace, column_descs, None, stats, None)
-    }
-
     /// Get a single row by point get
     pub async fn get_row(&self, pk: &Row, epoch: u64) -> StorageResult<Option<Row>> {
         // TODO: use multi-get for cell_based get_row

--- a/src/stream/src/from_proto/batch_query.rs
+++ b/src/stream/src/from_proto/batch_query.rs
@@ -46,10 +46,12 @@ impl ExecutorBuilder for BatchQueryExecutorBuilder {
             .map(|column_desc| ColumnDesc::from(column_desc.clone()))
             .collect_vec();
         let keyspace = Keyspace::table_root(state_store, &table_id);
-        let table = CellBasedTable::new_adhoc(
+        let table = CellBasedTable::new(
             keyspace,
             column_descs,
+            None,
             Arc::new(StateStoreMetrics::unused()),
+            None,
         );
         let key_indices = node
             .get_distribution_keys()


### PR DESCRIPTION
## What's changed and what's your intention?
It is not ad-hoc anymore. Was a workaround

## Checklist

~- [ ] I have written necessary docs and comments~
~- [ ] I have added necessary unit tests and integration tests~
- [x] All checks passed in `./risedev check` (or alias, `./risedev c`)

## Refer to a related PR or issue link (optional)
