### PR TITLE
refactor(frontend): modify Pin Snapshot in hummock_snapshot_manager.rs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4260,6 +4260,7 @@ dependencies = [
  "smallvec",
  "tempfile",
  "thiserror",
+ "tokio-retry",
  "tracing",
  "uuid 1.1.2",
  "workspace-hack",

--- a/src/frontend/Cargo.toml
+++ b/src/frontend/Cargo.toml
@@ -54,11 +54,11 @@ tokio = { version = "=0.2.0-alpha.3", package = "madsim-tokio", features = [
     "signal",
     "fs",
 ] }
+tokio-retry = "0.3"
 tonic = { version = "=0.2.0-alpha.3", package = "madsim-tonic" }
 tracing = { version = "0.1" }
 uuid = "1"
 workspace-hack = { version = "0.1", path = "../workspace-hack" }
-tokio-retry = "0.3"
 
 [dev-dependencies]
 assert_matches = "1"

--- a/src/frontend/Cargo.toml
+++ b/src/frontend/Cargo.toml
@@ -58,6 +58,7 @@ tonic = { version = "=0.2.0-alpha.3", package = "madsim-tonic" }
 tracing = { version = "0.1" }
 uuid = "1"
 workspace-hack = { version = "0.1", path = "../workspace-hack" }
+tokio-retry = "0.3"
 
 [dev-dependencies]
 assert_matches = "1"

--- a/src/frontend/src/observer/observer_manager.rs
+++ b/src/frontend/src/observer/observer_manager.rs
@@ -205,7 +205,6 @@ impl ObserverManager {
                 )
             }
             Info::HummockSnapshot(_hummock_snapshot) => {
-                // NOTE:DO NOTHING,FOR NOW WE DONT USE HUMMOCK SNAPSHOT
                 self._hummock_snapshot_manager
                     .update_snapshot_status(_hummock_snapshot.epoch)
                     .await;

--- a/src/frontend/src/observer/observer_manager.rs
+++ b/src/frontend/src/observer/observer_manager.rs
@@ -206,6 +206,9 @@ impl ObserverManager {
             }
             Info::HummockSnapshot(_hummock_snapshot) => {
                 // NOTE:DO NOTHING,FOR NOW WE DONT USE HUMMOCK SNAPSHOT
+                self._hummock_snapshot_manager
+                    .update_snapshot_status(_hummock_snapshot.epoch)
+                    .await;
             }
         }
     }

--- a/src/frontend/src/observer/observer_manager.rs
+++ b/src/frontend/src/observer/observer_manager.rs
@@ -44,7 +44,7 @@ pub(crate) struct ObserverManager {
     catalog_updated_tx: Sender<CatalogVersion>,
     user_info_manager: Arc<RwLock<UserInfoManager>>,
     user_info_updated_tx: Sender<UserInfoVersion>,
-    hummock_snapshot_manager: HummockSnapshotManagerRef,
+    _hummock_snapshot_manager: HummockSnapshotManagerRef,
 }
 
 const RE_SUBSCRIBE_RETRY_INTERVAL: Duration = Duration::from_millis(100);
@@ -74,7 +74,7 @@ impl ObserverManager {
             catalog_updated_tx,
             user_info_manager,
             user_info_updated_tx,
-            hummock_snapshot_manager,
+            _hummock_snapshot_manager: hummock_snapshot_manager,
         }
     }
 
@@ -204,10 +204,8 @@ impl ObserverManager {
                     resp
                 )
             }
-            Info::HummockSnapshot(hummock_snapshot) => {
-                self.hummock_snapshot_manager
-                    .update_snapshot_status(hummock_snapshot.epoch)
-                    .await;
+            Info::HummockSnapshot(_hummock_snapshot) => {
+                // NOTE:DO NOTHING,FOR NOW WE DONT USE HUMMOCK SNAPSHOT
             }
         }
     }

--- a/src/frontend/src/scheduler/distributed/query.rs
+++ b/src/frontend/src/scheduler/distributed/query.rs
@@ -376,9 +376,7 @@ mod tests {
             create_query().await,
             100,
             worker_node_manager,
-            Arc::new(HummockSnapshotManager::new(Arc::new(
-                MockFrontendMetaClient {},
-            ))),
+            HummockSnapshotManager::new(Arc::new(MockFrontendMetaClient {})).await,
             compute_client_pool,
         );
 

--- a/src/frontend/src/scheduler/error.rs
+++ b/src/frontend/src/scheduler/error.rs
@@ -16,12 +16,10 @@ use risingwave_common::error::{ErrorCode, RwError, TrackingIssue};
 use risingwave_rpc_client::error::RpcError;
 use thiserror::Error;
 
