### PR TITLE
feat(compaction): compress data with dynamic level

### DIFF
--- a/proto/hummock.proto
+++ b/proto/hummock.proto
@@ -134,6 +134,7 @@ message CompactTask {
   uint64 compaction_group_id = 12;
   // existing_table_ids for compaction drop key
   repeated uint32 existing_table_ids = 13;
+  uint32 compression_algorithm = 14;
 }
 
 message LevelHandler {
@@ -279,4 +280,5 @@ message CompactionConfig {
   uint64 level0_tigger_file_numer = 6;
   uint64 level0_tier_compact_file_number = 7;
   CompactionMode compaction_mode = 8;
+  repeated string compression_algorithm = 9;
 }

--- a/src/bench/ss_bench/main.rs
+++ b/src/bench/ss_bench/main.rs
@@ -157,7 +157,6 @@ async fn main() {
         local_object_store: "memory".to_string(),
         share_buffer_compaction_worker_threads_number: 1,
         share_buffer_upload_concurrency: 4,
-        enable_compression: true,
     });
 
     let (_env, hummock_manager_ref, _cluster_manager_ref, worker_node) =

--- a/src/common/src/config.rs
+++ b/src/common/src/config.rs
@@ -161,10 +161,6 @@ pub struct StorageConfig {
     /// Number of tasks shared buffer can upload in parallel.
     #[serde(default = "default::share_buffer_upload_concurrency")]
     pub share_buffer_upload_concurrency: usize,
-
-    /// whether enable compression when building sstable.
-    #[serde(default = "default::enable_compression")]
-    pub enable_compression: bool,
 }
 
 impl Default for StorageConfig {
@@ -276,8 +272,5 @@ mod default {
 
     pub fn share_buffer_upload_concurrency() -> usize {
         8
-    }
-    pub fn enable_compression() -> bool {
-        true
     }
 }

--- a/src/meta/src/hummock/compaction/compaction_config.rs
+++ b/src/meta/src/hummock/compaction/compaction_config.rs
@@ -39,6 +39,15 @@ impl CompactionConfigBuilder {
                 level0_tigger_file_numer: DEFAULT_TIER_COMPACT_TRIGGER_NUMBER * 2,
                 level0_tier_compact_file_number: DEFAULT_TIER_COMPACT_TRIGGER_NUMBER,
                 compaction_mode: CompactionMode::Range as i32,
+                compression_algorithm: vec![
+                    "None".to_string(),
+                    "None".to_string(),
+                    "Lz4".to_string(),
+                    "Lz4".to_string(),
+                    "Lz4".to_string(),
+                    "Zstd".to_string(),
+                    "Zstd".to_string(),
+                ],
             },
         }
     }
