### PR TITLE
feat(frontend): Add sql string into context for debugging

### DIFF
--- a/src/frontend/src/handler/mod.rs
+++ b/src/frontend/src/handler/mod.rs
@@ -45,8 +45,12 @@ mod set;
 mod show;
 pub mod util;
 
-pub(super) async fn handle(session: Arc<SessionImpl>, stmt: Statement) -> Result<PgResponse> {
-    let context = OptimizerContext::new(session.clone());
+pub(super) async fn handle(
+    session: Arc<SessionImpl>,
+    stmt: Statement,
+    raw_sql: &str,
+) -> Result<PgResponse> {
+    let context = OptimizerContext::new(session.clone(), Arc::new(String::from(raw_sql)));
     match stmt {
         Statement::Explain {
             statement, verbose, ..

--- a/src/frontend/src/handler/mod.rs
+++ b/src/frontend/src/handler/mod.rs
@@ -48,9 +48,9 @@ pub mod util;
 pub(super) async fn handle(
     session: Arc<SessionImpl>,
     stmt: Statement,
-    raw_sql: &str,
+    sql: &str,
 ) -> Result<PgResponse> {
-    let context = OptimizerContext::new(session.clone(), Arc::new(String::from(raw_sql)));
+    let context = OptimizerContext::new(session.clone(), Arc::new(String::from(sql)));
     match stmt {
         Statement::Explain {
             statement, verbose, ..

--- a/src/frontend/src/handler/mod.rs
+++ b/src/frontend/src/handler/mod.rs
@@ -50,7 +50,7 @@ pub(super) async fn handle(
     stmt: Statement,
     sql: &str,
 ) -> Result<PgResponse> {
-    let context = OptimizerContext::new(session.clone(), Arc::new(String::from(sql)));
+    let context = OptimizerContext::new(session.clone(), Arc::from(sql));
     match stmt {
         Statement::Explain {
             statement, verbose, ..

--- a/src/frontend/src/session.rs
+++ b/src/frontend/src/session.rs
@@ -63,7 +63,7 @@ pub struct OptimizerContext {
     // We use `AtomicI32` here because  `Arc<T>` implements `Send` only when `T: Send + Sync`.
     pub next_id: AtomicI32,
     /// For debugging purposes, store the SQL string in Context
-    pub sql: Arc<String>,
+    pub sql: Arc<str>,
 }
 
 #[derive(Clone, Debug)]
@@ -95,7 +95,7 @@ impl OptimizerContextRef {
 }
 
 impl OptimizerContext {
-    pub fn new(session_ctx: Arc<SessionImpl>, sql: Arc<String>) -> Self {
+    pub fn new(session_ctx: Arc<SessionImpl>, sql: Arc<str>) -> Self {
         Self {
             session_ctx,
             next_id: AtomicI32::new(0),
@@ -109,7 +109,7 @@ impl OptimizerContext {
         Self {
             session_ctx: Arc::new(SessionImpl::mock()),
             next_id: AtomicI32::new(0),
-            sql: Arc::new("".to_string()),
+            sql: Arc::from(""),
         }
         .into()
     }
@@ -589,7 +589,7 @@ impl Session for SessionImpl {
 
 /// Returns row description of the statement
 fn infer(session: Arc<SessionImpl>, stmt: Statement, sql: &str) -> Result<Vec<PgFieldDescriptor>> {
-    let context = OptimizerContext::new(session, Arc::new(String::from(sql)));
+    let context = OptimizerContext::new(session, Arc::from(sql));
     let session = context.session_ctx.clone();
 
     let bound = {

--- a/src/frontend/src/session.rs
+++ b/src/frontend/src/session.rs
@@ -63,7 +63,7 @@ pub struct OptimizerContext {
     // We use `AtomicI32` here because  `Arc<T>` implements `Send` only when `T: Send + Sync`.
     pub next_id: AtomicI32,
     /// For debugging purposes, store the SQL string in Context
-    pub raw_sql: Arc<String>,
+    pub sql: Arc<String>,
 }
 
 #[derive(Clone, Debug)]
@@ -95,11 +95,11 @@ impl OptimizerContextRef {
 }
 
 impl OptimizerContext {
-    pub fn new(session_ctx: Arc<SessionImpl>, raw_sql: Arc<String>) -> Self {
+    pub fn new(session_ctx: Arc<SessionImpl>, sql: Arc<String>) -> Self {
         Self {
             session_ctx,
             next_id: AtomicI32::new(0),
-            raw_sql,
+            sql,
         }
     }
 
@@ -109,7 +109,7 @@ impl OptimizerContext {
         Self {
             session_ctx: Arc::new(SessionImpl::mock()),
             next_id: AtomicI32::new(0),
-            raw_sql: Arc::new("".to_string()),
+            sql: Arc::new("".to_string()),
         }
         .into()
     }
@@ -535,11 +535,11 @@ impl SessionManagerImpl {
 impl Session for SessionImpl {
     async fn run_statement(
         self: Arc<Self>,
-        raw_sql: &str,
+        sql: &str,
     ) -> std::result::Result<PgResponse, BoxedError> {
         // Parse sql.
-        let mut stmts = Parser::parse_sql(raw_sql).map_err(|e| {
-            tracing::error!("failed to parse sql:\n{}:\n{}", raw_sql, e);
+        let mut stmts = Parser::parse_sql(sql).map_err(|e| {
+            tracing::error!("failed to parse sql:\n{}:\n{}", sql, e);
             e
         })?;
         // With pgwire, there would be at most 1 statement in the vec.
@@ -553,8 +553,8 @@ impl Session for SessionImpl {
             ));
         }
         let stmt = stmts.swap_remove(0);
-        let rsp = handle(self, stmt, raw_sql).await.map_err(|e| {
-            tracing::error!("failed to handle sql:\n{}:\n{}", raw_sql, e);
+        let rsp = handle(self, stmt, sql).await.map_err(|e| {
+            tracing::error!("failed to handle sql:\n{}:\n{}", sql, e);
             e
         })?;
         Ok(rsp)
@@ -562,11 +562,11 @@ impl Session for SessionImpl {
 
     async fn infer_return_type(
         self: Arc<Self>,
-        raw_sql: &str,
+        sql: &str,
     ) -> std::result::Result<Vec<PgFieldDescriptor>, BoxedError> {
         // Parse sql.
-        let mut stmts = Parser::parse_sql(raw_sql).map_err(|e| {
-            tracing::error!("failed to parse sql:\n{}:\n{}", raw_sql, e);
+        let mut stmts = Parser::parse_sql(sql).map_err(|e| {
+            tracing::error!("failed to parse sql:\n{}:\n{}", sql, e);
             e
         })?;
         // With pgwire, there would be at most 1 statement in the vec.
@@ -575,8 +575,8 @@ impl Session for SessionImpl {
             return Ok(vec![]);
         }
         let stmt = stmts.swap_remove(0);
-        let rsp = infer(self, stmt, raw_sql).map_err(|e| {
-            tracing::error!("failed to handle sql:\n{}:\n{}", raw_sql, e);
+        let rsp = infer(self, stmt, sql).map_err(|e| {
+            tracing::error!("failed to handle sql:\n{}:\n{}", sql, e);
             e
         })?;
         Ok(rsp)
@@ -588,12 +588,8 @@ impl Session for SessionImpl {
 }
 
 /// Returns row description of the statement
-fn infer(
-    session: Arc<SessionImpl>,
-    stmt: Statement,
-    raw_sql: &str,
-) -> Result<Vec<PgFieldDescriptor>> {
-    let context = OptimizerContext::new(session, Arc::new(String::from(raw_sql)));
+fn infer(session: Arc<SessionImpl>, stmt: Statement, sql: &str) -> Result<Vec<PgFieldDescriptor>> {
+    let context = OptimizerContext::new(session, Arc::new(String::from(sql)));
     let session = context.session_ctx.clone();
 
     let bound = {

--- a/src/frontend/src/test_utils.rs
+++ b/src/frontend/src/test_utils.rs
@@ -105,8 +105,7 @@ impl LocalFrontend {
                 );
                 binder.bind(Statement::Query(query.clone()))?
             };
-            let raw_sql_ptr = Arc::new(String::from(raw_sql));
-            Planner::new(OptimizerContext::new(session, raw_sql_ptr).into())
+            Planner::new(OptimizerContext::new(session, Arc::new(String::from(raw_sql))).into())
                 .plan(bound)
                 .unwrap()
                 .gen_batch_query_plan()

--- a/src/frontend/src/test_utils.rs
+++ b/src/frontend/src/test_utils.rs
@@ -105,7 +105,7 @@ impl LocalFrontend {
                 );
                 binder.bind(Statement::Query(query.clone()))?
             };
-            Planner::new(OptimizerContext::new(session, Arc::new(String::from(raw_sql))).into())
+            Planner::new(OptimizerContext::new(session, Arc::from(raw_sql.as_str())).into())
                 .plan(bound)
                 .unwrap()
                 .gen_batch_query_plan()

--- a/src/frontend/src/test_utils.rs
+++ b/src/frontend/src/test_utils.rs
@@ -92,7 +92,8 @@ impl LocalFrontend {
 
     /// Convert a sql (must be an `Query`) into an unoptimized batch plan.
     pub async fn to_batch_plan(&self, sql: impl Into<String>) -> Result<PlanRef> {
-        let statements = Parser::parse_sql(&sql.into()).unwrap();
+        let raw_sql = &sql.into();
+        let statements = Parser::parse_sql(raw_sql).unwrap();
         let statement = statements.get(0).unwrap();
         if let Statement::Query(query) = statement {
             let session = self.session_ref();
@@ -104,7 +105,8 @@ impl LocalFrontend {
                 );
                 binder.bind(Statement::Query(query.clone()))?
             };
-            Planner::new(OptimizerContext::new(session).into())
+            let raw_sql_ptr = Arc::new(String::from(raw_sql));
+            Planner::new(OptimizerContext::new(session, raw_sql_ptr).into())
                 .plan(bound)
                 .unwrap()
                 .gen_batch_query_plan()

--- a/src/frontend/test_runner/src/lib.rs
+++ b/src/frontend/test_runner/src/lib.rs
@@ -248,7 +248,7 @@ impl TestCase {
     ) -> Result<Option<TestCaseResult>> {
         let statements = Parser::parse_sql(sql).unwrap();
         for stmt in statements {
-            let context = OptimizerContext::new(session.clone(), Arc::new(String::from(sql)));
+            let context = OptimizerContext::new(session.clone(), Arc::from(sql));
             match stmt.clone() {
                 Statement::Query(_)
                 | Statement::Insert { .. }

--- a/src/frontend/test_runner/src/lib.rs
+++ b/src/frontend/test_runner/src/lib.rs
@@ -248,8 +248,7 @@ impl TestCase {
     ) -> Result<Option<TestCaseResult>> {
         let statements = Parser::parse_sql(sql).unwrap();
         for stmt in statements {
-            let raw_sql_ptr = Arc::new(String::from(sql));
-            let context = OptimizerContext::new(session.clone(), raw_sql_ptr);
+            let context = OptimizerContext::new(session.clone(), Arc::new(String::from(sql)));
             match stmt.clone() {
                 Statement::Query(_)
                 | Statement::Insert { .. }

--- a/src/frontend/test_runner/src/lib.rs
+++ b/src/frontend/test_runner/src/lib.rs
@@ -248,7 +248,8 @@ impl TestCase {
     ) -> Result<Option<TestCaseResult>> {
         let statements = Parser::parse_sql(sql).unwrap();
         for stmt in statements {
-            let context = OptimizerContext::new(session.clone());
+            let raw_sql_ptr = Arc::new(String::from(sql));
+            let context = OptimizerContext::new(session.clone(), raw_sql_ptr);
             match stmt.clone() {
                 Statement::Query(_)
                 | Statement::Insert { .. }


### PR DESCRIPTION
## What's changed and what's your intention?

Add `Arc<str>` into `OptimizerContext` to store `raw_sql` strings for debugging.

Please explain **IN DETAIL** what the changes are in this PR and why they are needed:

- Summarize your change (**mandatory**)

  - Add `Arc<str>` into `OptimizerContext`
  - Refactor to create `Arc<str>` at entry points

- How does this PR work? Need a brief introduction for the changed logic (optional)
- Describe clearly one logical change and avoid lazy messages (optional)
- Describe any limitations of the current code (optional)
- Add the 'user-facing changes' label if your PR contains changes that are visible to users (optional)

## Checklist

- [X] I have written necessary docs and comments
- [X] I have added necessary unit tests and integration tests
- [X] All checks passed in `./risedev check` (or alias, `./risedev c`)

## Refer to a related PR or issue link (optional)

Closes #2777 