### PR TITLE
refine(dashboard): layout and loading indicator

### DIFF
--- a/dashboard/components/Layout.js
+++ b/dashboard/components/Layout.js
@@ -16,9 +16,9 @@
  */
 import Head from 'next/head'
 import Link from 'next/link';
+import { useRouter } from 'next/router';
 
-import React from 'react';
-import { useState } from 'react';
+import React, { useState } from 'react';
 import { styled, useTheme } from '@mui/material/styles';
 import Box from '@mui/material/Box';
 import Drawer from '@mui/material/Drawer';
@@ -98,25 +98,24 @@ const NavBarNavigationItem = styled('div')(() => ({
   alignItems: "center"
 }));
 
-const NavBarItem = (props) => {
+const NavBarItem = ({ text, icon }) => {
+  const { pathname } = useRouter();
   return (
-    <ListItemButton key={props.text} selected={props.currentPage === props.text}>
-      <Link href={"/" + props.text}>
+    <Link href={`/${text}`}>
+      <ListItemButton key={text} selected={pathname.slice(1) === text}>
         <NavBarNavigationItem>
-          <ListItemIcon>
-            {props.icon}
-          </ListItemIcon>
-          <span style={{ fontSize: "15px" }}>{capitalize(props.text)}</span>
+          <ListItemIcon>{icon}</ListItemIcon>
+          <span style={{ fontSize: "15px" }}>{capitalize(text)}</span>
         </NavBarNavigationItem>
-      </Link>
-    </ListItemButton>
+      </ListItemButton>
+    </Link>
   )
-}
+};
 
-export default function Layout(props) {
+export default function Layout({ children }) {
+  const { pathname } = useRouter();
   const theme = useTheme();
   const [open, setOpen] = useState(true);
-  const [currentPage, setCurrentPage] = useState(props.currentPage ? props.currentPage : " ");
   const handleDrawerOpen = () => {
     setOpen(true);
   };
@@ -124,17 +123,6 @@ export default function Layout(props) {
   const handleDrawerClose = () => {
     setOpen(false);
   };
-
-  const WrapNavItem = (props) => (
-    <>
-      <NavBarItem
-        text={props.text}
-        icon={props.icon}
-        currentPage={currentPage}
-        setCurrentPage={setCurrentPage}
-      />
-    </>
-  )
 
   return (
     <>
@@ -156,7 +144,7 @@ export default function Layout(props) {
               <MenuIcon />
             </IconButton>
             <div>
-              {capitalize(currentPage)}
+              {capitalize(pathname.slice(1) || ' ')}
             </div>
           </Toolbar>
         </AppBar>
@@ -191,18 +179,18 @@ export default function Layout(props) {
           </DrawerHeader>
           <Divider />
           <List>
-            <WrapNavItem
+            <NavBarItem
               text='cluster'
               icon={<ViewComfyIcon fontSize="small" />}
             />
-            <WrapNavItem
+            <NavBarItem
               text='streaming'
               icon={<DoubleArrowIcon fontSize="small" />}
             />
           </List>
           <Divider />
           <List>
-            <WrapNavItem
+            <NavBarItem
               text='about'
               icon={<InfoIcon fontSize="small" />}
             />
@@ -211,7 +199,7 @@ export default function Layout(props) {
         <Main open={open}>
           <div style={{height: "68px"}}></div>
           <div style={{width: "calc(100vw - 275px)", height: "calc(100% - 68px)"}}>
-            {props.children}
+            {children}
           </div>
         </Main>
       </Box>

--- a/dashboard/pages/_app.js
+++ b/dashboard/pages/_app.js
@@ -30,12 +30,12 @@ export default function App({ Component, pageProps }) {
     router.events.on("routeChangeStart", () => setIsLoading(true));
     router.events.on('routeChangeComplete', () => setIsLoading(false));
     router.events.on('routeChangeError', () => setIsLoading(false));
-  })
+  }, [])
 
-  return isLoading
-    ? <div>Loading</div> 
-    : <Layout>
-      <Component {...pageProps} />
-    </Layout> ;
+  return (
+    <Layout>
+      {isLoading ? <p>Loading...</p> : <Component {...pageProps} />}
+    </Layout>
+  );
 }
 


### PR DESCRIPTION
I hereby agree to the terms of the [Singularity Data, Inc. Contributor License Agreement](https://gist.github.com/skyzh/0663682a70b0edde7ae991492f2314cb#file-s9y_cla).

## What's changed and what's your intention?

- Fix page flashing caused by loading wrapper.
- Add layout title and fix nav item animation

From: 
![image](https://user-images.githubusercontent.com/11549583/175504870-42fa9486-83b8-4e93-a6af-d3e855a196a4.png)
![image](https://user-images.githubusercontent.com/11549583/175504946-efd88c98-ad7e-47ca-abb1-3ebc6b3ee900.png)

To:
![image](https://user-images.githubusercontent.com/11549583/175503108-ca731cb2-a962-4536-9c66-6c9186be18e9.png)

## Checklist

- [x] I have written necessary docs and comments
- [x] I have added necessary unit tests and integration tests
- [x] All checks passed in `./risedev check` (or alias, `./risedev c`)

## Refer to a related PR or issue link (optional)
