### PR TITLE
refactor(batch): let QueryManager hold FrontendEnv

### DIFF
--- a/src/frontend/src/lib.rs
+++ b/src/frontend/src/lib.rs
@@ -37,6 +37,7 @@
 #![feature(assert_matches)]
 #![feature(map_first_last)]
 #![feature(lint_reasons)]
+#![feature(once_cell)]
 
 #[macro_use]
 pub mod catalog;


### PR DESCRIPTION
## What's changed and what's your intention?

`QueryManager` is lightweight as it is just holding several `Arc` referring to fields contained in `FrontendEnv`. And it is very likely that `QueryManager` will have more and more fields referring to fields in `FrontendEnv`. Let's just replace them with a single `FrontendEnv`. 

`context` in functions, i.e. `schedule` and `schedule_single`, is not being used now and it will not be needed to pass into these two functions anymore after this change. Previously, `QueryManager` is held by the `FrontendEnv` which in turn is held by `context`. We now make sure a `QueryManager` will not be mismatched with a `context` to which it does not belong.

~Note that this change effectively makes `QueryManager` only responsible for the execution of a single query. This is fine for now as currently, no role requires a view of all the queries.~

By implementing lazy initialization, the `QueryManager` is still held by `FrontendEnv` and manages all the batch queries.



## Checklist

~- [ ] I have written necessary docs and comments~
~- [ ] I have added necessary unit tests and integration tests~
- [x] All checks passed in `./risedev check` (or alias, `./risedev c`)

## Refer to a related PR or issue link (optional)