### PR TITLE
feat(storage): hummock support ttl ability with compaction_filter

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4543,6 +4543,7 @@ dependencies = [
  "criterion",
  "crossbeam",
  "dashmap",
+ "dyn-clone",
  "either",
  "enum-as-inner",
  "fail",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3944,6 +3944,7 @@ dependencies = [
  "async-stream",
  "async-trait",
  "auto_enums",
+ "bitflags",
  "byteorder",
  "bytes",
  "chrono",

--- a/proto/hummock.proto
+++ b/proto/hummock.proto
@@ -111,6 +111,10 @@ message KeyRange {
   bool inf = 3;
 }
 
+message TableOption {
+  uint32 ttl = 1;
+}
+
 message CompactTask {
   // SSTs to be compacted, which will be removed from LSM after compaction
   repeated Level input_ssts = 1;
@@ -136,6 +140,8 @@ message CompactTask {
   repeated uint32 existing_table_ids = 13;
   uint32 compression_algorithm = 14;
   uint64 target_file_size = 15;
+  uint32 compaction_filter_mask = 16;
+  map<uint32, TableOption> table_options = 17;
 }
 
 message LevelHandler {
@@ -158,11 +164,6 @@ message CompactionGroup {
   uint64 id = 1;
   repeated bytes member_prefixes = 2;
   CompactionConfig compaction_config = 3;
-
-  message TableOption {
-    uint32 ttl = 1;
-  }
-
   map<uint32, TableOption> table_id_to_options = 4;
 }
 
@@ -289,4 +290,5 @@ message CompactionConfig {
   CompactionMode compaction_mode = 8;
   repeated string compression_algorithm = 9;
   uint64 target_file_size_base = 10;
+  uint32 compaction_filter_mask = 11;
 }

--- a/src/common/Cargo.toml
+++ b/src/common/Cargo.toml
@@ -8,6 +8,7 @@ anyhow = "1"
 async-stream = "0.3"
 async-trait = "0.1"
 auto_enums = "0.7"
+bitflags = "1.3.2"
 byteorder = "1"
 bytes = "1"
 chrono = { version = "0.4", default-features = false, features = ["clock", "std"] }

--- a/src/common/src/config.rs
+++ b/src/common/src/config.rs
@@ -15,6 +15,7 @@
 use std::fs;
 use std::path::PathBuf;
 
+use bitflags::bitflags;
 use serde::{Deserialize, Serialize};
 
 use crate::error::ErrorCode::InternalError;
@@ -276,5 +277,21 @@ mod default {
     }
     pub fn share_buffer_upload_concurrency() -> usize {
         8
+    }
+}
+
+bitflags! {
+
+    #[derive(Default)]
+    pub struct CompactionFilterFlag: u32 {
+        const NONE = 0b00000000;
+        const STATE_CLEAN = 0b00000010;
+        const TTL = 0b00000100;
+    }
+}
+
+impl From<CompactionFilterFlag> for u32 {
+    fn from(flag: CompactionFilterFlag) -> Self {
+        flag.bits()
     }
 }

--- a/src/meta/src/hummock/compaction/compaction_config.rs
+++ b/src/meta/src/hummock/compaction/compaction_config.rs
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use risingwave_common::config::CompactionFilterFlag;
 use risingwave_pb::hummock::compaction_config::CompactionMode;
 use risingwave_pb::hummock::CompactionConfig;
 
@@ -53,6 +54,7 @@ impl CompactionConfigBuilder {
                     "Zstd".to_string(),
                     "Zstd".to_string(),
                 ],
+                compaction_filter_mask: (CompactionFilterFlag::NONE).into(),
             },
         }
     }
@@ -95,4 +97,5 @@ builder_field! {
     level0_tier_compact_file_number: u64,
     compaction_mode: i32,
     compression_algorithm: Vec<String>,
+    compaction_filter_mask: u32,
 }

