### PR TITLE
fix(frontend): remove redundant request to meta in frontend

### DIFF
--- a/src/frontend/src/scheduler/worker_node_manager.rs
+++ b/src/frontend/src/scheduler/worker_node_manager.rs
@@ -16,9 +16,7 @@ use std::sync::{Arc, RwLock};
 
 use rand::distributions::{Distribution as RandDistribution, Uniform};
 use risingwave_common::bail;
-use risingwave_common::error::Result;
-use risingwave_pb::common::{WorkerNode, WorkerType};
-use risingwave_rpc_client::MetaClient;
+use risingwave_pb::common::WorkerNode;
 
 use crate::scheduler::SchedulerResult;
 
@@ -29,14 +27,16 @@ pub struct WorkerNodeManager {
 
 pub type WorkerNodeManagerRef = Arc<WorkerNodeManager>;
 
+impl Default for WorkerNodeManager {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
 impl WorkerNodeManager {
-    pub async fn new(client: MetaClient) -> Result<Self> {
-        let worker_nodes = RwLock::new(
-            client
-                .list_all_nodes(WorkerType::ComputeNode, false)
-                .await?,
-        );
-        Ok(Self { worker_nodes })
+    pub fn new() -> Self {
+        let worker_nodes = RwLock::new(Vec::new());
+        Self { worker_nodes }
     }
 
     /// Used in tests.
@@ -84,7 +84,7 @@ impl WorkerNodeManager {
 mod tests {
 
     use risingwave_common::util::addr::HostAddr;
-    use risingwave_pb::common::worker_node;
+    use risingwave_pb::common::{worker_node, WorkerType};
 
     #[test]
     fn test_worker_node_manager() {

--- a/src/frontend/src/session.rs
+++ b/src/frontend/src/session.rs
@@ -221,7 +221,7 @@ impl FrontendEnv {
         ));
         let catalog_reader = CatalogReader::new(catalog.clone());
 
-        let worker_node_manager = Arc::new(WorkerNodeManager::new(meta_client.clone()).await?);
+        let worker_node_manager = Arc::new(WorkerNodeManager::new());
 
         let frontend_meta_client = Arc::new(FrontendMetaClientImpl(meta_client.clone()));
         let hummock_snapshot_manager =

--- a/src/rpc_client/src/meta_client.rs
+++ b/src/rpc_client/src/meta_client.rs
@@ -22,7 +22,7 @@ use risingwave_hummock_sdk::{HummockEpoch, HummockSSTableId, HummockVersionId, L
 use risingwave_pb::catalog::{
     Database as ProstDatabase, Schema as ProstSchema, Source as ProstSource, Table as ProstTable,
 };
-use risingwave_pb::common::{WorkerNode, WorkerType};
+use risingwave_pb::common::WorkerType;
 use risingwave_pb::ddl_service::ddl_service_client::DdlServiceClient;
 use risingwave_pb::ddl_service::*;
 use risingwave_pb::hummock::hummock_manager_service_client::HummockManagerServiceClient;
@@ -264,23 +264,6 @@ impl MetaClient {
         };
         self.inner.delete_worker_node(request).await?;
         Ok(())
-    }
-
-    /// Get live nodes with the specified type.
-    /// # Arguments
-    /// * `worker_type` `WorkerType` of the nodes
-    /// * `include_starting_nodes` Whether to include nodes still being created
-    pub async fn list_all_nodes(
-        &self,
-        worker_type: WorkerType,
-        include_starting_nodes: bool,
-    ) -> Result<Vec<WorkerNode>> {
-        let request = ListAllNodesRequest {
-            worker_type: worker_type as i32,
-            include_starting_nodes,
-        };
-        let resp = self.inner.list_all_nodes(request).await?;
-        Ok(resp.nodes)
     }
 
     pub fn start_heartbeat_loop(


### PR DESCRIPTION
## What's changed and what's your intention?

Since we have notification service now, frontend need not query meta by itself on initialization. 

## Checklist

- [x] All checks passed in `./risedev check` (or alias, `./risedev c`)
