### PR TITLE
feat: add pause barrier and resume barrier

### DIFF
--- a/proto/meta.proto
+++ b/proto/meta.proto
@@ -192,3 +192,17 @@ message MetaLeaseInfo {
   uint64 lease_register_time = 2;
   uint64 lease_expire_time = 3;
 }
+
+message PauseRequest {}
+
+message PauseResponse {}
+
+message ResumeRequest {}
+
+message ResumeResponse {}
+
+service ScaleService {
+  // TODO(Kexiang): delete them when config change interface is finished
+  rpc Pause(PauseRequest) returns (PauseResponse);
+  rpc Resume(ResumeRequest) returns (ResumeResponse);
+}

--- a/proto/stream_plan.proto
+++ b/proto/stream_plan.proto
@@ -42,6 +42,10 @@ message AddDispatcherMutation {
   map<uint32, source.ConnectorSplits> actor_splits = 2;
 }
 
+message PauseMutation {}
+
+message ResumeMutation {}
+
 message Barrier {
   data.Epoch epoch = 1;
   oneof mutation {
@@ -50,6 +54,8 @@ message Barrier {
     AddMutation add = 5;
     AddDispatcherMutation add_dispatcher = 8;
     SourceChangeSplitMutation splits = 7;
+    PauseMutation pause = 9;
+    ResumeMutation resume = 10;
   }
   bytes span = 6;
 }

--- a/src/meta/src/barrier/command.rs
+++ b/src/meta/src/barrier/command.rs
@@ -23,7 +23,9 @@ use risingwave_connector::source::SplitImpl;
 use risingwave_pb::source::{ConnectorSplit, ConnectorSplits};
 use risingwave_pb::stream_plan::add_dispatcher_mutation::Dispatchers;
 use risingwave_pb::stream_plan::barrier::Mutation;
-use risingwave_pb::stream_plan::{AddDispatcherMutation, Dispatcher, StopMutation};
+use risingwave_pb::stream_plan::{
+    AddDispatcherMutation, Dispatcher, PauseMutation, ResumeMutation, StopMutation,
+};
 use risingwave_pb::stream_service::DropActorsRequest;
 use risingwave_rpc_client::StreamClientPoolRef;
 use uuid::Uuid;
@@ -72,6 +74,14 @@ pub enum Command {
 impl Command {
     pub fn checkpoint() -> Self {
         Self::Plain(None)
+    }
+
+    pub fn pause() -> Self {
+        Self::Plain(Some(Mutation::Pause(PauseMutation {})))
+    }
+
+    pub fn resume() -> Self {
+        Self::Plain(Some(Mutation::Resume(ResumeMutation {})))
     }
 
     pub fn changed_table_id(&self) -> ChangedTableState {

--- a/src/meta/src/rpc/server.rs
+++ b/src/meta/src/rpc/server.rs
@@ -27,6 +27,7 @@ use risingwave_pb::hummock::hummock_manager_service_server::HummockManagerServic
 use risingwave_pb::meta::cluster_service_server::ClusterServiceServer;
 use risingwave_pb::meta::heartbeat_service_server::HeartbeatServiceServer;
 use risingwave_pb::meta::notification_service_server::NotificationServiceServer;
+use risingwave_pb::meta::scale_service_server::ScaleServiceServer;
 use risingwave_pb::meta::stream_manager_service_server::StreamManagerServiceServer;
 use risingwave_pb::meta::{MetaLeaderInfo, MetaLeaseInfo};
 use risingwave_pb::user::user_service_server::UserServiceServer;
@@ -35,6 +36,7 @@ use tokio::task::JoinHandle;
 
 use super::intercept::MetricsMiddlewareLayer;
 use super::service::notification_service::NotificationServiceImpl;
+use super::service::scale_service::ScaleServiceImpl;
 use super::DdlServiceImpl;
 use crate::barrier::GlobalBarrierManager;
 use crate::cluster::ClusterManager;
@@ -406,6 +408,7 @@ pub async fn rpc_serve_with_store<S: MetaStore>(
         fragment_manager.clone(),
     );
     let user_srv = UserServiceImpl::<S>::new(catalog_manager.clone(), user_manager.clone());
+    let scale_srv = ScaleServiceImpl::<S>::new(barrier_manager.clone());
     let cluster_srv = ClusterServiceImpl::<S>::new(cluster_manager.clone());
     let stream_srv = StreamServiceImpl::<S>::new(
         env.clone(),
@@ -477,6 +480,7 @@ pub async fn rpc_serve_with_store<S: MetaStore>(
             .add_service(NotificationServiceServer::new(notification_srv))
             .add_service(DdlServiceServer::new(ddl_srv))
             .add_service(UserServiceServer::new(user_srv))
+            .add_service(ScaleServiceServer::new(scale_srv))
             .serve(address_info.listen_addr)
             .await
             .unwrap();

--- a/src/meta/src/rpc/service/mod.rs
+++ b/src/meta/src/rpc/service/mod.rs
@@ -17,6 +17,7 @@ pub mod ddl_service;
 pub mod heartbeat_service;
 pub mod hummock_service;
 pub mod notification_service;
+pub mod scale_service;
 pub mod stream_service;
 pub mod user_service;
 

--- a/src/meta/src/rpc/service/scale_service.rs
+++ b/src/meta/src/rpc/service/scale_service.rs
@@ -1,0 +1,51 @@
+// Copyright 2022 Singularity Data
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use risingwave_pb::meta::scale_service_server::ScaleService;
+use risingwave_pb::meta::{PauseRequest, PauseResponse, ResumeRequest, ResumeResponse};
+use tonic::{Request, Response, Status};
+
+use crate::barrier::{BarrierManagerRef, Command};
+use crate::storage::MetaStore;
+
+pub struct ScaleServiceImpl<S: MetaStore> {
+    barrier_manager: BarrierManagerRef<S>,
+}
+
+impl<S> ScaleServiceImpl<S>
+where
+    S: MetaStore,
+{
+    pub fn new(barrier_manager: BarrierManagerRef<S>) -> Self {
+        Self { barrier_manager }
+    }
+}
+
+#[async_trait::async_trait]
+impl<S> ScaleService for ScaleServiceImpl<S>
+where
+    S: MetaStore,
+{
+    #[cfg_attr(coverage, no_coverage)]
+    async fn pause(&self, _: Request<PauseRequest>) -> Result<Response<PauseResponse>, Status> {
+        self.barrier_manager.run_command(Command::pause()).await?;
+        Ok(Response::new(PauseResponse {}))
+    }
+
+    #[cfg_attr(coverage, no_coverage)]
+    async fn resume(&self, _: Request<ResumeRequest>) -> Result<Response<ResumeResponse>, Status> {
+        self.barrier_manager.run_command(Command::resume()).await?;
+        Ok(Response::new(ResumeResponse {}))
+    }
+}

--- a/src/meta/src/rpc/service/scale_service.rs
+++ b/src/meta/src/rpc/service/scale_service.rs
@@ -12,8 +12,11 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use std::sync::Arc;
+
 use risingwave_pb::meta::scale_service_server::ScaleService;
 use risingwave_pb::meta::{PauseRequest, PauseResponse, ResumeRequest, ResumeResponse};
+use tokio::sync::RwLock;
 use tonic::{Request, Response, Status};
 
 use crate::barrier::{BarrierManagerRef, Command};
@@ -21,14 +24,18 @@ use crate::storage::MetaStore;
 
 pub struct ScaleServiceImpl<S: MetaStore> {
     barrier_manager: BarrierManagerRef<S>,
+    ddl_lock: Arc<RwLock<()>>,
 }
 
 impl<S> ScaleServiceImpl<S>
 where
     S: MetaStore,
 {
-    pub fn new(barrier_manager: BarrierManagerRef<S>) -> Self {
-        Self { barrier_manager }
+    pub fn new(barrier_manager: BarrierManagerRef<S>, ddl_lock: Arc<RwLock<()>>) -> Self {
+        Self {
+            barrier_manager,
+            ddl_lock,
+        }
     }
 }
 
@@ -39,12 +46,14 @@ where
 {
     #[cfg_attr(coverage, no_coverage)]
     async fn pause(&self, _: Request<PauseRequest>) -> Result<Response<PauseResponse>, Status> {
+        self.ddl_lock.write().await;
         self.barrier_manager.run_command(Command::pause()).await?;
         Ok(Response::new(PauseResponse {}))
     }
 
     #[cfg_attr(coverage, no_coverage)]
     async fn resume(&self, _: Request<ResumeRequest>) -> Result<Response<ResumeResponse>, Status> {
+        self.ddl_lock.write().await;
         self.barrier_manager.run_command(Command::resume()).await?;
         Ok(Response::new(ResumeResponse {}))
     }

--- a/src/stream/src/executor/mod.rs
+++ b/src/stream/src/executor/mod.rs
@@ -35,7 +35,7 @@ use risingwave_pb::stream_plan::barrier::Mutation as ProstMutation;
 use risingwave_pb::stream_plan::stream_message::StreamMessage;
 use risingwave_pb::stream_plan::{
     AddDispatcherMutation, AddMutation, Barrier as ProstBarrier, Dispatcher as ProstDispatcher,
-    DispatcherMutation, SourceChangeSplitMutation, StopMutation,
+    DispatcherMutation, PauseMutation, ResumeMutation, SourceChangeSplitMutation, StopMutation,
     StreamMessage as ProstStreamMessage, UpdateMutation,
 };
 use smallvec::SmallVec;
@@ -193,6 +193,8 @@ pub enum Mutation {
     AddOutput(AddOutput),
     AddDispatcher(AddDispatcher),
     SourceChangeSplit(HashMap<ActorId, ConnectorState>),
+    Pause,
+    Resume,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq)]
@@ -375,6 +377,8 @@ impl Mutation {
                         .collect(),
                 })
             }
+            Mutation::Pause => ProstMutation::Pause(PauseMutation {}),
+            Mutation::Resume => ProstMutation::Resume(ResumeMutation {}),
         }
     }
 
@@ -473,6 +477,8 @@ impl Mutation {
                         .collect::<HashMap<ActorId, ConnectorState>>(),
                 )
             }
+            ProstMutation::Pause(_) => Mutation::Pause,
+            ProstMutation::Resume(_) => Mutation::Resume,
         };
         Ok(mutation)
     }

