### PR TITLE
feat(storage): add manual compaction picker for targeted compaction

### DIFF
--- a/proto/hummock.proto
+++ b/proto/hummock.proto
@@ -231,6 +231,9 @@ message GetCompactionGroupsResponse {
 
 message TriggerManualCompactionRequest {
   uint64 compaction_group_id = 1;
+  KeyRange key_range = 2;
+  uint32 table_id = 3;
+  uint32 level = 4;
 }
 
 message TriggerManualCompactionResponse {

--- a/src/ctl/src/cmd_impl/hummock/trigger_manual_compaction.rs
+++ b/src/ctl/src/cmd_impl/hummock/trigger_manual_compaction.rs
@@ -16,11 +16,15 @@ use risingwave_rpc_client::HummockMetaClient;
 
 use crate::common::MetaServiceOpts;
 
-pub async fn trigger_manual_compaction(compaction_group_id: u64) -> anyhow::Result<()> {
+pub async fn trigger_manual_compaction(
+    compaction_group_id: u64,
+    table_id: u32,
+    level: u32,
+) -> anyhow::Result<()> {
     let meta_opts = MetaServiceOpts::from_env()?;
     let meta_client = meta_opts.create_meta_client().await?;
     let result = meta_client
-        .trigger_manual_compaction(compaction_group_id)
+        .trigger_manual_compaction(compaction_group_id, table_id, level)
         .await;
     println!("{:#?}", result);
     Ok(())

--- a/src/ctl/src/lib.rs
+++ b/src/ctl/src/lib.rs
@@ -55,9 +55,16 @@ enum HummockCommands {
         table_id: Option<u32>,
     },
     SstDump,
+    /// trigger a targeted compaction through compaction_group_id
     TriggerManualCompaction {
         #[clap(short, long = "compaction-group-id", default_value_t = 2)]
         compaction_group_id: u64,
+
+        #[clap(short, long = "table-id", default_value_t = 0)]
+        table_id: u32,
+
+        #[clap(short, long = "level", default_value_t = 1)]
+        level: u32,
     },
 }
 
@@ -82,9 +89,13 @@ pub async fn start(opts: CliOpts) -> Result<()> {
         Commands::Hummock(HummockCommands::SstDump) => cmd_impl::hummock::sst_dump().await.unwrap(),
         Commands::Hummock(HummockCommands::TriggerManualCompaction {
             compaction_group_id,
+            table_id,
+            level,
         }) => {
             tokio::spawn(cmd_impl::hummock::trigger_manual_compaction(
                 compaction_group_id,
+                table_id,
+                level,
             ))
             .await??
         }

--- a/src/meta/src/hummock/compaction/compaction_picker.rs
+++ b/src/meta/src/hummock/compaction/compaction_picker.rs
@@ -15,9 +15,10 @@
 use std::collections::HashSet;
 use std::sync::Arc;
 
-use risingwave_pb::hummock::{Level, SstableInfo};
+use risingwave_pb::hummock::{KeyRange, Level, SstableInfo};
 
-use crate::hummock::compaction::overlap_strategy::OverlapStrategy;
+use super::overlap_strategy::OverlapInfo;
+use crate::hummock::compaction::overlap_strategy::{OverlapStrategy, RangeOverlapInfo};
 use crate::hummock::compaction::SearchResult;
 use crate::hummock::level_handler::LevelHandler;
 
@@ -189,13 +190,151 @@ impl CompactionPicker for MinOverlappingPicker {
     }
 }
 
+pub struct ManualCompactionOption {
+    key_range: KeyRange,
+    internal_table_id: HashSet<u32>,
+}
+
+impl Default for ManualCompactionOption {
+    fn default() -> Self {
+        Self {
+            key_range: KeyRange {
+                left: vec![],
+                right: vec![],
+                inf: true,
+            },
+            internal_table_id: HashSet::default(),
+        }
+    }
+}
+
+pub struct ManualCompactionPicker {
+    compact_task_id: u64,
+    overlap_strategy: Arc<dyn OverlapStrategy>,
+    level: usize,
+    option: ManualCompactionOption,
+}
+
+impl ManualCompactionPicker {
+    pub fn new(
+        compact_task_id: u64,
+        level: usize,
+        overlap_strategy: Arc<dyn OverlapStrategy>,
+        option: ManualCompactionOption,
+    ) -> Self {
+        Self {
+            compact_task_id,
+            overlap_strategy,
+            level,
+            option,
+        }
+    }
+}
+
+impl CompactionPicker for ManualCompactionPicker {
+    fn pick_compaction(
+        &self,
+        levels: &[Level],
+        level_handlers: &mut [LevelHandler],
+    ) -> Option<SearchResult> {
+        let target_level = self.level + 1;
+
+        let mut select_input_ssts = vec![];
+        let mut tmp_sst_info = SstableInfo::default();
+        let mut range_overlap_info = RangeOverlapInfo::default();
+        tmp_sst_info.key_range = Some(self.option.key_range.clone());
+        range_overlap_info.update(&tmp_sst_info);
+
+        let level_table_infos: Vec<SstableInfo> = levels[self.level]
+            .table_infos
+            .iter()
+            .filter(|sst_info| range_overlap_info.check_overlap(sst_info))
+            .filter(|sst_info| {
+                if self.option.internal_table_id.is_empty() {
+                    return true;
+                }
+
+                // to collect internal_table_id from sst_info
+                let table_id_in_sst: Vec<u32> = sst_info
+                    .vnode_bitmaps
+                    .iter()
+                    .map(|vmap| vmap.table_id)
+                    .collect();
+
+                // to filter sst_file by table_id
+                for table_id in &table_id_in_sst {
+                    if self.option.internal_table_id.contains(table_id) {
+                        return true;
+                    }
+                }
+
+                false
+            })
+            .cloned()
+            .collect();
+
+        for table in &level_table_infos {
+            if level_handlers[self.level].is_pending_compact(&table.id) {
+                continue;
+            }
+
+            let mut pending_campct = false;
+            let overlap_files = self
+                .overlap_strategy
+                .check_base_level_overlap(&[table.clone()], &levels[target_level].table_infos);
+            for other in overlap_files {
+                if level_handlers[target_level].is_pending_compact(&other.id) {
+                    pending_campct = true;
+                    break;
+                }
+            }
+            if pending_campct {
+                continue;
+            }
+
+            select_input_ssts.push(table.clone());
+        }
+
+        if select_input_ssts.is_empty() {
+            return None;
+        }
+
+        let target_input_ssts = self
+            .overlap_strategy
+            .check_base_level_overlap(&select_input_ssts, &levels[target_level].table_infos);
+
+        level_handlers[self.level].add_pending_task(self.compact_task_id, &select_input_ssts);
+        if !target_input_ssts.is_empty() {
+            level_handlers[target_level].add_pending_task(self.compact_task_id, &target_input_ssts);
+        }
+
+        Some(SearchResult {
+            select_level: Level {
+                level_idx: self.level as u32,
+                level_type: levels[self.level].level_type,
+                table_infos: select_input_ssts,
+                total_file_size: 0,
+            },
+            target_level: Level {
+                level_idx: target_level as u32,
+                level_type: levels[target_level].level_type,
+                table_infos: target_input_ssts,
+                total_file_size: 0,
+            },
+            split_ranges: vec![],
+        })
+    }
+}
+
 #[cfg(test)]
 pub mod tests {
+    use risingwave_pb::common::VNodeBitmap;
     use risingwave_pb::hummock::LevelType;
 
     use super::*;
     use crate::hummock::compaction::overlap_strategy::RangeOverlapStrategy;
     use crate::hummock::compaction::tier_compaction_picker::tests::generate_table;
+    use crate::hummock::test_utils::iterator_test_key_of_epoch;
 
     #[test]
     fn test_compact_l1() {
@@ -317,5 +456,162 @@ pub mod tests {
 
         assert_eq!(ret.target_level.table_infos.len(), 1);
         assert_eq!(ret.target_level.table_infos[0].id, 4);
+    }
+
+    #[test]
+    fn test_manaul_compaction_picker() {
+        let mut levels = vec![
+            Level {
+                level_idx: 0,
+                level_type: LevelType::Overlapping as i32,
+                table_infos: vec![],
+                total_file_size: 0,
+            },
+            Level {
+                level_idx: 1,
+                level_type: LevelType::Nonoverlapping as i32,
+                table_infos: vec![
+                    generate_table(0, 1, 0, 100, 1),
+                    generate_table(1, 1, 101, 200, 1),
+                    generate_table(2, 1, 222, 300, 1),
+                ],
+                total_file_size: 0,
+            },
+            Level {
+                level_idx: 2,
+                level_type: LevelType::Nonoverlapping as i32,
+                table_infos: vec![
+                    generate_table(4, 1, 0, 100, 1),
+                    generate_table(5, 1, 101, 150, 1),
+                    generate_table(6, 1, 151, 201, 1),
+                    generate_table(7, 1, 501, 800, 1),
+                    generate_table(8, 2, 301, 400, 1),
+                ],
+                total_file_size: 0,
+            },
+        ];
+        let mut levels_handler = vec![
+            LevelHandler::new(0),
+            LevelHandler::new(1),
+            LevelHandler::new(2),
+        ];
+
+        let clean_task_state = |level_handler: &mut LevelHandler| {
+            for pending_task_id in &level_handler.pending_tasks_ids() {
+                level_handler.remove_task(*pending_task_id);
+            }
+        };
+
+        {
+            // test key_range option
+            let mut option = ManualCompactionOption::default();
+            let key_range = KeyRange {
+                left: iterator_test_key_of_epoch(1, 0, 1),
+                right: iterator_test_key_of_epoch(1, 201, 1),
+                inf: false,
+            };
+            option.key_range = key_range;
+            let picker = ManualCompactionPicker::new(
+                0,
+                1,
+                Arc::new(RangeOverlapStrategy::default()),
+                option,
+            );
+            let result = picker
+                .pick_compaction(&levels, &mut levels_handler)
+                .unwrap();
+
+            assert_eq!(2, result.select_level.table_infos.len());
+            assert_eq!(3, result.target_level.table_infos.len());
+        }
+
+        {
+            clean_task_state(&mut levels_handler[1]);
+            clean_task_state(&mut levels_handler[2]);
+
+            // test all key range
+            let option = ManualCompactionOption::default();
+            let picker = ManualCompactionPicker::new(
+                0,
+                1,
+                Arc::new(RangeOverlapStrategy::default()),
+                option,
+            );
+            let result = picker
+                .pick_compaction(&levels, &mut levels_handler)
+                .unwrap();
+
+            assert_eq!(3, result.select_level.table_infos.len());
+            assert_eq!(3, result.target_level.table_infos.len());
+        }
+
+        {
+            clean_task_state(&mut levels_handler[1]);
+            clean_task_state(&mut levels_handler[2]);
+
+            let level_table_info = &mut levels[1].table_infos;
+            let table_info_1 = &mut level_table_info[1];
+            table_info_1.vnode_bitmaps.resize(2, VNodeBitmap::default());
+            table_info_1.vnode_bitmaps[0].table_id = 1;
+            table_info_1.vnode_bitmaps[1].table_id = 2;
+
+            // test internal_table_id
+            let option = ManualCompactionOption {
+                internal_table_id: HashSet::from([2]),
+                ..Default::default()
+            };
+
+            let picker = ManualCompactionPicker::new(
+                0,
+                1,
+                Arc::new(RangeOverlapStrategy::default()),
+                option,
+            );
+
+            let result = picker
+                .pick_compaction(&levels, &mut levels_handler)
+                .unwrap();
+
+            assert_eq!(1, result.select_level.table_infos.len());
+            assert_eq!(2, result.target_level.table_infos.len());
+        }
+
+        {
+            clean_task_state(&mut levels_handler[1]);
+            clean_task_state(&mut levels_handler[2]);
+
+            // include all table_info
+            let level_table_info = &mut levels[1].table_infos;
+            for table_info in level_table_info {
+                table_info.vnode_bitmaps.resize(2, VNodeBitmap::default());
+                table_info.vnode_bitmaps[0].table_id = 1;
+                table_info.vnode_bitmaps[1].table_id = 2;
+            }
+
+            // test key range filter first
+            let option = ManualCompactionOption {
+                key_range: KeyRange {
+                    left: iterator_test_key_of_epoch(1, 101, 1),
+                    right: iterator_test_key_of_epoch(1, 199, 1),
+                    inf: false,
+                },
+                internal_table_id: HashSet::from([2]),
+                ..Default::default()
+            };
+
+            let picker = ManualCompactionPicker::new(
+                0,
+                1,
+                Arc::new(RangeOverlapStrategy::default()),
+                option,
+            );
+
+            let result = picker
+                .pick_compaction(&levels, &mut levels_handler)
+                .unwrap();
+
+            assert_eq!(1, result.select_level.table_infos.len());
+            assert_eq!(2, result.target_level.table_infos.len());
+        }
     }
 }

--- a/src/meta/src/hummock/compaction/level_selector.rs
+++ b/src/meta/src/hummock/compaction/level_selector.rs
@@ -23,12 +23,15 @@ use risingwave_hummock_sdk::HummockCompactionTaskId;
 use risingwave_pb::hummock::{CompactionConfig, Level};
 
 use crate::hummock::compaction::compaction_config::CompactionConfigBuilder;
+use crate::hummock::compaction::manual_compaction_picker::ManualCompactionPicker;
 use crate::hummock::compaction::min_overlap_compaction_picker::MinOverlappingPicker;
 use crate::hummock::compaction::overlap_strategy::OverlapStrategy;
 use crate::hummock::compaction::tier_compaction_picker::{
     LevelCompactionPicker, TierCompactionPicker,
 };
-use crate::hummock::compaction::{create_overlap_strategy, CompactionPicker, SearchResult};
+use crate::hummock::compaction::{
+    create_overlap_strategy, CompactionPicker, ManualCompactionOption, SearchResult,
+};
 use crate::hummock::level_handler::LevelHandler;
 
 const SCORE_BASE: u64 = 100;
@@ -41,6 +44,14 @@ pub trait LevelSelector: Sync + Send {
         task_id: HummockCompactionTaskId,
         levels: &[Level],
         level_handlers: &mut [LevelHandler],
+    ) -> Option<SearchResult>;
+
+    fn manual_pick_compaction(
+        &self,
+        task_id: HummockCompactionTaskId,
+        levels: &[Level],
+        level_handlers: &mut [LevelHandler],
+        option: ManualCompactionOption,
     ) -> Option<SearchResult>;
 
     fn name(&self) -> &'static str;
@@ -237,6 +248,30 @@ impl LevelSelector for DynamicLevelSelector {
             }
         }
         None
+    }
+
+    fn manual_pick_compaction(
+        &self,
+        task_id: HummockCompactionTaskId,
+        levels: &[Level],
+        level_handlers: &mut [LevelHandler],
+        option: ManualCompactionOption,
+    ) -> Option<SearchResult> {
+        let ctx = self.get_priority_levels(levels, level_handlers);
+        let target_level = if option.level == 0 {
+            ctx.base_level
+        } else {
+            option.level + 1
+        };
+
+        let picker = Box::new(ManualCompactionPicker::new(
+            task_id,
+            self.overlap_strategy.clone(),
+            option,
+            target_level,
+        ));
+
+        picker.pick_compaction(levels, level_handlers)
     }
 
     fn name(&self) -> &'static str {

--- a/src/meta/src/hummock/compaction/level_selector.rs
+++ b/src/meta/src/hummock/compaction/level_selector.rs
@@ -264,12 +264,12 @@ impl LevelSelector for DynamicLevelSelector {
             option.level + 1
         };
 
-        let picker = Box::new(ManualCompactionPicker::new(
+        let picker = ManualCompactionPicker::new(
             task_id,
             self.overlap_strategy.clone(),
             option,
             target_level,
-        ));
+        );
 
         picker.pick_compaction(levels, level_handlers)
     }

--- a/src/meta/src/hummock/compaction/level_selector.rs
+++ b/src/meta/src/hummock/compaction/level_selector.rs
@@ -23,12 +23,12 @@ use risingwave_hummock_sdk::HummockCompactionTaskId;
 use risingwave_pb::hummock::{CompactionConfig, Level};
 
 use crate::hummock::compaction::compaction_config::CompactionConfigBuilder;
-use crate::hummock::compaction::compaction_picker::{CompactionPicker, MinOverlappingPicker};
+use crate::hummock::compaction::min_overlap_compaction_picker::MinOverlappingPicker;
 use crate::hummock::compaction::overlap_strategy::OverlapStrategy;
 use crate::hummock::compaction::tier_compaction_picker::{
     LevelCompactionPicker, TierCompactionPicker,
 };
-use crate::hummock::compaction::{create_overlap_strategy, SearchResult};
+use crate::hummock::compaction::{create_overlap_strategy, CompactionPicker, SearchResult};
 use crate::hummock::level_handler::LevelHandler;
 
 const SCORE_BASE: u64 = 100;

--- a/src/meta/src/hummock/compaction/manual_compaction_picker.rs
+++ b/src/meta/src/hummock/compaction/manual_compaction_picker.rs
@@ -14,7 +14,6 @@
 
 use std::sync::Arc;
 
-use itertools::Itertools;
 use risingwave_pb::hummock::{Level, SstableInfo};
 
 use super::overlap_strategy::OverlapInfo;
@@ -114,9 +113,7 @@ impl CompactionPicker for ManualCompactionPicker {
 
         let target_input_ssts = self
             .overlap_strategy
-            .check_base_level_overlap(&select_input_ssts, &levels[target_level].table_infos)
-            .into_iter()
-            .collect_vec();
+            .check_base_level_overlap(&select_input_ssts, &levels[target_level].table_infos);
 
         if target_input_ssts
             .iter()
@@ -134,14 +131,14 @@ impl CompactionPicker for ManualCompactionPicker {
             select_level: Level {
                 level_idx: level as u32,
                 level_type: levels[level].level_type,
+                total_file_size: select_input_ssts.iter().map(|table| table.file_size).sum(),
                 table_infos: select_input_ssts,
-                total_file_size: 0,
             },
             target_level: Level {
                 level_idx: target_level as u32,
                 level_type: levels[target_level].level_type,
+                total_file_size: target_input_ssts.iter().map(|table| table.file_size).sum(),
                 table_infos: target_input_ssts,
-                total_file_size: 0,
             },
             split_ranges: vec![],
         })

--- a/src/meta/src/hummock/compaction/manual_compaction_picker.rs
+++ b/src/meta/src/hummock/compaction/manual_compaction_picker.rs
@@ -1,0 +1,296 @@
+// Copyright 2022 Singularity Data
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::sync::Arc;
+
+use risingwave_pb::hummock::{Level, SstableInfo};
+
+use super::overlap_strategy::OverlapInfo;
+use super::CompactionPicker;
+use crate::hummock::compaction::overlap_strategy::{OverlapStrategy, RangeOverlapInfo};
+use crate::hummock::compaction::{ManualCompactionOption, SearchResult};
+use crate::hummock::level_handler::LevelHandler;
+
+pub struct ManualCompactionPicker {
+    compact_task_id: u64,
+    overlap_strategy: Arc<dyn OverlapStrategy>,
+    option: ManualCompactionOption,
+}
+
+impl ManualCompactionPicker {
+    pub fn new(
+        compact_task_id: u64,
+        overlap_strategy: Arc<dyn OverlapStrategy>,
+        option: ManualCompactionOption,
+    ) -> Self {
+        Self {
+            compact_task_id,
+            overlap_strategy,
+            option,
+        }
+    }
+}
+
+impl CompactionPicker for ManualCompactionPicker {
+    fn pick_compaction(
+        &self,
+        levels: &[Level],
+        level_handlers: &mut [LevelHandler],
+    ) -> Option<SearchResult> {
+        let level = self.option.level;
+        let target_level = level + 1;
+
+        let mut select_input_ssts = vec![];
+        let mut tmp_sst_info = SstableInfo::default();
+        let mut range_overlap_info = RangeOverlapInfo::default();
+        tmp_sst_info.key_range = Some(self.option.key_range.clone());
+        range_overlap_info.update(&tmp_sst_info);
+
+        let level_table_infos: Vec<SstableInfo> = levels[level]
+            .table_infos
+            .iter()
+            .filter(|sst_info| range_overlap_info.check_overlap(sst_info))
+            .filter(|sst_info| {
+                if self.option.internal_table_id.is_empty() {
+                    return true;
+                }
+
+                // to collect internal_table_id from sst_info
+                let table_id_in_sst: Vec<u32> = sst_info
+                    .vnode_bitmaps
+                    .iter()
+                    .map(|vmap| vmap.table_id)
+                    .collect();
+
+                // to filter sst_file by table_id
+                for table_id in &table_id_in_sst {
+                    if self.option.internal_table_id.contains(table_id) {
+                        return true;
+                    }
+                }
+
+                false
+            })
+            .cloned()
+            .collect();
+
+        for table in &level_table_infos {
+            if level_handlers[level].is_pending_compact(&table.id) {
+                continue;
+            }
+
+            let mut pending_campct = false;
+            let overlap_files = self
+                .overlap_strategy
+                .check_base_level_overlap(&[table.clone()], &levels[target_level].table_infos);
+            for other in overlap_files {
+                if level_handlers[target_level].is_pending_compact(&other.id) {
+                    pending_campct = true;
+                    break;
+                }
+            }
+            if pending_campct {
+                continue;
+            }
+
+            select_input_ssts.push(table.clone());
+        }
+
+        if select_input_ssts.is_empty() {
+            return None;
+        }
+
+        let target_input_ssts = self
+            .overlap_strategy
+            .check_base_level_overlap(&select_input_ssts, &levels[target_level].table_infos);
+
+        level_handlers[level].add_pending_task(self.compact_task_id, &select_input_ssts);
+        if !target_input_ssts.is_empty() {
+            level_handlers[target_level].add_pending_task(self.compact_task_id, &target_input_ssts);
+        }
+
+        Some(SearchResult {
+            select_level: Level {
+                level_idx: level as u32,
+                level_type: levels[level].level_type,
+                table_infos: select_input_ssts,
+                total_file_size: 0,
+            },
+            target_level: Level {
+                level_idx: target_level as u32,
+                level_type: levels[target_level].level_type,
+                table_infos: target_input_ssts,
+                total_file_size: 0,
+            },
+            split_ranges: vec![],
+        })
+    }
+}
+
+#[cfg(test)]
+pub mod tests {
+    use std::collections::HashSet;
+
+    use risingwave_pb::common::VNodeBitmap;
+    pub use risingwave_pb::hummock::{KeyRange, LevelType};
+
+    use super::*;
+    use crate::hummock::compaction::overlap_strategy::RangeOverlapStrategy;
+    use crate::hummock::compaction::tier_compaction_picker::tests::generate_table;
+    use crate::hummock::test_utils::iterator_test_key_of_epoch;
+
+    #[test]
+    fn test_manaul_compaction_picker() {
+        let mut levels = vec![
+            Level {
+                level_idx: 0,
+                level_type: LevelType::Overlapping as i32,
+                table_infos: vec![],
+                total_file_size: 0,
+            },
+            Level {
+                level_idx: 1,
+                level_type: LevelType::Nonoverlapping as i32,
+                table_infos: vec![
+                    generate_table(0, 1, 0, 100, 1),
+                    generate_table(1, 1, 101, 200, 1),
+                    generate_table(2, 1, 222, 300, 1),
+                ],
+                total_file_size: 0,
+            },
+            Level {
+                level_idx: 2,
+                level_type: LevelType::Nonoverlapping as i32,
+                table_infos: vec![
+                    generate_table(4, 1, 0, 100, 1),
+                    generate_table(5, 1, 101, 150, 1),
+                    generate_table(6, 1, 151, 201, 1),
+                    generate_table(7, 1, 501, 800, 1),
+                    generate_table(8, 2, 301, 400, 1),
+                ],
+                total_file_size: 0,
+            },
+        ];
+        let mut levels_handler = vec![
+            LevelHandler::new(0),
+            LevelHandler::new(1),
+            LevelHandler::new(2),
+        ];
+
+        let clean_task_state = |level_handler: &mut LevelHandler| {
+            for pending_task_id in &level_handler.pending_tasks_ids() {
+                level_handler.remove_task(*pending_task_id);
+            }
+        };
+
+        {
+            // test key_range option
+            let option = ManualCompactionOption {
+                level: 1,
+                key_range: KeyRange {
+                    left: iterator_test_key_of_epoch(1, 0, 1),
+                    right: iterator_test_key_of_epoch(1, 201, 1),
+                    inf: false,
+                },
+                ..Default::default()
+            };
+            let picker =
+                ManualCompactionPicker::new(0, Arc::new(RangeOverlapStrategy::default()), option);
+            let result = picker
+                .pick_compaction(&levels, &mut levels_handler)
+                .unwrap();
+
+            assert_eq!(2, result.select_level.table_infos.len());
+            assert_eq!(3, result.target_level.table_infos.len());
+        }
+
+        {
+            clean_task_state(&mut levels_handler[1]);
+            clean_task_state(&mut levels_handler[2]);
+
+            // test all key range
+            let option = ManualCompactionOption::default();
+            let picker =
+                ManualCompactionPicker::new(0, Arc::new(RangeOverlapStrategy::default()), option);
+            let result = picker
+                .pick_compaction(&levels, &mut levels_handler)
+                .unwrap();
+
+            assert_eq!(3, result.select_level.table_infos.len());
+            assert_eq!(3, result.target_level.table_infos.len());
+        }
+
+        {
+            clean_task_state(&mut levels_handler[1]);
+            clean_task_state(&mut levels_handler[2]);
+
+            let level_table_info = &mut levels[1].table_infos;
+            let table_info_1 = &mut level_table_info[1];
+            table_info_1.vnode_bitmaps.resize(2, VNodeBitmap::default());
+            table_info_1.vnode_bitmaps[0].table_id = 1;
+            table_info_1.vnode_bitmaps[1].table_id = 2;
+
+            // test internal_table_id
+            let option = ManualCompactionOption {
+                level: 1,
+                internal_table_id: HashSet::from([2]),
+                ..Default::default()
+            };
+
+            let picker =
+                ManualCompactionPicker::new(0, Arc::new(RangeOverlapStrategy::default()), option);
+
+            let result = picker
+                .pick_compaction(&levels, &mut levels_handler)
+                .unwrap();
+
+            assert_eq!(1, result.select_level.table_infos.len());
+            assert_eq!(2, result.target_level.table_infos.len());
+        }
+
+        {
+            clean_task_state(&mut levels_handler[1]);
+            clean_task_state(&mut levels_handler[2]);
+
+            // include all table_info
+            let level_table_info = &mut levels[1].table_infos;
+            for table_info in level_table_info {
+                table_info.vnode_bitmaps.resize(2, VNodeBitmap::default());
+                table_info.vnode_bitmaps[0].table_id = 1;
+                table_info.vnode_bitmaps[1].table_id = 2;
+            }
+
+            // test key range filter first
+            let option = ManualCompactionOption {
+                level: 1,
+                key_range: KeyRange {
+                    left: iterator_test_key_of_epoch(1, 101, 1),
+                    right: iterator_test_key_of_epoch(1, 199, 1),
+                    inf: false,
+                },
+                internal_table_id: HashSet::from([2]),
+            };
+
+            let picker =
+                ManualCompactionPicker::new(0, Arc::new(RangeOverlapStrategy::default()), option);
+
+            let result = picker
+                .pick_compaction(&levels, &mut levels_handler)
+                .unwrap();
+
+            assert_eq!(1, result.select_level.table_infos.len());
+            assert_eq!(2, result.target_level.table_infos.len());
+        }
+    }
+}

--- a/src/meta/src/hummock/compaction/manual_compaction_picker.rs
+++ b/src/meta/src/hummock/compaction/manual_compaction_picker.rs
@@ -116,8 +116,14 @@ impl CompactionPicker for ManualCompactionPicker {
             .overlap_strategy
             .check_base_level_overlap(&select_input_ssts, &levels[target_level].table_infos)
             .into_iter()
-            .filter(|table| !level_handlers[level].is_pending_compact(&table.id))
             .collect_vec();
+
+        if target_input_ssts
+            .iter()
+            .any(|table| level_handlers[level].is_pending_compact(&table.id))
+        {
+            return None;
+        }
 
         level_handlers[level].add_pending_task(self.compact_task_id, &select_input_ssts);
         if !target_input_ssts.is_empty() {

--- a/src/meta/src/hummock/compaction/min_overlap_compaction_picker.rs
+++ b/src/meta/src/hummock/compaction/min_overlap_compaction_picker.rs
@@ -168,14 +168,14 @@ impl CompactionPicker for MinOverlappingPicker {
             select_level: Level {
                 level_idx: self.level as u32,
                 level_type: levels[self.level].level_type,
+                total_file_size: select_input_ssts.iter().map(|table| table.file_size).sum(),
                 table_infos: select_input_ssts,
-                total_file_size: 0,
             },
             target_level: Level {
                 level_idx: target_level as u32,
                 level_type: levels[target_level].level_type,
+                total_file_size: target_input_ssts.iter().map(|table| table.file_size).sum(),
                 table_infos: target_input_ssts,
-                total_file_size: 0,
             },
             split_ranges: vec![],
         })

--- a/src/meta/src/hummock/compaction/min_overlap_compaction_picker.rs
+++ b/src/meta/src/hummock/compaction/min_overlap_compaction_picker.rs
@@ -17,18 +17,10 @@ use std::sync::Arc;
 
 use risingwave_pb::hummock::{Level, SstableInfo};
 
-use super::overlap_strategy::OverlapInfo;
-use crate::hummock::compaction::overlap_strategy::{OverlapStrategy, RangeOverlapInfo};
-use crate::hummock::compaction::{ManualCompactionOption, SearchResult};
+use super::CompactionPicker;
+use crate::hummock::compaction::overlap_strategy::OverlapStrategy;
+use crate::hummock::compaction::SearchResult;
 use crate::hummock::level_handler::LevelHandler;
-
-pub trait CompactionPicker {
-    fn pick_compaction(
-        &self,
-        levels: &[Level],
-        level_handlers: &mut [LevelHandler],
-    ) -> Option<SearchResult>;
-}
 
 pub struct MinOverlappingPicker {
     compact_task_id: u64,
@@ -190,131 +182,13 @@ impl CompactionPicker for MinOverlappingPicker {
     }
 }
 
-pub struct ManualCompactionPicker {
-    compact_task_id: u64,
-    overlap_strategy: Arc<dyn OverlapStrategy>,
-    option: ManualCompactionOption,
-}
-
-impl ManualCompactionPicker {
-    pub fn new(
-        compact_task_id: u64,
-        overlap_strategy: Arc<dyn OverlapStrategy>,
-        option: ManualCompactionOption,
-    ) -> Self {
-        Self {
-            compact_task_id,
-            overlap_strategy,
-            option,
-        }
-    }
-}
-
-impl CompactionPicker for ManualCompactionPicker {
-    fn pick_compaction(
-        &self,
-        levels: &[Level],
-        level_handlers: &mut [LevelHandler],
-    ) -> Option<SearchResult> {
-        let level = self.option.level;
-        let target_level = level + 1;
-
-        let mut select_input_ssts = vec![];
-        let mut tmp_sst_info = SstableInfo::default();
-        let mut range_overlap_info = RangeOverlapInfo::default();
-        tmp_sst_info.key_range = Some(self.option.key_range.clone());
-        range_overlap_info.update(&tmp_sst_info);
-
-        let level_table_infos: Vec<SstableInfo> = levels[level]
-            .table_infos
-            .iter()
-            .filter(|sst_info| range_overlap_info.check_overlap(sst_info))
-            .filter(|sst_info| {
-                if self.option.internal_table_id.is_empty() {
-                    return true;
-                }
-
-                // to collect internal_table_id from sst_info
-                let table_id_in_sst: Vec<u32> = sst_info
-                    .vnode_bitmaps
-                    .iter()
-                    .map(|vmap| vmap.table_id)
-                    .collect();
-
-                // to filter sst_file by table_id
-                for table_id in &table_id_in_sst {
-                    if self.option.internal_table_id.contains(table_id) {
-                        return true;
-                    }
-                }
-
-                false
-            })
-            .cloned()
-            .collect();
-
-        for table in &level_table_infos {
-            if level_handlers[level].is_pending_compact(&table.id) {
-                continue;
-            }
-
-            let mut pending_campct = false;
-            let overlap_files = self
-                .overlap_strategy
-                .check_base_level_overlap(&[table.clone()], &levels[target_level].table_infos);
-            for other in overlap_files {
-                if level_handlers[target_level].is_pending_compact(&other.id) {
-                    pending_campct = true;
-                    break;
-                }
-            }
-            if pending_campct {
-                continue;
-            }
-
-            select_input_ssts.push(table.clone());
-        }
-
-        if select_input_ssts.is_empty() {
-            return None;
-        }
-
-        let target_input_ssts = self
-            .overlap_strategy
-            .check_base_level_overlap(&select_input_ssts, &levels[target_level].table_infos);
-
-        level_handlers[level].add_pending_task(self.compact_task_id, &select_input_ssts);
-        if !target_input_ssts.is_empty() {
-            level_handlers[target_level].add_pending_task(self.compact_task_id, &target_input_ssts);
-        }
-
-        Some(SearchResult {
-            select_level: Level {
-                level_idx: level as u32,
-                level_type: levels[level].level_type,
-                table_infos: select_input_ssts,
-                total_file_size: 0,
-            },
-            target_level: Level {
-                level_idx: target_level as u32,
-                level_type: levels[target_level].level_type,
-                table_infos: target_input_ssts,
-                total_file_size: 0,
-            },
-            split_ranges: vec![],
-        })
-    }
-}
-
 #[cfg(test)]
 pub mod tests {
-    use risingwave_pb::common::VNodeBitmap;
     pub use risingwave_pb::hummock::{KeyRange, LevelType};
 
     use super::*;
     use crate::hummock::compaction::overlap_strategy::RangeOverlapStrategy;
     use crate::hummock::compaction::tier_compaction_picker::tests::generate_table;
-    use crate::hummock::test_utils::iterator_test_key_of_epoch;
 
     #[test]
     fn test_compact_l1() {
@@ -436,149 +310,5 @@ pub mod tests {
 
         assert_eq!(ret.target_level.table_infos.len(), 1);
         assert_eq!(ret.target_level.table_infos[0].id, 4);
-    }
-
-    #[test]
-    fn test_manaul_compaction_picker() {
-        let mut levels = vec![
-            Level {
-                level_idx: 0,
-                level_type: LevelType::Overlapping as i32,
-                table_infos: vec![],
-                total_file_size: 0,
-            },
-            Level {
-                level_idx: 1,
-                level_type: LevelType::Nonoverlapping as i32,
-                table_infos: vec![
-                    generate_table(0, 1, 0, 100, 1),
-                    generate_table(1, 1, 101, 200, 1),
-                    generate_table(2, 1, 222, 300, 1),
-                ],
-                total_file_size: 0,
-            },
-            Level {
-                level_idx: 2,
-                level_type: LevelType::Nonoverlapping as i32,
-                table_infos: vec![
-                    generate_table(4, 1, 0, 100, 1),
-                    generate_table(5, 1, 101, 150, 1),
-                    generate_table(6, 1, 151, 201, 1),
-                    generate_table(7, 1, 501, 800, 1),
-                    generate_table(8, 2, 301, 400, 1),
-                ],
-                total_file_size: 0,
-            },
-        ];
-        let mut levels_handler = vec![
-            LevelHandler::new(0),
-            LevelHandler::new(1),
-            LevelHandler::new(2),
-        ];
-
-        let clean_task_state = |level_handler: &mut LevelHandler| {
-            for pending_task_id in &level_handler.pending_tasks_ids() {
-                level_handler.remove_task(*pending_task_id);
-            }
-        };
-
-        {
-            // test key_range option
-            let option = ManualCompactionOption {
-                level: 1,
-                key_range: KeyRange {
-                    left: iterator_test_key_of_epoch(1, 0, 1),
-                    right: iterator_test_key_of_epoch(1, 201, 1),
-                    inf: false,
-                },
-                ..Default::default()
-            };
-            let picker =
-                ManualCompactionPicker::new(0, Arc::new(RangeOverlapStrategy::default()), option);
-            let result = picker
-                .pick_compaction(&levels, &mut levels_handler)
-                .unwrap();
-
-            assert_eq!(2, result.select_level.table_infos.len());
-            assert_eq!(3, result.target_level.table_infos.len());
-        }
-
-        {
-            clean_task_state(&mut levels_handler[1]);
-            clean_task_state(&mut levels_handler[2]);
-
-            // test all key range
-            let option = ManualCompactionOption::default();
-            let picker =
-                ManualCompactionPicker::new(0, Arc::new(RangeOverlapStrategy::default()), option);
-            let result = picker
-                .pick_compaction(&levels, &mut levels_handler)
-                .unwrap();
-
-            assert_eq!(3, result.select_level.table_infos.len());
-            assert_eq!(3, result.target_level.table_infos.len());
-        }
-
-        {
-            clean_task_state(&mut levels_handler[1]);
-            clean_task_state(&mut levels_handler[2]);
-
-            let level_table_info = &mut levels[1].table_infos;
-            let table_info_1 = &mut level_table_info[1];
-            table_info_1.vnode_bitmaps.resize(2, VNodeBitmap::default());
-            table_info_1.vnode_bitmaps[0].table_id = 1;
-            table_info_1.vnode_bitmaps[1].table_id = 2;
-
-            // test internal_table_id
-            let option = ManualCompactionOption {
-                level: 1,
-                internal_table_id: HashSet::from([2]),
-                ..Default::default()
-            };
-
-            let picker =
-                ManualCompactionPicker::new(0, Arc::new(RangeOverlapStrategy::default()), option);
-
-            let result = picker
-                .pick_compaction(&levels, &mut levels_handler)
-                .unwrap();
-
-            assert_eq!(1, result.select_level.table_infos.len());
-            assert_eq!(2, result.target_level.table_infos.len());
-        }
-
-        {
-            clean_task_state(&mut levels_handler[1]);
-            clean_task_state(&mut levels_handler[2]);
-
-            // include all table_info
-            let level_table_info = &mut levels[1].table_infos;
-            for table_info in level_table_info {
-                table_info.vnode_bitmaps.resize(2, VNodeBitmap::default());
-                table_info.vnode_bitmaps[0].table_id = 1;
-                table_info.vnode_bitmaps[1].table_id = 2;
-            }
-
-            // test key range filter first
-            let option = ManualCompactionOption {
-                level: 1,
-                key_range: KeyRange {
-                    left: iterator_test_key_of_epoch(1, 101, 1),
-                    right: iterator_test_key_of_epoch(1, 199, 1),
-                    inf: false,
-                },
-                internal_table_id: HashSet::from([2]),
-            };
-
-            let picker =
-                ManualCompactionPicker::new(0, Arc::new(RangeOverlapStrategy::default()), option);
-
-            let result = picker
-                .pick_compaction(&levels, &mut levels_handler)
-                .unwrap();
-
-            assert_eq!(1, result.select_level.table_infos.len());
-            assert_eq!(2, result.target_level.table_infos.len());
-        }
     }
 }

--- a/src/meta/src/hummock/compaction/mod.rs
+++ b/src/meta/src/hummock/compaction/mod.rs
@@ -71,6 +71,7 @@ impl Clone for CompactStatus {
     }
 }
 
+#[derive(Debug, Default)]
 pub struct SearchResult {
     select_level: Level,
     target_level: Level,

--- a/src/meta/src/hummock/compaction/mod.rs
+++ b/src/meta/src/hummock/compaction/mod.rs
@@ -30,7 +30,6 @@ use risingwave_pb::hummock::compaction_config::CompactionMode;
 use risingwave_pb::hummock::{CompactTask, CompactionConfig, HummockVersion, KeyRange, Level};
 
 use crate::hummock::compaction::level_selector::{DynamicLevelSelector, LevelSelector};
-use crate::hummock::compaction::manual_compaction_picker::ManualCompactionPicker;
 use crate::hummock::compaction::overlap_strategy::{
     HashStrategy, OverlapStrategy, RangeOverlapStrategy,
 };
@@ -172,13 +171,12 @@ impl CompactStatus {
     ) -> Option<SearchResult> {
         // manual_compaction no need to select level
         // level determined by option
-        let picker = ManualCompactionPicker::new(
+        self.compaction_selector.manual_pick_compaction(
             task_id,
-            create_overlap_strategy(self.compaction_config.compaction_mode()),
+            levels,
+            &mut self.level_handlers,
             manual_compaction_option,
-        );
-
-        picker.pick_compaction(levels, &mut self.level_handlers)
+        )
     }
 
     /// Declares a task is either finished or canceled.

--- a/src/meta/src/hummock/compaction/mod.rs
+++ b/src/meta/src/hummock/compaction/mod.rs
@@ -13,12 +13,12 @@
 // limitations under the License.
 
 pub mod compaction_config;
-mod compaction_picker;
 mod level_selector;
+mod manual_compaction_picker;
+mod min_overlap_compaction_picker;
 mod overlap_strategy;
 mod prost_type;
 mod tier_compaction_picker;
-
 use std::collections::HashSet;
 use std::fmt::{Debug, Formatter};
 use std::sync::Arc;
@@ -29,8 +29,8 @@ use risingwave_hummock_sdk::{CompactionGroupId, HummockCompactionTaskId, Hummock
 use risingwave_pb::hummock::compaction_config::CompactionMode;
 use risingwave_pb::hummock::{CompactTask, CompactionConfig, HummockVersion, KeyRange, Level};
 
-use crate::hummock::compaction::compaction_picker::{CompactionPicker, ManualCompactionPicker};
 use crate::hummock::compaction::level_selector::{DynamicLevelSelector, LevelSelector};
+use crate::hummock::compaction::manual_compaction_picker::ManualCompactionPicker;
 use crate::hummock::compaction::overlap_strategy::{
     HashStrategy, OverlapStrategy, RangeOverlapStrategy,
 };
@@ -292,4 +292,12 @@ impl Default for ManualCompactionOption {
             level: 1,
         }
     }
+}
+
+pub trait CompactionPicker {
+    fn pick_compaction(
+        &self,
+        levels: &[Level],
+        level_handlers: &mut [LevelHandler],
+    ) -> Option<SearchResult>;
 }

--- a/src/meta/src/hummock/compaction/tier_compaction_picker.rs
+++ b/src/meta/src/hummock/compaction/tier_compaction_picker.rs
@@ -199,15 +199,20 @@ impl CompactionPicker for LevelCompactionPicker {
             select_level: Level {
                 level_idx: select_level as u32,
                 level_type: LevelType::Overlapping as i32,
+                total_file_size: select_level_inputs
+                    .iter()
+                    .map(|table| table.file_size)
+                    .sum(),
                 table_infos: select_level_inputs,
-                // no use
-                total_file_size: 0,
             },
             target_level: Level {
                 level_idx: target_level as u32,
                 level_type: LevelType::Nonoverlapping as i32,
+                total_file_size: target_level_inputs
+                    .iter()
+                    .map(|table| table.file_size)
+                    .sum(),
                 table_infos: target_level_inputs,
-                total_file_size: 0,
             },
             split_ranges: splits,
         })

--- a/src/meta/src/hummock/compaction/tier_compaction_picker.rs
+++ b/src/meta/src/hummock/compaction/tier_compaction_picker.rs
@@ -21,8 +21,8 @@ use risingwave_hummock_sdk::HummockEpoch;
 use risingwave_pb::hummock::{CompactionConfig, KeyRange, Level, LevelType, SstableInfo};
 
 use super::SearchResult;
-use crate::hummock::compaction::compaction_picker::CompactionPicker;
 use crate::hummock::compaction::overlap_strategy::OverlapStrategy;
+use crate::hummock::compaction::CompactionPicker;
 use crate::hummock::level_handler::LevelHandler;
 
 const MIN_COMPACTION_BYTES: u64 = 2 * 1024 * 1024; // 1MB

--- a/src/meta/src/hummock/mock_hummock_meta_client.rs
+++ b/src/meta/src/hummock/mock_hummock_meta_client.rs
@@ -146,7 +146,12 @@ impl HummockMetaClient for MockHummockMetaClient {
         todo!()
     }
 
-    async fn trigger_manual_compaction(&self, _compaction_group_id: u64) -> Result<()> {
+    async fn trigger_manual_compaction(
+        &self,
+        _compaction_group_id: u64,
+        _table_id: u32,
+        _level: u32,
+    ) -> Result<()> {
         todo!()
     }
 }

--- a/src/meta/src/rpc/server.rs
+++ b/src/meta/src/rpc/server.rs
@@ -406,6 +406,7 @@ pub async fn rpc_serve_with_store<S: MetaStore>(
         compactor_manager.clone(),
         vacuum_trigger.clone(),
         compaction_group_manager.clone(),
+        fragment_manager.clone(),
     );
     let notification_manager = env.notification_manager_ref();
     let notification_srv =

--- a/src/meta/src/rpc/service/hummock_service.rs
+++ b/src/meta/src/rpc/service/hummock_service.rs
@@ -244,6 +244,7 @@ where
             ..Default::default()
         };
 
