### PR TITLE
refactor: use bounded channel for 3 channels

### DIFF
--- a/src/batch/src/task/mod.rs
+++ b/src/batch/src/task/mod.rs
@@ -25,3 +25,5 @@ mod fifo_channel;
 mod hash_shuffle_channel;
 mod task_execution;
 mod task_manager;
+
+const BOUNDED_BUFFER_SIZE: usize = 64;


### PR DESCRIPTION
## What's changed and what's your intention?
ref: #3024 

For 3 channels:
FIFO, HASH, BROADCAST

## Checklist

- [x] I have written necessary docs and comments
- [x] I have added necessary unit tests and integration tests
- [x] All checks passed in `./risedev check` (or alias, `./risedev c`)

## Refer to a related PR or issue link (optional)