@@ -62,13 +71,9 @@ macro_rules! builder_field {
     ($( $name:ident: $type:ty ),* ,) => {
         impl CompactionConfigBuilder {
             $(
-                pub fn $name(&self, v:$type) -> Self {
-                    Self {
-                        config: CompactionConfig {
-                            $name: v,
-                            ..self.config
-                        },
-                    }
+                pub fn $name(mut self, v:$type) -> Self {
+                    self.config.$name = v;
+                    self
                 }
             )*
         }
@@ -84,4 +89,5 @@ builder_field! {
     level0_tigger_file_numer: u64,
     level0_tier_compact_file_number: u64,
     compaction_mode: i32,
+    compression_algorithm: Vec<String>,
 }

--- a/src/meta/src/hummock/compaction/level_selector.rs
+++ b/src/meta/src/hummock/compaction/level_selector.rs
@@ -243,7 +243,13 @@ impl LevelSelector for DynamicLevelSelector {
                 return None;
             }
             let picker = self.create_compaction_picker(select_level, target_level, task_id);
-            if let Some(ret) = picker.pick_compaction(levels, level_handlers) {
+            if let Some(mut ret) = picker.pick_compaction(levels, level_handlers) {
+                if ret.target_level.level_idx == 0 {
+                    ret.compression_algorithm = self.config.compression_algorithm[0].clone();
+                } else {
+                    let idx = ret.target_level.level_idx as usize - ctx.base_level + 1;
+                    ret.compression_algorithm = self.config.compression_algorithm[idx + 1].clone();
+                }
                 return Some(ret);
             }
         }
@@ -271,7 +277,14 @@ impl LevelSelector for DynamicLevelSelector {
             target_level,
         );
 
-        picker.pick_compaction(levels, level_handlers)
+        let mut ret = picker.pick_compaction(levels, level_handlers)?;
+        if ret.target_level.level_idx == 0 {
+            ret.compression_algorithm = self.config.compression_algorithm[0].clone();
+        } else {
+            let idx = ret.target_level.level_idx as usize - ctx.base_level + 1;
+            ret.compression_algorithm = self.config.compression_algorithm[idx + 1].clone();
+        }
+        Some(ret)
     }
 
     fn name(&self) -> &'static str {

--- a/src/meta/src/hummock/compaction/manual_compaction_picker.rs
+++ b/src/meta/src/hummock/compaction/manual_compaction_picker.rs
@@ -139,6 +139,7 @@ impl CompactionPicker for ManualCompactionPicker {
                 table_infos: target_input_ssts,
             },
             split_ranges: vec![],
+            compression_algorithm: "".to_string(),
         })
     }
 }

--- a/src/meta/src/hummock/compaction/min_overlap_compaction_picker.rs
+++ b/src/meta/src/hummock/compaction/min_overlap_compaction_picker.rs
@@ -178,6 +178,7 @@ impl CompactionPicker for MinOverlappingPicker {
                 table_infos: target_input_ssts,
             },
             split_ranges: vec![],
+            compression_algorithm: "".to_string(),
         })
     }
 }

--- a/src/meta/src/hummock/compaction/mod.rs
+++ b/src/meta/src/hummock/compaction/mod.rs
@@ -76,6 +76,7 @@ pub struct SearchResult {
     select_level: Level,
     target_level: Level,
     split_ranges: Vec<KeyRange>,
+    compression_algorithm: String,
 }
 
 pub fn create_overlap_strategy(compaction_mode: CompactionMode) -> Arc<dyn OverlapStrategy> {
@@ -114,18 +115,11 @@ impl CompactStatus {
         // conditions, for any user key, the epoch of it in the file existing in the lower
         // layer must be larger.
 
-        let ret;
-        if let Some(manual_compaction_option) = manual_compaction_option {
-            ret = match self.manual_pick_compaction(levels, task_id, manual_compaction_option) {
-                Some(ret) => ret,
-                None => return None,
-            };
+        let ret = if let Some(manual_compaction_option) = manual_compaction_option {
+            self.manual_pick_compaction(levels, task_id, manual_compaction_option)?
         } else {
-            ret = match self.pick_compaction(levels, task_id) {
-                Some(ret) => ret,
-                None => return None,
-            };
-        }
+            self.pick_compaction(levels, task_id)?
+        };
 
         let select_level_id = ret.select_level.level_idx;
         let target_level_id = ret.target_level.level_idx;
@@ -134,6 +128,12 @@ impl CompactStatus {
             vec![KeyRange::inf()]
         } else {
             ret.split_ranges
+        };
+
+        let compression_algorithm = match ret.compression_algorithm.as_str() {
+            "Lz4" => 1,
+            "Zstd" => 2,
+            _ => 0,
         };
 
         let compact_task = CompactTask {
@@ -150,6 +150,7 @@ impl CompactStatus {
             vnode_mappings: vec![],
             compaction_group_id,
             existing_table_ids: vec![],
+            compression_algorithm,
         };
         Some(compact_task)
     }

--- a/src/meta/src/hummock/compaction/tier_compaction_picker.rs
+++ b/src/meta/src/hummock/compaction/tier_compaction_picker.rs
@@ -113,6 +113,7 @@ impl CompactionPicker for TierCompactionPicker {
                     total_file_size: 0,
                 },
                 split_ranges: vec![],
+                compression_algorithm: "".to_string(),
             });
         }
         None
