### PR TITLE
refactor: deparallel hash agg apply batch + remove Arc Mutex

### DIFF
--- a/src/stream/src/executor/hash_agg.rs
+++ b/src/stream/src/executor/hash_agg.rs
@@ -30,7 +30,6 @@ use risingwave_common::hash::{HashCode, HashKey};
 use risingwave_common::util::hash_util::CRC32FastBuilder;
 use risingwave_storage::table::state_table::StateTable;
 use risingwave_storage::{Keyspace, StateStore};
-use tokio::sync::RwLock;
 
 use super::{
     expect_first_barrier, pk_input_arrays, Executor, PkDataTypes, PkIndicesRef,
@@ -84,7 +83,7 @@ struct HashAggExecutorExtra<S: StateStore> {
     /// all of the aggregation functions in this executor should depend on same group of keys
     key_indices: Vec<usize>,
 
-    state_tables: Arc<RwLock<Vec<StateTable<S>>>>,
+    state_tables: Vec<StateTable<S>>,
 }
 
 impl<K: HashKey, S: StateStore> Executor for HashAggExecutor<K, S> {
@@ -139,7 +138,7 @@ impl<K: HashKey, S: StateStore> HashAggExecutor<K, S> {
                 input_schema: input_info.schema,
                 agg_calls,
                 key_indices,
-                state_tables: Arc::new(RwLock::new(state_tables)),
+                state_tables,
             },
             _phantom: PhantomData,
         })
@@ -248,7 +247,7 @@ impl<K: HashKey, S: StateStore> HashAggExecutor<K, S> {
 
         let key_data_types = &schema.data_types()[..key_indices.len()];
         let mut futures = vec![];
-        for (key, hash_code, vis_map) in unique_keys {
+        for (key, hash_code, _) in &unique_keys {
             // Retrieve previous state from the KeyedState.
             let states = state_map.put(key.to_owned(), None);
 
@@ -256,8 +255,6 @@ impl<K: HashKey, S: StateStore> HashAggExecutor<K, S> {
             // To leverage more parallelism in IO operations, fetching and updating states for every
             // unique keys is created as futures and run in parallel.
             futures.push(async {
-                let vis_map = vis_map;
-
                 // 1. If previous state didn't exist, the ManagedState will automatically create new
                 // ones for them.
                 let mut states = {
@@ -273,8 +270,8 @@ impl<K: HashKey, S: StateStore> HashAggExecutor<K, S> {
                                 agg_calls,
                                 input_pk_data_types.clone(),
                                 epoch,
-                                Some(hash_code),
-                                &*state_tables.read().await,
+                                Some(hash_code.clone()),
+                                state_tables,
                             )
                             .await?,
                         ),
@@ -282,19 +279,25 @@ impl<K: HashKey, S: StateStore> HashAggExecutor<K, S> {
                 };
 
                 // 2. Mark the state as dirty by filling prev states
-                states
-                    .may_mark_as_dirty(epoch, &*state_tables.read().await)
-                    .await?;
+                states.may_mark_as_dirty(epoch, state_tables).await?;
 
-                Ok::<(_, Box<AggState<S>>, Bitmap), StreamExecutorError>((key, states, vis_map))
+                Ok::<(_, Box<AggState<S>>), StreamExecutorError>((key, states))
             });
         }
 
-        let mut buffered = stream::iter(futures).buffer_unordered(10);
-        while let Some(result) = buffered.next().await {
-            let (key, mut state, vis_map) = result?;
+        let mut buffered = stream::iter(futures).buffer_unordered(10).fuse();
 
-            let mut state_tables = state_tables.write().await;
+        while let Some(result) = buffered.next().await {
+            let (key, state) = result?;
+            state_map.put(key, Some(state));
+        }
+        // Drop the stream manually to teach compiler the async closure above will not use the read
+        // ref anymore.
+        drop(buffered);
+
+        // Apply batch in single-thread.
+        for (key, _, vis_map) in &unique_keys {
+            let state = state_map.get_mut(key).unwrap().as_mut().unwrap();
             // 3. Apply batch to each of the state (per agg_call)
             for ((agg_state, data), state_table) in state
                 .managed_states
@@ -304,11 +307,9 @@ impl<K: HashKey, S: StateStore> HashAggExecutor<K, S> {
             {
                 let data = data.iter().map(|d| &**d).collect_vec();
                 agg_state
-                    .apply_batch(&ops, Some(&vis_map), &data, epoch, state_table)
+                    .apply_batch(&ops, Some(vis_map), &data, epoch, state_table)
                     .await?;
             }
-
-            state_map.put(key, Some(state));
         }
 
         Ok(())
@@ -330,7 +331,6 @@ impl<K: HashKey, S: StateStore> HashAggExecutor<K, S> {
         // fully flushed.
         let dirty_cnt = {
             let mut dirty_cnt = 0;
-            let mut state_tables = state_tables.write().await;
             for states in state_map.values_mut() {
                 if states.as_ref().unwrap().is_dirty() {
                     dirty_cnt += 1;
@@ -354,11 +354,10 @@ impl<K: HashKey, S: StateStore> HashAggExecutor<K, S> {
             return Ok(());
         } else {
             // Batch commit data.
-            for state_table in state_tables.write().await.iter_mut() {
+            for state_table in state_tables.iter_mut() {
                 state_table.commit(epoch).await?;
             }
 
-            let state_tables = state_tables.read().await;
             // --- Produce the stream chunk ---
             let mut batches = IterChunks::chunks(state_map.iter_mut(), PROCESSING_WINDOW_SIZE);
             while let Some(batch) = batches.next() {
@@ -379,7 +378,7 @@ impl<K: HashKey, S: StateStore> HashAggExecutor<K, S> {
                             &mut builders[key_indices.len()..],
                             &mut new_ops,
                             epoch,
-                            &state_tables,
+                            state_tables,
                         )
                         .await?;
 


### PR DESCRIPTION
## What's changed and what's your intention?

* Remove Arc Mutex on StateTable Vector
* Deparallel states apply_batch. It is by design single-thread as we only have one mem_table for write and it is not thread safe. The mem write should be fast so not bothered to be multithread. Now we only paralllelize the async remove fetch. 

## Checklist

- [x] I have written necessary docs and comments
- [x] I have added necessary unit tests and integration tests
- [x] All checks passed in `./risedev check` (or alias, `./risedev c`)

## Refer to a related PR or issue link (optional)
