### PR TITLE
refactor(binder): prepare for implicit cast support

### DIFF
--- a/src/frontend/src/expr/function_call.rs
+++ b/src/frontend/src/expr/function_call.rs
@@ -178,7 +178,7 @@ impl FunctionCall {
             Ok(Literal::new(None, target).into())
         } else if source == target {
             Ok(child)
-        } else if cast_ok(&source, &target, &allows) {
+        } else if cast_ok(&source, &target, allows) {
             Ok(Self {
                 func_type: ExprType::Cast,
                 return_type: target,

--- a/src/frontend/src/expr/function_call.rs
+++ b/src/frontend/src/expr/function_call.rs
@@ -156,10 +156,13 @@ impl FunctionCall {
                 Ok(DataType::Varchar)
             }
 
-            _ => infer_type(
-                func_type,
-                inputs.iter().map(|expr| expr.return_type()).collect(),
-            ),
+            _ => {
+                // TODO(xiangjin): move variadic functions above as part of `infer_type`, as its
+                // interface has been enhanced to support mutating (casting) inputs as well.
+                let ret;
+                (inputs, ret) = infer_type(func_type, inputs)?;
+                Ok(ret)
+            }
         }?;
         Ok(Self {
             func_type,

--- a/src/frontend/src/expr/type_inference/func.rs
+++ b/src/frontend/src/expr/type_inference/func.rs
@@ -26,24 +26,7 @@ use crate::expr::{Expr as _, ExprImpl, ExprType};
 pub fn infer_type(func_type: ExprType, inputs: Vec<ExprImpl>) -> Result<(Vec<ExprImpl>, DataType)> {
     // With our current simplified type system, where all types are nullable and not parameterized
     // by things like length or precision, the inference can be done with a map lookup.
-    let ret_type = infer_type_name(func_type, &inputs).map(|type_name| match type_name {
-        DataTypeName::Boolean => DataType::Boolean,
-        DataTypeName::Int16 => DataType::Int16,
-        DataTypeName::Int32 => DataType::Int32,
-        DataTypeName::Int64 => DataType::Int64,
-        DataTypeName::Decimal => DataType::Decimal,
-        DataTypeName::Float32 => DataType::Float32,
-        DataTypeName::Float64 => DataType::Float64,
-        DataTypeName::Varchar => DataType::Varchar,
-        DataTypeName::Date => DataType::Date,
-        DataTypeName::Timestamp => DataType::Timestamp,
-        DataTypeName::Timestampz => DataType::Timestampz,
-        DataTypeName::Time => DataType::Time,
-        DataTypeName::Interval => DataType::Interval,
-        DataTypeName::Struct | DataTypeName::List => {
-            panic!("Functions returning struct or list can not be inferred. Please use `FunctionCall::new_unchecked`.")
-        }
-    })?;
+    let ret_type = infer_type_name(func_type, &inputs)?.into();
     Ok((inputs, ret_type))
 }
 

--- a/src/frontend/src/expr/type_inference/mod.rs
+++ b/src/frontend/src/expr/type_inference/mod.rs
@@ -69,3 +69,26 @@ impl From<DataType> for DataTypeName {
         (&ty).into()
     }
 }
+
+impl From<DataTypeName> for DataType {
+    fn from(type_name: DataTypeName) -> Self {
+        match type_name {
+            DataTypeName::Boolean => DataType::Boolean,
+            DataTypeName::Int16 => DataType::Int16,
+            DataTypeName::Int32 => DataType::Int32,
+            DataTypeName::Int64 => DataType::Int64,
+            DataTypeName::Decimal => DataType::Decimal,
+            DataTypeName::Float32 => DataType::Float32,
+            DataTypeName::Float64 => DataType::Float64,
+            DataTypeName::Varchar => DataType::Varchar,
+            DataTypeName::Date => DataType::Date,
+            DataTypeName::Timestamp => DataType::Timestamp,
+            DataTypeName::Timestampz => DataType::Timestampz,
+            DataTypeName::Time => DataType::Time,
+            DataTypeName::Interval => DataType::Interval,
+            DataTypeName::Struct | DataTypeName::List => {
+                panic!("Functions returning struct or list can not be inferred. Please use `FunctionCall::new_unchecked`.")
+            }
+        }
+    }
+}

--- a/src/frontend/src/expr/type_inference/mod.rs
+++ b/src/frontend/src/expr/type_inference/mod.rs
@@ -18,7 +18,7 @@ use risingwave_common::types::DataType;
 
 mod cast;
 mod func;
-pub use cast::{align_types, cast_ok, least_restrictive, CastContext};
+pub use cast::{align_types, cast_ok, cast_ok_base, least_restrictive, CastContext};
 pub use func::{func_sig_map, infer_type, FuncSign};
 
 /// `DataTypeName` is designed for type derivation here. In other scenarios,


### PR DESCRIPTION
## What's changed and what's your intention?

This PR contains 4 refactors that prepares for implicit cast (preview in #3296).
* `FuncSigMap` hides the implementation of `HashMap<FuncSign, DataTypeName>`. It will be updated to another lookup structure. With this refactoring, the `build_type_derive_map` with `insert` calls can be reused.
* `infer_type` interface takes input exprs and potentially returns them casted to the matching function's parameters.
* `DataTypeName` to `DataType` mapping extracted
* `cast_ok_base` works on `DataTypeName` rather than `DataType`.

## Checklist

- [x] I have written necessary docs and comments
- [x] I have added necessary unit tests and integration tests
- [x] All checks passed in `./risedev check` (or alias, `./risedev c`)

## Refer to a related PR or issue link (optional)
