### PR TITLE
feat: modify interfaces to support specifying parallelism for each fr…

### DIFF
--- a/src/meta/src/rpc/service/ddl_service.rs
+++ b/src/meta/src/rpc/service/ddl_service.rs
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use std::collections::HashSet;
+use std::collections::{HashMap, HashSet};
 
 use risingwave_common::catalog::CatalogVersion;
 use risingwave_common::error::{tonic_err, ErrorCode, Result as RwResult};
@@ -29,7 +29,7 @@ use tonic::{Request, Response, Status};
 
 use crate::cluster::ClusterManagerRef;
 use crate::manager::{CatalogManagerRef, IdCategory, MetaSrvEnv, SourceId, TableId};
-use crate::model::TableFragments;
+use crate::model::{FragmentId, TableFragments};
 use crate::storage::MetaStore;
 use crate::stream::{
     ActorGraphBuilder, FragmentManagerRef, GlobalStreamManagerRef, SourceManagerRef,
@@ -440,14 +440,32 @@ where
             affiliated_source,
             ..Default::default()
         };
-        let graph = ActorGraphBuilder::generate_graph(
-            self.env.id_gen_manager_ref(),
-            self.fragment_manager.clone(),
-            parallel_degree as u32,
-            &fragment_graph,
-            &mut ctx,
-        )
-        .await?;
+
+        let mut actor_graph_builder =
+            ActorGraphBuilder::new(self.env.id_gen_manager_ref(), &fragment_graph, &mut ctx)
+                .await?;
+
+        // TODO(Kexiang): now simply use Count(ParallelUnit) - 1 as parallelism of each fragment
+        let parallelisms: HashMap<FragmentId, u32> = actor_graph_builder
+            .list_fragment_ids()
+            .into_iter()
+            .map(|(fragment_id, is_singleton)| {
+                if is_singleton {
+                    (fragment_id, 1)
+                } else {
+                    (fragment_id, parallel_degree as u32)
+                }
+            })
+            .collect();
+
+        let graph = actor_graph_builder
+            .generate_graph(
+                self.env.id_gen_manager_ref(),
+                self.fragment_manager.clone(),
+                parallelisms,
+                &mut ctx,
+            )
+            .await?;
         assert_eq!(
             fragment_graph.table_ids_cnt,
             ctx.internal_table_id_set.len() as u32

--- a/src/meta/src/stream/scheduler.rs
+++ b/src/meta/src/stream/scheduler.rs
@@ -202,10 +202,13 @@ where
             // Normal fragment
 
             // Find out all the hash parallel units in the cluster.
-            let parallel_units = self
+            let mut parallel_units = self
                 .cluster_manager
                 .list_parallel_units(Some(ParallelUnitType::Hash))
                 .await;
+            // FIXME(Kexiang): select appropriate parallel_units, currently only support
+            // `parallel_degree < parallel_units.size()`
+            parallel_units.truncate(fragment.actors.len());
 
             // Build vnode mapping according to the parallel units.
             self.set_fragment_vnode_mapping(fragment, &parallel_units)?;

--- a/src/meta/src/stream/stream_graph.rs
+++ b/src/meta/src/stream/stream_graph.rs
@@ -688,61 +688,80 @@ impl BuildActorGraphState {
 
 /// [`ActorGraphBuilder`] generates the proto for interconnected actors for a streaming pipeline.
 pub struct ActorGraphBuilder {
-    /// degree of parallelism
-    parallel_degree: u32,
+    /// GlobalFragmentId -> parallel_degree
+    parallelisms: Option<HashMap<FragmentId, u32>>,
+
+    fragment_graph: StreamFragmentGraph,
 }
 
 impl ActorGraphBuilder {
+    pub async fn new<S>(
+        id_gen_manager: IdGeneratorManagerRef<S>,
+        fragment_graph: &StreamFragmentGraphProto,
+        ctx: &mut CreateMaterializedViewContext,
+    ) -> Result<Self>
+    where
+        S: MetaStore,
+    {
+        // save dependent table ids in ctx
+        ctx.dependent_table_ids = fragment_graph
+            .dependent_table_ids
+            .iter()
+            .map(|table_id| TableId::new(*table_id))
+            .collect();
+
+        let fragment_len = fragment_graph.fragments.len() as u32;
+        let offset = id_gen_manager
+            .generate_interval::<{ IdCategory::Fragment }>(fragment_len as i32)
+            .await? as _;
+
+        // Compute how many table ids should be allocated for all actors.
+        // Allocate all needed table ids for current MV.
+        let table_ids_cnt = fragment_graph.table_ids_cnt;
+        let start_table_id = id_gen_manager
+            .generate_interval::<{ IdCategory::Table }>(table_ids_cnt as i32)
+            .await? as _;
+        ctx.table_id_offset = start_table_id;
+
+        Ok(Self {
+            fragment_graph: StreamFragmentGraph::from_protobuf(fragment_graph.clone(), offset),
+            parallelisms: None,
+        })
+    }
+
     pub async fn generate_graph<S>(
+        &mut self,
         id_gen_manager: IdGeneratorManagerRef<S>,
         fragment_manager: FragmentManagerRef<S>,
-        parallel_degree: u32,
-        fragment_graph: &StreamFragmentGraphProto,
+        parallelisms: HashMap<FragmentId, u32>,
         ctx: &mut CreateMaterializedViewContext,
     ) -> Result<BTreeMap<FragmentId, Fragment>>
     where
         S: MetaStore,
     {
-        Self { parallel_degree }
-            .generate_graph_inner(id_gen_manager, fragment_manager, fragment_graph, ctx)
+        self.parallelisms = Some(parallelisms);
+        self.generate_graph_inner(id_gen_manager, fragment_manager, ctx)
             .await
+    }
+
+    pub fn list_fragment_ids(&self) -> Vec<(FragmentId, bool)> {
+        self.fragment_graph
+            .fragments()
+            .iter()
+            .map(|(id, fragment)| (id.as_global_id(), fragment.is_singleton))
+            .collect_vec()
     }
 
     /// Build a stream graph by duplicating each fragment as parallel actors.
     async fn generate_graph_inner<S>(
-        self,
+        &self,
         id_gen_manager: IdGeneratorManagerRef<S>,
         fragment_manager: FragmentManagerRef<S>,
-        fragment_graph: &StreamFragmentGraphProto,
         ctx: &mut CreateMaterializedViewContext,
     ) -> Result<BTreeMap<FragmentId, Fragment>>
     where
         S: MetaStore,
     {
-        let fragment_graph = {
-            // save dependent table ids in ctx
-            ctx.dependent_table_ids = fragment_graph
-                .dependent_table_ids
-                .iter()
-                .map(|table_id| TableId::new(*table_id))
-                .collect();
-
-            let fragment_len = fragment_graph.fragments.len() as u32;
-            let offset = id_gen_manager
-                .generate_interval::<{ IdCategory::Fragment }>(fragment_len as i32)
-                .await? as _;
-
-            // Compute how many table ids should be allocated for all actors.
-            // Allocate all needed table ids for current MV.
-            let table_ids_cnt = fragment_graph.table_ids_cnt;
-            let start_table_id = id_gen_manager
-                .generate_interval::<{ IdCategory::Table }>(table_ids_cnt as i32)
-                .await? as _;
-            ctx.table_id_offset = start_table_id;
-
-            StreamFragmentGraph::from_protobuf(fragment_graph.clone(), offset)
-        };
-
         let stream_graph = {
             let BuildActorGraphState {
                 stream_graph_builder,
@@ -760,7 +779,7 @@ impl ActorGraphBuilder {
                 state.stream_graph_builder.fill_info(info);
 
                 // Generate actors of the streaming plan
-                self.build_actor_graph(&mut state, &fragment_graph)?;
+                self.build_actor_graph(&mut state, &self.fragment_graph)?;
                 state
             };
 
@@ -782,7 +801,7 @@ impl ActorGraphBuilder {
         let stream_graph = stream_graph
             .into_iter()
             .map(|(fragment_id, actors)| {
-                let fragment = fragment_graph.get_fragment(fragment_id).unwrap();
+                let fragment = self.fragment_graph.get_fragment(fragment_id).unwrap();
                 let fragment_id = fragment_id.as_global_id();
                 (
                     fragment_id,
@@ -859,11 +878,13 @@ impl ActorGraphBuilder {
     ) -> Result<()> {
         let current_fragment = fragment_graph.get_fragment(fragment_id).unwrap().clone();
 
-        let parallel_degree = if current_fragment.is_singleton {
-            1
-        } else {
-            self.parallel_degree
-        };
+        let parallel_degree = self
+            .parallelisms
+            .as_ref()
+            .unwrap()
+            .get(&fragment_id.as_global_id())
+            .unwrap()
+            .to_owned();
 
         let node = Arc::new(current_fragment.node.unwrap());
         let actor_ids = state


### PR DESCRIPTION
…agment

## What's changed and what's your intention?

***PLEASE DO NOT LEAVE THIS EMPTY !!!***

Modify interfaces of`ActorGraphBuilder`, `TableFragments` and `Scheduler` to support specifying parallelisms for each fragment. 
Limitation: 
- still use `node_count * (number of parallel_unit - 1)` as default parallelism
- the parallelism can only be less than `node_count * (number of parallel_unit - 1)` now.

## Checklist

- [x] I have written necessary docs and comments
- [x] I have added necessary unit tests and integration tests
- [x] All checks passed in `./risedev check` (or alias, `./risedev c`)

## Refer to a related PR or issue link (optional)
