### PR TITLE
perf(hummock manager): store incremental hummock version in meta

### DIFF
--- a/proto/hummock.proto
+++ b/proto/hummock.proto
@@ -65,8 +65,9 @@ message HummockVersionDelta {
     repeated LevelDelta level_deltas = 1;
   }
   uint64 id = 1;
+  uint64 prev_id = 2;
   // Levels of each compaction group
-  map<uint64, LevelDeltas> level_deltas = 2;
+  map<uint64, LevelDeltas> level_deltas = 3;
   uint64 max_committed_epoch = 4;
   // Snapshots with epoch less than the safe epoch have been GCed.
   // Reads against such an epoch will fail.

--- a/proto/hummock.proto
+++ b/proto/hummock.proto
@@ -36,6 +36,12 @@ message Level {
   uint64 total_file_size = 4;
 }
 
+message LevelDelta {
+  uint32 level_idx = 1;
+  repeated uint64 removed_table_ids = 2;
+  repeated SstableInfo inserted_table_infos = 3;
+}
+
 message UncommittedEpoch {
   uint64 epoch = 1;
   repeated SstableInfo tables = 2;
@@ -48,6 +54,19 @@ message HummockVersion {
   uint64 id = 1;
   // Levels of each compaction group
   map<uint64, Levels> levels = 2;
+  uint64 max_committed_epoch = 4;
+  // Snapshots with epoch less than the safe epoch have been GCed.
+  // Reads against such an epoch will fail.
+  uint64 safe_epoch = 5;
+}
+
+message HummockVersionDelta {
+  message LevelDeltas {
+    repeated LevelDelta level_deltas = 1;
+  }
+  uint64 id = 1;
+  // Levels of each compaction group
+  map<uint64, LevelDeltas> level_deltas = 2;
   uint64 max_committed_epoch = 4;
   // Snapshots with epoch less than the safe epoch have been GCed.
   // Reads against such an epoch will fail.

--- a/src/meta/src/hummock/hummock_manager.rs
+++ b/src/meta/src/hummock/hummock_manager.rs
@@ -226,6 +226,12 @@ where
             .map(|version| (version.id, version))
             .collect();
 
+        versioning_guard.hummock_version_deltas = HummockVersionDelta::list(self.env.meta_store())
+            .await?
+            .into_iter()
+            .map(|version_delta| (version_delta.id, version_delta))
+            .collect();
+
         // Insert the initial version.
         if versioning_guard.hummock_versions.is_empty() {
             let mut init_version = HummockVersion {

--- a/src/meta/src/hummock/hummock_manager.rs
+++ b/src/meta/src/hummock/hummock_manager.rs
@@ -31,8 +31,8 @@ use risingwave_hummock_sdk::{
 use risingwave_pb::hummock::hummock_version::Levels;
 use risingwave_pb::hummock::{
     CompactTask, CompactTaskAssignment, HummockPinnedSnapshot, HummockPinnedVersion,
-    HummockSnapshot, HummockStaleSstables, HummockVersion, Level, LevelType, SstableIdInfo,
-    SstableInfo,
+    HummockSnapshot, HummockStaleSstables, HummockVersion, HummockVersionDelta, Level, LevelDelta,
+    LevelType, SstableIdInfo, SstableInfo,
 };
 use risingwave_pb::meta::subscribe_response::{Info, Operation};
 use risingwave_pb::meta::MetaLeaderInfo;
@@ -136,6 +136,7 @@ struct Versioning {
     current_version_id: CurrentHummockVersionId,
     // TODO #2065: split levels by compaction group id in `HummockVersion`
     hummock_versions: BTreeMap<HummockVersionId, HummockVersion>,
+    hummock_version_deltas: BTreeMap<HummockVersionId, HummockVersionDelta>,
     pinned_versions: BTreeMap<HummockContextId, HummockPinnedVersion>,
     pinned_snapshots: BTreeMap<HummockContextId, HummockPinnedSnapshot>,
     stale_sstables: BTreeMap<HummockVersionId, HummockStaleSstables>,
@@ -763,6 +764,8 @@ where
             let versioning = versioning_guard.deref_mut();
             let mut current_version_id = VarTransaction::new(&mut versioning.current_version_id);
             let mut hummock_versions = VarTransaction::new(&mut versioning.hummock_versions);
+            let mut hummock_version_deltas =
+                VarTransaction::new(&mut versioning.hummock_version_deltas);
             let mut stale_sstables = VarTransaction::new(&mut versioning.stale_sstables);
             let mut sstable_id_infos = VarTransaction::new(&mut versioning.sstable_id_infos);
             let mut version_stale_sstables = stale_sstables.new_entry_txn_or_default(
@@ -772,15 +775,37 @@ where
                     id: vec![],
                 },
             );
+            let mut version_delta = HummockVersionDelta::default();
+            let level_deltas = &mut version_delta
+                .level_deltas
+                .entry(compact_task.compaction_group_id)
+                .or_default()
+                .level_deltas;
             for level in &compact_task.input_ssts {
                 version_stale_sstables
                     .id
                     .extend(level.table_infos.iter().map(|sst| sst.id).collect_vec());
+                let level_delta = LevelDelta {
+                    level_idx: level.level_idx,
+                    removed_table_ids: level.table_infos.iter().map(|sst| sst.id).collect_vec(),
+                    ..Default::default()
+                };
+                level_deltas.push(level_delta);
             }
+            let level_delta = LevelDelta {
+                level_idx: compact_task.target_level,
+                inserted_table_infos: compact_task.sorted_output_ssts.clone(),
+                ..Default::default()
+            };
+            level_deltas.push(level_delta);
             let mut new_version = CompactStatus::apply_compact_result(compact_task, old_version);
+            version_delta.safe_epoch = new_version.safe_epoch;
+
             current_version_id.increase();
             new_version.id = current_version_id.id();
+            version_delta.id = current_version_id.id();
             hummock_versions.insert(new_version.id, new_version);
+            hummock_version_deltas.insert(version_delta.id, version_delta);
 
             for SstableInfo { id: ref sst_id, .. } in &compact_task.sorted_output_ssts {
                 match sstable_id_infos.get_mut(sst_id) {
@@ -803,6 +828,7 @@ where
                 compact_task_assignment,
                 current_version_id,
                 hummock_versions,
+                hummock_version_deltas,
                 version_stale_sstables,
                 sstable_id_infos
             )?;
@@ -858,11 +884,16 @@ where
         let versioning = versioning_guard.deref_mut();
         let mut current_version_id = VarTransaction::new(&mut versioning.current_version_id);
         let mut hummock_versions = VarTransaction::new(&mut versioning.hummock_versions);
+        let mut hummock_version_deltas =
+            VarTransaction::new(&mut versioning.hummock_version_deltas);
         let mut sstable_id_infos = VarTransaction::new(&mut versioning.sstable_id_infos);
         current_version_id.increase();
         let mut new_hummock_version =
             hummock_versions.new_entry_txn_or_default(current_version_id.id(), old_version);
+        let mut new_version_delta = hummock_version_deltas
+            .new_entry_txn_or_default(current_version_id.id(), HummockVersionDelta::default());
         new_hummock_version.id = current_version_id.id();
+        new_version_delta.id = current_version_id.id();
         if epoch <= new_hummock_version.max_committed_epoch {
             return Err(Error::InternalError(format!(
                 "Epoch {} <= max_committed_epoch {}",
@@ -903,6 +934,18 @@ where
             }
         }
 
+        let level_deltas = &mut new_version_delta
+            .level_deltas
+            .entry(StaticCompactionGroupId::StateDefault.into())
+            .or_default()
+            .level_deltas;
+        let level_delta = LevelDelta {
+            level_idx: 0,
+            inserted_table_infos: sstables.clone(),
+            ..Default::default()
+        };
+        level_deltas.push(level_delta);
+
         // Create a new_version, possibly merely to bump up the version id and max_committed_epoch.
         // TODO #2065: use correct compaction group id
         let version_first_level = new_hummock_version
@@ -916,11 +959,13 @@ where
         );
         version_first_level.table_infos.extend(sstables);
         version_first_level.total_file_size += total_files_size;
+        new_version_delta.max_committed_epoch = epoch;
         new_hummock_version.max_committed_epoch = epoch;
         commit_multi_var!(
             self,
             None,
             new_hummock_version,
+            new_version_delta,
             current_version_id,
             sstable_id_infos
         )?;

--- a/src/meta/src/hummock/model/mod.rs
+++ b/src/meta/src/hummock/model/mod.rs
@@ -19,6 +19,7 @@ mod pinned_version;
 pub mod sstable_id_info;
 mod stale_sstables;
 mod version;
+mod version_delta;
 
 pub use current_version_id::*;
 pub use pinned_snapshot::*;
@@ -26,6 +27,7 @@ pub use pinned_version::*;
 pub use sstable_id_info::*;
 pub use stale_sstables::*;
 pub use version::*;
+pub use version_delta::*;
 
 /// Column family name for hummock epoch.
 pub(crate) const HUMMOCK_DEFAULT_CF_NAME: &str = "cf/hummock_default";

--- a/src/meta/src/hummock/model/version_delta.rs
+++ b/src/meta/src/hummock/model/version_delta.rs
@@ -1,0 +1,49 @@
+// Copyright 2022 Singularity Data
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use prost::Message;
+use risingwave_hummock_sdk::HummockVersionId;
+use risingwave_pb::hummock::HummockVersionDelta;
+
+use crate::model::MetadataModel;
+
+/// Column family name for hummock version delta.
+/// `cf(hummock_version_delta)`: `HummockVersionId` -> `HummockVersionDelta`
+const HUMMOCK_VERSION_DELTA_CF_NAME: &str = "cf/hummock_version_delta";
+
+/// `HummockVersionDelta` tracks delta of `SSTables` in given version based on previous version.
+impl MetadataModel for HummockVersionDelta {
+    type KeyType = HummockVersionId;
+    type ProstType = HummockVersionDelta;
+
+    fn cf_name() -> String {
+        String::from(HUMMOCK_VERSION_DELTA_CF_NAME)
+    }
+
+    fn to_protobuf(&self) -> Self::ProstType {
+        self.clone()
+    }
+
+    fn to_protobuf_encoded_vec(&self) -> Vec<u8> {
+        self.encode_to_vec()
+    }
+
+    fn from_protobuf(prost: Self::ProstType) -> Self {
+        prost
+    }
+
+    fn key(&self) -> risingwave_common::error::Result<Self::KeyType> {
+        Ok(self.id)
+    }
+}


### PR DESCRIPTION
I hereby agree to the terms of the [Singularity Data, Inc. Contributor License Agreement](https://gist.github.com/skyzh/0663682a70b0edde7ae991492f2314cb#file-s9y_cla).

## What's changed and what's your intention?

***PLEASE DO NOT LEAVE THIS EMPTY !!!***

store incremental hummock version in meta
it will replace hummock version

## Checklist

- [x] I have written necessary docs and comments

## Refer to a related PR or issue link (optional)
