### PR TITLE
feat(batch): serialize chunk broadcasted only once

### DIFF
--- a/src/batch/src/task/broadcast_channel.rs
+++ b/src/batch/src/task/broadcast_channel.rs
@@ -22,7 +22,7 @@ use risingwave_pb::batch_plan::*;
 use tokio::sync::mpsc;
 
 use crate::task::channel::{ChanReceiver, ChanReceiverImpl, ChanSender, ChanSenderImpl};
-use crate::task::data_chunk_in_channel::{BroadcastDataChunk, DataChunkInChannel};
+use crate::task::data_chunk_in_channel::DataChunkInChannel;
 use crate::task::BOUNDED_BUFFER_SIZE;
 
 /// `BroadcastSender` sends the same chunk to a number of `BroadcastReceiver`s.
@@ -36,8 +36,7 @@ impl ChanSender for BroadcastSender {
 
     fn send(&mut self, chunk: Option<DataChunk>) -> Self::SendFuture<'_> {
         async move {
-            let broadcast_data_chunk =
-                chunk.map(|c| DataChunkInChannel::Broadcast(BroadcastDataChunk::new(c)));
+            let broadcast_data_chunk = chunk.map(DataChunkInChannel::new);
             for sender in &self.senders {
                 sender
                     .send(broadcast_data_chunk.as_ref().cloned())

--- a/src/batch/src/task/broadcast_channel.rs
+++ b/src/batch/src/task/broadcast_channel.rs
@@ -22,11 +22,12 @@ use risingwave_pb::batch_plan::*;
 use tokio::sync::mpsc;
 
 use crate::task::channel::{ChanReceiver, ChanReceiverImpl, ChanSender, ChanSenderImpl};
+use crate::task::data_chunk_in_channel::{BroadcastDataChunk, DataChunkInChannel};
 use crate::task::BOUNDED_BUFFER_SIZE;
 
 /// `BroadcastSender` sends the same chunk to a number of `BroadcastReceiver`s.
 pub struct BroadcastSender {
-    senders: Vec<mpsc::Sender<Option<DataChunk>>>,
+    senders: Vec<mpsc::Sender<Option<DataChunkInChannel>>>,
     broadcast_info: BroadcastInfo,
 }
 
@@ -35,9 +36,11 @@ impl ChanSender for BroadcastSender {
 
     fn send(&mut self, chunk: Option<DataChunk>) -> Self::SendFuture<'_> {
         async move {
+            let broadcast_data_chunk =
+                chunk.map(|c| DataChunkInChannel::Broadcast(BroadcastDataChunk::new(c)));
             for sender in &self.senders {
                 sender
-                    .send(chunk.clone())
+                    .send(broadcast_data_chunk.as_ref().cloned())
                     .await
                     .to_rw_result_with(|| "BroadcastSender::send".into())?;
             }
@@ -49,11 +52,11 @@ impl ChanSender for BroadcastSender {
 
 /// One or more `BroadcastReceiver`s corresponds to a single `BroadcastReceiver`
 pub struct BroadcastReceiver {
-    receiver: mpsc::Receiver<Option<DataChunk>>,
+    receiver: mpsc::Receiver<Option<DataChunkInChannel>>,
 }
 
 impl ChanReceiver for BroadcastReceiver {
-    type RecvFuture<'a> = impl Future<Output = Result<Option<DataChunk>>>;
+    type RecvFuture<'a> = impl Future<Output = Result<Option<DataChunkInChannel>>>;
 
     fn recv(&mut self) -> Self::RecvFuture<'_> {
         async move {

--- a/src/batch/src/task/data_chunk_in_channel.rs
+++ b/src/batch/src/task/data_chunk_in_channel.rs
@@ -1,0 +1,89 @@
+// Copyright 2022 Singularity Data
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use anyhow::anyhow;
+use either::Either;
+use risingwave_common::array::DataChunk;
+use risingwave_common::error::{ErrorCode, Result};
+use risingwave_pb::data::DataChunk as ProstDataChunk;
+use tokio::sync::OnceCell;
+
+#[derive(Debug, Clone)]
+pub(super) struct BroadcastDataChunk {
+    data_chunk: DataChunk,
+    /// If the data chunk is only needed to transfer locally,
+    /// this field should not be initialized.
+    prost_data_chunk: OnceCell<Either<ProstDataChunk, String>>,
+}
+
+impl BroadcastDataChunk {
+    pub fn new(data_chunk: DataChunk) -> Self {
+        Self {
+            data_chunk,
+            prost_data_chunk: OnceCell::new(),
+        }
+    }
+
+    pub async fn to_protobuf(&self) -> Result<ProstDataChunk> {
+        let prost_data_chunk = self
+            .prost_data_chunk
+            .get_or_init(|| async {
+                let res = self.data_chunk.clone().compact();
+                match res {
+                    Ok(chunk) => Either::Left(chunk.to_protobuf()),
+                    Err(e) => Either::Right(format!("{:?}", e)),
+                }
+            })
+            .await;
+        // Pass the error message out in this ugly way. Better way to do this?
+        match prost_data_chunk {
+            Either::Left(chunk) => Ok(chunk.clone()),
+            Either::Right(error_msg) => {
+                Err(ErrorCode::ArrayError(anyhow!(error_msg.clone()).into()).into())
+            }
+        }
+    }
+}
+
+#[derive(Debug, Clone)]
+pub(super) enum DataChunkInChannel {
+    Normal(DataChunk),
+    Broadcast(BroadcastDataChunk),
+}
+
+impl DataChunkInChannel {
+    pub async fn into_protobuf(self) -> Result<ProstDataChunk> {
+        match self {
+            Self::Normal(c) => {
+                let c = c.compact()?;
+                Ok(c.to_protobuf())
+            }
+            Self::Broadcast(c) => c.to_protobuf().await,
+        }
+    }
+
+    pub fn into_data_chunk(self) -> DataChunk {
+        match self {
+            Self::Normal(chunk) => chunk,
+            Self::Broadcast(chunk) => chunk.data_chunk,
+        }
+    }
+
+    pub fn cardinality(&self) -> usize {
+        match self {
+            Self::Normal(chunk) => chunk.cardinality(),
+            Self::Broadcast(chunk) => chunk.data_chunk.cardinality(),
+        }
+    }
+}

--- a/src/batch/src/task/fifo_channel.rs
+++ b/src/batch/src/task/fifo_channel.rs
@@ -37,7 +37,7 @@ impl ChanSender for FifoSender {
     fn send(&mut self, chunk: Option<DataChunk>) -> Self::SendFuture<'_> {
         async move {
             self.sender
-                .send(chunk.map(DataChunkInChannel::Normal))
+                .send(chunk.map(DataChunkInChannel::new))
                 .await
                 .to_rw_result_with(|| "FifoSender::send".into())
         }

--- a/src/batch/src/task/hash_shuffle_channel.rs
+++ b/src/batch/src/task/hash_shuffle_channel.rs
@@ -123,7 +123,7 @@ impl HashShuffleSender {
             // `generate_new_data_chunks` may generate an empty chunk.
             if new_data_chunk.cardinality() > 0 {
                 self.senders[sink_id]
-                    .send(Some(DataChunkInChannel::Normal(new_data_chunk)))
+                    .send(Some(DataChunkInChannel::new(new_data_chunk)))
                     .await
                     .to_rw_result_with(|| "HashShuffleSender::send".into())?;
             }

--- a/src/batch/src/task/mod.rs
+++ b/src/batch/src/task/mod.rs
@@ -20,6 +20,7 @@ pub use task_manager::*;
 mod broadcast_channel;
 mod channel;
 mod context;
+mod data_chunk_in_channel;
 mod env;
 mod fifo_channel;
 mod hash_shuffle_channel;

--- a/src/batch/src/task/task_execution.rs
+++ b/src/batch/src/task/task_execution.rs
@@ -116,13 +116,12 @@ impl TaskOutput {
             match self.receiver.recv().await {
                 // Received some data
                 Ok(Some(chunk)) => {
-                    let chunk = chunk.compact()?;
                     trace!(
                         "Task output id: {:?}, data len: {:?}",
                         self.output_id,
                         chunk.cardinality()
                     );
-                    let pb = chunk.to_protobuf();
+                    let pb = chunk.into_protobuf().await?;
                     let resp = GetDataResponse {
                         status: Default::default(),
                         record_batch: Some(pb),
@@ -151,7 +150,7 @@ impl TaskOutput {
 
     /// Directly takes data without serialization.
     pub async fn direct_take_data(&mut self) -> Result<Option<DataChunk>> {
-        self.receiver.recv().await
+        Ok(self.receiver.recv().await?.map(|c| c.into_data_chunk()))
     }
 
     pub fn id(&self) -> &TaskOutputId {

--- a/src/batch/src/task/task_execution.rs
+++ b/src/batch/src/task/task_execution.rs
@@ -121,7 +121,7 @@ impl TaskOutput {
                         self.output_id,
                         chunk.cardinality()
                     );
-                    let pb = chunk.into_protobuf().await?;
+                    let pb = chunk.to_protobuf().await?;
                     let resp = GetDataResponse {
                         status: Default::default(),
                         record_batch: Some(pb),


### PR DESCRIPTION
## What's changed and what's your intention?
Chunk being broadcasted should only be serialized once at most. If it is always being sent via local channels, then it should never be serialized.

For FIFO/hash channels, they should not pay an extra cost, i.e. stay the same.

## Checklist

- [x] I have written necessary docs and comments
~- [ ] I have added necessary unit tests and integration tests~
- [x] All checks passed in `./risedev check` (or alias, `./risedev c`)

## Refer to a related PR or issue link (optional)
closes #3282 