### PR TITLE
fix(array): inconsistent hash behavior of `Datum` and `Array::Item`

### DIFF
--- a/src/common/src/array/mod.rs
+++ b/src/common/src/array/mod.rs
@@ -75,7 +75,7 @@ pub type F64ArrayBuilder = PrimitiveArrayBuilder<OrderedF64>;
 pub type F32ArrayBuilder = PrimitiveArrayBuilder<OrderedF32>;
 
 /// The hash source for `None` values when hashing an item.
-static NULL_VAL_FOR_HASH: u32 = 0xfffffff0;
+pub(crate) static NULL_VAL_FOR_HASH: u32 = 0xfffffff0;
 
 /// A trait over all array builders.
 ///

--- a/src/common/src/types/mod.rs
+++ b/src/common/src/types/mod.rs
@@ -592,8 +592,8 @@ impl Hash for ScalarImpl {
                     Self::Bool(b) => b.hash(state),
                     Self::Utf8(s) => state.write(s.as_bytes()),
                     Self::Decimal(decimal) => decimal.normalize().hash(state),
-                    Self::Struct(v) => v.hash(state), // TODO: check if this is consistent to `StructArray::hash_at`
-                    Self::List(v) => v.hash(state),   // TODO: check if this is consistent to `ListArray::hash_at`
+                    Self::Struct(v) => v.hash(state), // TODO: check if this is consistent with `StructArray::hash_at`
+                    Self::List(v) => v.hash(state),   // TODO: check if this is consistent with `ListArray::hash_at`
                 }
             };
         }

--- a/src/common/src/types/mod.rs
+++ b/src/common/src/types/mod.rs
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 use std::convert::TryFrom;
+use std::hash::Hash;
 use std::sync::Arc;
 
 use anyhow::anyhow;
@@ -20,7 +21,7 @@ use bytes::{Buf, BufMut};
 use risingwave_pb::data::DataType as ProstDataType;
 use serde::{Deserialize, Serialize};
 
-use crate::array::{ArrayError, ArrayResult};
+use crate::array::{ArrayError, ArrayResult, NULL_VAL_FOR_HASH};
 mod native_type;
 mod ops;
 mod scalar_impl;
@@ -530,7 +531,7 @@ macro_rules! impl_convert {
 
 for_all_scalar_variants! { impl_convert }
 
-// Implement `From<raw float>` for `ScalarImpl` manually/
+// Implement `From<raw float>` for `ScalarImpl` manually
 impl From<f32> for ScalarImpl {
     fn from(f: f32) -> Self {
         Self::Float32(f.into())
@@ -571,30 +572,43 @@ macro_rules! impl_scalar_impl_ref_conversion {
 
 for_all_scalar_variants! { impl_scalar_impl_ref_conversion }
 
-// FIXME: should implement Hash and Eq all by deriving
-// TODO: may take type information into consideration later
+/// Should behave the same as [`crate::array::Array::hash_at`] for non-null items.
 #[expect(clippy::derive_hash_xor_eq)]
-impl std::hash::Hash for ScalarImpl {
+impl Hash for ScalarImpl {
     fn hash<H: std::hash::Hasher>(&self, state: &mut H) {
         macro_rules! impl_all_hash {
             ([$self:ident], $({ $variant_type:ty, $scalar_type:ident } ),*) => {
                 match $self {
+                    // Primitive types
                     $( Self::$scalar_type(inner) => {
                         NativeType::hash_wrapper(inner, state);
                     }, )*
-                    Self::Bool(b) => b.hash(state),
-                    Self::Utf8(s) => s.hash(state),
-                    Self::Decimal(decimal) => decimal.hash(state),
                     Self::Interval(interval) => interval.hash(state),
                     Self::NaiveDate(naivedate) => naivedate.hash(state),
-                    Self::NaiveDateTime(naivedatetime) => naivedatetime.hash(state),
                     Self::NaiveTime(naivetime) => naivetime.hash(state),
-                    Self::Struct(v) => v.hash(state),
-                    Self::List(v) => v.hash(state),
+                    Self::NaiveDateTime(naivedatetime) => naivedatetime.hash(state),
+
+                    // Manually implemented
+                    Self::Bool(b) => b.hash(state),
+                    Self::Utf8(s) => state.write(s.as_bytes()),
+                    Self::Decimal(decimal) => decimal.normalize().hash(state),
+                    Self::Struct(v) => v.hash(state), // TODO: check if this is consistent to `StructArray::hash_at`
+                    Self::List(v) => v.hash(state),   // TODO: check if this is consistent to `ListArray::hash_at`
                 }
             };
         }
         for_all_native_types! { impl_all_hash, self }
+    }
+}
+
+/// Feeds the raw scalar of `datum` to the given `state`, which should behave the same as
+/// [`crate::array::Array::hash_at`]. NULL value will be carefully handled.
+///
+/// Caveats: this relies on the above implementation of [`Hash`].
+pub fn hash_datum(datum: &Datum, state: &mut impl std::hash::Hasher) {
+    match datum {
+        Some(scalar) => scalar.hash(state),
+        None => NULL_VAL_FOR_HASH.hash(state),
     }
 }
 

--- a/src/storage/src/table/cell_based_table.rs
+++ b/src/storage/src/table/cell_based_table.rs
@@ -240,10 +240,7 @@ impl<S: StateStore, const T: AccessType> CellBasedTable<S, T> {
     /// Get vnode value with given primary key.
     fn compute_vnode_by_pk(&self, pk: &Row) -> VirtualNode {
         let vnode = match self.dist_key_in_pk_indices.as_ref() {
-            Some(indices) => pk
-                .hash_by_indices(indices, &CRC32FastBuilder {})
-                .unwrap()
-                .to_vnode(),
+            Some(indices) => pk.hash_by_indices(indices, &CRC32FastBuilder {}).to_vnode(),
             None => DEFAULT_VNODE,
         };
         // This table should only be used to access entries with vnode specified in `self.vnodes`.
@@ -323,7 +320,6 @@ impl<S: StateStore> CellBasedTable<S, READ_WRITE> {
         let vnode = match self.dist_key_indices.as_ref() {
             Some(indices) => row
                 .hash_by_indices(indices, &CRC32FastBuilder {})
-                .unwrap()
                 .to_vnode(),
             None => DEFAULT_VNODE,
         };


### PR DESCRIPTION
I hereby agree to the terms of the [Singularity Data, Inc. Contributor License Agreement](https://gist.github.com/skyzh/0663682a70b0edde7ae991492f2314cb#file-s9y_cla).

## What's changed and what's your intention?

As title. This is a fix for common types except for array and struct. Check #3457 for more details.

## Checklist

- [x] I have written necessary docs and comments
- [x] I have added necessary unit tests and integration tests
- [x] All checks passed in `./risedev check` (or alias, `./risedev c`)

## Refer to a related PR or issue link (optional)
- #3457