### PR TITLE
refactor(hash-agg): rename distribution keys to group keys

### DIFF
--- a/proto/stream_plan.proto
+++ b/proto/stream_plan.proto
@@ -65,7 +65,7 @@ message SimpleAggNode {
 }
 
 message HashAggNode {
-  repeated uint32 distribution_keys = 1;
+  repeated uint32 group_keys = 1;
   repeated expr.AggCall agg_calls = 2;
   repeated catalog.Table internal_tables = 3;
   map<uint32, int32> column_mapping = 4;

--- a/src/frontend/src/optimizer/plan_node/stream_hash_agg.rs
+++ b/src/frontend/src/optimizer/plan_node/stream_hash_agg.rs
@@ -51,7 +51,7 @@ impl StreamHashAgg {
         self.logical.agg_calls()
     }
 
-    pub fn distribution_keys(&self) -> &[usize] {
+    pub fn group_keys(&self) -> &[usize] {
         self.logical.group_keys()
     }
 }
@@ -67,7 +67,7 @@ impl fmt::Display for StreamHashAgg {
             .field(
                 "group_keys",
                 &self
-                    .distribution_keys()
+                    .group_keys()
                     .iter()
                     .copied()
                     .map(InputRefDisplay)
@@ -94,8 +94,8 @@ impl ToStreamProst for StreamHashAgg {
         use risingwave_pb::stream_plan::*;
         let (internal_tables, column_mapping) = self.logical.infer_internal_table_catalog();
         ProstStreamNode::HashAgg(HashAggNode {
-            distribution_keys: self
-                .distribution_keys()
+            group_keys: self
+                .group_keys()
                 .iter()
                 .map(|idx| *idx as u32)
                 .collect_vec(),

--- a/src/frontend/test_runner/tests/testdata/stream_proto.yaml
+++ b/src/frontend/test_runner/tests/testdata/stream_proto.yaml
@@ -737,7 +737,7 @@
                   isNullable: true
                 name: "agg#1"
             hashAgg:
-              distributionKeys:
+              groupKeys:
                 - 0
               aggCalls:
                 - type: COUNT

--- a/src/stream/src/from_proto/hash_agg.rs
+++ b/src/stream/src/from_proto/hash_agg.rs
@@ -64,7 +64,7 @@ impl ExecutorBuilder for HashAggExecutorBuilder {
     ) -> Result<BoxedExecutor> {
         let node = try_match_expand!(node.get_node_body().unwrap(), NodeBody::HashAgg)?;
         let key_indices = node
-            .get_distribution_keys()
+            .get_group_keys()
             .iter()
             .map(|key| *key as usize)
             .collect::<Vec<_>>();


### PR DESCRIPTION
I hereby agree to the terms of the [Singularity Data, Inc. Contributor License Agreement](https://gist.github.com/skyzh/0663682a70b0edde7ae991492f2314cb#file-s9y_cla).

## What's changed and what's your intention?

![image](https://user-images.githubusercontent.com/36908971/175896241-85b1ae2a-52d2-4fc2-8a16-50bf4651c92d.png)

As you can see in the code, when serialize "distribution_keys" in FE, it's `logical.group_keys()`. However in some cases, the dist key might be different from group keys (See the pic above, the hash agg and hash join are in same fragment). So it's better to distinguish dist keys and group keys. 

In future, after we done the refactor of state table, might no need to pass dist keys in each StreamNode. Ideally, we can get dist keys from state table and encode it as vnode.

ref: #3456.  

## Checklist

- [x] I have written necessary docs and comments
- [x] I have added necessary unit tests and integration tests
- [x] All checks passed in `./risedev check` (or alias, `./risedev c`)

## Refer to a related PR or issue link (optional)
