### PR TITLE
fix(expr): bool has different output format and cast-string format

### DIFF
--- a/e2e_test/batch/func.slt
+++ b/e2e_test/batch/func.slt
@@ -96,7 +96,7 @@ NULL
 query T
 select concat_ws(',', 1, 1.01, 'A', true, NULL);
 ----
-1,1.01,A,true
+1,1.01,A,t
 
 statement ok
 create table t (v1 varchar, v2 smallint, v3 int, v4 decimal, v5 real, v6 double, v7 bool, v8 string);
@@ -107,7 +107,7 @@ insert into t values (',', 1, 2, 3.01, 4, 5.01, true, NULL);
 query T
 select concat_ws(v1, v2, v3, v4, v5, v6, v7, v8) from t;
 ----
-1,2,3.01,4,5.01,true
+1,2,3.01,4,5.01,t
 
 
 statement ok

--- a/e2e_test/batch/functions/concat.slt
+++ b/e2e_test/batch/functions/concat.slt
@@ -26,11 +26,10 @@ select concat('a', NULL);
 ----
 a
 
-# FIXME: should be '11.01At'
 query T
 select concat(1, 1.01, 'A', true, NULL);
 ----
-11.01Atrue
+11.01At
 
 statement error
 select concat();
@@ -41,11 +40,10 @@ create table t (v1 smallint, v2 int, v3 decimal, v4 real, v5 double precision, v
 statement ok
 insert into t values (1, 2, 3.01, 4, 5.01, true, NULL);
 
-# FIXME: should be '123.0145.01t'
 query T
 select concat(v1, v2, v3, v4, v5, v6, v7) from t;
 ----
-123.0145.01true
+123.0145.01t
 
 statement ok
 drop table t;

--- a/proto/expr.proto
+++ b/proto/expr.proto
@@ -70,6 +70,8 @@ message ExprNode {
     CHAR_LENGTH = 225;
     REPEAT = 226;
     CONCAT_OP = 227;
+    // BOOL_OUT is different from CAST-bool-to-varchar in PostgreSQL.
+    BOOL_OUT = 228;
 
     // Boolean comparison
     IS_TRUE = 301;

--- a/src/expr/src/expr/expr_unary.rs
+++ b/src/expr/src/expr/expr_unary.rs
@@ -211,6 +211,13 @@ pub fn new_unary_expr(
 
     let expr: BoxedExpression = match (expr_type, return_type.clone(), child_expr.return_type()) {
         (ProstType::Cast, _, _) => gen_cast! { child_expr, return_type, },
+        (ProstType::BoolOut, _, DataType::Boolean) => {
+            Box::new(UnaryExpression::<BoolArray, Utf8Array, _>::new(
+                child_expr,
+                return_type,
+                bool_out,
+            ))
+        }
         (ProstType::Not, _, _) => {
             Box::new(UnaryNullableExpression::<BoolArray, BoolArray, _>::new(
                 child_expr,

--- a/src/expr/src/expr/mod.rs
+++ b/src/expr/src/expr/mod.rs
@@ -81,9 +81,8 @@ pub fn build_from_prost(prost: &ExprNode) -> Result<BoxedExpression> {
 
     match prost.get_expr_type().unwrap() {
         Cast | Upper | Lower | Md5 | Not | IsTrue | IsNotTrue | IsFalse | IsNotFalse | IsNull
-        | IsNotNull | Neg | Ascii | Abs | Ceil | Floor | Round | BitwiseNot | CharLength => {
-            build_unary_expr_prost(prost)
-        }
+        | IsNotNull | Neg | Ascii | Abs | Ceil | Floor | Round | BitwiseNot | CharLength
+        | BoolOut => build_unary_expr_prost(prost),
         Equal | NotEqual | LessThan | LessThanOrEqual | GreaterThan | GreaterThanOrEqual | Add
         | Subtract | Multiply | Divide | Modulus | Extract | RoundDigit | TumbleStart
         | Position | BitwiseShiftLeft | BitwiseShiftRight | BitwiseAnd | BitwiseOr | BitwiseXor

--- a/src/expr/src/vector_op/cast.rs
+++ b/src/expr/src/vector_op/cast.rs
@@ -182,6 +182,12 @@ pub fn general_to_string<T: std::fmt::Display>(elem: T) -> Result<String> {
     Ok(elem.to_string())
 }
 
+/// `bool_out` is different from `general_to_string<bool>` to produce a single char. `PostgreSQL`
+/// uses different variants of bool-to-string in different situations.
+pub fn bool_out(input: bool) -> Result<String> {
+    Ok(if input { "t".into() } else { "f".into() })
+}
+
 #[cfg(test)]
 mod tests {
     use num_traits::FromPrimitive;

--- a/src/frontend/src/expr/function_call.rs
+++ b/src/frontend/src/expr/function_call.rs
@@ -142,8 +142,8 @@ impl FunctionCall {
                     .map(|(i, input)| match i {
                         // 0-th arg must be string
                         0 => input.cast_implicit(DataType::Varchar),
-                        // subsequent can be any type
-                        _ => input.cast_explicit(DataType::Varchar),
+                        // subsequent can be any type, using the output format
+                        _ => input.cast_output(),
                     })
                     .try_collect()?;
                 Ok(DataType::Varchar)

--- a/src/frontend/src/expr/mod.rs
+++ b/src/frontend/src/expr/mod.rs
@@ -135,6 +135,8 @@ impl ExprImpl {
         if self.return_type() == DataType::Boolean {
             return Ok(FunctionCall::new(ExprType::BoolOut, vec![self])?.into());
         }
+        // Use normal cast for other types. Both `assign` and `explicit` can pass the castability
+        // check and there is no difference.
         self.cast_assign(DataType::Varchar)
     }
 }

--- a/src/frontend/src/expr/mod.rs
+++ b/src/frontend/src/expr/mod.rs
@@ -120,6 +120,23 @@ impl ExprImpl {
     pub fn cast_explicit(self, target: DataType) -> Result<ExprImpl> {
         FunctionCall::new_cast(self, target, CastContext::Explicit)
     }
+
+    /// Create "cast" expr to string (`varchar`) type. This is different from a real cast, as
+    /// boolean is converted to a single char rather than full word.
+    ///
+    /// Choose between `cast_output` and `cast_{assign,explicit}(Varchar)` based on `PostgreSQL`'s
+    /// behavior on bools. For example, `concat(':', true)` is `:t` but `':' || true` is `:true`.
+    /// All other types have the same behavior when formatting to output and casting to string.
+    ///
+    /// References in `PostgreSQL`:
+    /// * [cast](https://github.com/postgres/postgres/blob/a3ff08e0b08dbfeb777ccfa8f13ebaa95d064c04/src/include/catalog/pg_cast.dat#L437-L444)
+    /// * [impl](https://github.com/postgres/postgres/blob/27b77ecf9f4d5be211900eda54d8155ada50d696/src/backend/utils/adt/bool.c#L204-L209)
+    pub fn cast_output(self) -> Result<ExprImpl> {
+        if self.return_type() == DataType::Boolean {
+            return Ok(FunctionCall::new(ExprType::BoolOut, vec![self])?.into());
+        }
+        self.cast_assign(DataType::Varchar)
+    }
 }
 
 /// Implement helper functions which recursively checks whether an variant is included in the

--- a/src/frontend/src/expr/type_inference.rs
+++ b/src/frontend/src/expr/type_inference.rs
@@ -211,6 +211,7 @@ fn build_type_derive_map() -> HashMap<FuncSign, DataTypeName> {
     for e in [E::And, E::Or] {
         map.insert(FuncSign::new(e, vec![T::Boolean, T::Boolean]), T::Boolean);
     }
+    map.insert(FuncSign::new(E::BoolOut, vec![T::Boolean]), T::Varchar);
 
     // comparison expressions
     for e in [E::IsNull, E::IsNotNull] {

--- a/src/frontend/test_runner/tests/testdata/expr.yaml
+++ b/src/frontend/test_runner/tests/testdata/expr.yaml
@@ -278,3 +278,13 @@
     create table t (v1 int);
     select concat() from t;
   binder_error: 'Bind error: Function `Concat` takes at least 1 arguments (0 given)'
+- sql: |
+    select concat(':', true);
+  batch_plan: |
+    BatchProject { exprs: [ConcatWs('':Varchar, ':':Varchar, BoolOut(true:Boolean))] }
+      BatchValues { rows: [[]] }
+- sql: |
+    select ':' || true;
+  batch_plan: |
+    BatchProject { exprs: [ConcatOp(':':Varchar, true:Boolean::Varchar)] }
+      BatchValues { rows: [[]] }


### PR DESCRIPTION
## What's changed and what's your intention?

Fixes #3146 by introducing a dedicated `BoolOut` expr. All other types can share the same expr/func for **I/O** and **from/to-string cast**.

Check doc comment of `cast_output` for details. The 2 different implementations in PostgreSQL are called `boolout` and `booltext`.

In PostgreSQL, only 4 types have cast-to-string different from output format: `bool`, `cidr`, `inet`, `xml`, and only 1 type has cast-from-string different from input format: `xml`.

## Checklist

- [x] I have written necessary docs and comments
- [x] I have added necessary unit tests and integration tests
- [x] All checks passed in `./risedev check` (or alias, `./risedev c`)

## Refer to a related PR or issue link (optional)
