### PR TITLE
fix(storage): disable compaction filter temporarily.

### DIFF
--- a/src/storage/src/hummock/compactor.rs
+++ b/src/storage/src/hummock/compactor.rs
@@ -98,6 +98,7 @@ trait CompactionFilter {
     }
 }
 
+#[derive(Clone, Default)]
 pub struct DummyCompactionFilter;
 impl CompactionFilter for DummyCompactionFilter {}
 
@@ -107,6 +108,7 @@ pub struct StateCleanUpCompactionFilter {
 }
 
 impl StateCleanUpCompactionFilter {
+    #[expect(dead_code)]
     fn new(table_id_set: HashSet<u32>) -> Self {
         StateCleanUpCompactionFilter {
             existing_table_ids: table_id_set,
@@ -390,8 +392,11 @@ impl Compactor {
             );
         }
 
-        let compaction_filter =
-            StateCleanUpCompactionFilter::new(HashSet::from_iter(compact_task.existing_table_ids));
+        // TODO #2065: re-enable it after all states are registered correctly.
+        let compaction_filter = DummyCompactionFilter::default();
+        // let compaction_filter =
+        //     StateCleanUpCompactionFilter::new(HashSet::from_iter(compact_task.
+        // existing_table_ids));
 
         for (split_index, _) in compact_task.splits.iter().enumerate() {
             let compactor = compactor.clone();

--- a/src/storage/src/hummock/compactor_tests.rs
+++ b/src/storage/src/hummock/compactor_tests.rs
@@ -169,6 +169,8 @@ mod tests {
     }
 
     #[tokio::test]
+    // TODO #2065: re-enable it after all states are registered correctly.
+    #[ignore]
     async fn test_compaction_drop_all_key() {
         let (_env, hummock_manager_ref, _cluster_manager_ref, worker_node) =
             setup_compute_env(8080).await;
@@ -247,6 +249,8 @@ mod tests {
     }
 
     #[tokio::test]
+    // TODO #2065: re-enable it after all states are registered correctly.
+    #[ignore]
     async fn test_compaction_drop_key_by_existing_table_id() {
         let (_env, hummock_manager_ref, _cluster_manager_ref, worker_node) =
             setup_compute_env(8080).await;


### PR DESCRIPTION
## What's changed and what's your intention?

This PR temporarily disables compaction filter.

Compaction filter relies on compaction group manager to provide `existing_table_ids`. Current source is not in `existing_table_ids`, so its state can be incorrectly removed by compaction filter.

## Checklist

## Refer to a related PR or issue link (optional)
