### PR TITLE
fix(binder): do not allow correlated subquery in join tables

### DIFF
--- a/src/frontend/src/binder/query.rs
+++ b/src/frontend/src/binder/query.rs
@@ -140,7 +140,7 @@ impl Binder {
                 }
             },
             expr => {
-                extra_order_exprs.push(self.bind_expr(expr.clone())?);
+                extra_order_exprs.push(self.bind_expr(expr)?);
                 visible_output_num + extra_order_exprs.len() - 1
             }
         };

--- a/src/frontend/src/binder/query.rs
+++ b/src/frontend/src/binder/query.rs
@@ -47,6 +47,10 @@ impl BoundQuery {
 
     pub fn is_correlated(&self) -> bool {
         self.body.is_correlated()
+            || self
+                .extra_order_exprs
+                .iter()
+                .any(|e| e.has_correlated_input_ref())
     }
 }
 
@@ -136,11 +140,7 @@ impl Binder {
                 }
             },
             expr => {
-                let order_expr = self.bind_expr(expr.clone())?;
-                if order_expr.has_correlated_input_ref() {
-                    return Err(ErrorCode::BindError(format!("ORDER BY expression \"{}\" has correlated input reference", expr)).into());
-                }
-                extra_order_exprs.push(order_expr);
+                extra_order_exprs.push(self.bind_expr(expr.clone())?);
                 visible_output_num + extra_order_exprs.len() - 1
             }
         };

--- a/src/frontend/test_runner/tests/testdata/subquery.yaml
+++ b/src/frontend/test_runner/tests/testdata/subquery.yaml
@@ -87,4 +87,12 @@
 - sql: |
     create table t(x int);
     select * from t, (select * from t as t2 order by t.x desc) as t3;
-  binder_error: 'Bind error: ORDER BY expression "t.x" has correlated input reference'
+  binder_error: 'Bind error: Join table "(SELECT * FROM t AS t2 ORDER BY t.x DESC) AS t3" has correlated input reference'
+- sql: |
+    create table t(x int);
+    select * from t, (select t.x) as t1;
+  binder_error: 'Bind error: Join table "(SELECT t.x) AS t1" has correlated input reference'
+- sql: |
+    create table t(x int);
+    select * from t JOIN (select t.x) as t1;
+  binder_error: 'Bind error: Join table "(SELECT t.x) AS t1" has correlated input reference'


### PR DESCRIPTION
## What's changed and what's your intention?
After reconsidering https://github.com/singularity-data/risingwave/pull/3346/, I think the actual problem is correlated input ref should not occur in join tables, not only order exprs.

## Checklist

- [x] I have written necessary docs and comments
- [x] I have added necessary unit tests and integration tests
- [x] All checks passed in `./risedev check` (or alias, `./risedev c`)

## Refer to a related PR or issue link (optional)