--- a/src/stream/src/executor/source/source_executor.rs
+++ b/src/stream/src/executor/source/source_executor.rs
@@ -247,24 +247,31 @@ impl<S: StateStore> SourceExecutor<S> {
                     let epoch = barrier.epoch.prev;
                     self.take_snapshot(epoch).await?;
 
-                    if let Some(Mutation::SourceChangeSplit(mapping)) = barrier.mutation.as_deref()
-                    {
-                        if let Some(target_splits) = mapping.get(&self.actor_id).cloned() {
-                            if let Some(target_state) = self.get_diff(target_splits) {
-                                log::info!(
-                                    "actor {:?} apply source split change to {:?}",
-                                    self.actor_id,
-                                    target_state
-                                );
+                    if let Some(mutation) = barrier.mutation.as_deref() {
+                        match mutation {
+                            Mutation::SourceChangeSplit(mapping) => {
+                                if let Some(target_splits) = mapping.get(&self.actor_id).cloned() {
+                                    if let Some(target_state) = self.get_diff(target_splits) {
+                                        log::info!(
+                                            "actor {:?} apply source split change to {:?}",
+                                            self.actor_id,
+                                            target_state
+                                        );
 
-                                // Replace the source reader with a new one of the new state.
-                                let reader = self
-                                    .build_stream_source_reader(Some(target_state.clone()))
-                                    .await?;
-                                stream.replace_source_chunk_reader(reader);
+                                        // Replace the source reader with a new one of the new
+                                        // state.
+                                        let reader = self
+                                            .build_stream_source_reader(Some(target_state.clone()))
+                                            .await?;
+                                        stream.replace_source_chunk_reader(reader);
 
-                                self.stream_source_splits = target_state;
+                                        self.stream_source_splits = target_state;
+                                    }
+                                }
                             }
+                            Mutation::Pause => stream.pause_source(),
+                            Mutation::Resume => stream.resume_source(),
+                            _ => {}
                         }
                     }
                     self.state_cache.clear();
@@ -783,6 +790,13 @@ mod tests {
         );
         assert_eq!(drop_row_id(chunk_3.unwrap()), drop_row_id(chunk_3_truth));
 
+        let pause_barrier =
+            Barrier::new_test_barrier(curr_epoch + 2).with_mutation(Mutation::Pause);
+        barrier_tx.send(pause_barrier).unwrap();
+
+        let pause_barrier =
+            Barrier::new_test_barrier(curr_epoch + 3).with_mutation(Mutation::Resume);
+        barrier_tx.send(pause_barrier).unwrap();
         Ok(())
     }
 }


### PR DESCRIPTION
I hereby agree to the terms of the [Singularity Data, Inc. Contributor License Agreement](https://gist.github.com/skyzh/0663682a70b0edde7ae991492f2314cb#file-s9y_cla).

## What's changed and what's your intention?

Add pause barrier and resume barrier.
Once received pause barrier, the source executor will stop to read from source and only receive new barriers.
Scale service in Meta and two interfaces are added to do testing and controling.

## Checklist

- [x] I have written necessary docs and comments
- [x] I have added necessary unit tests and integration tests
- [x] All checks passed in `./risedev check` (or alias, `./risedev c`)

## Refer to a related PR or issue link (optional)
https://github.com/singularity-data/risingwave/issues/3292