### PR TITLE
chore(meta): deprecate VirtualTable in catalog.proto

### DIFF
--- a/proto/catalog.proto
+++ b/proto/catalog.proto
@@ -33,13 +33,6 @@ message Source {
   string owner = 7;
 }
 
-// VirtualTable defines a view in system catalogs, it can only be queried and not be treated as a source.
-message VirtualTable {
-  uint32 id = 1;
-  string name = 2;
-  repeated plan_common.ColumnCatalog columns = 3;
-}
-
 /// See `TableCatalog` struct in frontend crate for more information.
 message Table {
   uint32 id = 1;

--- a/proto/meta.proto
+++ b/proto/meta.proto
@@ -131,7 +131,6 @@ message MetaSnapshot {
   repeated catalog.Schema schema = 3;
   repeated catalog.Source source = 4;
   repeated catalog.Table table = 5;
-  repeated catalog.VirtualTable view = 6;
   repeated user.UserInfo users = 7;
 }
 

--- a/src/meta/src/rpc/service/notification_service.rs
+++ b/src/meta/src/rpc/service/notification_service.rs
@@ -95,7 +95,6 @@ where
                     source,
                     table,
                     users,
-                    view: Default::default(),
                 };
                 tx.send(Ok(SubscribeResponse {
                     status: None,


### PR DESCRIPTION
I hereby agree to the terms of the [Singularity Data, Inc. Contributor License Agreement](https://gist.github.com/skyzh/0663682a70b0edde7ae991492f2314cb#file-s9y_cla).

## What's changed and what's your intention?

As title.

Please explain **IN DETAIL** what the changes are in this PR and why they are needed:

- Summarize your change (**mandatory**)
- How does this PR work? Need a brief introduction for the changed logic (optional)
- Describe clearly one logical change and avoid lazy messages (optional)
- Describe any limitations of the current code (optional)
- Add the 'user-facing changes' label if your PR contains changes that are visible to users (optional)

## Checklist

- [x] I have written necessary docs and comments
- [x] I have added necessary unit tests and integration tests
- [x] All checks passed in `./risedev check` (or alias, `./risedev c`)

## Refer to a related PR or issue link (optional)
