### PR TITLE
feat(risedev): generate risectl config

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3897,6 +3897,7 @@ dependencies = [
 name = "risingwave_cmd"
 version = "0.1.9"
 dependencies = [
+ "anyhow",
  "clap 3.1.18",
  "log",
  "madsim",

--- a/Makefile.toml
+++ b/Makefile.toml
@@ -297,6 +297,25 @@ set -ex
 RUST_BACKTRACE=1 RW_NODE=playground cargo run --bin risingwave --profile "${RISINGWAVE_BUILD_PROFILE}"
 '''
 
+[tasks.ctl]
+category = "RiseDev - Start"
+description = "Start RiseCtl"
+script = '''
+#!@shell
+
+RC_ENV_FILE="${PREFIX_CONFIG}/risectl-env"
+
+if [ ! -f "${RC_ENV_FILE}" ]; then
+  echo "risectl-env file not found. Did you start cluster using $(tput setaf 4)\`./risedev d\`$(tput sgr0)?"
+  exit 1
+fi
+
+source "${RC_ENV_FILE}"
+
+cargo run --bin risectl --profile "${RISINGWAVE_BUILD_PROFILE}" -- "$@"
+test $? -eq 0 || exit 1
+'''
+
 [tasks.d]
 alias = "dev"
 

--- a/src/cmd/Cargo.toml
+++ b/src/cmd/Cargo.toml
@@ -7,6 +7,7 @@ edition = "2021"
 static-link = ["workspace-static-link"]
 
 [dependencies]
+anyhow = "1"
 clap = { version = "3", features = ["derive"] }
 log = { version = "0.4", features = ["release_max_level_info"] }
 madsim = "=0.2.0-alpha.3"

--- a/src/cmd/src/bin/ctl.rs
+++ b/src/cmd/src/bin/ctl.rs
@@ -14,6 +14,7 @@
 
 #![cfg_attr(coverage, feature(no_coverage))]
 
+use anyhow::Result;
 use tikv_jemallocator::Jemalloc;
 
 #[global_allocator]
@@ -21,7 +22,7 @@ static GLOBAL: Jemalloc = Jemalloc;
 
 #[cfg_attr(coverage, no_coverage)]
 #[tokio::main(flavor = "multi_thread", worker_threads = 4)]
-async fn main() {
+async fn main() -> Result<()> {
     use clap::StructOpt;
 
     let opts = risingwave_ctl::CliOpts::parse();

--- a/src/ctl/src/lib.rs
+++ b/src/ctl/src/lib.rs
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use anyhow::Result;
 use clap::{Parser, Subcommand};
 mod cmd_impl;
 pub(crate) mod common;
@@ -69,33 +70,25 @@ enum TableCommands {
     },
 }
 
-pub async fn start(opts: CliOpts) {
+pub async fn start(opts: CliOpts) -> Result<()> {
     match opts.command {
         Commands::Hummock(HummockCommands::ListVersion) => {
-            tokio::spawn(cmd_impl::hummock::list_version())
-                .await
-                .unwrap()
-                .unwrap()
+            tokio::spawn(cmd_impl::hummock::list_version()).await??;
         }
         Commands::Hummock(HummockCommands::ListKv { epoch, table_id }) => {
-            tokio::spawn(cmd_impl::hummock::list_kv(epoch, table_id))
-                .await
-                .unwrap()
-                .unwrap()
+            tokio::spawn(cmd_impl::hummock::list_kv(epoch, table_id)).await??;
         }
         Commands::Hummock(HummockCommands::TriggerManualCompaction {
             compaction_group_id,
-        }) => tokio::spawn(cmd_impl::hummock::trigger_manual_compaction(
-            compaction_group_id,
-        ))
-        .await
-        .unwrap()
-        .unwrap(),
+        }) => {
+            tokio::spawn(cmd_impl::hummock::trigger_manual_compaction(
+                compaction_group_id,
+            ))
+            .await??
+        }
         Commands::Table(TableCommands::Scan { mv_name }) => {
-            tokio::spawn(cmd_impl::table::scan(mv_name))
-                .await
-                .unwrap()
-                .unwrap()
+            tokio::spawn(cmd_impl::table::scan(mv_name)).await??
         }
     }
+    Ok(())
 }

--- a/src/risedevtool/src/bin/risedev-playground.rs
+++ b/src/risedevtool/src/bin/risedev-playground.rs
@@ -29,10 +29,10 @@ use console::style;
 use indicatif::{MultiProgress, ProgressBar};
 use risedev::util::{complete_spin, fail_spin};
 use risedev::{
-    preflight_check, AwsS3Config, CompactorService, ComputeNodeService, ConfigExpander,
-    ConfigureTmuxTask, EnsureStopService, ExecuteContext, FrontendService, GrafanaService,
-    JaegerService, KafkaService, MetaNodeService, MinioService, PrometheusService, ServiceConfig,
-    Task, ZooKeeperService, RISEDEV_SESSION_NAME,
+    compute_risectl_env, preflight_check, AwsS3Config, CompactorService, ComputeNodeService,
+    ConfigExpander, ConfigureTmuxTask, EnsureStopService, ExecuteContext, FrontendService,
+    GrafanaService, JaegerService, KafkaService, MetaNodeService, MinioService, PrometheusService,
+    ServiceConfig, Task, ZooKeeperService, RISEDEV_SESSION_NAME,
 };
 use tempfile::tempdir;
 use yaml_rust::YamlEmitter;
@@ -384,6 +384,16 @@ fn main() -> Result<()> {
             }
             println!("-------------------------------");
             println!();
+
+            let risectl_env = match compute_risectl_env(&services) {
+                Ok(x) => x,
+                Err(_) => "".into(),
+            };
+
+            std::fs::write(
+                Path::new(&env::var("PREFIX_CONFIG")?).join("risectl-env"),
+                &risectl_env,
+            )?;
 
             println!("All services started successfully.");
 

--- a/src/risedevtool/src/lib.rs
+++ b/src/risedevtool/src/lib.rs
@@ -30,6 +30,8 @@ mod compose;
 pub use compose::*;
 mod compose_deploy;
 pub use compose_deploy::*;
+mod risectl_env;
+pub use risectl_env::*;
 
 mod task;
 pub mod util;

--- a/src/risedevtool/src/risectl_env.rs
+++ b/src/risedevtool/src/risectl_env.rs
@@ -1,3 +1,17 @@
+// Copyright 2022 Singularity Data
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 use std::collections::HashMap;
 use std::process::Command;
 
@@ -8,25 +22,22 @@ use crate::{add_storage_backend, ServiceConfig};
 pub fn compute_risectl_env(services: &HashMap<String, ServiceConfig>) -> Result<String> {
     // Pick one of the compute node and generate risectl config
     for item in services.values() {
-        match item {
-            ServiceConfig::ComputeNode(c) => {
-                let mut cmd = Command::new("compute-node");
-                add_storage_backend(
-                    "risectl",
-                    c.provide_minio.as_ref().unwrap(),
-                    c.provide_aws_s3.as_ref().unwrap(),
-                    false,
-                    &mut cmd,
-                )?;
-                let meta_node = &c.provide_meta_node.as_ref().unwrap()[0];
-                return Ok(format!(
-                    "export RW_HUMMOCK_URL=\"{}\"\nexport RW_META_ADDR=\"http://{}:{}\"",
-                    cmd.get_args().nth(1).unwrap().to_str().unwrap(),
-                    meta_node.address,
-                    meta_node.port
-                ));
-            }
-            _ => {}
+        if let ServiceConfig::ComputeNode(c) = item {
+            let mut cmd = Command::new("compute-node");
+            add_storage_backend(
+                "risectl",
+                c.provide_minio.as_ref().unwrap(),
+                c.provide_aws_s3.as_ref().unwrap(),
+                false,
+                &mut cmd,
+            )?;
+            let meta_node = &c.provide_meta_node.as_ref().unwrap()[0];
+            return Ok(format!(
+                "export RW_HUMMOCK_URL=\"{}\"\nexport RW_META_ADDR=\"http://{}:{}\"",
+                cmd.get_args().nth(1).unwrap().to_str().unwrap(),
+                meta_node.address,
+                meta_node.port
+            ));
         }
     }
     Ok("".into())

--- a/src/risedevtool/src/risectl_env.rs
+++ b/src/risedevtool/src/risectl_env.rs
@@ -1,0 +1,33 @@
+use std::collections::HashMap;
+use std::process::Command;
+
+use anyhow::Result;
+
+use crate::{add_storage_backend, ServiceConfig};
+
+pub fn compute_risectl_env(services: &HashMap<String, ServiceConfig>) -> Result<String> {
+    // Pick one of the compute node and generate risectl config
+    for item in services.values() {
+        match item {
+            ServiceConfig::ComputeNode(c) => {
+                let mut cmd = Command::new("compute-node");
+                add_storage_backend(
+                    "risectl",
+                    c.provide_minio.as_ref().unwrap(),
+                    c.provide_aws_s3.as_ref().unwrap(),
+                    false,
+                    &mut cmd,
+                )?;
+                let meta_node = &c.provide_meta_node.as_ref().unwrap()[0];
+                return Ok(format!(
+                    "export RW_HUMMOCK_URL=\"{}\"\nexport RW_META_ADDR=\"http://{}:{}\"",
+                    cmd.get_args().nth(1).unwrap().to_str().unwrap(),
+                    meta_node.address,
+                    meta_node.port
+                ));
+            }
+            _ => {}
+        }
+    }
+    Ok("".into())
+}


### PR DESCRIPTION
Signed-off-by: Alex Chi <iskyzh@gmail.com>

## What's changed and what's your intention?

As title. Now developers should use `./risedev d && ./risedev ctl` to start risectl. An environment file will be generated, like:

```
export RW_HUMMOCK_URL="hummock+minio://hummockadmin:hummockadmin@127.0.0.1:9301/hummock001"
export RW_META_ADDR="http://127.0.0.1:5690"
```

## Checklist

- [x] I have written necessary docs and comments
- [x] I have added necessary unit tests and integration tests
- [x] All checks passed in `./risedev check` (or alias, `./risedev c`)

## Refer to a related PR or issue link (optional)
