### PR TITLE
chore(meta): make vnodes sequential in initial hash mapping

### DIFF
--- a/src/meta/src/manager/hash_mapping.rs
+++ b/src/meta/src/manager/hash_mapping.rs
@@ -148,27 +148,24 @@ impl HashMappingManagerCore {
         let mut owner_mapping: HashMap<ParallelUnitId, Vec<VirtualNode>> = HashMap::new();
         let mut load_balancer: BTreeMap<usize, Vec<ParallelUnitId>> = BTreeMap::new();
         let hash_shard_size = VIRTUAL_NODE_COUNT / parallel_units.len();
-        let mut init_bound = hash_shard_size;
+        let mut one_more_count = VIRTUAL_NODE_COUNT % parallel_units.len();
+        let mut init_bound = 0;
 
         parallel_units.iter().for_each(|parallel_unit| {
+            let vnode_count = if one_more_count > 0 {
+                one_more_count -= 1;
+                hash_shard_size + 1
+            } else {
+                hash_shard_size
+            };
             let parallel_unit_id = parallel_unit.id;
+            init_bound += vnode_count;
             vnode_mapping.resize(init_bound, parallel_unit_id);
-            let vnodes = (init_bound - hash_shard_size..init_bound)
+            let vnodes = (init_bound - vnode_count..init_bound)
                 .map(|id| id as VirtualNode)
                 .collect();
             owner_mapping.insert(parallel_unit_id, vnodes);
-            init_bound += hash_shard_size;
         });
-
-        let mut parallel_unit_iter = parallel_units.iter().cycle();
-        for vnode in init_bound - hash_shard_size..VIRTUAL_NODE_COUNT {
-            let id = parallel_unit_iter.next().unwrap().id;
-            vnode_mapping.push(id);
-            owner_mapping
-                .entry(id)
-                .or_default()
-                .push(vnode as VirtualNode);
-        }
 
         owner_mapping.iter().for_each(|(parallel_unit_id, vnodes)| {
             let vnode_count = vnodes.len();


### PR DESCRIPTION
## What's changed and what's your intention?

### Summarize your change

Alter strategy of assigning vnodes to parallel unit when generating vnode mappings, so that initial vnode mapping will look like:
```
[1,1,1,1,2,2,2,2,3,3,3,3,4,4,4]
```
instead of 
```
[1,1,1,2,2,2,3,3,3,4,4,4,1,2,3]
```

In this way:
- The compression could achieve better effects. 
- It looks prettier.

## Checklist

- [x] All checks passed in `./risedev check` (or alias, `./risedev c`)