--- a/src/meta/src/hummock/compaction/level_selector.rs
+++ b/src/meta/src/hummock/compaction/level_selector.rs
@@ -306,6 +306,7 @@ pub mod tests {
     use std::ops::Range;
 
     use itertools::Itertools;
+    use risingwave_common::config::CompactionFilterFlag;
     use risingwave_pb::hummock::compaction_config::CompactionMode;
     use risingwave_pb::hummock::{LevelType, SstableInfo};
 
@@ -458,10 +459,12 @@ pub mod tests {
         assert_eq!(compaction.select_level.table_infos.len(), 10);
         assert_eq!(compaction.target_level.table_infos.len(), 0);
 
+        let compaction_filter_flag = CompactionFilterFlag::STATE_CLEAN | CompactionFilterFlag::TTL;
         let config = CompactionConfigBuilder::new_with(config)
             .min_compaction_bytes(1)
             .max_bytes_for_level_base(100)
             .level0_tigger_file_numer(8)
+            .compaction_filter_mask(compaction_filter_flag.into())
             .build();
         let selector = DynamicLevelSelector::new(
             Arc::new(config.clone()),

--- a/src/meta/src/hummock/compaction/mod.rs
+++ b/src/meta/src/hummock/compaction/mod.rs
@@ -19,7 +19,7 @@ mod min_overlap_compaction_picker;
 mod overlap_strategy;
 mod prost_type;
 mod tier_compaction_picker;
-use std::collections::HashSet;
+use std::collections::{HashMap, HashSet};
 use std::fmt::{Debug, Formatter};
 use std::sync::Arc;
 
@@ -39,7 +39,7 @@ pub struct CompactStatus {
     compaction_group_id: CompactionGroupId,
     pub(crate) level_handlers: Vec<LevelHandler>,
     // TODO: remove this `CompactionConfig`, which is a duplicate of that in `CompactionGroup`.
-    compaction_config: CompactionConfig,
+    pub compaction_config: CompactionConfig,
     compaction_selector: Arc<dyn LevelSelector>,
 }
 
@@ -153,6 +153,8 @@ impl CompactStatus {
             existing_table_ids: vec![],
             compression_algorithm,
             target_file_size: ret.target_file_size,
+            compaction_filter_mask: 0,
+            table_options: HashMap::default(),
         };
         Some(compact_task)
     }

--- a/src/meta/src/hummock/compaction_group/manager.rs
+++ b/src/meta/src/hummock/compaction_group/manager.rs
@@ -82,7 +82,6 @@ impl<S: MetaStore> CompactionGroupManager<S> {
         table_properties: &HashMap<String, String>,
     ) -> Result<()> {
         let table_option = CompactionGroup::build_table_option(table_properties);
-
         let mut pairs = vec![];
         // materialized_view or materialized_source
         pairs.push((

--- a/src/meta/src/hummock/compaction_group/mod.rs
+++ b/src/meta/src/hummock/compaction_group/mod.rs
@@ -158,15 +158,15 @@ pub struct TableOption {
     ttl: u32,
 }
 
-impl From<&risingwave_pb::hummock::compaction_group::TableOption> for TableOption {
-    fn from(table_option: &risingwave_pb::hummock::compaction_group::TableOption) -> Self {
+impl From<&risingwave_pb::hummock::TableOption> for TableOption {
+    fn from(table_option: &risingwave_pb::hummock::TableOption) -> Self {
         Self {
             ttl: table_option.ttl,
         }
     }
 }
 
-impl From<&TableOption> for risingwave_pb::hummock::compaction_group::TableOption {
+impl From<&TableOption> for risingwave_pb::hummock::TableOption {
     fn from(table_option: &TableOption) -> Self {
         Self {
             ttl: table_option.ttl,

--- a/src/meta/src/hummock/compactor_manager.rs
+++ b/src/meta/src/hummock/compactor_manager.rs
@@ -143,6 +143,8 @@ impl CompactorManager {
 
 #[cfg(test)]
 mod tests {
+    use std::collections::HashMap;
+
     use risingwave_hummock_sdk::compaction_group::StaticCompactionGroupId;
     use risingwave_pb::hummock::CompactTask;
     use tokio::sync::mpsc::error::TryRecvError;
@@ -183,8 +185,10 @@ mod tests {
             vnode_mappings: vec![],
             compaction_group_id: StaticCompactionGroupId::StateDefault.into(),
             existing_table_ids: vec![],
-            target_file_size: 1,
             compression_algorithm: 0,
+            target_file_size: 1,
+            compaction_filter_mask: 0,
+            table_options: HashMap::default(),
         }
     }
 

--- a/src/meta/src/hummock/hummock_manager.rs
+++ b/src/meta/src/hummock/hummock_manager.rs
@@ -636,6 +636,22 @@ where
                     }
                 }
 
+                // build table_options
+                let compaction_group = self
+                    .compaction_group_manager
+                    .compaction_group(compaction_group_id)
+                    .await
+                    .unwrap();
+                compact_task.table_options = compaction_group
+                    .table_id_to_options()
+                    .iter()
+                    .filter(|id_to_option| compact_task.existing_table_ids.contains(id_to_option.0))
+                    .map(|id_to_option| (*id_to_option.0, id_to_option.1.into()))
+                    .collect();
+
+                compact_task.compaction_filter_mask =
+                    compact_status.compaction_config.compaction_filter_mask;
+
                 commit_multi_var!(self, None, compact_status)?;
                 tracing::trace!(
                     "For compaction group {}: pick up {} tables in level {} to compact, The number of total tables is {}. cost time: {:?}",

--- a/src/storage/Cargo.toml
+++ b/src/storage/Cargo.toml
@@ -9,10 +9,14 @@ async-trait = "0.1"
 auto_enums = { version = "0.7", features = ["futures"] }
 byteorder = "1"
 bytes = { version = "1", features = ["serde"] }
-chrono = { version = "0.4", default-features = false, features = ["clock", "std"] }
+chrono = { version = "0.4", default-features = false, features = [
+    "clock",
+    "std",
+] }
 crc32fast = "1"
 crossbeam = "0.8.1"
 dashmap = { version = "5", default-features = false }
+dyn-clone = "1.0.4"
 either = "1"
 enum-as-inner = "0.5"
 fail = "0.5"
@@ -69,7 +73,6 @@ twox-hash = "1"
 value-encoding = { path = "../utils/value-encoding" }
 workspace-hack = { version = "0.1", path = "../workspace-hack" }
 zstd = "0.11.2"
-dyn-clone = "1.0.4"
 
 [target.'cfg(target_os = "linux")'.dependencies]
 procinfo = { git = "https://github.com/tikv/procinfo-rs", rev = "6599eb9dca74229b2c1fcc44118bef7eff127128" }

--- a/src/storage/Cargo.toml
+++ b/src/storage/Cargo.toml
@@ -69,6 +69,7 @@ twox-hash = "1"
 value-encoding = { path = "../utils/value-encoding" }
 workspace-hack = { version = "0.1", path = "../workspace-hack" }
 zstd = "0.11.2"
+dyn-clone = "1.0.4"
 
 [target.'cfg(target_os = "linux")'.dependencies]
 procinfo = { git = "https://github.com/tikv/procinfo-rs", rev = "6599eb9dca74229b2c1fcc44118bef7eff127128" }

--- a/src/storage/hummock_sdk/src/key.rs
+++ b/src/storage/hummock_sdk/src/key.rs
@@ -56,6 +56,7 @@ pub fn split_key_epoch(full_key: &[u8]) -> (&[u8], &[u8]) {
 }
 
 /// Extracts epoch part from key
+#[inline(always)]
 pub fn get_epoch(full_key: &[u8]) -> Epoch {
     let mut epoch: Epoch = 0;
 
@@ -73,12 +74,24 @@ pub fn user_key(full_key: &[u8]) -> &[u8] {
 }
 
 /// Extract table id in key prefix
+#[inline(always)]
 pub fn get_table_id(full_key: &[u8]) -> Option<u32> {
     if full_key[0] == b't' {
         let mut buf = &full_key[1..];
         Some(buf.get_u32())
     } else {
         None
+    }
+}
+
+pub fn extract_table_id_and_epoch(full_key: &[u8]) -> (Option<u32>, Epoch) {
+    match get_table_id(full_key) {
+        Some(table_id) => {
+            let epoch = get_epoch(full_key);
+            (Some(table_id), epoch)
+        }
+
+        None => (None, 0),
     }
 }
 

--- a/src/storage/src/hummock/compactor.rs
+++ b/src/storage/src/hummock/compactor.rs
@@ -144,7 +144,16 @@ impl CompactionFilter for TTLCompactionFilter {
         let (table_id, epoch) = extract_table_id_and_epoch(key);
         match table_id {
             Some(table_id) => {
-                let ttl = self.table_id_to_ttl[&table_id];
+                let ttl = match self.table_id_to_ttl.get(&table_id) {
+                    Some(ttl_u32) => *ttl_u32,
+                    None => 0,
+                };
+
+                if ttl == 0 {
+                    // means not config ttl
+                    return true;
+                }
+
                 epoch + ttl as u64 > self.expire
             }
 

--- a/src/storage/src/hummock/compactor_tests.rs
+++ b/src/storage/src/hummock/compactor_tests.rs
@@ -121,7 +121,7 @@ mod tests {
             .await
             .unwrap()
             .unwrap();
-        let compaction_filter_flag = CompactionFilterFlag::STATE_CLEAN;
+        let compaction_filter_flag = CompactionFilterFlag::STATE_CLEAN | CompactionFilterFlag::TTL;
         compact_task.compaction_filter_mask = compaction_filter_flag.bits();
 
         hummock_manager_ref
@@ -250,7 +250,7 @@ mod tests {
             .unwrap()
             .unwrap();
 
-        let compaction_filter_flag = CompactionFilterFlag::STATE_CLEAN;
+        let compaction_filter_flag = CompactionFilterFlag::STATE_CLEAN | CompactionFilterFlag::TTL;
         compact_task.compaction_filter_mask = compaction_filter_flag.bits();
         // assert compact_task
         assert_eq!(
@@ -347,9 +347,8 @@ mod tests {
             .unwrap()
             .unwrap();
         compact_task.existing_table_ids.push(2);
-        let compaction_filter_flag = CompactionFilterFlag::STATE_CLEAN;
+        let compaction_filter_flag = CompactionFilterFlag::STATE_CLEAN | CompactionFilterFlag::TTL;
         compact_task.compaction_filter_mask = compaction_filter_flag.bits();
-        println!("compact_task watermark {}", compact_task.watermark);
 
         hummock_manager_ref
             .assign_compaction_task(&compact_task, worker_node.id, async { true })

--- a/src/storage/src/hummock/compactor_tests.rs
+++ b/src/storage/src/hummock/compactor_tests.rs
@@ -15,6 +15,7 @@
 #[cfg(test)]
 mod tests {
 
+    use std::collections::HashMap;
     use std::sync::Arc;
 
     use bytes::Bytes;
@@ -23,10 +24,10 @@ mod tests {
     use risingwave_common::config::{CompactionFilterFlag, StorageConfig};
     use risingwave_hummock_sdk::compaction_group::hummock_version_ext::HummockVersionExt;
     use risingwave_hummock_sdk::compaction_group::StaticCompactionGroupId;
-    use risingwave_hummock_sdk::key::get_table_id;
+    use risingwave_hummock_sdk::key::{get_epoch, get_table_id};
     use risingwave_meta::hummock::test_utils::setup_compute_env;
     use risingwave_meta::hummock::MockHummockMetaClient;
-    use risingwave_pb::hummock::HummockVersion;
+    use risingwave_pb::hummock::{HummockVersion, TableOption};
     use risingwave_rpc_client::HummockMetaClient;
 
     use crate::hummock::compactor::{get_remote_sstable_id_generator, Compactor, CompactorContext};
@@ -331,6 +332,7 @@ mod tests {
         compact_task.existing_table_ids.push(2);
         let compaction_filter_flag = CompactionFilterFlag::STATE_CLEAN;
         compact_task.compaction_filter_mask = compaction_filter_flag.bits();
+        println!("compact_task watermark {}", compact_task.watermark);
 
         hummock_manager_ref
             .assign_compaction_task(&compact_task, worker_node.id, async { true })
@@ -397,6 +399,128 @@ mod tests {
         for (k, _) in scan_result {
             let table_id = get_table_id(&k).unwrap();
             assert_eq!(table_id, existing_table_ids);
+            scan_count += 1;
+        }
+        assert_eq!(key_count, scan_count);
+    }
+
+    #[tokio::test]
+    async fn test_compaction_drop_key_by_ttl() {
+        let (_env, hummock_manager_ref, _cluster_manager_ref, worker_node) =
+            setup_compute_env(8080).await;
+        let hummock_meta_client = Arc::new(MockHummockMetaClient::new(
+            hummock_manager_ref.clone(),
+            worker_node.id,
+        ));
+        let storage = get_hummock_storage(hummock_meta_client.clone()).await;
+        let compact_ctx = CompactorContext {
+            options: storage.options().clone(),
+            sstable_store: storage.sstable_store(),
+            hummock_meta_client: hummock_meta_client.clone(),
+            stats: Arc::new(StateStoreMetrics::unused()),
+            is_share_buffer_compact: false,
+            sstable_id_generator: get_remote_sstable_id_generator(hummock_meta_client.clone()),
+            compaction_executor: None,
+        };
+
+        // 1. add sstables
+        let val = Bytes::from(b"0"[..].repeat(1 << 10)); // 1024 Byte value
+
+        let existing_table_id = 2;
+        let kv_count = 128;
+        let mut epoch: u64 = 1;
+        for _ in 0..kv_count {
+            let table_id = existing_table_id;
+            let keyspace = Keyspace::table_root(storage.clone(), &TableId::new(table_id));
+            let mut write_batch = keyspace.state_store().start_write_batch();
+            let mut local = write_batch.prefixify(&keyspace);
+            epoch += 1;
+
+            let ramdom_key = rand::thread_rng().gen::<[u8; 32]>();
+            local.put(ramdom_key, StorageValue::new_default_put(val.clone()));
+            write_batch.ingest(epoch).await.unwrap();
+
+            storage.sync(Some(epoch)).await.unwrap();
+            hummock_meta_client
+                .commit_epoch(
+                    epoch,
+                    storage.local_version_manager.get_uncommitted_ssts(epoch),
+                )
+                .await
+                .unwrap();
+        }
+
+        // 2. get compact task
+        let mut compact_task = hummock_manager_ref
+            .get_compact_task(StaticCompactionGroupId::StateDefault.into())
+            .await
+            .unwrap()
+            .unwrap();
+        compact_task.existing_table_ids.push(existing_table_id);
+        let compaction_filter_flag = CompactionFilterFlag::STATE_CLEAN | CompactionFilterFlag::TTL;
+        compact_task.compaction_filter_mask = compaction_filter_flag.bits();
+        let ttl_expire = 60;
+        compact_task.table_options =
+            HashMap::from_iter([(existing_table_id, TableOption { ttl: ttl_expire })]);
+        let watermark = compact_task.watermark;
+
+        hummock_manager_ref
+            .assign_compaction_task(&compact_task, worker_node.id, async { true })
+            .await
+            .unwrap();
+
+        // assert compact_task
+        assert_eq!(
+            compact_task.input_ssts.first().unwrap().table_infos.len(),
+            kv_count
+        );
+
+        // 3. compact
+        Compactor::compact(Arc::new(compact_ctx), compact_task.clone()).await;
+
+        // 4. get the latest version and check
+        let version: HummockVersion = hummock_manager_ref.get_current_version().await;
+        let table_ids_from_version: Vec<_> = version
+            .get_compaction_group_levels(StaticCompactionGroupId::StateDefault.into())
+            .iter()
+            .flat_map(|level| level.table_infos.iter())
+            .map(|table_info| table_info.id)
+            .collect::<Vec<_>>();
+
+        let mut key_count = 0;
+        for table_id in table_ids_from_version {
+            key_count += storage
+                .sstable_store()
+                .sstable(table_id, &mut StoreLocalStatistic::default())
+                .await
+                .unwrap()
+                .value()
+                .meta
+                .key_count;
+        }
+        assert_eq!(ttl_expire, key_count);
+
+        // 5. get compact task and there should be none
+        let compact_task = hummock_manager_ref
+            .get_compact_task(StaticCompactionGroupId::StateDefault.into())
+            .await
+            .unwrap();
+        assert!(compact_task.is_none());
+
+        epoch += 1;
+        // to update version for hummock_storage
+        storage
+            .local_version_manager()
+            .try_update_pinned_version(version);
+
+        // 6. scan kv to check key table_id
+        let scan_result = storage.scan::<_, Vec<u8>>(.., None, epoch).await.unwrap();
+        let mut scan_count = 0;
+        for (k, _) in scan_result {
+            let table_id = get_table_id(&k).unwrap();
+            let epoch = get_epoch(&k);
+            assert_eq!(table_id, existing_table_id);
+            assert!(epoch >= (watermark - ttl_expire as u64));
             scan_count += 1;
         }
         assert_eq!(key_count, scan_count);


### PR DESCRIPTION
I hereby agree to the terms of the [Singularity Data, Inc. Contributor License Agreement](https://gist.github.com/skyzh/0663682a70b0edde7ae991492f2314cb#file-s9y_cla).

hummock support ttl ability with compaction_filter

- bitflags to control compaction_filter 
- multi_compaction_filter (state_clean_up and ttl)
- transfer table_opiton and mask to compactor for compaction_filter
- unit-test for ttl_compaction_filter

## Checklist

- [x] I have written necessary docs and comments
- [x] I have added necessary unit tests and integration tests

## Refer to a related PR or issue link (optional)
- https://github.com/singularity-data/risingwave/issues/3298