### PR TITLE
refactor(vnode bitmap): remove vnode bitmap in sst info

### DIFF
--- a/proto/hummock.proto
+++ b/proto/hummock.proto
@@ -20,7 +20,7 @@ message SstableInfo {
   uint64 id = 1;
   KeyRange key_range = 2;
   uint64 file_size = 3;
-  repeated common.VNodeBitmap vnode_bitmaps = 4;
+  repeated uint32 table_ids = 4;
   uint64 unit_id = 5;
 }
 

--- a/src/meta/src/hummock/compaction/tier_compaction_picker.rs
+++ b/src/meta/src/hummock/compaction/tier_compaction_picker.rs
@@ -379,7 +379,7 @@ pub mod tests {
                 inf: false,
             }),
             file_size: (right - left + 1) as u64,
-            vnode_bitmaps: vec![],
+            table_ids: vec![],
             unit_id: u64::MAX,
         }
     }

--- a/src/meta/src/hummock/hummock_manager.rs
+++ b/src/meta/src/hummock/hummock_manager.rs
@@ -622,9 +622,7 @@ where
                         level
                             .table_infos
                             .iter()
-                            .flat_map(|sst_info| {
-                                sst_info.vnode_bitmaps.iter().map(|bitmap| bitmap.table_id)
-                            })
+                            .flat_map(|sst_info| sst_info.table_ids.iter().cloned())
                             .collect_vec()
                     })
                     .collect::<HashSet<u32>>();

--- a/src/meta/src/hummock/test_utils.rs
+++ b/src/meta/src/hummock/test_utils.rs
@@ -20,7 +20,7 @@ use risingwave_hummock_sdk::compaction_group::hummock_version_ext::HummockVersio
 use risingwave_hummock_sdk::compaction_group::StaticCompactionGroupId;
 use risingwave_hummock_sdk::key::key_with_epoch;
 use risingwave_hummock_sdk::{HummockContextId, HummockEpoch, HummockSSTableId, LocalSstableInfo};
-use risingwave_pb::common::{HostAddress, VNodeBitmap, WorkerNode, WorkerType};
+use risingwave_pb::common::{HostAddress, WorkerNode, WorkerType};
 use risingwave_pb::hummock::{HummockVersion, KeyRange, SstableInfo};
 
 use crate::cluster::{ClusterManager, ClusterManagerRef};
@@ -106,16 +106,7 @@ pub fn generate_test_tables(epoch: u64, sst_ids: Vec<HummockSSTableId>) -> Vec<S
                 inf: false,
             }),
             file_size: 1,
-            vnode_bitmaps: vec![
-                VNodeBitmap {
-                    table_id: (i + 1) as u32,
-                    bitmap: None,
-                },
-                VNodeBitmap {
-                    table_id: (i + 2) as u32,
-                    bitmap: None,
-                },
-            ],
+            table_ids: vec![(i + 1) as u32, (i + 2) as u32],
             unit_id: 0,
         });
     }