-use crate::scheduler::plan_fragmenter::QueryId;
-
 #[derive(Error, Debug)]
 pub enum SchedulerError {
-    #[error("Pin snapshot error: {0} fails to get epoch {1}")]
-    PinSnapshot(QueryId, u64),
+    #[error("Pin snapshot error: fails to get epoch {0}, max retry reahced {1}")]
+    PinSnapshot(u64, u64),
 
     #[error("Rpc error: {0}")]
     RpcError(#[from] RpcError),

--- a/src/frontend/src/scheduler/hummock_snapshot_manager.rs
+++ b/src/frontend/src/scheduler/hummock_snapshot_manager.rs
@@ -36,7 +36,10 @@ pub type HummockSnapshotManagerRef = Arc<HummockSnapshotManager>;
 impl HummockSnapshotManager {
     pub async fn new(meta_client: Arc<dyn FrontendMetaClient>) -> Arc<Self> {
         // Get epoch at first.
-        let epoch = Self::pin_epoch_with_retry(meta_client.clone(), 0, usize::MAX, || false)
+        let epoch =
+            Self::pin_epoch_with_retry(meta_client.clone(), Default::default(), usize::MAX, || {
+                false
+            })
             .await
             .expect("should be `Some` since `break_condition` is always false")
             .expect("should be able to pinned the first epoch");

--- a/src/frontend/src/scheduler/hummock_snapshot_manager.rs
+++ b/src/frontend/src/scheduler/hummock_snapshot_manager.rs
@@ -80,7 +80,7 @@ impl HummockSnapshotManager {
             // epoch to be unpin.
             let mut min_epoch = None;
             if let Some((epoch, query_ids)) = core_guard.epoch_to_query_ids.first_key_value() {
-                if query_ids.is_empty() {
+                if query_ids.is_empty() && *epoch != core_guard.last_pinned {
                     min_epoch = Some(*epoch)
                 }
             }

--- a/src/frontend/src/scheduler/hummock_snapshot_manager.rs
+++ b/src/frontend/src/scheduler/hummock_snapshot_manager.rs
@@ -60,9 +60,6 @@ impl HummockSnapshotManager {
             let query_ids = core_guard.epoch_to_query_ids.get_mut(&epoch);
             if let Some(query_ids) = query_ids {
                 query_ids.remove(query_id);
-                if query_ids.is_empty() && epoch == core_guard.last_pinned {
-                    core_guard.is_outdated = true;
-                }
             }
 
             // Check the min epoch, if the epoch has no query running on it, this should be the min

--- a/src/frontend/src/session.rs
+++ b/src/frontend/src/session.rs
@@ -109,7 +109,7 @@ impl OptimizerContext {
     #[cfg(test)]
     pub async fn mock() -> OptimizerContextRef {
         Self {
-            session_ctx: Arc::new(SessionImpl::mock()),
+            session_ctx: Arc::new(SessionImpl::mock().await),
             next_id: AtomicI32::new(0),
             sql: Arc::from(""),
         }
@@ -160,7 +160,7 @@ impl FrontendEnv {
         Self::with_meta_client(meta_client, opts).await
     }
 
-    pub fn mock() -> Self {
+    pub async fn mock() -> Self {
         use crate::test_utils::{MockCatalogWriter, MockFrontendMetaClient};
 
         let catalog = Arc::new(RwLock::new(Catalog::default()));
@@ -171,7 +171,7 @@ impl FrontendEnv {
         let user_info_reader = UserInfoReader::new(user_info_manager);
         let worker_node_manager = Arc::new(WorkerNodeManager::mock(vec![]));
         let meta_client = Arc::new(MockFrontendMetaClient {});
-        let hummock_snapshot_manager = Arc::new(HummockSnapshotManager::new(meta_client.clone()));
+        let hummock_snapshot_manager = HummockSnapshotManager::new(meta_client.clone()).await;
         let compute_client_pool = Arc::new(ComputeClientPool::new(u64::MAX));
         let query_manager = QueryManager::new(
             worker_node_manager.clone(),
@@ -227,7 +227,7 @@ impl FrontendEnv {
 
         let frontend_meta_client = Arc::new(FrontendMetaClientImpl(meta_client.clone()));
         let hummock_snapshot_manager =
-            Arc::new(HummockSnapshotManager::new(frontend_meta_client.clone()));
+            HummockSnapshotManager::new(frontend_meta_client.clone()).await;
         let compute_client_pool = Arc::new(ComputeClientPool::new(u64::MAX));
         let query_manager = QueryManager::new(
             worker_node_manager.clone(),
@@ -402,9 +402,9 @@ impl SessionImpl {
     }
 
     #[cfg(test)]
-    pub fn mock() -> Self {
+    pub async fn mock() -> Self {
         Self {
-            env: FrontendEnv::mock(),
+            env: FrontendEnv::mock().await,
             auth_context: Arc::new(AuthContext::new(
                 DEFAULT_DATABASE_NAME.to_string(),
                 DEFAULT_SUPPER_USER.to_string(),

--- a/src/frontend/src/test_utils.rs
+++ b/src/frontend/src/test_utils.rs
@@ -71,7 +71,7 @@ impl SessionManager for LocalFrontend {
 
 impl LocalFrontend {
     pub async fn new(opts: FrontendOpts) -> Self {
-        let env = FrontendEnv::mock();
+        let env = FrontendEnv::mock().await;
         Self { opts, env }
     }
 


### PR DESCRIPTION
I hereby agree to the terms of the [Singularity Data, Inc. Contributor License Agreement](https://gist.github.com/skyzh/0663682a70b0edde7ae991492f2314cb#file-s9y_cla).

## What's changed and what's your intention?

This PR modifies the Pin Snapshot method in hummock_snapshot_manager.rs.

In the old version, we check if the epoch is outdated to determine whether call pin_snapshot when we want to get an epoch.
For now, we create a background thread to pin_snapshot automatically.  When we want an epoch, we can directly read the last_epoch and needn't do other extra work. 

This method is refer to [local_version_manager.rs/{pin_version_with_retry, start_pin_worker}](https://github.com/singularity-data/risingwave/blob/main/src/storage/src/hummock/local_version_manager.rs#:~:text=%7D-,///%20Pin%20a%20version%20with%20retry.,%7D,-async%20fn%20start_unpin_worker)

## Checklist

- [x] I have written necessary docs and comments
- [x] I have added necessary unit tests and integration tests
- [x] All checks passed in `./risedev check` (or alias, `./risedev c`)

## Refer to a related PR or issue link (optional)
#2364 