### PR TITLE
fix(binder): do not allow correlated input ref in order by

### DIFF
--- a/src/frontend/src/binder/query.rs
+++ b/src/frontend/src/binder/query.rs
@@ -136,7 +136,11 @@ impl Binder {
                 }
             },
             expr => {
-                extra_order_exprs.push(self.bind_expr(expr)?);
+                let order_expr = self.bind_expr(expr.clone())?;
+                if order_expr.has_correlated_input_ref() {
+                    return Err(ErrorCode::BindError(format!("ORDER BY expression \"{}\" has correlated input reference", expr)).into());
+                }
+                extra_order_exprs.push(order_expr);
                 visible_output_num + extra_order_exprs.len() - 1
             }
         };

--- a/src/frontend/test_runner/tests/testdata/subquery.yaml
+++ b/src/frontend/test_runner/tests/testdata/subquery.yaml
@@ -84,3 +84,7 @@
     create table t (v1 bigint, v2 double precision);
     select * from (select * from t) as tt(a, b, c) join t on a=v1;
   binder_error: 'Bind error: table "tt" has less columns available but more aliases specified'
+- sql: |
+    create table t(x int);
+    select * from t, (select * from t as t2 order by t.x desc) as t3;
+  binder_error: 'Bind error: ORDER BY expression "t.x" has correlated input reference'


### PR DESCRIPTION
## What's changed and what's your intention?

as title

## Checklist

- [x] I have written necessary docs and comments
- [x] I have added necessary unit tests and integration tests
- [x] All checks passed in `./risedev check` (or alias, `./risedev c`)

## Refer to a related PR or issue link (optional)
close https://github.com/singularity-data/risingwave/issues/3345