### PR TITLE
doc: no need to manually check in PR from forks

### DIFF
--- a/docs/developer-guide.md
+++ b/docs/developer-guide.md
@@ -356,17 +356,6 @@ workspace.
 
 And use [cargo-sort](https://crates.io/crates/cargo-sort) to ensure all deps are get sorted.
 
-## Check in PRs from forks
-
-```shell
-gh pr checkout <PR id>
-git checkout -b forks/<PR id>
-git push origin HEAD -u
-```
-
-After that, CI checks will begin on branches of RisingWave's main repo,
-and the status will be automatically updated to PRs from forks.
-
 ## Submit PRs
 
 Instructions about submitting PRs are included in the [contribution guidelines](../CONTRIBUTING.md).


### PR DESCRIPTION
## What's changed and what's your intention?
We can now directly `approve and run` instead.

## Checklist

~- [ ] I have written necessary docs and comments~
~- [ ] I have added necessary unit tests and integration tests~
- [x] All checks passed in `./risedev check` (or alias, `./risedev c`)

## Refer to a related PR or issue link (optional)
