### PR TITLE
feat(ctl): add bench command

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4140,6 +4140,7 @@ dependencies = [
  "risingwave_pb",
  "risingwave_rpc_client",
  "risingwave_storage",
+ "size",
  "tracing",
  "workspace-hack",
 ]
@@ -4980,6 +4981,15 @@ name = "siphasher"
 version = "0.3.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7bd3e3206899af3f8b12af284fafc038cc1dc2b41d1b89dd17297221c5d225de"
+
+[[package]]
+name = "size"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4fb3f61ca4410df5894add0b47d4d2c882c837dfa660d579c9b3fd29b1ce3a0e"
+dependencies = [
+ "num-traits",
+]
 
 [[package]]
 name = "skeptic"

--- a/src/cmd/src/bin/ctl.rs
+++ b/src/cmd/src/bin/ctl.rs
@@ -21,14 +21,15 @@ use tikv_jemallocator::Jemalloc;
 static GLOBAL: Jemalloc = Jemalloc;
 
 #[cfg_attr(coverage, no_coverage)]
-#[tokio::main(flavor = "multi_thread", worker_threads = 4)]
+#[tokio::main]
 async fn main() -> Result<()> {
     use clap::StructOpt;
 
     let opts = risingwave_ctl::CliOpts::parse();
 
-    risingwave_logging::oneshot_common();
-    risingwave_logging::init_risingwave_logger(false, true);
+    // risingwave_logging::oneshot_common();
+    // risingwave_logging::init_risingwave_logger(false, true);
+    console_subscriber::init();
 
     risingwave_ctl::start(opts).await
 }

--- a/src/cmd/src/bin/ctl.rs
+++ b/src/cmd/src/bin/ctl.rs
@@ -27,9 +27,9 @@ async fn main() -> Result<()> {
 
     let opts = risingwave_ctl::CliOpts::parse();
 
-    // risingwave_logging::oneshot_common();
-    // risingwave_logging::init_risingwave_logger(false, true);
-    console_subscriber::init();
+    risingwave_logging::oneshot_common();
+    risingwave_logging::init_risingwave_logger(false, true);
+    // console_subscriber::init();
 
     risingwave_ctl::start(opts).await
 }

--- a/src/ctl/Cargo.toml
+++ b/src/ctl/Cargo.toml
@@ -14,6 +14,7 @@ risingwave_hummock_sdk = { path = "../storage/hummock_sdk" }
 risingwave_pb = { path = "../prost" }
 risingwave_rpc_client = { path = "../rpc_client" }
 risingwave_storage = { path = "../storage" }
