### PR TITLE
feat(build): compress debug info in docker builds

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -27,6 +27,11 @@ RUN mkdir -p /risingwave/bin
 RUN cargo build -p risingwave_cmd -p risingwave_cmd_all --release --features static-link && \
   mv /risingwave/target/release/{frontend,compute-node,meta-node,compactor,risingwave} /risingwave/bin/ && \
   cargo clean
+RUN objcopy --compress-debug-sections=zlib-gnu /risingwave/bin/risingwave && \
+  objcopy --compress-debug-sections=zlib-gnu /risingwave/bin/frontend && \
+  objcopy --compress-debug-sections=zlib-gnu /risingwave/bin/compute-node && \
+  objcopy --compress-debug-sections=zlib-gnu /risingwave/bin/meta-node && \
+  objcopy --compress-debug-sections=zlib-gnu /risingwave/bin/compactor
 
 FROM ubuntu:22.04 as image-base
 RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get -y install ca-certificates && rm -rf /var/lib/{apt,dpkg,cache,log}/


### PR DESCRIPTION
Signed-off-by: Alex Chi <iskyzh@gmail.com>

I hereby agree to the terms of the [Singularity Data, Inc. Contributor License Agreement](https://gist.github.com/skyzh/0663682a70b0edde7ae991492f2314cb#file-s9y_cla).

## What's changed and what's your intention?

As title, 1GB -> 300MB

## Checklist

- [x] I have written necessary docs and comments
- [x] I have added necessary unit tests and integration tests
- [x] All checks passed in `./risedev check` (or alias, `./risedev c`)

## Refer to a related PR or issue link (optional)
