### PR TITLE
feat(binder): (WIP) overloaded operator/function resolution with implicit arg cast

### DIFF
--- a/src/frontend/src/expr/function_call.rs
+++ b/src/frontend/src/expr/function_call.rs
@@ -156,10 +156,11 @@ impl FunctionCall {
                 Ok(DataType::Varchar)
             }
 
-            _ => infer_type(
-                func_type,
-                inputs.iter().map(|expr| expr.return_type()).collect(),
-            ),
+            _ => {
+                let ret;
+                (inputs, ret) = infer_type(func_type, inputs)?;
+                Ok(ret)
+            }
         }?;
         Ok(Self {
             func_type,

--- a/src/frontend/src/expr/type_inference/func.rs
+++ b/src/frontend/src/expr/type_inference/func.rs
@@ -27,24 +27,7 @@ pub fn infer_type(func_type: ExprType, inputs_type: Vec<DataType>) -> Result<Dat
     // With our current simplified type system, where all types are nullable and not parameterized
     // by things like length or precision, the inference can be done with a map lookup.
     let input_type_names = inputs_type.iter().map(name_of).collect();
-    infer_type_name(func_type, input_type_names).map(|type_name| match type_name {
-        DataTypeName::Boolean => DataType::Boolean,
-        DataTypeName::Int16 => DataType::Int16,
-        DataTypeName::Int32 => DataType::Int32,
-        DataTypeName::Int64 => DataType::Int64,
-        DataTypeName::Decimal => DataType::Decimal,
-        DataTypeName::Float32 => DataType::Float32,
-        DataTypeName::Float64 => DataType::Float64,
-        DataTypeName::Varchar => DataType::Varchar,
-        DataTypeName::Date => DataType::Date,
-        DataTypeName::Timestamp => DataType::Timestamp,
-        DataTypeName::Timestampz => DataType::Timestampz,
-        DataTypeName::Time => DataType::Time,
-        DataTypeName::Interval => DataType::Interval,
-        DataTypeName::Struct | DataTypeName::List => {
-            panic!("Functions returning struct or list can not be inferred. Please use `FunctionCall::new_unchecked`.")
-        }
-    })
+    infer_type_name(func_type, input_type_names).map(Into::into)
 }
 
 /// Infer the return type name without parameters like length or precision.

--- a/src/frontend/src/expr/type_inference/func.rs
+++ b/src/frontend/src/expr/type_inference/func.rs
@@ -454,12 +454,19 @@ fn build_type_derive_map() -> FuncSigMap {
         (T::Timestamp, T::Interval),
         (T::Timestampz, T::Interval),
         (T::Time, T::Interval),
-        (T::Interval, T::Interval),
     ] {
         build_commutative_funcs(&mut map, E::Add, base, delta, base);
         map.insert(FuncSign::new(E::Subtract, vec![base, delta]), base);
         map.insert(FuncSign::new(E::Subtract, vec![base, base]), delta);
     }
+    map.insert(
+        FuncSign::new(E::Add, vec![T::Interval, T::Interval]),
+        T::Interval,
+    );
+    map.insert(
+        FuncSign::new(E::Subtract, vec![T::Interval, T::Interval]),
+        T::Interval,
+    );
 
     // date + interval = timestamp, date - interval = timestamp
     build_commutative_funcs(&mut map, E::Add, T::Date, T::Interval, T::Timestamp);

--- a/src/frontend/src/expr/type_inference/func.rs
+++ b/src/frontend/src/expr/type_inference/func.rs
@@ -140,7 +140,7 @@ fn rule_f<'a, 'b>(
             return cand_temp;
         }
     }
-    return best_candidate;
+    best_candidate
 }
 fn rule_e<'a, 'b>(
     inputs: &'a [ExprImpl],
@@ -157,11 +157,9 @@ fn rule_e<'a, 'b>(
             if tc == &DataType::Varchar {
                 t = Some(&DataType::Varchar);
             } else if let Some(tt) = t {
-                if tt == &DataType::Varchar {
-                } else if tt == tc {
+                if tt == &DataType::Varchar || tc == tt || cast_ok(tc, tt, &CastContext::Implicit) {
                 } else if cast_ok(tt, tc, &CastContext::Implicit) {
                     t = Some(tc);
-                } else if cast_ok(tc, tt, &CastContext::Implicit) {
                 } else {
                     t = None;
                 }
@@ -193,10 +191,8 @@ fn rule_e<'a, 'b>(
                     if p != *t {
                         return false;
                     }
-                } else {
-                    if !cast_ok(p, t, &CastContext::Implicit) {
-                        return false;
-                    }
+                } else if !cast_ok(p, t, &CastContext::Implicit) {
+                    return false;
                 }
             }
             true

--- a/src/frontend/src/expr/type_inference/mod.rs
+++ b/src/frontend/src/expr/type_inference/mod.rs
@@ -61,3 +61,26 @@ fn name_of(ty: &DataType) -> DataTypeName {
         DataType::List { .. } => DataTypeName::List,
     }
 }
+
+impl From<DataTypeName> for DataType {
+    fn from(type_name: DataTypeName) -> Self {
+        match type_name {
+            DataTypeName::Boolean => DataType::Boolean,
+            DataTypeName::Int16 => DataType::Int16,
+            DataTypeName::Int32 => DataType::Int32,
+            DataTypeName::Int64 => DataType::Int64,
+            DataTypeName::Decimal => DataType::Decimal,
+            DataTypeName::Float32 => DataType::Float32,
+            DataTypeName::Float64 => DataType::Float64,
+            DataTypeName::Varchar => DataType::Varchar,
+            DataTypeName::Date => DataType::Date,
+            DataTypeName::Timestamp => DataType::Timestamp,
+            DataTypeName::Timestampz => DataType::Timestampz,
+            DataTypeName::Time => DataType::Time,
+            DataTypeName::Interval => DataType::Interval,
+            DataTypeName::Struct | DataTypeName::List => {
+                panic!("Functions returning struct or list can not be inferred. Please use `FunctionCall::new_unchecked`.")
+            }
+        }
+    }
+}

--- a/src/frontend/test_runner/tests/testdata/struct_query.yaml
+++ b/src/frontend/test_runner/tests/testdata/struct_query.yaml
@@ -239,7 +239,7 @@
 - sql: |
     create materialized view t as select * from s;
     select (country + country) from t;
-  binder_error: 'Feature is not yet implemented: Add[Struct, Struct], Tracking issue: https://github.com/singularity-data/risingwave/issues/112'
+  binder_error: 'Feature is not yet implemented: Add[Struct { fields: [Varchar, Varchar] }, Struct { fields: [Varchar, Varchar] }], Tracking issue: https://github.com/singularity-data/risingwave/issues/112'
   create_source:
     row_format: protobuf
     name: s


### PR DESCRIPTION
## What's changed and what's your intention?

Not intended to be merged. This will be split into smaller parts once finished.

Implements the PostgreSQL logic of resolving overloaded operator/function:
https://www.postgresql.org/docs/current/typeconv-oper.html
https://www.postgresql.org/docs/current/typeconv-func.html

This is necessary to determine the type of literal `null` used in a function (#3149). And allows us to unify adhoc casting logic scattered in bind_xxx / rewrite_xxx / FunctionCall::new.

## Checklist

- [ ] I have written necessary docs and comments
- [ ] I have added necessary unit tests and integration tests
- [ ] All checks passed in `./risedev check` (or alias, `./risedev c`)

## Refer to a related PR or issue link (optional)

#1386

supersedes #1648