### PR TITLE
refactor(storage): remove `Option` on pk serializer of cell-based table

### DIFF
--- a/src/common/src/util/ordered/serde.rs
+++ b/src/common/src/util/ordered/serde.rs
@@ -75,6 +75,7 @@ impl OrderedRowSerializer {
         Self { order_types }
     }
 
+    #[must_use]
     pub fn prefix(&self, len: usize) -> Self {
         Self {
             order_types: self.order_types[..len].to_vec(),

--- a/src/common/src/util/ordered/serde.rs
+++ b/src/common/src/util/ordered/serde.rs
@@ -115,10 +115,6 @@ impl OrderedRowSerializer {
             append_to.extend(serializer.into_inner());
         }
     }
-
-    pub fn into_order_types(self) -> Vec<OrderType> {
-        self.order_types
-    }
 }
 
 /// Deserializer of the `Row`.

--- a/src/compute/tests/integration_tests.rs
+++ b/src/compute/tests/integration_tests.rs
@@ -201,7 +201,12 @@ async fn test_table_v2_materialize() -> Result<()> {
 
     // Since we have not polled `Materialize`, we cannot scan anything from this table
     let keyspace = Keyspace::table_root(memory_state_store, &source_table_id);
-    let table = CellBasedTable::new(keyspace, column_descs.clone(), None, None);
+    let table = CellBasedTable::new(
+        keyspace,
+        column_descs.clone(),
+        vec![OrderType::Ascending],
+        None,
+    );
 
     let ordered_column_descs: Vec<OrderedColumnDesc> = column_descs
         .iter()
@@ -395,7 +400,12 @@ async fn test_row_seq_scan() -> Result<()> {
         None,
         vec![0_usize],
     );
-    let table = CellBasedTable::new(keyspace, column_descs.clone(), None, None);
+    let table = CellBasedTable::new(
+        keyspace,
+        column_descs.clone(),
+        vec![OrderType::Ascending],
+        None,
+    );
 
     let epoch: u64 = 0;
 

--- a/src/storage/src/lib.rs
+++ b/src/storage/src/lib.rs
@@ -40,6 +40,7 @@
 #![feature(lint_reasons)]
 #![feature(allocator_api)]
 #![feature(strict_provenance)]
+#![feature(let_else)]
 #![test_runner(risingwave_test_runner::test_runner::run_failpont_tests)]
 
 pub mod cell_based_row_deserializer;

--- a/src/storage/src/table/cell_based_table.rs
+++ b/src/storage/src/table/cell_based_table.rs
@@ -118,6 +118,13 @@ impl<S: StateStore> CellBasedTable<S> {
         &self.schema
     }
 
+    pub(super) fn pk_serializer(&self) -> &OrderedRowSerializer {
+        &self.pk_serializer
+    }
+}
+
+/// Get & Write
+impl<S: StateStore> CellBasedTable<S> {
     /// Get a single row by point get
     pub async fn get_row(&self, pk: &Row, epoch: u64) -> StorageResult<Option<Row>> {
         // TODO: use multi-get for cell_based get_row
@@ -307,7 +314,7 @@ impl<S: PkAndRowStream + Unpin> TableIter for S {
     }
 }
 
-/// Iterator functions.
+/// Iterators
 impl<S: StateStore> CellBasedTable<S> {
     /// Get a [`StreamingIter`] with given `encoded_key_range`.
     pub(super) async fn streaming_iter_with_encoded_key_range<R, B>(

--- a/src/storage/src/table/state_table.rs
+++ b/src/storage/src/table/state_table.rs
@@ -53,14 +53,14 @@ impl<S: StateStore> StateTable<S> {
         dist_key_indices: Option<Vec<usize>>,
         pk_indices: Vec<usize>,
     ) -> Self {
-        let pk_serializer = OrderedRowSerializer::new(order_types);
+        let pk_serializer = OrderedRowSerializer::new(order_types.clone());
 
         Self {
             mem_table: MemTable::new(),
             cell_based_table: CellBasedTable::new(
                 keyspace,
                 column_descs,
-                Some(pk_serializer.clone()),
+                order_types,
                 dist_key_indices,
             ),
             pk_serializer,

--- a/src/storage/src/table/state_table.rs
+++ b/src/storage/src/table/state_table.rs
@@ -203,8 +203,7 @@ impl<S: StateStore> StateTable<S> {
         pk_prefix: &'a Row,
         epoch: u64,
     ) -> StorageResult<RowStream<'a, S>> {
-        let order_types = &self.pk_serializer().clone().into_order_types()[0..pk_prefix.size()];
-        let prefix_serializer = OrderedRowSerializer::new(order_types.into());
+        let prefix_serializer = self.pk_serializer().prefix(pk_prefix.size());
         let encoded_prefix = serialize_pk(pk_prefix, &prefix_serializer);
         let encoded_key_range = range_of_prefix(&encoded_prefix);
 

--- a/src/stream/src/from_proto/batch_query.rs
+++ b/src/stream/src/from_proto/batch_query.rs
@@ -14,7 +14,7 @@
 
 use itertools::Itertools;
 use risingwave_common::buffer::Bitmap;
-use risingwave_common::catalog::ColumnDesc;
+use risingwave_common::catalog::{ColumnDesc, OrderedColumnDesc};
 use risingwave_common::types::VIRTUAL_NODE_COUNT;
 use risingwave_storage::table::cell_based_table::CellBasedTable;
 use risingwave_storage::{Keyspace, StateStore};
@@ -35,7 +35,11 @@ impl ExecutorBuilder for BatchQueryExecutorBuilder {
         let table_id = node.table_desc.as_ref().unwrap().table_id.into();
 
         let pk_descs_proto = &node.table_desc.as_ref().unwrap().order_key;
-        let pk_descs = pk_descs_proto.iter().map(|d| d.into()).collect();
+        let pk_descs = pk_descs_proto
+            .iter()
+            .map(OrderedColumnDesc::from)
+            .collect_vec();
+        let order_types = pk_descs.iter().map(|desc| desc.order).collect_vec();
 
         let column_descs = node
             .column_descs
@@ -43,7 +47,7 @@ impl ExecutorBuilder for BatchQueryExecutorBuilder {
             .map(|column_desc| ColumnDesc::from(column_desc.clone()))
             .collect_vec();
         let keyspace = Keyspace::table_root(state_store, &table_id);
-        let table = CellBasedTable::new(keyspace, column_descs, None, None);
+        let table = CellBasedTable::new(keyspace, column_descs, order_types, None);
         let key_indices = node
             .get_distribution_keys()
             .iter()


### PR DESCRIPTION
## What's changed and what's your intention?

As title. This PR also refactors some unused logic.

## Checklist

- [x] I have written necessary docs and comments
- [x] I have added necessary unit tests and integration tests
- [x] All checks passed in `./risedev check` (or alias, `./risedev c`)

## Refer to a related PR or issue link (optional)
- #3316 