### PR TITLE
fix(risedev): fix install-tools

### DIFF
--- a/Makefile.toml
+++ b/Makefile.toml
@@ -367,7 +367,7 @@ set -e
 for tool in cargo-llvm-cov cargo-nextest cargo-udeps cargo-hakari cargo-sort cargo-make
 do
   echo "install: $(tput setaf 4)$tool$(tput sgr0)"
-  cargo install $tool
+  cargo install $tool --locked
   echo
 done
 


### PR DESCRIPTION
I hereby agree to the terms of the [Singularity Data, Inc. Contributor License Agreement](https://gist.github.com/skyzh/0663682a70b0edde7ae991492f2314cb#file-s9y_cla).

## What's changed and what's your intention?

About 4 hours ago, `cargo_metadata` released 0.14.3 which broke semantic versioning and caused `./risedev install-tools` to fail. 🤪

```
error[E0277]: the trait bound `Box<str>: From<Edition>` is not satisfied
   --> /Users/wangrunji/.cargo/registry/src/github.com-1ecc6299db9ec823/guppy-0.14.2/src/graph/build.rs:328:42
    |
328 |                 edition: package.edition.into(),
    |                                          ^^^^ the trait `From<Edition>` is not implemented for `Box<str>`
    |
    = help: the following other types implement trait `From<T>`:
              <Box<(dyn StdError + 'a)> as From<E>>
              <Box<(dyn StdError + 'static)> as From<&str>>
              <Box<(dyn StdError + 'static)> as From<Cow<'a, str>>>
              <Box<(dyn StdError + 'static)> as From<std::string::String>>
              <Box<(dyn StdError + Send + Sync + 'a)> as From<&str>>
              <Box<(dyn StdError + Send + Sync + 'a)> as From<Cow<'b, str>>>
              <Box<(dyn StdError + Send + Sync + 'a)> as From<E>>
              <Box<(dyn StdError + Send + Sync + 'static)> as From<std::string::String>>
            and 22 others
    = note: required because of the requirements on the impl of `Into<Box<str>>` for `Edition`

error[E0599]: no method named `into_boxed_str` found for enum `Edition` in the current scope
   --> /Users/wangrunji/.cargo/registry/src/github.com-1ecc6299db9ec823/guppy-0.14.2/src/graph/build.rs:519:45
    |
519 |                     edition: target.edition.into_boxed_str(),
    |                                             ^^^^^^^^^^^^^^ method not found in `Edition`

Some errors have detailed explanations: E0277, E0599.
For more information about an error, try `rustc --explain E0277`.
error: could not compile `guppy` due to 2 previous errors
```
This PR fixes this issue by adding `--locked` to `cargo install`.

## Checklist

- [x] I have written necessary docs and comments
- [x] I have added necessary unit tests and integration tests
- [x] All checks passed in `./risedev check` (or alias, `./risedev c`)

## Refer to a related PR or issue link (optional)
