### PR TITLE
refactor(relational_states): use fe table catalog for hash agg

### DIFF
--- a/src/common/src/catalog/column.rs
+++ b/src/common/src/catalog/column.rs
@@ -189,7 +189,7 @@ impl ColumnDesc {
     }
 }
 
-impl From<ProstColumnDesc> for ColumnDesc {
+impl std::convert::From<ProstColumnDesc> for ColumnDesc {
     fn from(prost: ProstColumnDesc) -> Self {
         let field_descs: Vec<ColumnDesc> = prost
             .field_descs
@@ -206,7 +206,7 @@ impl From<ProstColumnDesc> for ColumnDesc {
     }
 }
 
-impl From<&ProstColumnDesc> for ColumnDesc {
+impl std::convert::From<&ProstColumnDesc> for ColumnDesc {
     fn from(prost: &ProstColumnDesc) -> Self {
         prost.clone().into()
     }

--- a/src/common/src/catalog/column.rs
+++ b/src/common/src/catalog/column.rs
@@ -189,7 +189,7 @@ impl ColumnDesc {
     }
 }
 
-impl std::convert::From<ProstColumnDesc> for ColumnDesc {
+impl From<ProstColumnDesc> for ColumnDesc {
     fn from(prost: ProstColumnDesc) -> Self {
         let field_descs: Vec<ColumnDesc> = prost
             .field_descs
@@ -206,7 +206,7 @@ impl std::convert::From<ProstColumnDesc> for ColumnDesc {
     }
 }
 
-impl std::convert::From<&ProstColumnDesc> for ColumnDesc {
+impl From<&ProstColumnDesc> for ColumnDesc {
     fn from(prost: &ProstColumnDesc) -> Self {
         prost.clone().into()
     }

--- a/src/frontend/src/optimizer/plan_node/logical_agg.rs
+++ b/src/frontend/src/optimizer/plan_node/logical_agg.rs
@@ -135,10 +135,8 @@ impl LogicalAgg {
             let mut columns = vec![];
             let mut column_names = HashMap::new(); // avoid duplicate column name
             let mut order_desc = vec![];
-            // TODO: Should maintain column_mappings correctly.
-            // TODO: Refactor, re-use this part of code..
             for &idx in &self.group_keys {
-                Self::append_column_desc(
+                Self::add_column_desc(
                     &mut columns,
                     &mut column_mapping,
                     &mut column_names,
@@ -159,7 +157,7 @@ impl LogicalAgg {
                         // Add sort key as part of pk.
                         // TODO: Need to check whether string agg needs this.
                         for input in &agg_call.inputs {
-                            Self::append_column_desc(
+                            Self::add_column_desc(
                                 &mut columns,
                                 &mut column_mapping,
                                 &mut column_names,
@@ -181,7 +179,7 @@ impl LogicalAgg {
 
                         // Add upstream pk.
                         for pk_index in &base.pk_indices {
-                            Self::append_column_desc(
+                            Self::add_column_desc(
                                 &mut columns,
                                 &mut column_mapping,
                                 &mut column_names,
@@ -200,7 +198,7 @@ impl LogicalAgg {
 
                     // TODO: Remove this (3474)
                     for input in &agg_call.inputs {
-                        Self::append_column_desc(
+                        Self::add_column_desc(
                             &mut columns,
                             &mut column_mapping,
                             &mut column_names,
@@ -244,7 +242,9 @@ impl LogicalAgg {
         (table_catalogs, column_mapping)
     }
 
-    fn append_column_desc(
+    /// Add a column catalog to the end of `columns`. Also update the `column_mapping` and
+    /// `column_names`.
+    fn add_column_desc(
         columns: &mut Vec<ColumnCatalog>,
         column_mapping: &mut HashMap<usize, i32>,
         column_names: &mut HashMap<String, i32>,

--- a/src/stream/src/executor/aggregation/mod.rs
+++ b/src/stream/src/executor/aggregation/mod.rs
@@ -399,6 +399,7 @@ pub fn generate_column_descs(
 
 /// Generate state table for agg executor.
 /// Relational pk = `table_desc.len` - 1.
+/// After finished the refactor of frontend infer table catalog, should mark it as unit test only.
 pub fn generate_state_table<S: StateStore>(
     ks: Keyspace<S>,
     agg_call: &AggCall,

--- a/src/stream/src/executor/hash_agg.rs
+++ b/src/stream/src/executor/hash_agg.rs
@@ -29,15 +29,14 @@ use risingwave_common::error::Result;
 use risingwave_common::hash::{HashCode, HashKey};
 use risingwave_common::util::hash_util::CRC32FastBuilder;
 use risingwave_storage::table::state_table::StateTable;
-use risingwave_storage::{StateStore};
+use risingwave_storage::StateStore;
 
 use super::{
     expect_first_barrier, pk_input_arrays, Executor, PkDataTypes, PkIndicesRef,
     StreamExecutorResult,
 };
 use crate::executor::aggregation::{
-    agg_input_arrays, generate_agg_schema, generate_managed_agg_state,
-    AggCall, AggState,
+    agg_input_arrays, generate_agg_schema, generate_managed_agg_state, AggCall, AggState,
 };
 use crate::executor::error::StreamExecutorError;
 use crate::executor::{BoxedMessageStream, Message, PkIndices, PROCESSING_WINDOW_SIZE};
@@ -111,7 +110,7 @@ impl<K: HashKey, S: StateStore> HashAggExecutor<K, S> {
         pk_indices: PkIndices,
         executor_id: u64,
         key_indices: Vec<usize>,
-        state_tables: Vec<StateTable<S>>
+        state_tables: Vec<StateTable<S>>,
     ) -> Result<Self> {
         let input_info = input.info();
         let schema = generate_agg_schema(input.as_ref(), &agg_calls, Some(&key_indices));
@@ -453,10 +452,12 @@ mod tests {
     use risingwave_common::hash::{calc_hash_key_kind, HashKey, HashKeyDispatcher};
     use risingwave_common::types::DataType;
     use risingwave_expr::expr::*;
-    use risingwave_storage::{Keyspace, StateStore};
     use risingwave_storage::table::state_table::StateTable;
+    use risingwave_storage::{Keyspace, StateStore};
 
-    use crate::executor::aggregation::{AggArgs, AggCall, generate_agg_schema, generate_state_table};
+    use crate::executor::aggregation::{
+        generate_agg_schema, generate_state_table, AggArgs, AggCall,
+    };
     use crate::executor::test_utils::*;
     use crate::executor::{Executor, HashAggExecutor, Message, PkIndices};
 
@@ -482,7 +483,7 @@ mod tests {
                 args.pk_indices,
                 args.executor_id,
                 args.key_indices,
-                args.state_tables
+                args.state_tables,
             )?))
         }
     }
@@ -500,21 +501,27 @@ mod tests {
             .map(|idx| input.schema().fields[*idx].data_type())
             .collect_vec();
         let agg_schema = generate_agg_schema(input.as_ref(), &agg_calls, Some(&key_indices));
-        let state_tables = keyspace.iter().zip_eq(agg_calls.iter()).map(|(ks, agg_call) | generate_state_table(
-            ks.clone(),
-            agg_call,
-            &key_indices,
-            &pk_indices,
-            &agg_schema,
-            input.as_ref(),
-        )).collect();
+        let state_tables = keyspace
+            .iter()
+            .zip_eq(agg_calls.iter())
+            .map(|(ks, agg_call)| {
+                generate_state_table(
+                    ks.clone(),
+                    agg_call,
+                    &key_indices,
+                    &pk_indices,
+                    &agg_schema,
+                    input.as_ref(),
+                )
+            })
+            .collect();
         let args = HashAggExecutorDispatcherArgs {
             input,
             agg_calls,
             key_indices,
             pk_indices,
             executor_id,
-            state_tables
+            state_tables,
         };
         let kind = calc_hash_key_kind(&keys);
         HashAggExecutorDispatcher::dispatch_by_kind(kind, args).unwrap()

--- a/src/stream/src/from_proto/hash_agg.rs
+++ b/src/stream/src/from_proto/hash_agg.rs
@@ -44,7 +44,6 @@ impl<S: StateStore> HashKeyDispatcher for HashAggExecutorDispatcher<S> {
         Ok(HashAggExecutor::<K, S>::new(
             args.input,
             args.agg_calls,
-            // args.keyspace,
             args.pk_indices,
             args.executor_id,
             args.key_indices,

--- a/src/stream/src/from_proto/hash_agg.rs
+++ b/src/stream/src/from_proto/hash_agg.rs
@@ -16,8 +16,10 @@
 
 use std::marker::PhantomData;
 
-use risingwave_common::catalog::TableId;
+use risingwave_common::catalog::{ColumnDesc, TableId};
 use risingwave_common::hash::{calc_hash_key_kind, HashKey, HashKeyDispatcher};
+use risingwave_common::util::sort_util::OrderType;
+use risingwave_storage::table::state_table::StateTable;
 
 use super::*;
 use crate::executor::aggregation::AggCall;
@@ -29,9 +31,9 @@ struct HashAggExecutorDispatcherArgs<S: StateStore> {
     input: BoxedExecutor,
     agg_calls: Vec<AggCall>,
     key_indices: Vec<usize>,
-    keyspace: Vec<Keyspace<S>>,
     pk_indices: PkIndices,
     executor_id: u64,
+    state_tables: Vec<StateTable<S>>,
 }
 
 impl<S: StateStore> HashKeyDispatcher for HashAggExecutorDispatcher<S> {
@@ -42,10 +44,11 @@ impl<S: StateStore> HashKeyDispatcher for HashAggExecutorDispatcher<S> {
         Ok(HashAggExecutor::<K, S>::new(
             args.input,
             args.agg_calls,
-            args.keyspace,
+            // args.keyspace,
             args.pk_indices,
             args.executor_id,
             args.key_indices,
+            args.state_tables
         )?
         .boxed())
     }
@@ -73,7 +76,7 @@ impl ExecutorBuilder for HashAggExecutorBuilder {
             .try_collect()?;
         // Build vector of keyspace via table ids.
         // One keyspace for one agg call.
-        let keyspace = node
+        let keyspace: Vec<Keyspace<_>> = node
             .internal_tables
             .iter()
             .map(|table| Keyspace::table_root(store.clone(), &TableId::new(table.id)))
@@ -84,13 +87,38 @@ impl ExecutorBuilder for HashAggExecutorBuilder {
             .map(|idx| input.schema().fields[*idx].data_type())
             .collect_vec();
         let kind = calc_hash_key_kind(&keys);
+        let agg_calls_len = agg_calls.len();
+        // Create internal tables used by hash agg.
+        let mut state_tables = Vec::with_capacity(agg_calls_len);
+        for (ks, table_catalog) in keyspace.iter().zip_eq(node.internal_tables.iter()) {
+            // Parse info from proto and create state table.
+            let state_table = {
+                let table_columns = table_catalog.columns.iter().map(|col| ColumnDesc::unnamed(
+                    col.column_desc.as_ref().unwrap().column_id.into(),
+                    col.column_desc.as_ref().unwrap().column_type.as_ref().unwrap().into()
+                )).collect();
+                let order_types = table_catalog.orders.iter().map(|order_type| OrderType::from_prost(&risingwave_pb::plan_common::OrderType::from_i32(*order_type).unwrap())).collect();
+                let dist_key_indices = table_catalog.distribution_keys.iter().map(|dist_index| *dist_index as usize).collect();
+                let pk_indices = table_catalog.pk.iter().map(|pk_index| *pk_index as usize).collect();
+                StateTable::new(
+                    ks.clone(),
+                    table_columns,
+                    order_types,
+                    Some(dist_key_indices),
+                    pk_indices
+                )
+            };
+
+            state_tables.push(state_table)
+        }
+
         let args = HashAggExecutorDispatcherArgs {
             input,
             agg_calls,
             key_indices,
-            keyspace,
             pk_indices: params.pk_indices,
             executor_id: params.executor_id,
+            state_tables
         };
         HashAggExecutorDispatcher::dispatch_by_kind(kind, args)
     }

--- a/src/stream/src/from_proto/hash_agg.rs
+++ b/src/stream/src/from_proto/hash_agg.rs
@@ -16,7 +16,7 @@
 
 use std::marker::PhantomData;
 
-use risingwave_common::catalog::{ColumnDesc, TableId};
+use risingwave_common::catalog::TableId;
 use risingwave_common::hash::{calc_hash_key_kind, HashKey, HashKeyDispatcher};
 use risingwave_common::util::sort_util::OrderType;
 use risingwave_storage::table::state_table::StateTable;
@@ -95,18 +95,7 @@ impl ExecutorBuilder for HashAggExecutorBuilder {
                 let table_columns = table_catalog
                     .columns
                     .iter()
-                    .map(|col| {
-                        ColumnDesc::unnamed(
-                            col.column_desc.as_ref().unwrap().column_id.into(),
-                            col.column_desc
-                                .as_ref()
-                                .unwrap()
-                                .column_type
-                                .as_ref()
-                                .unwrap()
-                                .into(),
-                        )
-                    })
+                    .map(|col| col.column_desc.as_ref().unwrap().into())
                     .collect();
                 let order_types = table_catalog
                     .orders


### PR DESCRIPTION
I hereby agree to the terms of the [Singularity Data, Inc. Contributor License Agreement](https://gist.github.com/skyzh/0663682a70b0edde7ae991492f2314cb#file-s9y_cla).

## What's changed and what's your intention?
* Fix the wrong infer in `infer_internal_table_catalog`. Done some Simple DRY. Previous code is hard to maintain and read... May need more work in future.
* CN parse the table catalog and init the state table.
* Tweak some unit test, infer table catalog manually. 

Part of #3475 

## Checklist

- [x] I have written necessary docs and comments
- [x] I have added necessary unit tests and integration tests
- [x] All checks passed in `./risedev check` (or alias, `./risedev c`)

## Refer to a related PR or issue link (optional)