+        // rewrite the key_range
         match request.key_range {
             Some(key_range) => {
                 option.key_range = key_range;
@@ -266,6 +267,12 @@ where
         {
             option.internal_table_id = HashSet::from_iter(table_frgament.internal_table_ids());
         }
+
+        tracing::info!(
+            "Try trigger_manual_compaction compaction_group_id {} option {:?}",
+            compaction_group_id,
+            &option
+        );
 
         let result_state = match self
             .hummock_manager

--- a/src/meta/src/rpc/service/hummock_service.rs
+++ b/src/meta/src/rpc/service/hummock_service.rs
@@ -240,7 +240,6 @@ where
         let request = request.into_inner();
         let compaction_group_id = request.compaction_group_id;
         let mut option = ManualCompactionOption {
-            // key_range: request.key_range,
             level: request.level as usize,
             ..Default::default()
         };

--- a/src/meta/src/rpc/service/hummock_service.rs
+++ b/src/meta/src/rpc/service/hummock_service.rs
@@ -267,6 +267,7 @@ where
         {
             option.internal_table_id = HashSet::from_iter(table_frgament.internal_table_ids());
         }
+        option.internal_table_id.insert(request.table_id); // need to handle outter table_id (mv)
 
         tracing::info!(
             "Try trigger_manual_compaction compaction_group_id {} option {:?}",

--- a/src/rpc_client/src/hummock_meta_client.rs
+++ b/src/rpc_client/src/hummock_meta_client.rs
@@ -39,5 +39,10 @@ pub trait HummockMetaClient: Send + Sync + 'static {
     async fn subscribe_compact_tasks(&self) -> Result<Streaming<SubscribeCompactTasksResponse>>;
     async fn report_vacuum_task(&self, vacuum_task: VacuumTask) -> Result<()>;
     async fn get_compaction_groups(&self) -> Result<Vec<CompactionGroup>>;
-    async fn trigger_manual_compaction(&self, compaction_group_id: u64) -> Result<()>;
+    async fn trigger_manual_compaction(
+        &self,
+        compaction_group_id: u64,
+        table_id: u32,
+        level: u32,
+    ) -> Result<()>;
 }

--- a/src/rpc_client/src/meta_client.rs
+++ b/src/rpc_client/src/meta_client.rs
@@ -434,9 +434,16 @@ impl HummockMetaClient for MetaClient {
         Ok(resp.compaction_groups)
     }
 
-    async fn trigger_manual_compaction(&self, compaction_group_id: u64) -> Result<()> {
+    async fn trigger_manual_compaction(
+        &self,
+        compaction_group_id: u64,
+        table_id: u32,
+        level: u32,
+    ) -> Result<()> {
         let req = TriggerManualCompactionRequest {
             compaction_group_id,
+            table_id,
+            level,
             ..Default::default()
         };
 

--- a/src/rpc_client/src/meta_client.rs
+++ b/src/rpc_client/src/meta_client.rs
@@ -437,6 +437,7 @@ impl HummockMetaClient for MetaClient {
     async fn trigger_manual_compaction(&self, compaction_group_id: u64) -> Result<()> {
         let req = TriggerManualCompactionRequest {
             compaction_group_id,
+            ..Default::default()
         };
 
         self.inner.trigger_manual_compaction(req).await?;

--- a/src/rpc_client/src/meta_client.rs
+++ b/src/rpc_client/src/meta_client.rs
@@ -440,9 +440,11 @@ impl HummockMetaClient for MetaClient {
         table_id: u32,
         level: u32,
     ) -> Result<()> {
+        // TODO: support key_range parameter
         let req = TriggerManualCompactionRequest {
             compaction_group_id,
-            table_id,
+            table_id, /* if table_id not exist, manual_compaction will include all the sst
+                       * without check internal_table_id */
             level,
             ..Default::default()
         };

--- a/src/storage/src/hummock/hummock_meta_client.rs
+++ b/src/storage/src/hummock/hummock_meta_client.rs
@@ -112,9 +112,14 @@ impl HummockMetaClient for MonitoredHummockMetaClient {
         self.meta_client.get_compaction_groups().await
     }
 
-    async fn trigger_manual_compaction(&self, compaction_group_id: u64) -> Result<()> {
+    async fn trigger_manual_compaction(
+        &self,
+        compaction_group_id: u64,
+        table_id: u32,
+        level: u32,
+    ) -> Result<()> {
         self.meta_client
-            .trigger_manual_compaction(compaction_group_id)
+            .trigger_manual_compaction(compaction_group_id, table_id, level)
             .await
     }
 }


### PR DESCRIPTION
## What's changed and what's your intention?

add manual compaction picker  and support more optional parameters for  targeted compaction

Please explain **IN DETAIL** what the changes are in this PR and why they are needed:

- a new indenpendent compaction_picker for manual_compaction
- support more optional parameters for manual_compaction and distinguish get_compaction_task for manual
- risectl support  parameters above

## Checklist

- [x] I have written necessary docs and comments
- [x] I have added necessary unit tests and integration tests

## Refer to a related PR or issue link (optional)
- https://github.com/singularity-data/risingwave/issues/3097