### PR TITLE
feat(storage): compaction group support table_option of internal_table

### DIFF
--- a/proto/hummock.proto
+++ b/proto/hummock.proto
@@ -158,6 +158,12 @@ message CompactionGroup {
   uint64 id = 1;
   repeated bytes member_prefixes = 2;
   CompactionConfig compaction_config = 3;
+
+  message TableOption {
+    uint32 ttl = 1;
+  }
+
+  map<uint32, TableOption> table_options = 4;
 }
 
 message CompactTaskAssignment {

--- a/proto/hummock.proto
+++ b/proto/hummock.proto
@@ -163,7 +163,7 @@ message CompactionGroup {
     uint32 ttl = 1;
   }
 
-  map<uint32, TableOption> table_options = 4;
+  map<uint32, TableOption> table_id_to_options = 4;
 }
 
 message CompactTaskAssignment {

--- a/src/meta/src/hummock/compaction_group/manager.rs
+++ b/src/meta/src/hummock/compaction_group/manager.rs
@@ -269,7 +269,7 @@ impl CompactionGroupManagerInner {
                 .ok_or(Error::InvalidCompactionGroup(*compaction_group_id))?;
             compaction_group.member_prefixes.insert(*prefix);
             compaction_group
-                .table_options
+                .table_id_to_options
                 .insert(prefix.into(), table_option.clone());
         }
         let mut trx = Transaction::default();
@@ -301,7 +301,7 @@ impl CompactionGroupManagerInner {
                 .ok_or(Error::InvalidCompactionGroup(compaction_group_id))?;
             compaction_group.member_prefixes.remove(prefix);
             let table_id: u32 = prefix.into();
-            compaction_group.table_options.remove(&table_id);
+            compaction_group.table_id_to_options.remove(&table_id);
         }
         let mut trx = Transaction::default();
         compaction_groups.apply_to_txn(&mut trx)?;
@@ -337,7 +337,7 @@ impl CompactionGroupManagerInner {
         table_id: u32,
     ) -> Result<TableOption> {
         let compaction_group = self.compaction_group(compaction_group_id)?;
-        match compaction_group.table_options().get(&table_id) {
+        match compaction_group.table_id_to_options().get(&table_id) {
             Some(table_option) => Ok(table_option.clone()),
 
             None => Ok(TableOption::default()),
@@ -378,7 +378,7 @@ mod tests {
             inner
                 .compaction_groups
                 .iter()
-                .map(|(_, cg)| cg.table_options().len())
+                .map(|(_, cg)| cg.table_id_to_options().len())
                 .sum::<usize>()
         };
 

--- a/src/meta/src/hummock/compaction_group/manager.rs
+++ b/src/meta/src/hummock/compaction_group/manager.rs
@@ -300,6 +300,8 @@ impl CompactionGroupManagerInner {
                 .get_mut(&compaction_group_id)
                 .ok_or(Error::InvalidCompactionGroup(compaction_group_id))?;
             compaction_group.member_prefixes.remove(prefix);
+            let table_id: u32 = prefix.into();
+            compaction_group.table_options.remove(&table_id);
         }
         let mut trx = Transaction::default();
         compaction_groups.apply_to_txn(&mut trx)?;
@@ -372,6 +374,14 @@ mod tests {
                 .sum::<usize>()
         };
 
+        let table_option_number = |inner: &CompactionGroupManagerInner| {
+            inner
+                .compaction_groups
+                .iter()
+                .map(|(_, cg)| cg.table_options().len())
+                .sum::<usize>()
+        };
+
         assert!(inner.read().await.index.is_empty());
         assert_eq!(registered_number(inner.read().await.deref()), 0);
 
@@ -413,6 +423,7 @@ mod tests {
         let inner = compaction_group_manager.inner;
         assert_eq!(inner.read().await.index.len(), 2);
         assert_eq!(registered_number(inner.read().await.deref()), 2);
+        assert_eq!(table_option_number(inner.read().await.deref()), 2);
 
         // Test unregister
         inner
@@ -423,12 +434,34 @@ mod tests {
             .unwrap();
         assert_eq!(inner.read().await.index.len(), 1);
         assert_eq!(registered_number(inner.read().await.deref()), 1);
+        assert_eq!(table_option_number(inner.read().await.deref()), 1);
 
         // Test init
         let compaction_group_manager = CompactionGroupManager::new(env.clone()).await.unwrap();
         let inner = compaction_group_manager.inner;
         assert_eq!(inner.read().await.index.len(), 1);
         assert_eq!(registered_number(inner.read().await.deref()), 1);
+        assert_eq!(table_option_number(inner.read().await.deref()), 1);
+
+        // Test table_option_by_table_id
+        {
+            let table_option = inner
+                .read()
+                .await
+                .table_option_by_table_id(StaticCompactionGroupId::StateDefault.into(), 1u32)
+                .unwrap();
+            assert_eq!(300, table_option.ttl);
+        }
+
+        {
+            // unregistered table_id
+            let table_option_default = inner
+                .read()
+                .await
+                .table_option_by_table_id(StaticCompactionGroupId::StateDefault.into(), 2u32);
+            assert!(table_option_default.is_ok());
+            assert_eq!(0, table_option_default.unwrap().ttl);
+        }
     }
 
     #[tokio::test]

--- a/src/meta/src/hummock/compaction_group/manager.rs
+++ b/src/meta/src/hummock/compaction_group/manager.rs
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use std::collections::{BTreeMap, HashSet};
+use std::collections::{BTreeMap, HashMap, HashSet};
 use std::sync::Arc;
 
 use itertools::Itertools;
@@ -22,7 +22,7 @@ use risingwave_pb::hummock::CompactionConfig;
 use tokio::sync::RwLock;
 
 use crate::hummock::compaction::compaction_config::CompactionConfigBuilder;
-use crate::hummock::compaction_group::CompactionGroup;
+use crate::hummock::compaction_group::{CompactionGroup, TableOption};
 use crate::hummock::error::{Error, Result};
 use crate::manager::{MetaSrvEnv, SourceId};
 use crate::model::{MetadataModel, TableFragments, ValTransaction, VarTransaction};
@@ -76,7 +76,13 @@ impl<S: MetaStore> CompactionGroupManager<S> {
     }
 
     /// Registers `table_fragments` to compaction groups.
-    pub async fn register_table_fragments(&self, table_fragments: &TableFragments) -> Result<()> {
+    pub async fn register_table_fragments(
+        &self,
+        table_fragments: &TableFragments,
+        table_properties: &HashMap<String, String>,
+    ) -> Result<()> {
+        let table_option = CompactionGroup::build_table_option(table_properties);
+
         let mut pairs = vec![];
         // materialized_view or materialized_source
         pairs.push((
@@ -85,6 +91,7 @@ impl<S: MetaStore> CompactionGroupManager<S> {
             // `StateDefault`.
             CompactionGroupId::from(StaticCompactionGroupId::StateDefault),
             // CompactionGroupId::from(StaticCompactionGroupId::MaterializedView),
+            table_option.clone(),
         ));
         // internal states
         for table_id in table_fragments.internal_table_ids() {
@@ -92,6 +99,7 @@ impl<S: MetaStore> CompactionGroupManager<S> {
             pairs.push((
                 Prefix::from(table_id),
                 CompactionGroupId::from(StaticCompactionGroupId::StateDefault),
+                table_option.clone(),
             ));
         }
         self.inner
@@ -117,7 +125,12 @@ impl<S: MetaStore> CompactionGroupManager<S> {
             .await
     }
 
-    pub async fn register_source(&self, source_id: u32) -> Result<()> {
+    pub async fn register_source(
+        &self,
+        source_id: u32,
+        table_properties: &HashMap<String, String>,
+    ) -> Result<()> {
+        let table_option = CompactionGroup::build_table_option(table_properties);
         self.inner
             .write()
             .await
@@ -125,6 +138,7 @@ impl<S: MetaStore> CompactionGroupManager<S> {
                 &[(
                     source_id.into(),
                     StaticCompactionGroupId::StateDefault.into(),
+                    table_option,
                 )],
                 self.env.meta_store(),
             )
@@ -182,6 +196,15 @@ impl<S: MetaStore> CompactionGroupManager<S> {
 
         Ok(prefix_set.into_iter().map(u32::from).collect())
     }
+
+    pub async fn get_table_option(
+        &self,
+        id: CompactionGroupId,
+        table_id: u32,
+    ) -> Result<TableOption> {
+        let inner = self.inner.read().await;
+        inner.table_option_by_table_id(id, table_id)
+    }
 }
 
 #[derive(Default)]
@@ -236,15 +259,18 @@ impl CompactionGroupManagerInner {
 
     async fn register<S: MetaStore>(
         &mut self,
-        pairs: &[(Prefix, CompactionGroupId)],
+        pairs: &[(Prefix, CompactionGroupId, TableOption)],
         meta_store: &S,
     ) -> Result<()> {
         let mut compaction_groups = VarTransaction::new(&mut self.compaction_groups);
-        for (prefix, compaction_group_id) in pairs {
+        for (prefix, compaction_group_id, table_option) in pairs {
             let compaction_group = compaction_groups
                 .get_mut(compaction_group_id)
                 .ok_or(Error::InvalidCompactionGroup(*compaction_group_id))?;
             compaction_group.member_prefixes.insert(*prefix);
+            compaction_group
+                .table_options
+                .insert(prefix.into(), table_option.clone());
         }
         let mut trx = Transaction::default();
         compaction_groups.apply_to_txn(&mut trx)?;
@@ -252,7 +278,7 @@ impl CompactionGroupManagerInner {
         compaction_groups.commit();
 
         // Update in-memory index
-        for (prefix, compaction_group_id) in pairs {
+        for (prefix, compaction_group_id, _) in pairs {
             self.index.insert(*prefix, *compaction_group_id);
         }
         Ok(())
@@ -287,11 +313,32 @@ impl CompactionGroupManagerInner {
         Ok(())
     }
 
-    fn prefixs_by_compaction_group_id(&self, compaction_group_id: u64) -> Result<HashSet<Prefix>> {
+    fn compaction_group(&self, compaction_group_id: u64) -> Result<CompactionGroup> {
         match self.compaction_groups.get(&compaction_group_id) {
-            Some(compaction_group) => Ok(compaction_group.member_prefixes.clone()),
+            Some(compaction_group) => Ok(compaction_group.clone()),
 
             None => Err(Error::InvalidCompactionGroup(compaction_group_id)),
+        }
+    }
+
+    pub fn prefixs_by_compaction_group_id(
+        &self,
+        compaction_group_id: u64,
+    ) -> Result<HashSet<Prefix>> {
+        let compaction_group = self.compaction_group(compaction_group_id)?;
+        Ok(compaction_group.member_prefixes)
+    }
+
+    pub fn table_option_by_table_id(
+        &self,
+        compaction_group_id: u64,
+        table_id: u32,
+    ) -> Result<TableOption> {
+        let compaction_group = self.compaction_group(compaction_group_id)?;
+        match compaction_group.table_options().get(&table_id) {
+            Some(table_option) => Ok(table_option.clone()),
+
+            None => Ok(TableOption::default()),
         }
     }
 }
@@ -299,13 +346,14 @@ impl CompactionGroupManagerInner {
 #[cfg(test)]
 mod tests {
 
+    use std::collections::HashMap;
     use std::ops::Deref;
 
     use risingwave_common::catalog::TableId;
     use risingwave_hummock_sdk::compaction_group::{Prefix, StaticCompactionGroupId};
 
     use crate::hummock::compaction_group::manager::{
-        CompactionGroupManager, CompactionGroupManagerInner,
+        CompactionGroup, CompactionGroupManager, CompactionGroupManagerInner,
     };
     use crate::hummock::test_utils::setup_compute_env;
     use crate::model::TableFragments;
@@ -327,6 +375,9 @@ mod tests {
         assert!(inner.read().await.index.is_empty());
         assert_eq!(registered_number(inner.read().await.deref()), 0);
 
+        let table_properties = HashMap::from([(String::from("ttl"), String::from("300"))]);
+        let table_option = CompactionGroup::build_table_option(&table_properties);
+
         // Test register
         inner
             .write()
@@ -335,6 +386,7 @@ mod tests {
                 &[(
                     Prefix::from(1u32),
                     StaticCompactionGroupId::StateDefault.into(),
+                    table_option.clone(),
                 )],
                 env.meta_store(),
             )
@@ -347,6 +399,7 @@ mod tests {
                 &[(
                     Prefix::from(2u32),
                     StaticCompactionGroupId::MaterializedView.into(),
+                    table_option.clone(),
                 )],
                 env.meta_store(),
             )
@@ -400,13 +453,15 @@ mod tests {
                 .sum::<usize>()
         };
         assert_eq!(registered_number().await, 0);
+        let table_properties = HashMap::from([(String::from("ttl"), String::from("300"))]);
+
         compaction_group_manager
-            .register_table_fragments(&table_fragment_1)
+            .register_table_fragments(&table_fragment_1, &table_properties)
             .await
             .unwrap();
         assert_eq!(registered_number().await, 4);
         compaction_group_manager
-            .register_table_fragments(&table_fragment_2)
+            .register_table_fragments(&table_fragment_2, &table_properties)
             .await
             .unwrap();
         assert_eq!(registered_number().await, 8);
@@ -432,22 +487,22 @@ mod tests {
 
         // Test register_source
         compaction_group_manager
-            .register_source(source_1)
+            .register_source(source_1, &table_properties)
             .await
             .unwrap();
         assert_eq!(registered_number().await, 1);
         compaction_group_manager
-            .register_source(source_2)
+            .register_source(source_2, &table_properties)
             .await
             .unwrap();
         assert_eq!(registered_number().await, 2);
         compaction_group_manager
-            .register_source(source_2)
+            .register_source(source_2, &table_properties)
             .await
             .unwrap();
         assert_eq!(registered_number().await, 2);
         compaction_group_manager
-            .register_source(source_3)
+            .register_source(source_3, &table_properties)
             .await
             .unwrap();
         assert_eq!(registered_number().await, 3);

--- a/src/meta/src/hummock/compaction_group/mod.rs
+++ b/src/meta/src/hummock/compaction_group/mod.rs
@@ -15,7 +15,7 @@
 pub mod manager;
 
 use std::borrow::Borrow;
-use std::collections::HashSet;
+use std::collections::{HashMap, HashSet};
 
 use itertools::Itertools;
 use risingwave_hummock_sdk::compaction_group::Prefix;
@@ -29,6 +29,7 @@ pub struct CompactionGroup {
     group_id: CompactionGroupId,
     member_prefixes: HashSet<Prefix>,
     compaction_config: CompactionConfig,
+    table_options: HashMap<u32, TableOption>,
 }
 
 impl CompactionGroup {
@@ -37,6 +38,7 @@ impl CompactionGroup {
             group_id,
             member_prefixes: Default::default(),
             compaction_config,
+            table_options: HashMap::default(),
         }
     }
 
@@ -50,6 +52,38 @@ impl CompactionGroup {
 
     pub fn compaction_config(&self) -> &CompactionConfig {
         &self.compaction_config
+    }
+
+    pub fn table_options(&self) -> &HashMap<u32, TableOption> {
+        &self.table_options
+    }
+
+    pub fn build_table_option(table_properties: &HashMap<String, String>) -> TableOption {
+        // now we only support ttl for TableOption
+        let mut result = TableOption::default();
+
+        const PROPERTIES_TTL_KEY: &str = "ttl";
+        match table_properties.get(PROPERTIES_TTL_KEY) {
+            Some(ttl_string) => {
+                let ttl_u32 = match ttl_string.trim().parse::<u32>() {
+                    Ok(num) => num,
+                    Err(e) => {
+                        tracing::info!(
+                            "build_table_option parse option ttl_string {} fail {}",
+                            ttl_string,
+                            e
+                        );
+                        0
+                    }
+                };
+
+                result.ttl = ttl_u32;
+            }
+
+            None => {}
+        }
+
+        result
     }
 }
 
@@ -70,6 +104,11 @@ impl From<&risingwave_pb::hummock::CompactionGroup> for CompactionGroup {
                 .as_ref()
                 .cloned()
                 .unwrap(),
+            table_options: compaction_group
+                .table_options
+                .iter()
+                .map(|id_to_table_option| (*id_to_table_option.0, id_to_table_option.1.into()))
+                .collect::<HashMap<_, _>>(),
         }
     }
 }
@@ -80,6 +119,11 @@ impl From<&CompactionGroup> for risingwave_pb::hummock::CompactionGroup {
             id: compaction_group.group_id,
             member_prefixes: compaction_group.member_prefixes.iter().map_into().collect(),
             compaction_config: Some(compaction_group.compaction_config.clone()),
+            table_options: compaction_group
+                .table_options
+                .iter()
+                .map(|id_to_table_option| (*id_to_table_option.0, id_to_table_option.1.into()))
+                .collect::<HashMap<_, _>>(),
         }
     }
 }
@@ -104,5 +148,26 @@ impl MetadataModel for CompactionGroup {
 
     fn key(&self) -> risingwave_common::error::Result<Self::KeyType> {
         Ok(self.group_id)
+    }
+}
+
+#[derive(Clone, Debug, PartialEq, Default)]
+pub struct TableOption {
+    ttl: u32,
+}
+
+impl From<&risingwave_pb::hummock::compaction_group::TableOption> for TableOption {
+    fn from(table_option: &risingwave_pb::hummock::compaction_group::TableOption) -> Self {
+        Self {
+            ttl: table_option.ttl,
+        }
+    }
+}
+
+impl From<&TableOption> for risingwave_pb::hummock::compaction_group::TableOption {
+    fn from(table_option: &TableOption) -> Self {
+        Self {
+            ttl: table_option.ttl,
+        }
     }
 }

--- a/src/meta/src/rpc/service/ddl_service.rs
+++ b/src/meta/src/rpc/service/ddl_service.rs
@@ -418,11 +418,6 @@ where
         &self,
         mut fragment_graph: StreamFragmentGraph,
         id: TableId,
-        // schema_id: SchemaId,
-        // database_id: DatabaseId,
-        // table_name: String,
-        // affiliated_source: Option<Source>,
-        // table_properties: HashMap<String, String>,
         mut ctx: CreateMaterializedViewContext,
     ) -> RwResult<Vec<Table>> {
         use risingwave_common::catalog::TableId;
@@ -457,14 +452,6 @@ where
             .cluster_manager
             .get_parallel_unit_count(Some(ParallelUnitType::Hash))
             .await;
-        // let mut ctx = CreateMaterializedViewContext {
-        //     affiliated_source,
-        //     schema_id,
-        //     database_id,
-        //     mview_name: table_name,
-        //     table_properties,
-        //     ..Default::default()
-        // };
 
         let mut actor_graph_builder =
             ActorGraphBuilder::new(self.env.id_gen_manager_ref(), &fragment_graph, &mut ctx)

--- a/src/meta/src/rpc/service/ddl_service.rs
+++ b/src/meta/src/rpc/service/ddl_service.rs
@@ -28,13 +28,12 @@ use risingwave_pb::stream_plan::{StreamFragmentGraph, StreamNode};
 use tonic::{Request, Response, Status};
 
 use crate::cluster::ClusterManagerRef;
-use crate::manager::{
-    CatalogManagerRef, DatabaseId, IdCategory, MetaSrvEnv, SchemaId, SourceId, TableId,
-};
+use crate::manager::{CatalogManagerRef, IdCategory, MetaSrvEnv, SourceId, TableId};
 use crate::model::{FragmentId, TableFragments};
 use crate::storage::MetaStore;
 use crate::stream::{
-    ActorGraphBuilder, FragmentManagerRef, GlobalStreamManagerRef, SourceManagerRef,
+    ActorGraphBuilder, CreateMaterializedViewContext, FragmentManagerRef, GlobalStreamManagerRef,
+    SourceManagerRef,
 };
 
 #[derive(Clone)]
@@ -289,15 +288,16 @@ where
             .map_err(tonic_err)?;
 
         // 3. Create mview in stream manager. The id in stream node will be filled.
+        let ctx = CreateMaterializedViewContext {
+            schema_id: mview.schema_id,
+            database_id: mview.database_id,
+            mview_name: mview.name.clone(),
+            table_properties: mview.properties.clone(),
+            affiliated_source: None,
+            ..Default::default()
+        };
         let internal_tables = match self
-            .create_mview_on_compute_node(
-                fragment_graph,
-                id,
-                mview.schema_id,
-                mview.database_id,
-                mview.name.clone(),
-                None,
-            )
+            .create_mview_on_compute_node(fragment_graph, id, ctx)
             .await
         {
             Err(e) => {
@@ -418,14 +418,14 @@ where
         &self,
         mut fragment_graph: StreamFragmentGraph,
         id: TableId,
-        schema_id: SchemaId,
-        database_id: DatabaseId,
-        table_name: String,
-        affiliated_source: Option<Source>,
+        // schema_id: SchemaId,
+        // database_id: DatabaseId,
+        // table_name: String,
+        // affiliated_source: Option<Source>,
+        // table_properties: HashMap<String, String>,
+        mut ctx: CreateMaterializedViewContext,
     ) -> RwResult<Vec<Table>> {
         use risingwave_common::catalog::TableId;
-
-        use crate::stream::CreateMaterializedViewContext;
 
         // Fill in the correct mview id for stream node.
         fn fill_mview_id(stream_node: &mut StreamNode, mview_id: TableId) -> usize {
@@ -457,13 +457,14 @@ where
             .cluster_manager
             .get_parallel_unit_count(Some(ParallelUnitType::Hash))
             .await;
-        let mut ctx = CreateMaterializedViewContext {
-            affiliated_source,
-            schema_id,
-            database_id,
-            mview_name: table_name,
-            ..Default::default()
-        };
+        // let mut ctx = CreateMaterializedViewContext {
+        //     affiliated_source,
+        //     schema_id,
+        //     database_id,
+        //     mview_name: table_name,
+        //     table_properties,
+        //     ..Default::default()
+        // };
 
         let mut actor_graph_builder =
             ActorGraphBuilder::new(self.env.id_gen_manager_ref(), &fragment_graph, &mut ctx)
@@ -570,15 +571,17 @@ where
 
         // Create mview on compute node.
         // Noted that this progress relies on the source just created, so we pass it here.
+        let ctx = CreateMaterializedViewContext {
+            schema_id: source.schema_id,
+            database_id: source.database_id,
+            mview_name: source.name.clone(),
+            table_properties: mview.properties.clone(),
+            affiliated_source: Some(source.clone()),
+            ..Default::default()
+        };
+
         let internal_tables = match self
-            .create_mview_on_compute_node(
-                fragment_graph,
-                mview_id,
-                source.schema_id,
-                source.database_id,
-                source.name.clone(),
-                Some(source.clone()),
-            )
+            .create_mview_on_compute_node(fragment_graph, mview_id, ctx)
             .await
         {
             Err(e) => {

--- a/src/meta/src/stream/meta.rs
+++ b/src/meta/src/stream/meta.rs
@@ -131,7 +131,11 @@ where
 
     /// Start create a new `TableFragments` and insert it into meta store, currently the actors'
     /// state is `ActorState::Inactive`.
-    pub async fn start_create_table_fragments(&self, table_fragment: TableFragments) -> Result<()> {
+    pub async fn start_create_table_fragments(
+        &self,
+        table_fragment: TableFragments,
+        table_properties: HashMap<String, String>,
+    ) -> Result<()> {
         let map = &mut self.core.write().await.table_fragments;
 
         match map.entry(table_fragment.table_id()) {
@@ -143,7 +147,7 @@ where
                 // Register to compaction group beforehand.
                 // If any following operation fails, the registration will be eventually reverted.
                 self.compaction_group_manager
-                    .register_table_fragments(&table_fragment)
+                    .register_table_fragments(&table_fragment, &table_properties)
                     .await?;
 
                 table_fragment.insert(&*self.meta_store).await?;

--- a/src/meta/src/stream/source_manager.rs
+++ b/src/meta/src/stream/source_manager.rs
@@ -579,7 +579,7 @@ where
     pub async fn create_source(&self, source: &Source) -> Result<()> {
         // Register beforehand and is safeguarded by CompactionGroupManager::purge_stale_members.
         self.compaction_group_manager
-            .register_source(source.id)
+            .register_source(source.id, &HashMap::new())
             .await?;
         let futures = self
             .all_stream_clients()

--- a/src/meta/src/stream/stream_manager.rs
+++ b/src/meta/src/stream/stream_manager.rs
@@ -65,6 +65,7 @@ pub struct CreateMaterializedViewContext {
     pub database_id: DatabaseId,
     /// Name of mview, for internal table name generation.
     pub mview_name: String,
+    pub table_properties: HashMap<String, String>,
 }
 
 /// `GlobalStreamManager` manages all the streams in the system.
@@ -276,6 +277,7 @@ where
             mut upstream_node_actors,
             table_sink_map,
             dependent_table_ids,
+            table_properties,
             ..
         }: CreateMaterializedViewContext,
     ) -> Result<()> {
@@ -554,7 +556,7 @@ where
 
         // Add table fragments to meta store with state: `State::Creating`.
         self.fragment_manager
-            .start_create_table_fragments(table_fragments.clone())
+            .start_create_table_fragments(table_fragments.clone(), table_properties)
             .await?;
 
         let table_id = table_fragments.table_id();


### PR DESCRIPTION
I hereby agree to the terms of the [Singularity Data, Inc. Contributor License Agreement](https://gist.github.com/skyzh/0663682a70b0edde7ae991492f2314cb#file-s9y_cla).

## What's changed and what's your intention?
compaction group support table_option of internal_table

Please explain **IN DETAIL** what the changes are in this PR and why they are needed:

- TableOption proto 
- register table_option to compaction_group
- interface for table_option read

## Checklist

- [x] I have written necessary docs and comments
- [x] I have added necessary unit tests and integration tests

## Refer to a related PR or issue link (optional)
- https://github.com/singularity-data/risingwave/issues/3298