### PR TITLE
feat(executor): streaming hyperloglog improvements

### DIFF
--- a/src/stream/src/executor/aggregation/approx_count_distinct.rs
+++ b/src/stream/src/executor/aggregation/approx_count_distinct.rs
@@ -357,7 +357,7 @@ mod tests {
     use super::*;
 
     #[test]
-    fn test_insert_and_delete_dense() {
+    fn test_streaming_approx_count_distinct_insert_and_delete_dense() {
         let mut agg = StreamingApproxCountDistinct::<4>::new();
         assert_eq!(agg.get_output().unwrap().unwrap().as_int64(), &0);
 
@@ -387,7 +387,7 @@ mod tests {
     }
 
     #[test]
-    fn test_insert_and_delete_sparse() {
+    fn test_streaming_approx_count_distinct_insert_and_delete_sparse() {
         let mut agg = StreamingApproxCountDistinct::<0>::new();
         assert_eq!(agg.get_output().unwrap().unwrap().as_int64(), &0);
 

--- a/src/stream/src/executor/aggregation/approx_count_distinct.rs
+++ b/src/stream/src/executor/aggregation/approx_count_distinct.rs
@@ -63,7 +63,7 @@ impl SparseCount {
 
     fn add(&mut self, k: u8) -> bool {
         let mut last = 0;
-        for (key, count) in self.inner.iter_mut() {
+        for (key, count) in &mut self.inner {
             if *key == k {
                 *count += 1;
                 return true;
@@ -123,7 +123,7 @@ impl<const DENSE_BITS: usize> RegisterBucket<DENSE_BITS> {
             bail!("HyperLogLog: Invalid bucket index");
         }
 
-        if index >= 17 {
+        if index > DENSE_BITS {
             if let Some(counts) = &self.sparse_counts {
                 return Ok(counts.get(index as u8));
             } else {
@@ -144,7 +144,7 @@ impl<const DENSE_BITS: usize> RegisterBucket<DENSE_BITS> {
         let count = self.get_bucket(index)?;
 
         if is_insert {
-            if index >= 17 {
+            if index > DENSE_BITS {
                 if let Some(counts) = &mut self.sparse_counts {
                     counts.add(index as u8);
                 } else {
@@ -165,7 +165,7 @@ impl<const DENSE_BITS: usize> RegisterBucket<DENSE_BITS> {
         } else {
             // We don't have to worry about the user deleting nonexistent elements, so the counts
             // can never go below 0.
-            if index >= 17 {
+            if index > DENSE_BITS {
                 if let Some(counts) = &mut self.sparse_counts {
                     counts.subtract(index as u8);
                     if counts.is_empty() {

--- a/src/stream/src/executor/aggregation/approx_count_distinct.rs
+++ b/src/stream/src/executor/aggregation/approx_count_distinct.rs
@@ -27,7 +27,7 @@ use risingwave_common::types::{Datum, DatumRef, Scalar, ScalarImpl};
 use super::StreamingAggStateImpl;
 use crate::executor::error::StreamExecutorResult;
 
-const INDEX_BITS: u8 = 14; // number of bits used for finding the index of each 64-bit hash
+const INDEX_BITS: u8 = 16; // number of bits used for finding the index of each 64-bit hash
 const NUM_OF_REGISTERS: usize = 1 << INDEX_BITS; // number of registers available
 const COUNT_BITS: u8 = 64 - INDEX_BITS; // number of non-index bits in each 64-bit hash
 
@@ -35,86 +35,147 @@ const COUNT_BITS: u8 = 64 - INDEX_BITS; // number of non-index bits in each 64-b
 // near-optimal cardinality estimation algorithm" by Philippe Flajolet et al.
 const BIAS_CORRECTION: f64 = 0.72125;
 
+pub(crate) const DENSE_BITS_DEFAULT: usize = 16; // number of bits in the dense repr of the `RegisterBucket`
+
 #[derive(Clone, Debug)]
-struct RegisterBucket {
-    count_1_to_16: Vec<u32>,
-    count_17_to_24: Vec<u16>,
-    count_25_to_32: Vec<u8>,
-    count_33_to_64: u32,
+struct SparseCount {
+    inner: Vec<(u8, u64)>,
 }
 
-impl RegisterBucket {
-    pub fn new() -> Self {
+impl SparseCount {
+    fn new() -> Self {
         Self {
-            count_1_to_16: vec![0; 16],
-            count_17_to_24: vec![0; 8],
-            count_25_to_32: vec![0; 8],
-            count_33_to_64: 0,
+            inner: Vec::default(),
         }
     }
 
-    fn get_bucket(&self, index: usize) -> StreamExecutorResult<u32> {
-        if !(1..=64).contains(&index) {
+    fn get(&self, k: u8) -> u64 {
+        for (key, count) in &self.inner {
+            if *key == k {
+                return *count;
+            }
+            if *key > k {
+                break;
+            }
+        }
+        0
+    }
+
+    fn add(&mut self, k: u8) -> bool {
+        let mut last = 0;
+        for (key, count) in self.inner.iter_mut() {
+            if *key == k {
+                *count += 1;
+                return true;
+            }
+            if *key > k {
+                break;
+            }
+            last += 1;
+        }
+        self.inner.insert(last, (k, 1));
+        false
+    }
+
+    fn subtract(&mut self, k: u8) -> bool {
+        for (i, (key, count)) in self.inner.iter_mut().enumerate() {
+            if *key == k {
+                *count -= 1;
+                if *count == 0 {
+                    // delete the count
+                    self.inner.remove(i);
+                }
+                return true;
+            }
+            if *key > k {
+                break;
+            }
+        }
+        false
+    }
+
+    fn is_empty(&self) -> bool {
+        self.inner.len() == 0
+    }
+
+    fn last_key(&self) -> u8 {
+        assert!(!self.is_empty());
+        self.inner.last().unwrap().0
+    }
+}
+
+#[derive(Clone, Debug)]
+struct RegisterBucket<const DENSE_BITS: usize> {
+    dense_counts: [u64; DENSE_BITS],
+    sparse_counts: Option<SparseCount>,
+}
+
+impl<const DENSE_BITS: usize> RegisterBucket<DENSE_BITS> {
+    pub fn new() -> Self {
+        Self {
+            dense_counts: [0u64; DENSE_BITS],
+            sparse_counts: None,
+        }
+    }
+
+    fn get_bucket(&self, index: usize) -> StreamExecutorResult<u64> {
+        if index > 64 || index == 0 {
             bail!("HyperLogLog: Invalid bucket index");
         }
 
-        if index >= 33 {
-            return Ok((self.count_33_to_64 >> (index - 33)) & 1);
-        }
-
-        if index >= 25 {
-            return Ok(self.count_25_to_32[index - 25] as u32);
-        }
-
         if index >= 17 {
-            return Ok(self.count_17_to_24[index - 17] as u32);
+            if let Some(counts) = &self.sparse_counts {
+                return Ok(counts.get(index as u8));
+            } else {
+                return Ok(0);
+            }
         }
 
-        Ok(self.count_1_to_16[index - 1])
+        Ok(self.dense_counts[index - 1])
     }
 
     /// Increments or decrements the bucket at `index` depending on the state of `is_insert`.
     /// Returns an Error if `index` is invalid or if inserting will cause an overflow in the bucket.
     fn update_bucket(&mut self, index: usize, is_insert: bool) -> StreamExecutorResult<()> {
-        if !(1..=64).contains(&index) {
+        if index > 64 || index == 0 {
             bail!("HyperLogLog: Invalid bucket index");
         }
 
         let count = self.get_bucket(index)?;
 
         if is_insert {
-            if index >= 33 {
-                if count == 1 {
-                    bail!("HyperLogLog: Count exceeds maximum bucket value. Your data stream may have too many repeated values or too large a cardinality for approx_count_distinct to handle.");
+            if index >= 17 {
+                if let Some(counts) = &mut self.sparse_counts {
+                    counts.add(index as u8);
+                } else {
+                    let mut counts = SparseCount::new();
+                    counts.add(index as u8);
+                    self.sparse_counts = Some(counts);
                 }
-                self.count_33_to_64 |= 1 << (index - 33);
-            } else if index >= 25 {
-                if count as u8 == u8::MAX {
-                    bail!("HyperLogLog: Count exceeds maximum bucket value. Your data stream may have too many repeated values or too large a cardinality for approx_count_distinct to handle.");
-                }
-                self.count_25_to_32[index - 25] = count as u8 + 1;
-            } else if index >= 17 {
-                if count as u16 == u16::MAX {
-                    bail!("HyperLogLog: Count exceeds maximum bucket value. Your data stream may have too many repeated values or too large a cardinality for approx_count_distinct to handle.");
-                }
-                self.count_17_to_24[index - 17] = count as u16 + 1;
             } else if index >= 1 {
-                if count == u32::MAX {
-                    bail!("HyperLogLog: Count exceeds maximum bucket value. Your data stream may have too many repeated values or too large a cardinality for approx_count_distinct to handle.");
+                if count == u64::MAX {
+                    bail!(
+                        "HyperLogLog: Count exceeds maximum bucket value.\
+                        Your data stream may have too many repeated values or too large a\
+                        cardinality for approx_count_distinct to handle (max: 2^64 - 1)"
+                    );
                 }
-                self.count_1_to_16[index - 1] = count + 1;
+                self.dense_counts[index - 1] = count + 1;
             }
         } else {
             // We don't have to worry about the user deleting nonexistent elements, so the counts
             // can never go below 0.
-            if index >= 33 {
-                self.count_33_to_64 ^= 1 << (index - 33);
-            } else if index >= 25 {
-                self.count_25_to_32[index - 25] = count as u8 - 1;
-            } else if index >= 17 {
-                self.count_17_to_24[index - 17] = count as u16 - 1;
+            if index >= 17 {
+                if let Some(counts) = &mut self.sparse_counts {
+                    counts.subtract(index as u8);
+                    if counts.is_empty() {
+                        self.sparse_counts = None;
+                    }
+                } else {
+                    bail!("HyperLogLog: Deletion of non-existent count");
+                }
             } else if index >= 1 {
-                self.count_1_to_16[index - 1] = count - 1;
+                self.dense_counts[index - 1] = count - 1;
             }
         }
 
@@ -123,12 +184,14 @@ impl RegisterBucket {
 
     /// Gets the number of the maximum bucket which has a count greater than zero.
     fn get_max(&self) -> StreamExecutorResult<u8> {
-        for i in (1..64).rev() {
-            if self.get_bucket(i)? > 0 {
+        if let Some(counts) = &self.sparse_counts && !counts.is_empty() {
+            return Ok(counts.last_key());
+        }
+        for i in (0..DENSE_BITS).rev() {
+            if self.dense_counts[i] > 0 {
                 return Ok(i as u8);
             }
         }
-
         Ok(0)
     }
 }
@@ -138,20 +201,18 @@ impl RegisterBucket {
 /// have x trailing zeroes for all x from 1-64. This allows the algorithm to support insertion and
 /// deletion, but uses up more memory and limits the number of rows that can be counted.
 ///
-/// Currently, each `RegisterBucket` can count 2^33 rows on average. `StreamingApproxCountDistinct`
-/// stores 2^14 `RegisterBuckets`, so about 2^47 or 141 trillion rows can be counted on average.
-/// Each `RegisterBucket` takes up 736 bits, so the memory usage of `StreamingApproxCountDistinct`
-/// is about 1.5 MB.
+/// `StreamingApproxCountDistinct` can count up to a total of 2^64 rows.
 ///
-/// The estimation error for `HyperLogLog` is 1.04/sqrt(num of registers). With 2^14 registers this
-/// is ~1/128.
+/// The estimation error for `HyperLogLog` is 1.04/sqrt(num of registers). With 2^16 registers this
+/// is ~1/256, or about 0.4%. The memory usage for the default choice of parameters is about
+/// 1024 bits * 2^16 buckets, which is about 8.4 MB.
 #[derive(Clone, Debug)]
-pub struct StreamingApproxCountDistinct {
-    registers: Vec<RegisterBucket>,
+pub struct StreamingApproxCountDistinct<const DENSE_BITS: usize> {
+    registers: Vec<RegisterBucket<DENSE_BITS>>,
     initial_count: i64,
 }
 
-impl StreamingApproxCountDistinct {
+impl<const DENSE_BITS: usize> StreamingApproxCountDistinct<DENSE_BITS> {
     pub fn new() -> Self {
         StreamingApproxCountDistinct::new_with_datum(None)
     }
@@ -213,7 +274,7 @@ impl StreamingApproxCountDistinct {
     }
 }
 
-impl StreamingAggStateImpl for StreamingApproxCountDistinct {
+impl<const DENSE_BITS: usize> StreamingAggStateImpl for StreamingApproxCountDistinct<DENSE_BITS> {
     fn apply_batch(
         &mut self,
         ops: Ops<'_>,
@@ -296,8 +357,8 @@ mod tests {
     use super::*;
 
     #[test]
-    fn test_insert_and_delete() {
-        let mut agg = StreamingApproxCountDistinct::new();
+    fn test_insert_and_delete_dense() {
+        let mut agg = StreamingApproxCountDistinct::<4>::new();
         assert_eq!(agg.get_output().unwrap().unwrap().as_int64(), &0);
 
         agg.apply_batch(
@@ -326,8 +387,56 @@ mod tests {
     }
 
     #[test]
-    fn test_register_bucket_get_and_update() {
-        let mut rb = RegisterBucket::new();
+    fn test_insert_and_delete_sparse() {
+        let mut agg = StreamingApproxCountDistinct::<0>::new();
+        assert_eq!(agg.get_output().unwrap().unwrap().as_int64(), &0);
+
+        agg.apply_batch(
+            &[Op::Insert, Op::Insert, Op::Insert],
+            None,
+            &[&array_nonnull!(I64Array, [1, 2, 3]).into()],
+        )
+        .unwrap();
+        assert_matches!(agg.get_output().unwrap(), Some(_));
+
+        agg.apply_batch(
+            &[Op::Insert, Op::Delete, Op::Insert],
+            Some(&(vec![true, false, false]).try_into().unwrap()),
+            &[&array_nonnull!(I64Array, [3, 3, 1]).into()],
+        )
+        .unwrap();
+        assert_matches!(agg.get_output().unwrap(), Some(_));
+
+        agg.apply_batch(
+            &[Op::Delete, Op::Delete, Op::Delete, Op::Delete],
+            Some(&(vec![true, true, true, true]).try_into().unwrap()),
+            &[&array_nonnull!(I64Array, [3, 3, 1, 2]).into()],
+        )
+        .unwrap();
+        assert_eq!(agg.get_output().unwrap().unwrap().into_int64(), 0);
+    }
+
+    #[test]
+    fn test_register_bucket_get_and_update_dense() {
+        let mut rb = RegisterBucket::<4>::new();
+
+        for i in 0..20 {
+            rb.update_bucket(i % 2 + 1, true).unwrap();
+        }
+        assert_eq!(rb.get_bucket(1).unwrap(), 10);
+        assert_eq!(rb.get_bucket(2).unwrap(), 10);
+
+        rb.update_bucket(1, false).unwrap();
+        assert_eq!(rb.get_bucket(1).unwrap(), 9);
+        assert_eq!(rb.get_bucket(2).unwrap(), 10);
+
+        rb.update_bucket(64, true).unwrap();
+        assert_eq!(rb.get_bucket(64).unwrap(), 1);
+    }
+
+    #[test]
+    fn test_register_bucket_get_and_update_sparse() {
+        let mut rb = RegisterBucket::<0>::new();
 
         for i in 0..20 {
             rb.update_bucket(i % 2 + 1, true).unwrap();
@@ -345,24 +454,11 @@ mod tests {
 
     #[test]
     fn test_register_bucket_invalid_register() {
-        let mut rb = RegisterBucket::new();
+        let mut rb = RegisterBucket::<0>::new();
 
         assert_matches!(rb.get_bucket(0), Err(_));
         assert_matches!(rb.get_bucket(65), Err(_));
         assert_matches!(rb.update_bucket(0, true), Err(_));
         assert_matches!(rb.update_bucket(65, true), Err(_));
-    }
-
-    #[test]
-    fn test_register_bucket_overflow() {
-        let mut rb = RegisterBucket::new();
-
-        rb.update_bucket(64, true).unwrap();
-        assert_matches!(rb.update_bucket(64, true), Err(_));
-
-        for _i in 0..u8::MAX {
-            rb.update_bucket(32, true).unwrap();
-        }
-        assert_matches!(rb.update_bucket(32, true), Err(_));
     }
 }

--- a/src/stream/src/executor/aggregation/mod.rs
+++ b/src/stream/src/executor/aggregation/mod.rs
@@ -141,10 +141,10 @@ pub fn create_streaming_agg_state(
                     }
                 )*
                 (AggKind::ApproxCountDistinct, _, DataType::Int64, Some(datum)) => {
-                    Box::new(StreamingApproxCountDistinct::new_with_datum(datum))
+                    Box::new(StreamingApproxCountDistinct::<{approx_count_distinct::DENSE_BITS_DEFAULT}>::new_with_datum(datum))
                 }
                 (AggKind::ApproxCountDistinct, _, DataType::Int64, None) => {
-                    Box::new(StreamingApproxCountDistinct::new())
+                    Box::new(StreamingApproxCountDistinct::<{approx_count_distinct::DENSE_BITS_DEFAULT}>::new())
                 }
                 (other_agg, other_input, other_return, _) => panic!(
                     "streaming agg state not implemented: {:?} {:?} {:?}",


### PR DESCRIPTION
## What's changed and what's your intention?
Increase applicability to any total number of rows counted < 2^64
Use sparse representation.

## Refer to a related PR or issue link (optional)
Follow up on: https://github.com/singularity-data/risingwave/pull/3121
Tracked in: https://github.com/singularity-data/risingwave/issues/3162 (fixes items 2, 3, 4)

We assume bucket overflows simply will not happen and do not spend much time handling it.