--- a/src/storage/src/hummock/shared_buffer/shared_buffer_uploader.rs
+++ b/src/storage/src/hummock/shared_buffer/shared_buffer_uploader.rs
@@ -204,7 +204,7 @@ impl SharedBufferUploader {
 
         let uploaded_sst_info = tables
             .into_iter()
-            .map(|(compaction_group_id, sst, unit_id, vnode_bitmaps)| {
+            .map(|(compaction_group_id, sst, unit_id, table_ids)| {
                 (
                     compaction_group_id,
                     SstableInfo {
@@ -215,7 +215,7 @@ impl SharedBufferUploader {
                             inf: false,
                         }),
                         file_size: sst.meta.estimated_size as u64,
-                        vnode_bitmaps,
+                        table_ids,
                         unit_id,
                     },
                 )

--- a/src/storage/src/hummock/sstable/builder.rs
+++ b/src/storage/src/hummock/sstable/builder.rs
@@ -12,14 +12,11 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use std::collections::BTreeMap;
+use std::collections::BTreeSet;
 
 use bytes::{BufMut, Bytes, BytesMut};
-use risingwave_common::buffer::BitmapBuilder;
 use risingwave_common::config::StorageConfig;
-use risingwave_common::types::VIRTUAL_NODE_COUNT;
 use risingwave_hummock_sdk::key::{get_table_id, user_key};
-use risingwave_pb::common::VNodeBitmap;
 
 use super::bloom::Bloom;
 use super::utils::CompressionAlgorithm;
@@ -80,8 +77,8 @@ pub struct SSTableBuilder {
     block_builder: Option<BlockBuilder>,
     /// Block metadata vec.
     block_metas: Vec<BlockMeta>,
-    /// `table_id` -> Bitmaps of value meta.
-    vnode_bitmaps: BTreeMap<u32, BitmapBuilder>,
+    /// `table_id` of added keys.
+    table_ids: BTreeSet<u32>,
     /// Hashes of user keys.
     user_key_hashes: Vec<u32>,
     /// Last added full key.
@@ -97,7 +94,7 @@ impl SSTableBuilder {
             buf: BytesMut::with_capacity(options.capacity),
             block_builder: None,
             block_metas: Vec::with_capacity(options.capacity / options.block_capacity + 1),
-            vnode_bitmaps: BTreeMap::new(),
+            table_ids: BTreeSet::new(),
             user_key_hashes: Vec::with_capacity(options.capacity / DEFAULT_ENTRY_SIZE + 1),
             last_full_key: Bytes::default(),
             key_count: 0,
@@ -126,14 +123,9 @@ impl SSTableBuilder {
 
         // TODO: refine me
         let mut raw_value = BytesMut::default();
-        let value_meta = value.encode(&mut raw_value) % VIRTUAL_NODE_COUNT as u16;
+        value.encode(&mut raw_value);
         if let Some(table_id) = get_table_id(full_key) {
-            // We use 8 bit of bitmap[x] to indicate existence of virtual node x*8..(x+1)*8,
-            // respectively
-            self.vnode_bitmaps
-                .entry(table_id)
-                .or_insert_with(|| BitmapBuilder::zeroed(VIRTUAL_NODE_COUNT))
-                .set(value_meta as _, true);
+            self.table_ids.insert(table_id);
         }
         let raw_value = raw_value.freeze();
 
@@ -165,7 +157,7 @@ impl SSTableBuilder {
     /// ```plain
     /// | Block 0 | ... | Block N-1 | N (4B) |
     /// ```
-    pub fn finish(mut self) -> (u64, Bytes, SstableMeta, Vec<VNodeBitmap>) {
+    pub fn finish(mut self) -> (u64, Bytes, SstableMeta, Vec<u32>) {
         let smallest_key = self.block_metas[0].smallest_key.clone();
         let largest_key = self.last_full_key.to_vec();
         self.build_block();
@@ -193,13 +185,7 @@ impl SSTableBuilder {
             self.sstable_id,
             self.buf.freeze(),
             meta,
-            self.vnode_bitmaps
-                .into_iter()
-                .map(|(table_id, vnode_bitmaps)| VNodeBitmap {
-                    table_id,
-                    bitmap: Some(vnode_bitmaps.finish().to_protobuf()),
-                })
-                .collect(),
+            self.table_ids.into_iter().collect(),
         )
     }
 

--- a/src/storage/src/hummock/sstable/mod.rs
+++ b/src/storage/src/hummock/sstable/mod.rs
@@ -96,7 +96,7 @@ impl Sstable {
                 inf: false,
             }),
             file_size: self.meta.estimated_size as u64,
-            vnode_bitmaps: vec![],
+            table_ids: vec![],
             unit_id: 0,
         }
     }

--- a/src/storage/src/hummock/sstable/multi_builder.rs
+++ b/src/storage/src/hummock/sstable/multi_builder.rs
@@ -15,7 +15,6 @@
 use futures::Future;
 use risingwave_hummock_sdk::key::{Epoch, FullKey};
 use risingwave_hummock_sdk::HummockSSTableId;
-use risingwave_pb::common::VNodeBitmap;
 use tokio::task::JoinHandle;
 
 use super::SstableMeta;
@@ -26,7 +25,7 @@ use crate::hummock::{CachePolicy, HummockResult, SSTableBuilder, Sstable};
 pub struct SealedSstableBuilder {
     pub id: HummockSSTableId,
     pub meta: SstableMeta,
-    pub vnode_bitmaps: Vec<VNodeBitmap>,
+    pub table_ids: Vec<u32>,
     pub upload_join_handle: JoinHandle<HummockResult<()>>,
     pub data_len: usize,
     pub unit_id: u64,
@@ -125,7 +124,7 @@ where
     /// will be no-op.
     pub fn seal_current(&mut self) {
         if let Some(builder) = self.current_builder.take() {
-            let (table_id, data, meta, vnode_bitmap) = builder.finish();
+            let (table_id, data, meta, table_ids) = builder.finish();
             let len = data.len();
             let sstable_store = self.sstable_store.clone();
             let meta_clone = meta.clone();
@@ -144,7 +143,7 @@ where
             self.sealed_builders.push(SealedSstableBuilder {
                 id: table_id,
                 meta,
-                vnode_bitmaps: vnode_bitmap,
+                table_ids,
                 upload_join_handle,
                 data_len: len,
                 unit_id: 0,

--- a/src/storage/src/hummock/test_utils.rs
+++ b/src/storage/src/hummock/test_utils.rs
@@ -23,7 +23,6 @@ use risingwave_hummock_sdk::key::key_with_epoch;
 use risingwave_hummock_sdk::HummockSSTableId;
 use risingwave_meta::hummock::test_utils::setup_compute_env;
 use risingwave_meta::hummock::MockHummockMetaClient;
-use risingwave_pb::common::VNodeBitmap;
 use risingwave_pb::hummock::{KeyRange, SstableInfo};
 
 use super::{CompressionAlgorithm, SstableMeta, DEFAULT_RESTART_INTERVAL};
@@ -83,7 +82,7 @@ pub fn gen_dummy_sst_info(id: HummockSSTableId, batches: Vec<SharedBufferBatch>)
             inf: false,
         }),
         file_size: batches.len() as u64,
-        vnode_bitmaps: vec![],
+        table_ids: vec![],
         unit_id: u64::MAX,
     }
 }
@@ -123,13 +122,13 @@ pub fn default_builder_opt_for_test() -> SSTableBuilderOptions {
 pub fn gen_test_sstable_data(
     opts: SSTableBuilderOptions,
     kv_iter: impl Iterator<Item = (Vec<u8>, HummockValue<Vec<u8>>)>,
-) -> (Bytes, SstableMeta, Vec<VNodeBitmap>) {
+) -> (Bytes, SstableMeta, Vec<u32>) {
     let mut b = SSTableBuilder::new(0, opts);
     for (key, value) in kv_iter {
         b.add(&key, value.as_slice())
     }
-    let (_, data, meta, vnodes) = b.finish();
-    (data, meta, vnodes)
+    let (_, data, meta, table_ids) = b.finish();
+    (data, meta, table_ids)
 }
 
 /// Generates a test table from the given `kv_iter` and put the kv value to `sstable_store`


### PR DESCRIPTION
## What's changed and what's your intention?

remove vnode bitmap in sst info, because we no longer need that

## Checklist

## Refer to a related PR or issue link (optional)
