### PR TITLE
fix(pgwire): fix the wrong typeOID of Decimal type

### DIFF
--- a/src/utils/pgwire/src/pg_field_descriptor.rs
+++ b/src/utils/pgwire/src/pg_field_descriptor.rs
@@ -104,7 +104,7 @@ pub enum TypeOid {
 }
 
 impl TypeOid {
-    // Error handle need modify later!
+    // TODO: support more type.
     pub fn as_type(oid: i32) -> Result<TypeOid, String> {
         match oid {
             1043 => Ok(TypeOid::Varchar),
@@ -112,6 +112,12 @@ impl TypeOid {
         }
     }
 
+    // NOTE:
+    // Refer https://github.com/postgres/postgres/blob/master/src/include/catalog/pg_type.dat when add new TypeOid.
+    // Be careful to distinguish oid from array_type_oid.
+    // Such as:
+    //  https://github.com/postgres/postgres/blob/master/src/include/catalog/pg_type.dat#L347
+    //  For Numeric(aka Decimal): oid = 1700, array_type_oid = 1231
     pub fn as_number(&self) -> i32 {
         match self {
             TypeOid::Boolean => 16,
@@ -126,7 +132,7 @@ impl TypeOid {
             TypeOid::Time => 1083,
             TypeOid::Timestamp => 1114,
             TypeOid::Timestampz => 1184,
-            TypeOid::Decimal => 1231,
+            TypeOid::Decimal => 1700,
         }
     }
 }


### PR DESCRIPTION
## What's changed and what's your intention?
- fix the wrong typeOID of Decimal type.
- Add the comment to avoid bug like this in the future.


## Checklist

- [x] I have written necessary docs and comments
- [x] I have added necessary unit tests and integration tests
- [x] All checks passed in `./risedev check` (or alias, `./risedev c`)

## Refer to a related PR or issue link (optional)
#3015 