### PR TITLE
fix(expr): trim

### DIFF
--- a/e2e_test/batch/distribution_mode.slt
+++ b/e2e_test/batch/distribution_mode.slt
@@ -8,3 +8,4 @@ SET QUERY_MODE TO distributed;
 include ./basic/*.slt.part
 include ./aggregate/*.slt.part
 include ./types/*.slt.part
+include ./functions/*.slt.part

--- a/e2e_test/batch/functions/trim.slt.part
+++ b/e2e_test/batch/functions/trim.slt.part
@@ -1,0 +1,24 @@
+query T
+select trim(both 'cba' from 'abcxyzabc');
+----
+xyz
+
+query T
+select trim(leading 'cba' from 'abcxyzabc');
+----
+xyzabc
+
+query T
+select trim(trailing 'cba' from 'abcxyzabc');
+----
+abcxyz
+
+query T
+select ltrim('abcxyzabc', 'bca');
+----
+xyzabc
+
+query T
+select rtrim('abcxyzabc', 'bca');
+----
+abcxyz

--- a/e2e_test/batch/local_mode.slt
+++ b/e2e_test/batch/local_mode.slt
@@ -7,6 +7,7 @@ SET QUERY_MODE TO local;
 include ./basic/*.slt.part
 include ./aggregate/*.slt.part
 include ./types/*.slt.part
+include ./functions/*.slt.part
 
 statement ok
 SET QUERY_MODE TO distributed;

--- a/src/expr/src/expr/build_expr_from_prost.rs
+++ b/src/expr/src/expr/build_expr_from_prost.rs
@@ -17,7 +17,10 @@ use risingwave_common::types::{DataType, ToOwnedDatum};
 use risingwave_pb::expr::expr_node::RexNode;
 use risingwave_pb::expr::ExprNode;
 
-use crate::expr::expr_binary_bytes::{new_repeat, new_substr_start, new_to_char};
+use crate::expr::expr_binary_bytes::{
+    new_ltrim_characters, new_repeat, new_rtrim_characters, new_substr_start, new_to_char,
+    new_trim_characters,
+};
 use crate::expr::expr_binary_nonnull::{new_binary_expr, new_like_default};
 use crate::expr::expr_binary_nullable::new_nullable_binary_expr;
 use crate::expr::expr_case::{CaseExpression, WhenClause};
@@ -99,26 +102,44 @@ pub fn build_substr_expr(prost: &ExprNode) -> Result<BoxedExpression> {
 
 pub fn build_trim_expr(prost: &ExprNode) -> Result<BoxedExpression> {
     let (children, ret_type) = get_children_and_return_type(prost)?;
-    // TODO: add expr with the delimiter parameter
-    ensure!(children.len() == 1);
-    let child = expr_build_from_prost(&children[0])?;
-    Ok(new_trim_expr(child, ret_type))
+    ensure!(!children.is_empty() && children.len() <= 2);
+    let original = expr_build_from_prost(&children[0])?;
+    match children.len() {
+        1 => Ok(new_trim_expr(original, ret_type)),
+        2 => {
+            let characters = expr_build_from_prost(&children[1])?;
+            Ok(new_trim_characters(original, characters, ret_type))
+        }
+        _ => unreachable!(),
+    }
 }
 
 pub fn build_ltrim_expr(prost: &ExprNode) -> Result<BoxedExpression> {
     let (children, ret_type) = get_children_and_return_type(prost)?;
-    // TODO: add expr with the delimiter parameter
-    ensure!(children.len() == 1);
-    let child = expr_build_from_prost(&children[0])?;
-    Ok(new_ltrim_expr(child, ret_type))
+    ensure!(!children.is_empty() && children.len() <= 2);
+    let original = expr_build_from_prost(&children[0])?;
+    match children.len() {
+        1 => Ok(new_ltrim_expr(original, ret_type)),
+        2 => {
+            let characters = expr_build_from_prost(&children[1])?;
+            Ok(new_ltrim_characters(original, characters, ret_type))
+        }
+        _ => unreachable!(),
+    }
 }
 
 pub fn build_rtrim_expr(prost: &ExprNode) -> Result<BoxedExpression> {
     let (children, ret_type) = get_children_and_return_type(prost)?;
-    // TODO: add expr with the delimiter parameter
-    ensure!(children.len() == 1);
-    let child = expr_build_from_prost(&children[0])?;
-    Ok(new_rtrim_expr(child, ret_type))
+    ensure!(!children.is_empty() && children.len() <= 2);
+    let original = expr_build_from_prost(&children[0])?;
+    match children.len() {
+        1 => Ok(new_rtrim_expr(original, ret_type)),
+        2 => {
+            let characters = expr_build_from_prost(&children[1])?;
+            Ok(new_rtrim_characters(original, characters, ret_type))
+        }
+        _ => unreachable!(),
+    }
 }
 
 pub fn build_replace_expr(prost: &ExprNode) -> Result<BoxedExpression> {

--- a/src/expr/src/expr/expr_binary_bytes.rs
+++ b/src/expr/src/expr/expr_binary_bytes.rs
@@ -24,6 +24,7 @@ use crate::vector_op::concat_op::concat_op;
 use crate::vector_op::repeat::repeat;
 use crate::vector_op::substr::*;
 use crate::vector_op::to_char::to_char_timestamp;
+use crate::vector_op::trim_characters::{ltrim_characters, rtrim_characters, trim_characters};
 
 pub fn new_substr_start(
     expr_ia1: BoxedExpression,
@@ -78,19 +79,36 @@ pub fn new_repeat(
         .boxed()
 }
 
-pub fn new_concat_op(
-    expr_ia1: BoxedExpression,
-    expr_ia2: BoxedExpression,
-    return_type: DataType,
-) -> BoxedExpression {
-    BinaryBytesExpression::<Utf8Array, Utf8Array, _>::new(
-        expr_ia1,
-        expr_ia2,
-        return_type,
-        concat_op,
-    )
-    .boxed()
+macro_rules! impl_utf8_utf8 {
+    ($({ $func_name:ident, $method:ident }),*) => {
+        $(pub fn $func_name(
+            expr_ia1: BoxedExpression,
+            expr_ia2: BoxedExpression,
+            return_type: DataType,
+        ) -> BoxedExpression {
+            BinaryBytesExpression::<Utf8Array, Utf8Array, _>::new(
+                expr_ia1,
+                expr_ia2,
+                return_type,
+                $method,
+            )
+            .boxed()
+        })*
+    };
 }
+
+macro_rules! for_all_utf8_utf8_op {
+    ($macro:ident) => {
+        $macro! {
+            { new_trim_characters, trim_characters },
+            { new_ltrim_characters, ltrim_characters },
+            { new_rtrim_characters, rtrim_characters },
+            { new_concat_op, concat_op }
+        }
+    };
+}
+
+for_all_utf8_utf8_op! { impl_utf8_utf8 }
 
 #[cfg(test)]
 mod tests {

--- a/src/expr/src/vector_op/mod.rs
+++ b/src/expr/src/vector_op/mod.rs
@@ -37,6 +37,7 @@ pub mod substr;
 pub mod to_char;
 pub mod translate;
 pub mod trim;
+pub mod trim_characters;
 pub mod tumble;
 pub mod upper;
 

--- a/src/expr/src/vector_op/trim.rs
+++ b/src/expr/src/vector_op/trim.rs
@@ -28,7 +28,7 @@ mod tests {
     use super::*;
 
     #[test]
-    fn test_trim() -> Result<()> {
+    fn test_trim() {
         let cases = [
             (" Hello\tworld\t", "Hello\tworld"),
             (" 空I ❤️ databases空 ", "空I ❤️ databases空"),
@@ -37,11 +37,10 @@ mod tests {
         for (s, expected) in cases {
             let builder = Utf8ArrayBuilder::new(1).unwrap();
             let writer = builder.writer();
-            let guard = trim(s, writer)?;
+            let guard = trim(s, writer).unwrap();
             let array = guard.into_inner().finish().unwrap();
             let v = array.value_at(0).unwrap();
             assert_eq!(v, expected);
         }
-        Ok(())
     }
 }

--- a/src/expr/src/vector_op/trim_characters.rs
+++ b/src/expr/src/vector_op/trim_characters.rs
@@ -1,0 +1,106 @@
+// Copyright 2022 Singularity Data
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use itertools::Itertools;
+use risingwave_common::array::{BytesGuard, BytesWriter};
+
+use crate::Result;
+
+macro_rules! gen_trim {
+    ($( { $func_name:ident, $method:ident }),*) => {
+        $(#[inline(always)]
+        pub fn $func_name(s: &str, characters: &str, writer: BytesWriter) -> Result<BytesGuard> {
+            let slices = characters.chars().collect_vec();
+            // We remark that feeding a &str and a slice of chars into trim_left/right_matches
+            // means different, one is matching with the entire string and the other one is matching
+            // with any char in the slice.
+            writer
+                .write_ref(s.$method(&slices[..]))
+                .map_err(Into::into)
+        })*
+    }
+}
+
+macro_rules! for_three_variants {
+    ($macro:ident) => {
+        $macro! {
+            { trim_characters, trim_matches },
+            { ltrim_characters, trim_start_matches },
+            { rtrim_characters, trim_end_matches }
+        }
+    };
+}
+
+for_three_variants! { gen_trim }
+
+#[cfg(test)]
+mod tests {
+    use risingwave_common::array::{Array, ArrayBuilder, Utf8ArrayBuilder};
+
+    use super::*;
+
+    #[test]
+    fn test_trim_characters() {
+        let cases = [
+            ("Hello world", "Hdl", "ello wor"),
+            ("abcde", "aae", "bcd"),
+            ("zxy", "yxz", ""),
+        ];
+
+        for (s, characters, expected) in cases {
+            let builder = Utf8ArrayBuilder::new(1).unwrap();
+            let writer = builder.writer();
+            let guard = trim_characters(s, characters, writer).unwrap();
+            let array = guard.into_inner().finish().unwrap();
+            let v = array.value_at(0).unwrap();
+            assert_eq!(v, expected);
+        }
+    }
+
+    #[test]
+    fn test_ltrim_characters() {
+        let cases = [
+            ("Hello world", "Hdl", "ello world"),
+            ("abcde", "aae", "bcde"),
+            ("zxy", "yxz", ""),
+        ];
+
+        for (s, characters, expected) in cases {
+            let builder = Utf8ArrayBuilder::new(1).unwrap();
+            let writer = builder.writer();
+            let guard = ltrim_characters(s, characters, writer).unwrap();
+            let array = guard.into_inner().finish().unwrap();
+            let v = array.value_at(0).unwrap();
+            assert_eq!(v, expected);
+        }
+    }
+
+    #[test]
+    fn test_rtrim_characters() {
+        let cases = [
+            ("Hello world", "Hdl", "Hello wor"),
+            ("abcde", "aae", "abcd"),
+            ("zxy", "yxz", ""),
+        ];
+
+        for (s, characters, expected) in cases {
+            let builder = Utf8ArrayBuilder::new(1).unwrap();
+            let writer = builder.writer();
+            let guard = rtrim_characters(s, characters, writer).unwrap();
+            let array = guard.into_inner().finish().unwrap();
+            let v = array.value_at(0).unwrap();
+            assert_eq!(v, expected);
+        }
+    }
+}


### PR DESCRIPTION
I hereby agree to the terms of the [Singularity Data, Inc. Contributor License Agreement](https://gist.github.com/skyzh/0663682a70b0edde7ae991492f2314cb#file-s9y_cla).

## What's changed and what's your intention?
Previously, `trim/ltrim/rtrim` does not support trimming user-defined characters other than spaces.

## Checklist

- [x] I have written necessary docs and comments
- [x] I have added necessary unit tests and integration tests
- [x] All checks passed in `./risedev check` (or alias, `./risedev c`)

## Refer to a related PR or issue link (optional)
closes #3356 