### PR TITLE
feat: implement infer_return_type in frontend

### DIFF
--- a/src/frontend/src/session.rs
+++ b/src/frontend/src/session.rs
@@ -583,6 +583,7 @@ impl Session for SessionImpl {
     }
 }
 
+/// Returns row description of the statement
 fn infer(session: Arc<SessionImpl>, stmt: Statement) -> Result<Vec<PgFieldDescriptor>> {
     let context = OptimizerContext::new(session);
     let session = context.session_ctx.clone();

--- a/src/frontend/src/session.rs
+++ b/src/frontend/src/session.rs
@@ -571,7 +571,7 @@ impl Session for SessionImpl {
             return Ok(vec![]);
         }
         let stmt = stmts.swap_remove(0);
-        let rsp = infer(self, stmt).await.map_err(|e| {
+        let rsp = infer(self, stmt).map_err(|e| {
             tracing::error!("failed to handle sql:\n{}:\n{}", sql, e);
             e
         })?;
@@ -583,8 +583,8 @@ impl Session for SessionImpl {
     }
 }
 
-async fn infer(session: Arc<SessionImpl>, stmt: Statement) -> Result<Vec<PgFieldDescriptor>> {
-    let context = OptimizerContext::new(session.clone());
+fn infer(session: Arc<SessionImpl>, stmt: Statement) -> Result<Vec<PgFieldDescriptor>> {
+    let context = OptimizerContext::new(session);
     let session = context.session_ctx.clone();
 
     let bound = {


### PR DESCRIPTION
## What's changed and what's your intention?

The original implementation of infer_return_type interface in frontend is copied from run_statement. It will actually execute the statement and get the result description from the result of execution. This implementation is primarily for testing purposes but it's inefficient. Infer_return_type API is to get the result description but needn't execute.

Hence we give a new implementation for infer_return_type. It calls a new function "infer", "infer" will get the result description 
 of the query statement but not execute. 

## Checklist

- [x] I have written necessary docs and comments
- [x] I have added necessary unit tests and integration tests
- [x] All checks passed in `./risedev check` (or alias, `./risedev c`)

## Refer to a related PR or issue link (optional)
#3131 