### PR TITLE
feat(stream): enable append-only mv plan for kafka source

### DIFF
--- a/src/frontend/src/catalog/source_catalog.rs
+++ b/src/frontend/src/catalog/source_catalog.rs
@@ -11,6 +11,8 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
+use std::collections::HashMap;
+
 use itertools::Itertools;
 use risingwave_pb::catalog::source::Info;
 use risingwave_pb::catalog::Source as ProstSource;
@@ -22,7 +24,10 @@ use super::{ColumnId, SourceId, TABLE_SOURCE_PK_COLID};
 #[expect(non_snake_case, non_upper_case_globals)]
 pub mod WithOptions {
     pub const AppenOnly: &str = "appendonly";
+    pub const Connector: &str = "connector";
 }
+
+pub const KAFKA_CONNECTOR: &str = "kafka";
 
 /// this struct `SourceCatalog` is used in frontend and compared with `ProstSource` it only maintain
 /// information which will be used during optimization.
@@ -85,13 +90,7 @@ impl From<&ProstSource> for SourceCatalog {
         };
         let columns = prost_columns.into_iter().map(ColumnCatalog::from).collect();
 
-        // parse options in WITH clause
-        let mut append_only = false;
-        if let Some(val) = with_options.get(WithOptions::AppenOnly) {
-            if val.to_lowercase() == "true" {
-                append_only = true;
-            }
-        }
+        let append_only = check_append_only(&with_options);
         let owner: String = prost.owner.clone();
 
         Self {
@@ -104,4 +103,19 @@ impl From<&ProstSource> for SourceCatalog {
             owner,
         }
     }
+}
+
+fn check_append_only(with_options: &HashMap<String, String>) -> bool {
+    if let Some(val) = with_options.get(WithOptions::AppenOnly) {
+        if val.to_lowercase() == "true" {
+            return true;
+        }
+    }
+    if let Some(val) = with_options.get(WithOptions::Connector) {
+        // Kafka source is append-only
+        if val.to_lowercase() == KAFKA_CONNECTOR {
+            return true;
+        }
+    }
+    false
 }


### PR DESCRIPTION
## What's changed and what's your intention?

As title.

Dashboard executor info of tpch Q12
```
{
  "operatorId": "89",
  "pkIndices": [
    2,
    5
  ],
  "appendOnly": true,
  "identity": "StreamAppendOnlyHashJoin { type: Inner, predicate: $0 = $3 }",
  "fields": [
    ...
  ],
  "hashJoin": {
    "leftKey": [
      0
    ],
    "rightKey": [
      0
    ],
    "leftTableId": 20,
    "rightTableId": 21,
    "distKeyL": [
      0
    ],
    "distKeyR": [
      0
    ],
    "isAppendOnly": true
  }
}
```

## Checklist

- [x] I have written necessary docs and comments
- [x] I have added necessary unit tests and integration tests
- [x] All checks passed in `./risedev check` (or alias, `./risedev c`)

## Refer to a related PR or issue link (optional)
