### PR TITLE
refactor: use packed bitmap struct for vnode bitmap

### DIFF
--- a/proto/common.proto
+++ b/proto/common.proto
@@ -61,6 +61,15 @@ message Cluster {
   map<string, string> config = 3;
 }
 
+message Buffer {
+  enum CompressionType {
+    INVALID = 0;
+    NONE = 1;
+  }
+  CompressionType compression = 1;
+  bytes body = 2;
+}
+
 // Vnode mapping for stream fragments / relational state tables. Stores mapping from virtual node to parallel unit id.
 message ParallelUnitMapping {
   uint32 table_id = 1;
@@ -71,5 +80,5 @@ message ParallelUnitMapping {
 // Bitmap that records whether vnodes are present.
 message VNodeBitmap {
   uint32 table_id = 1;
-  bytes bitmap = 2;
+  Buffer bitmap = 2;
 }

--- a/proto/data.proto
+++ b/proto/data.proto
@@ -13,15 +13,6 @@ message IntervalUnit {
   int64 ms = 3;
 }
 
-message Buffer {
-  enum CompressionType {
-    INVALID = 0;
-    NONE = 1;
-  }
-  CompressionType compression = 1;
-  bytes body = 2;
-}
-
 message DataType {
   enum IntervalType {
     INVALID = 0;
@@ -102,8 +93,8 @@ enum ArrayType {
 
 message Array {
   ArrayType array_type = 1;
-  Buffer null_bitmap = 2;
-  repeated Buffer values = 3;
+  common.Buffer null_bitmap = 2;
+  repeated common.Buffer values = 3;
   StructArrayData struct_array_data = 4;
   ListArrayData list_array_data = 5;
 }

--- a/proto/stream_plan.proto
+++ b/proto/stream_plan.proto
@@ -2,6 +2,7 @@ syntax = "proto3";
 
 package stream_plan;
 
+import "common.proto";
 import "data.proto";
 import "expr.proto";
 import "plan_common.proto";
@@ -297,7 +298,7 @@ message StreamActor {
   bool same_worker_node_as_upstream = 7;
   // Vnodes that the executors in this actor own. If this actor is the only actor in its fragment, `vnode_bitmap`
   // will be empty.
-  data.Buffer vnode_bitmap = 8;
+  common.Buffer vnode_bitmap = 8;
 }
 
 enum FragmentType {

--- a/proto/stream_plan.proto
+++ b/proto/stream_plan.proto
@@ -297,7 +297,7 @@ message StreamActor {
   bool same_worker_node_as_upstream = 7;
   // Vnodes that the executors in this actor own. If this actor is the only actor in its fragment, `vnode_bitmap`
   // will be empty.
-  bytes vnode_bitmap = 8;
+  data.Buffer vnode_bitmap = 8;
 }
 
 enum FragmentType {

--- a/src/common/src/array/decimal_array.rs
+++ b/src/common/src/array/decimal_array.rs
@@ -16,8 +16,9 @@ use std::hash::{Hash, Hasher};
 use std::mem::size_of;
 
 use itertools::Itertools;
-use risingwave_pb::data::buffer::CompressionType;
-use risingwave_pb::data::{Array as ProstArray, ArrayType, Buffer};
+use risingwave_pb::common::buffer::CompressionType;
+use risingwave_pb::common::Buffer;
+use risingwave_pb::data::{Array as ProstArray, ArrayType};
 
 use super::{Array, ArrayBuilder, ArrayIterator, ArrayResult, NULL_VAL_FOR_HASH};
 use crate::array::{ArrayBuilderImpl, ArrayMeta};

--- a/src/common/src/array/primitive_array.rs
+++ b/src/common/src/array/primitive_array.rs
@@ -17,8 +17,9 @@ use std::hash::{Hash, Hasher};
 use std::io::Write;
 use std::mem::size_of;
 
-use risingwave_pb::data::buffer::CompressionType;
-use risingwave_pb::data::{Array as ProstArray, ArrayType, Buffer};
+use risingwave_pb::common::buffer::CompressionType;
+use risingwave_pb::common::Buffer;
+use risingwave_pb::data::{Array as ProstArray, ArrayType};
 
 use super::{Array, ArrayBuilder, ArrayIterator, ArrayResult, NULL_VAL_FOR_HASH};
 use crate::array::{ArrayBuilderImpl, ArrayImpl, ArrayMeta};

--- a/src/common/src/array/utf8_array.rs
+++ b/src/common/src/array/utf8_array.rs
@@ -17,8 +17,9 @@ use std::iter;
 use std::mem::size_of;
 
 use itertools::Itertools;
-use risingwave_pb::data::buffer::CompressionType;
-use risingwave_pb::data::{Array as ProstArray, ArrayType, Buffer};
+use risingwave_pb::common::Buffer;
+use risingwave_pb::common::buffer::CompressionType;
+use risingwave_pb::data::{Array as ProstArray, ArrayType};
 
 use super::{Array, ArrayBuilder, ArrayIterator, ArrayMeta, ArrayResult, NULL_VAL_FOR_HASH};
 use crate::array::ArrayBuilderImpl;

--- a/src/common/src/array/utf8_array.rs
+++ b/src/common/src/array/utf8_array.rs
@@ -17,8 +17,8 @@ use std::iter;
 use std::mem::size_of;
 
 use itertools::Itertools;
-use risingwave_pb::common::Buffer;
 use risingwave_pb::common::buffer::CompressionType;
+use risingwave_pb::common::Buffer;
 use risingwave_pb::data::{Array as ProstArray, ArrayType};
 
 use super::{Array, ArrayBuilder, ArrayIterator, ArrayMeta, ArrayResult, NULL_VAL_FOR_HASH};

--- a/src/common/src/buffer/bitmap.rs
+++ b/src/common/src/buffer/bitmap.rs
@@ -37,8 +37,8 @@ use std::ops::{BitAnd, BitOr};
 
 use bytes::Bytes;
 use itertools::Itertools;
-use risingwave_pb::data::buffer::CompressionType;
-use risingwave_pb::data::Buffer as ProstBuffer;
+use risingwave_pb::common::buffer::CompressionType;
+use risingwave_pb::common::Buffer as ProstBuffer;
 
 use crate::array::error::ArrayError;
 use crate::array::{Array, ArrayResult, BoolArray};

--- a/src/common/src/buffer/bitmap.rs
+++ b/src/common/src/buffer/bitmap.rs
@@ -64,6 +64,33 @@ impl BitmapBuilder {
         }
     }
 
+    pub fn zeroed(len: usize) -> BitmapBuilder {
+        BitmapBuilder {
+            len,
+            data: vec![0; len / 8],
+            num_high_bits: 0,
+            head: 0,
+        }
+    }
+
+    pub fn set(&mut self, n: usize, val: bool) {
+        assert!(n < self.len);
+
+        let byte = self.data.get_mut(n / 8).unwrap_or(&mut self.head);
+        let mask = 1 << (n % 8);
+        match (*byte & mask > 0, val) {
+            (true, false) => {
+                *byte &= !mask;
+                self.num_high_bits -= 1;
+            }
+            (false, true) => {
+                *byte |= mask;
+                self.num_high_bits += 1;
+            }
+            _ => {}
+        }
+    }
+
     pub fn append(&mut self, bit_set: bool) -> &mut Self {
         self.head |= (bit_set as u8) << (self.len % 8);
         self.num_high_bits += bit_set as usize;
@@ -536,5 +563,28 @@ mod tests {
         let bm1 = Bitmap::new(1).unwrap();
         let bm2 = (vec![false]).try_into().unwrap();
         assert_eq!(bm1, bm2);
+    }
+
+    #[test]
+    fn test_bitmap_set() {
+        let mut b = BitmapBuilder::zeroed(10);
+        assert_eq!(b.num_high_bits, 0);
+
+        b.set(0, true);
+        b.set(7, true);
+        b.set(8, true);
+        b.set(9, true);
+        assert_eq!(b.num_high_bits, 4);
+
+        b.set(7, false);
+        b.set(8, false);
+        assert_eq!(b.num_high_bits, 2);
+
+        b.append(true);
+        assert_eq!(b.len, 11);
+        assert_eq!(b.num_high_bits, 3);
+
+        let b = b.finish();
+        assert_eq!(b.bits.to_vec(), &[0b0000_0001, 0b0000_0110]);
     }
 }

--- a/src/common/src/types/mod.rs
+++ b/src/common/src/types/mod.rs
@@ -65,7 +65,6 @@ pub type ParallelUnitId = u32;
 pub type VirtualNode = u16;
 pub const VNODE_BITS: usize = 11;
 pub const VIRTUAL_NODE_COUNT: usize = 1 << VNODE_BITS;
-pub const VNODE_BITMAP_LEN: usize = 1 << (VNODE_BITS - 3);
 
 pub type OrderedF32 = ordered_float::OrderedFloat<f32>;
 pub type OrderedF64 = ordered_float::OrderedFloat<f64>;

--- a/src/meta/src/hummock/test_utils.rs
+++ b/src/meta/src/hummock/test_utils.rs
@@ -102,11 +102,11 @@ pub fn generate_test_tables(epoch: u64, sst_ids: Vec<HummockSSTableId>) -> Vec<S
             vnode_bitmaps: vec![
                 VNodeBitmap {
                     table_id: (i + 1) as u32,
-                    bitmap: vec![],
+                    bitmap: None,
                 },
                 VNodeBitmap {
                     table_id: (i + 2) as u32,
-                    bitmap: vec![],
+                    bitmap: None,
                 },
             ],
             unit_id: 0,

--- a/src/meta/src/manager/hash_mapping.rs
+++ b/src/meta/src/manager/hash_mapping.rs
@@ -108,7 +108,7 @@ impl HashMappingManager {
 
 /// `HashMappingInfo` stores the vnode mapping and some other helpers for maintaining a
 /// load-balanced vnode mapping.
-#[derive(Clone)]
+#[derive(Clone, Debug)]
 struct HashMappingInfo {
     /// Hash mapping from virtual node to parallel unit.
     vnode_mapping: Vec<ParallelUnitId>,
@@ -179,6 +179,8 @@ impl HashMappingManagerCore {
             owner_mapping,
             load_balancer,
         };
+        dbg!(fragment_id, parallel_units, &mapping_info);
+
         self.hash_mapping_infos.insert(fragment_id, mapping_info);
 
         vnode_mapping

--- a/src/meta/src/manager/hash_mapping.rs
+++ b/src/meta/src/manager/hash_mapping.rs
@@ -179,7 +179,6 @@ impl HashMappingManagerCore {
             owner_mapping,
             load_balancer,
         };
-        dbg!(fragment_id, parallel_units, &mapping_info);
 
         self.hash_mapping_infos.insert(fragment_id, mapping_info);
 

--- a/src/meta/src/stream/scheduler.rs
+++ b/src/meta/src/stream/scheduler.rs
@@ -15,9 +15,10 @@
 use std::collections::{BTreeMap, HashMap};
 use std::sync::atomic::{AtomicUsize, Ordering};
 
+use risingwave_common::buffer::BitmapBuilder;
 use risingwave_common::error::ErrorCode::InternalError;
 use risingwave_common::error::{internal_error, Result};
-use risingwave_common::types::VNODE_BITMAP_LEN;
+use risingwave_common::types::VIRTUAL_NODE_COUNT;
 use risingwave_common::util::compress::compress_data;
 use risingwave_pb::common::{ActorInfo, ParallelUnit, ParallelUnitMapping, ParallelUnitType};
 use risingwave_pb::meta::table_fragments::fragment::FragmentDistributionType;
@@ -215,6 +216,7 @@ where
                 .hash_mapping_manager
                 .get_fragment_hash_mapping(&fragment.fragment_id)
                 .unwrap();
+
             let mut vnode_bitmaps = HashMap::new();
             vnode_mapping
                 .iter()
@@ -222,24 +224,31 @@ where
                 .for_each(|(vnode, parallel_unit)| {
                     vnode_bitmaps
                         .entry(*parallel_unit)
-                        .or_insert([0; VNODE_BITMAP_LEN])[(vnode >> 3) as usize] |=
-                        1 << (vnode & 0b111);
+                        .or_insert_with(|| BitmapBuilder::zeroed(VIRTUAL_NODE_COUNT))
+                        .set(vnode, true);
                 });
+            let vnode_bitmaps = vnode_bitmaps
+                .into_iter()
+                .map(|(u, b)| (u, b.finish()))
+                .collect::<HashMap<_, _>>();
 
             // Record actor locations and set vnodes into the actors.
             for (idx, actor) in fragment.actors.iter_mut().enumerate() {
                 if actor.same_worker_node_as_upstream && !actor.upstream_actor_id.is_empty() {
                     let parallel_unit =
                         locations.schedule_colocate_with(&actor.upstream_actor_id)?;
-                    actor.vnode_bitmap = vnode_bitmaps.get(&parallel_unit.id).unwrap().to_vec();
+                    actor.vnode_bitmap =
+                        Some(vnode_bitmaps.get(&parallel_unit.id).unwrap().to_protobuf());
                     locations
                         .actor_locations
                         .insert(actor.actor_id, parallel_unit);
                 } else {
-                    actor.vnode_bitmap = vnode_bitmaps
-                        .get(&parallel_units[idx % parallel_units.len()].id)
-                        .unwrap()
-                        .to_vec();
+                    actor.vnode_bitmap = Some(
+                        vnode_bitmaps
+                            .get(&parallel_units[idx % parallel_units.len()].id)
+                            .unwrap()
+                            .to_protobuf(),
+                    );
                     locations.actor_locations.insert(
                         actor.actor_id,
                         parallel_units[idx % parallel_units.len()].clone(),
@@ -288,6 +297,7 @@ mod test {
     use std::time::Duration;
 
     use itertools::Itertools;
+    use risingwave_common::buffer::Bitmap;
     use risingwave_common::types::VIRTUAL_NODE_COUNT;
     use risingwave_pb::common::{HostAddress, WorkerType};
     use risingwave_pb::meta::table_fragments::fragment::FragmentDistributionType;
@@ -339,7 +349,7 @@ mod test {
                         dispatcher: vec![],
                         upstream_actor_id: vec![],
                         same_worker_node_as_upstream: false,
-                        vnode_bitmap: vec![],
+                        vnode_bitmap: None,
                     }],
                     vnode_mapping: None,
                 };
@@ -368,7 +378,7 @@ mod test {
                         dispatcher: vec![],
                         upstream_actor_id: vec![],
                         same_worker_node_as_upstream: false,
-                        vnode_bitmap: vec![],
+                        vnode_bitmap: None,
                     })
                     .collect_vec();
                 actor_id += node_count * 7;
@@ -404,7 +414,7 @@ mod test {
                 None
             );
             for actor in fragment.actors {
-                assert!(actor.vnode_bitmap.is_empty());
+                assert!(actor.vnode_bitmap.is_none());
             }
         }
 
@@ -440,10 +450,7 @@ mod test {
             );
             let mut vnode_sum = 0;
             for actor in fragment.actors {
-                assert!(!actor.vnode_bitmap.is_empty());
-                for byte in actor.vnode_bitmap {
-                    vnode_sum += byte.count_ones();
-                }
+                vnode_sum += Bitmap::try_from(actor.get_vnode_bitmap()?)?.num_high_bits();
             }
             assert_eq!(vnode_sum as usize, VIRTUAL_NODE_COUNT);
         }

--- a/src/meta/src/stream/stream_graph.rs
+++ b/src/meta/src/stream/stream_graph.rs
@@ -336,7 +336,7 @@ impl StreamActorBuilder {
                         },
                     )| *same_worker_node,
                 ),
-            vnode_bitmap: vec![],
+            vnode_bitmap: None,
         }
     }
 }

--- a/src/meta/src/stream/stream_manager.rs
+++ b/src/meta/src/stream/stream_manager.rs
@@ -952,8 +952,7 @@ mod tests {
                 .cloned()
                 .unwrap()
                 .clone();
-            assert!(!scheduled_actor.vnode_bitmap.is_empty());
-            scheduled_actor.vnode_bitmap.clear();
+            scheduled_actor.vnode_bitmap.take().unwrap();
             assert_eq!(scheduled_actor, actor);
             assert!(services
                 .state
@@ -1053,8 +1052,7 @@ mod tests {
                 .get(&actor.get_actor_id())
                 .cloned()
                 .unwrap();
-            assert!(!scheduled_actor.vnode_bitmap.is_empty());
-            scheduled_actor.vnode_bitmap.clear();
+            scheduled_actor.vnode_bitmap.take().unwrap();
             assert_eq!(scheduled_actor, actor);
             assert!(services
                 .state

--- a/src/stream/src/from_proto/batch_query.rs
+++ b/src/stream/src/from_proto/batch_query.rs
@@ -13,9 +13,7 @@
 // limitations under the License.
 
 use itertools::Itertools;
-use risingwave_common::buffer::Bitmap;
 use risingwave_common::catalog::ColumnDesc;
-use risingwave_common::types::VIRTUAL_NODE_COUNT;
 use risingwave_storage::table::cell_based_table::CellBasedTable;
 use risingwave_storage::{Keyspace, StateStore};
 
@@ -50,8 +48,7 @@ impl ExecutorBuilder for BatchQueryExecutorBuilder {
             .map(|key| *key as usize)
             .collect_vec();
 
-        let mapping = (*params.vnode_bitmap).clone();
-        let hash_filter = Bitmap::from_bytes_with_num_bits(mapping.into(), VIRTUAL_NODE_COUNT);
+        let hash_filter = params.vnode_bitmap;
 
         let schema = table.schema().clone();
         let executor = BatchQueryExecutor::new(

--- a/src/stream/src/from_proto/batch_query.rs
+++ b/src/stream/src/from_proto/batch_query.rs
@@ -48,7 +48,7 @@ impl ExecutorBuilder for BatchQueryExecutorBuilder {
             .map(|key| *key as usize)
             .collect_vec();
 
-        let hash_filter = params.vnode_bitmap;
+        let hash_filter = params.vnode_bitmap.expect("no vnode bitmap");
 
         let schema = table.schema().clone();
         let executor = BatchQueryExecutor::new(


### PR DESCRIPTION
## What's changed and what's your intention?

As title.
- `Bitmap` is easier to set and get the value for some index.
- `Bitmap` is implemented with `Bytes` (#2831) which is born to clone cheaply.

## Checklist

- [x] I have written necessary docs and comments
- [x] I have added necessary unit tests and integration tests
- [x] All checks passed in `./risedev check` (or alias, `./risedev c`)

## Refer to a related PR or issue link (optional)