@@ -215,6 +216,7 @@ impl CompactionPicker for LevelCompactionPicker {
                 table_infos: target_level_inputs,
             },
             split_ranges: splits,
+            compression_algorithm: "".to_string(),
         })
     }
 }

--- a/src/storage/src/hummock/compactor.rs
+++ b/src/storage/src/hummock/compactor.rs
@@ -242,6 +242,7 @@ impl Compactor {
             vnode_mappings: vec![],
             compaction_group_id: StaticCompactionGroupId::StateDefault.into(),
             existing_table_ids: vec![],
+            compression_algorithm: 0,
         };
 
         let sstable_store = context.sstable_store.clone();
@@ -570,20 +571,15 @@ impl Compactor {
                 let timer = Instant::now();
                 let table_id = (self.context.sstable_id_generator)().await?;
                 let cost = (timer.elapsed().as_secs_f64() * 1000000.0).round() as u64;
-                let options = {
-                    let mut options: SSTableBuilderOptions = self.context.options.as_ref().into();
+                let mut options: SSTableBuilderOptions = self.context.options.as_ref().into();
 
-                    if self.context.options.enable_compression {
-                        // support compression setting per level
-                        // L0 and L1 do not use compression algorithms
-                        // L2 - L4 use Lz4, else use Zstd
-                        options.compression_algorithm = match self.compact_task.target_level {
-                            0 | 1 => CompressionAlgorithm::None,
-                            2 | 3 | 4 => CompressionAlgorithm::Lz4,
-                            _ => CompressionAlgorithm::Zstd,
-                        }
-                    };
-                    options
+                // support compression setting per level
+                // L0 and L1 do not use compression algorithms
+                // L2 - L4 use Lz4, else use Zstd
+                options.compression_algorithm = match self.compact_task.compression_algorithm {
+                    0 => CompressionAlgorithm::None,
+                    1 => CompressionAlgorithm::Lz4,
+                    _ => CompressionAlgorithm::Zstd,
                 };
                 let builder = SSTableBuilder::new(table_id, options);
                 get_id_time.fetch_add(cost, Ordering::Relaxed);

--- a/src/storage/src/hummock/compactor_tests.rs
+++ b/src/storage/src/hummock/compactor_tests.rs
@@ -46,7 +46,6 @@ mod tests {
             bloom_false_positive: 0.1,
             data_directory: remote_dir.clone(),
             write_conflict_detection_enabled: true,
-            enable_compression: false,
             ..Default::default()
         });
         let sstable_store = mock_sstable_store();

--- a/src/storage/src/hummock/test_utils.rs
+++ b/src/storage/src/hummock/test_utils.rs
@@ -53,7 +53,6 @@ pub fn default_config_for_test() -> StorageConfig {
         enable_local_spill: false,
         local_object_store: "memory".to_string(),
         share_buffer_upload_concurrency: 1,
-        enable_compression: true,
     }
 }
 


### PR DESCRIPTION
Signed-off-by: Little-Wallace <bupt2013211450@gmail.com>

I hereby agree to the terms of the [Singularity Data, Inc. Contributor License Agreement](https://gist.github.com/skyzh/0663682a70b0edde7ae991492f2314cb#file-s9y_cla).

## What's changed and what's your intention?

- Our project use dynamic leveled-compaction to organize data. It means that the files in L0 will be compacted to L6 at first when L6 is empty. So we shall decide compression algorithm in meta-service
- In the future we may use different compaction configure for M-view and state group, so storing compression configuration in meta-service is a better choice.

## Checklist

- [ ] I have written necessary docs and comments
- [ ] I have added necessary unit tests and integration tests
- [ ] All checks passed in `./risedev check` (or alias, `./risedev c`)

## Refer to a related PR or issue link (optional)