+size = "0.2"
 tokio = { version = "=0.2.0-alpha.3", package = "madsim-tokio", features = [
     "rt",
     "rt-multi-thread",

--- a/src/ctl/src/cmd_impl/bench.rs
+++ b/src/ctl/src/cmd_impl/bench.rs
@@ -11,3 +11,105 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
+
+use std::sync::atomic::AtomicU64;
+use std::sync::Arc;
+use std::time::Instant;
+
+use anyhow::Result;
+use clap::Subcommand;
+use futures::future::try_join_all;
+use futures::{pin_mut, Future, StreamExt};
+use size::Size;
+use tokio::task::JoinHandle;
+
+use super::table::{get_table_catalog, make_state_table};
+use crate::common::HummockServiceOpts;
+
+#[derive(Subcommand)]
+pub enum BenchCommands {
+    /// benchmark scan state table
+    Scan {
+        /// name of the materialized view to operate on
+        mv_name: String,
+        /// number of futures doing scan
+        threads: usize,
+    },
+}
+
+fn spawn_okk(fut: impl Future<Output = Result<()>> + Send + 'static) -> JoinHandle<Result<()>> {
+    tokio::spawn(fut)
+}
+
+#[derive(Clone, Debug)]
+pub struct InterestedMetrics {
+    object_store_read: u64,
+    object_store_write: u64,
+    next_cnt: u64,
+    now: Instant,
+}
+
+impl InterestedMetrics {
+    pub fn report(&self, metrics: &InterestedMetrics) {
+        let elapsed = self.now.elapsed().as_secs_f64();
+        let read_rate = (self.object_store_read - metrics.object_store_read) as f64 / elapsed;
+        let write_rate = (self.object_store_write - metrics.object_store_write) as f64 / elapsed;
+        let next_rate = (self.next_cnt - metrics.next_cnt) as f64 / elapsed;
+        println!(
+            "read_rate: {}/s\nwrite_rate:{}/s\nnext_rate:{}/s\n",
+            Size::Bytes(read_rate),
+            Size::Bytes(write_rate),
+            next_rate
+        );
+    }
+}
+
+pub async fn do_bench(cmd: BenchCommands) -> Result<()> {
+    let hummock_opts = HummockServiceOpts::from_env()?;
+    let (meta, hummock, metrics) = hummock_opts.create_hummock_store_with_metrics().await?;
+    let next_cnt = Arc::new(AtomicU64::new(0));
+    match cmd {
+        BenchCommands::Scan { mv_name, threads } => {
+            let table = get_table_catalog(meta.clone(), mv_name).await?;
+            let mut handlers = vec![];
+            for _ in 0..threads {
+                let table = table.clone();
+                let next_cnt = next_cnt.clone();
+                let hummock = hummock.clone();
+                let handler = spawn_okk(async move {
+                    let state_table = make_state_table(hummock, &table);
+                    loop {
+                        let stream = state_table.iter(u64::MAX).await?;
+                        pin_mut!(stream);
+                        while let Some(item) = stream.next().await {
+                            next_cnt.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+                            item?;
+                        }
+                    }
+                });
+                handlers.push(handler);
+            }
+            let handler = spawn_okk(async move {
+                let mut last_collected_metrics = None;
+                loop {
+                    let collected_metrics = InterestedMetrics {
+                        object_store_read: metrics.object_store_metrics.read_bytes.get(),
+                        object_store_write: metrics.object_store_metrics.write_bytes.get(),
+                        next_cnt: next_cnt.load(std::sync::atomic::Ordering::Relaxed),
+                        now: Instant::now(),
+                    };
+                    if let Some(ref last_collected_metrics) = last_collected_metrics {
+                        collected_metrics.report(&last_collected_metrics);
+                    }
+                    last_collected_metrics = Some(collected_metrics);
+                    tokio::time::sleep(std::time::Duration::from_secs(5)).await;
+                }
+            });
+            handlers.push(handler);
+            for result in try_join_all(handlers).await? {
+                result?;
+            }
+        }
+    }
+    Ok(())
+}

--- a/src/ctl/src/cmd_impl/bench.rs
+++ b/src/ctl/src/cmd_impl/bench.rs
@@ -57,6 +57,7 @@ impl InterestedMetrics {
         let read_rate = (self.object_store_read - metrics.object_store_read) as f64 / elapsed;
         let write_rate = (self.object_store_write - metrics.object_store_write) as f64 / elapsed;
         let next_rate = (self.next_cnt - metrics.next_cnt) as f64 / elapsed;
+        let iter_rate = (self.iter_cnt - metrics.iter_cnt) as f64 / elapsed;
         println!(
             "read_rate: {}/s\nwrite_rate:{}/s\nnext_rate:{}/s\niter_rate:{}/s\n",
             Size::Bytes(read_rate),
@@ -79,6 +80,7 @@ pub async fn do_bench(cmd: BenchCommands) -> Result<()> {
             for i in 0..threads {
                 let table = table.clone();
                 let next_cnt = next_cnt.clone();
+                let iter_cnt = iter_cnt.clone();
                 let hummock = hummock.clone();
                 let handler = spawn_okk(async move {
                     tracing::info!(thread = i, "starting scan");
@@ -108,7 +110,7 @@ pub async fn do_bench(cmd: BenchCommands) -> Result<()> {
                         now: Instant::now(),
                     };
                     if let Some(ref last_collected_metrics) = last_collected_metrics {
-                        collected_metrics.report(&last_collected_metrics);
+                        collected_metrics.report(last_collected_metrics);
                     }
                     last_collected_metrics = Some(collected_metrics);
                     tracing::info!("starting report metrics");

--- a/src/ctl/src/cmd_impl/bench.rs
+++ b/src/ctl/src/cmd_impl/bench.rs
@@ -38,6 +38,8 @@ pub enum BenchCommands {
     },
 }
 
+/// Spawn a tokio task with output of `anyhow::Result`, so that we can write dead loop in async
+/// functions.
 fn spawn_okk(fut: impl Future<Output = Result<()>> + Send + 'static) -> JoinHandle<Result<()>> {
     tokio::spawn(fut)
 }

--- a/src/ctl/src/cmd_impl/table/scan.rs
+++ b/src/ctl/src/cmd_impl/table/scan.rs
@@ -31,6 +31,12 @@ pub async fn get_table_catalog(meta: MetaClient, table_id: String) -> Result<Tab
     Ok(TableCatalog::from(&mv))
 }
 
+pub fn print_table_catalog(table: &TableCatalog) {
+    let mut catalog = table.clone();
+    catalog.vnode_mapping = None;
+    println!("{:#?}", catalog);
+}
+
 pub fn make_state_table<S: StateStore>(hummock: S, table: &TableCatalog) -> StateTable<S> {
     StateTable::new(
         Keyspace::table_root(hummock, &table.id),
@@ -49,7 +55,7 @@ pub async fn scan(table_id: String) -> Result<()> {
     let hummock_opts = HummockServiceOpts::from_env()?;
     let (meta, hummock) = hummock_opts.create_hummock_store().await?;
     let table = get_table_catalog(meta.clone(), table_id).await?;
-    println!("{:#?}", table);
+    print_table_catalog(&table);
     let state_table = make_state_table(hummock.clone(), &table);
     let stream = state_table.iter(u64::MAX).await?;
     pin_mut!(stream);

--- a/src/ctl/src/cmd_impl/table/scan.rs
+++ b/src/ctl/src/cmd_impl/table/scan.rs
@@ -14,26 +14,26 @@
 
 use anyhow::{anyhow, Result};
 use futures::{pin_mut, StreamExt};
-use risingwave_common::catalog::TableId;
 use risingwave_frontend::catalog::TableCatalog;
+use risingwave_rpc_client::MetaClient;
 use risingwave_storage::table::state_table::StateTable;
-use risingwave_storage::Keyspace;
+use risingwave_storage::{Keyspace, StateStore};
 
 use crate::common::HummockServiceOpts;
 
-pub async fn scan(table_id: String) -> Result<()> {
-    let hummock_opts = HummockServiceOpts::from_env()?;
-    let (meta, hummock) = hummock_opts.create_hummock_store().await?;
+pub async fn get_table_catalog(meta: MetaClient, table_id: String) -> Result<TableCatalog> {
     let mvs = meta.list_materialize_view().await?;
     let mv = mvs
         .iter()
         .find(|x| x.name == table_id)
         .ok_or_else(|| anyhow!("mv not found"))?
         .clone();
-    println!("{:#?}", mv);
-    let table = TableCatalog::from(&mv);
-    let state_table = StateTable::new(
-        Keyspace::table_root(hummock, &TableId::new(mv.id)),
+    Ok(TableCatalog::from(&mv))
+}
+
+pub fn make_state_table<S: StateStore>(hummock: S, table: &TableCatalog) -> StateTable<S> {
+    StateTable::new(
+        Keyspace::table_root(hummock, &table.id),
         table
             .columns()
             .iter()
@@ -42,8 +42,15 @@ pub async fn scan(table_id: String) -> Result<()> {
         table.order_desc().iter().map(|x| x.order).collect(),
         Some(table.pks.clone()),
         table.distribution_keys().to_vec(),
-    );
+    )
+}
 
+pub async fn scan(table_id: String) -> Result<()> {
+    let hummock_opts = HummockServiceOpts::from_env()?;
+    let (meta, hummock) = hummock_opts.create_hummock_store().await?;
+    let table = get_table_catalog(meta.clone(), table_id).await?;
+    println!("{:#?}", table);
+    let state_table = make_state_table(hummock.clone(), &table);
     let stream = state_table.iter(u64::MAX).await?;
     pin_mut!(stream);
     while let Some(item) = stream.next().await {

--- a/src/ctl/src/common/hummock_service.rs
+++ b/src/ctl/src/common/hummock_service.rs
@@ -68,7 +68,8 @@ impl HummockServiceOpts {
         let meta_client = self.meta_opts.create_meta_client().await?;
 
         // FIXME: allow specify custom config
-        let config = StorageConfig::default();
+        let mut config = StorageConfig::default();
+        config.share_buffer_compaction_worker_threads_number = 0;
 
         tracing::info!("using Hummock config: {:#?}", config);
 

--- a/src/ctl/src/common/hummock_service.rs
+++ b/src/ctl/src/common/hummock_service.rs
@@ -32,6 +32,12 @@ pub struct HummockServiceOpts {
     pub hummock_url: String,
 }
 
+pub struct Metrics {
+    pub hummock_metrics: Arc<HummockMetrics>,
+    pub state_store_metrics: Arc<StateStoreMetrics>,
+    pub object_store_metrics: Arc<ObjectStoreMetrics>,
+}
+
 impl HummockServiceOpts {
     /// Recover hummock service options from env variable
     ///
@@ -56,9 +62,9 @@ impl HummockServiceOpts {
         })
     }
 
-    pub async fn create_hummock_store(
+    pub async fn create_hummock_store_with_metrics(
         &self,
-    ) -> Result<(MetaClient, MonitoredStateStore<HummockStorage>)> {
+    ) -> Result<(MetaClient, MonitoredStateStore<HummockStorage>, Metrics)> {
         let meta_client = self.meta_opts.create_meta_client().await?;
 
         // FIXME: allow specify custom config
@@ -66,22 +72,35 @@ impl HummockServiceOpts {
 
         tracing::info!("using Hummock config: {:#?}", config);
 
+        let metrics = Metrics {
+            hummock_metrics: Arc::new(HummockMetrics::unused()),
+            state_store_metrics: Arc::new(StateStoreMetrics::unused()),
+            object_store_metrics: Arc::new(ObjectStoreMetrics::unused()),
+        };
+
         let state_store_impl = StateStoreImpl::new(
             &self.hummock_url,
             Arc::new(config),
             Arc::new(MonitoredHummockMetaClient::new(
                 meta_client.clone(),
-                Arc::new(HummockMetrics::unused()),
+                metrics.hummock_metrics.clone(),
             )),
-            Arc::new(StateStoreMetrics::unused()),
-            Arc::new(ObjectStoreMetrics::unused()),
+            metrics.state_store_metrics.clone(),
+            metrics.object_store_metrics.clone(),
         )
         .await?;
 
         if let StateStoreImpl::HummockStateStore(hummock_state_store) = state_store_impl {
-            Ok((meta_client, hummock_state_store))
+            Ok((meta_client, hummock_state_store, metrics))
         } else {
             Err(anyhow!("only Hummock state store is supported in risectl"))
         }
+    }
+
+    pub async fn create_hummock_store(
+        &self,
+    ) -> Result<(MetaClient, MonitoredStateStore<HummockStorage>)> {
+        let (meta_client, hummock_client, _) = self.create_hummock_store_with_metrics().await?;
+        Ok((meta_client, hummock_client))
     }
 }

--- a/src/ctl/src/common/hummock_service.rs
+++ b/src/ctl/src/common/hummock_service.rs
@@ -68,8 +68,10 @@ impl HummockServiceOpts {
         let meta_client = self.meta_opts.create_meta_client().await?;
 
         // FIXME: allow specify custom config
-        let mut config = StorageConfig::default();
-        config.share_buffer_compaction_worker_threads_number = 0;
+        let config = StorageConfig {
+            share_buffer_compaction_worker_threads_number: 0,
+            ..Default::default()
+        };
 
         tracing::info!("using Hummock config: {:#?}", config);
 

--- a/src/ctl/src/lib.rs
+++ b/src/ctl/src/lib.rs
@@ -14,6 +14,7 @@
 
 use anyhow::Result;
 use clap::{Parser, Subcommand};
+use cmd_impl::bench::BenchCommands;
 mod cmd_impl;
 pub(crate) mod common;
 
@@ -37,9 +38,12 @@ enum Commands {
     /// Commands for Hummock
     #[clap(subcommand)]
     Hummock(HummockCommands),
-    /// Commands for Benchmarks
+    /// Commands for Tables
     #[clap(subcommand)]
     Table(TableCommands),
+    /// Commands for Benchmarks
+    #[clap(subcommand)]
+    Bench(BenchCommands),
 }
 
 #[derive(Subcommand)]
@@ -73,7 +77,6 @@ enum TableCommands {
     /// benchmark state table
     Scan {
         /// name of the materialized view to operate on
-        #[clap()]
         mv_name: String,
     },
 }
@@ -102,6 +105,7 @@ pub async fn start(opts: CliOpts) -> Result<()> {
         Commands::Table(TableCommands::Scan { mv_name }) => {
             tokio::spawn(cmd_impl::table::scan(mv_name)).await??
         }
+        Commands::Bench(cmd) => tokio::spawn(cmd_impl::bench::do_bench(cmd)).await??,
     }
     Ok(())
 }


### PR DESCRIPTION
## What's changed and what's your intention?

This bench command is very simple now. We can use risectl to connect to an existing cluster and bench on an existing table. In the future, we can mock some workloads like join, agg, etc. to know more about the system performance.

Generally, this should be used like:

* Start a cluster and create materialized view, use data source to ingest real data.
* Run risectl on existing data to do benchmarks.

## Checklist

- [x] I have written necessary docs and comments
- [x] I have added necessary unit tests and integration tests
- [x] All checks passed in `./risedev check` (or alias, `./risedev c`)

## Refer to a related PR or issue link (optional)
