### PR TITLE
fix: clear shared buffer on stop_all_actors

### DIFF
--- a/src/compute/src/rpc/service/stream_service.rs
+++ b/src/compute/src/rpc/service/stream_service.rs
@@ -152,17 +152,16 @@ impl StreamService for StreamServiceImpl {
         request: Request<BarrierCompleteRequest>,
     ) -> Result<Response<BarrierCompleteResponse>, Status> {
         let req = request.into_inner();
-        let collect_result = self
-            .mgr
-            .collect_barrier_and_sync(req.prev_epoch, true)
-            .await;
+        let collect_result = self.mgr.collect_barrier(req.prev_epoch).await;
+        // Must finish syncing data written in the epoch before respond back to ensure persistency
+        // of the state.
+        let synced_sstables = self.mgr.sync_epoch(req.prev_epoch).await;
 
         Ok(Response::new(BarrierCompleteResponse {
             request_id: req.request_id,
             status: None,
             create_mview_progress: collect_result.create_mview_progress,
-            sycned_sstables: collect_result
-                .synced_sstables
+            sycned_sstables: synced_sstables
                 .into_iter()
                 .map(|(compaction_group_id, sst)| GroupedSstableInfo {
                     compaction_group_id,

--- a/src/storage/src/hummock/local_version.rs
+++ b/src/storage/src/hummock/local_version.rs
@@ -106,6 +106,10 @@ impl LocalVersion {
             pinned_version,
         }
     }
+
+    pub fn clear_shared_buffer(&mut self) {
+        self.shared_buffer.clear();
+    }
 }
 
 #[derive(Debug)]

--- a/src/storage/src/hummock/local_version_manager.rs
+++ b/src/storage/src/hummock/local_version_manager.rs
@@ -770,6 +770,10 @@ impl LocalVersionManager {
             }
         }
     }
+
+    pub fn clear_shared_buffer(&self) {
+        self.local_version.write().clear_shared_buffer();
+    }
 }
 
 #[cfg(test)]

--- a/src/storage/src/hummock/local_version_manager.rs
+++ b/src/storage/src/hummock/local_version_manager.rs
@@ -19,7 +19,7 @@ use std::sync::{Arc, Weak};
 use std::time::Duration;
 
 use bytes::Bytes;
-use futures::future::join_all;
+use futures::future::{join_all, try_join_all};
 use itertools::Itertools;
 use parking_lot::RwLock;
 use risingwave_common::config::StorageConfig;
@@ -764,6 +764,30 @@ impl LocalVersionManager {
                             epoch
                         );
                     }
+
+                    SharedBufferEvent::Clear(notifier) => {
+                        // Cancel and wait for all ongoing flush.
+                        let ongoing_flush_handles: Vec<_> =
+                            epoch_join_handle.drain().flat_map(|e| e.1).collect();
+                        for handle in &ongoing_flush_handles {
+                            handle.abort();
+                        }
+                        if let Err(e) = try_join_all(ongoing_flush_handles).await {
+                            error!("Failed to join flush handle {:?}", e)
+                        }
+
+                        // Clear pending write requests.
+                        pending_write_requests.clear();
+
+                        // Clear shared buffer
+                        local_version_manager
+                            .local_version
+                            .write()
+                            .clear_shared_buffer();
+
+                        // Notify completion of the Clear event.
+                        notifier.send(()).unwrap();
+                    }
                 };
             } else {
                 break;
@@ -771,8 +795,10 @@ impl LocalVersionManager {
         }
     }
 
-    pub fn clear_shared_buffer(&self) {
-        self.local_version.write().clear_shared_buffer();
+    pub async fn clear_shared_buffer(&self) {
+        let (tx, rx) = oneshot::channel();
+        self.buffer_tracker.send_event(SharedBufferEvent::Clear(tx));
+        rx.await.unwrap();
     }
 }
 
@@ -1105,5 +1131,56 @@ mod tests {
         // Check uncommitted ssts
         assert!(local_version.get_shared_buffer(epochs[0]).is_none());
         assert!(local_version.get_shared_buffer(epochs[1]).is_none());
+    }
+
+    #[tokio::test]
+    async fn test_clear_shared_buffer() {
+        let opt = Arc::new(default_config_for_test());
+        let (_, hummock_manager_ref, _, worker_node) = setup_compute_env(8080).await;
+        let local_version_manager = LocalVersionManager::new(
+            opt.clone(),
+            mock_sstable_store(),
+            Arc::new(StateStoreMetrics::unused()),
+            Arc::new(MockHummockMetaClient::new(
+                hummock_manager_ref.clone(),
+                worker_node.id,
+            )),
+            ConflictDetector::new_from_config(opt),
+        )
+        .await;
+
+        let pinned_version = local_version_manager.get_pinned_version();
+        let initial_max_commit_epoch = pinned_version.max_committed_epoch();
+
+        let epochs: Vec<u64> = vec![initial_max_commit_epoch + 1, initial_max_commit_epoch + 2];
+        let batches: Vec<Vec<(Bytes, StorageValue)>> =
+            epochs.iter().map(|e| gen_dummy_batch(*e)).collect();
+
+        // Fill shared buffer with a dummy empty batch in epochs[0] and epochs[1]
+        for i in 0..2 {
+            local_version_manager
+                .write_shared_buffer(epochs[i], batches[i].clone(), false)
+                .await
+                .unwrap();
+            let local_version = local_version_manager.get_local_version();
+            assert_eq!(
+                local_version
+                    .get_shared_buffer(epochs[i])
+                    .unwrap()
+                    .read()
+                    .size(),
+                SharedBufferBatch::measure_batch_size(
+                    &LocalVersionManager::build_shared_buffer_item_batches(
+                        batches[i].clone(),
+                        epochs[i]
+                    )
+                )
+            );
+        }
+
+        // Clear shared buffer and check
+        local_version_manager.clear_shared_buffer().await;
+        let local_version = local_version_manager.get_local_version();
+        assert_eq!(local_version.iter_shared_buffer().count(), 0)
     }
 }

--- a/src/storage/src/hummock/shared_buffer/mod.rs
+++ b/src/storage/src/hummock/shared_buffer/mod.rs
@@ -192,6 +192,9 @@ pub enum SharedBufferEvent {
 
     /// An epoch has been synced.
     EpochSynced(HummockEpoch),
+
+    /// Clear shared buffer and reset all states
+    Clear(oneshot::Sender<()>),
 }
 
 impl SharedBuffer {

--- a/src/storage/src/hummock/state_store.rs
+++ b/src/storage/src/hummock/state_store.rs
@@ -443,9 +443,11 @@ impl StateStore for HummockStorage {
         self.local_version_manager.get_uncommitted_ssts(epoch)
     }
 
-    fn clear_shared_buffer(&self) -> StorageResult<()> {
-        self.local_version_manager.clear_shared_buffer();
-        Ok(())
+    fn clear_shared_buffer(&self) -> Self::ClearSharedBufferFuture<'_> {
+        async move {
+            self.local_version_manager.clear_shared_buffer().await;
+            Ok(())
+        }
     }
 }
 

--- a/src/storage/src/hummock/state_store.rs
+++ b/src/storage/src/hummock/state_store.rs
@@ -442,6 +442,11 @@ impl StateStore for HummockStorage {
     fn get_uncommitted_ssts(&self, epoch: u64) -> Vec<LocalSstableInfo> {
         self.local_version_manager.get_uncommitted_ssts(epoch)
     }
+
+    fn clear_shared_buffer(&self) -> StorageResult<()> {
+        self.local_version_manager.clear_shared_buffer();
+        Ok(())
+    }
 }
 
 pub struct HummockStateStoreIter {

--- a/src/storage/src/memory.rs
+++ b/src/storage/src/memory.rs
@@ -239,8 +239,8 @@ impl StateStore for MemoryStateStore {
         }
     }
 
-    fn clear_shared_buffer(&self) -> StorageResult<()> {
-        Ok(())
+    fn clear_shared_buffer(&self) -> Self::ClearSharedBufferFuture<'_> {
+        async move { Ok(()) }
     }
 }
 

--- a/src/storage/src/memory.rs
+++ b/src/storage/src/memory.rs
@@ -238,6 +238,10 @@ impl StateStore for MemoryStateStore {
             Ok(())
         }
     }
+
+    fn clear_shared_buffer(&self) -> StorageResult<()> {
+        Ok(())
+    }
 }
 
 pub struct MemoryStateStoreIter {

--- a/src/storage/src/monitor/monitored_store.rs
+++ b/src/storage/src/monitor/monitored_store.rs
@@ -254,6 +254,15 @@ where
     fn get_uncommitted_ssts(&self, epoch: u64) -> Vec<LocalSstableInfo> {
         self.inner.get_uncommitted_ssts(epoch)
     }
+
+    fn clear_shared_buffer(&self) -> Self::ClearSharedBufferFuture<'_> {
+        async move {
+            self.inner
+                .clear_shared_buffer()
+                .await
+                .inspect_err(|e| error!("Failed in clear_shared_buffer: {:?}", e))
+        }
+    }
 }
 
 /// A state store iterator wrapper for monitoring metrics.

--- a/src/storage/src/panic_store.rs
+++ b/src/storage/src/panic_store.rs
@@ -122,6 +122,12 @@ impl StateStore for PanicStateStore {
             panic!("should not sync from the panic state store!");
         }
     }
+
+    fn clear_shared_buffer(&self) -> Self::ClearSharedBufferFuture<'_> {
+        async move {
+            panic!("should not clear shared buffer from the panic state store!");
+        }
+    }
 }
 
 pub struct PanicStateStoreIter {}

--- a/src/storage/src/store.rs
+++ b/src/storage/src/store.rs
@@ -42,6 +42,7 @@ macro_rules! define_state_store_associated_type {
         type SyncFuture<'a> = impl EmptyFutureTrait<'a>;
         type IterFuture<'a, R, B> = impl Future<Output = $crate::error::StorageResult<Self::Iter>> + Send where R: 'static + Send, B: 'static + Send;
         type BackwardIterFuture<'a, R, B> = impl Future<Output = $crate::error::StorageResult<Self::Iter>> + Send where R: 'static + Send, B: 'static + Send;
+        type ClearSharedBufferFuture<'a> = impl EmptyFutureTrait<'a>;
     }
 }
 
@@ -77,6 +78,8 @@ pub trait StateStore: Send + Sync + 'static + Clone {
     where
         R: 'static + Send,
         B: 'static + Send;
+
+    type ClearSharedBufferFuture<'a>: EmptyFutureTrait<'a>;
 
     /// Point gets a value from the state store.
     /// The result is based on a snapshot corresponding to the given `epoch`.
@@ -174,7 +177,7 @@ pub trait StateStore: Send + Sync + 'static + Clone {
 
     /// Clears contents in shared buffer.
     /// This method should only be called when dropping all actors in the local compute node.
-    fn clear_shared_buffer(&self) -> StorageResult<()> {
+    fn clear_shared_buffer(&self) -> Self::ClearSharedBufferFuture<'_> {
         todo!()
     }
 }

--- a/src/storage/src/store.rs
+++ b/src/storage/src/store.rs
@@ -171,6 +171,12 @@ pub trait StateStore: Send + Sync + 'static + Clone {
     fn get_uncommitted_ssts(&self, _epoch: u64) -> Vec<LocalSstableInfo> {
         todo!()
     }
+
+    /// Clears contents in shared buffer.
+    /// This method should only be called when dropping all actors in the local compute node.
+    fn clear_shared_buffer(&self) -> StorageResult<()> {
+        todo!()
+    }
 }
 
 pub trait StateStoreIter: Send + 'static {

--- a/src/stream/src/task/barrier_manager.rs
+++ b/src/stream/src/task/barrier_manager.rs
@@ -28,7 +28,6 @@ mod progress;
 mod tests;
 
 pub use progress::CreateMviewProgress;
-use risingwave_hummock_sdk::LocalSstableInfo;
 
 /// If enabled, all actors will be grouped in the same tracing span within one epoch.
 /// Note that this option will significantly increase the overhead of tracing.
@@ -38,8 +37,6 @@ pub const ENABLE_BARRIER_AGGREGATION: bool = false;
 #[derive(Debug)]
 pub struct CollectResult {
     pub create_mview_progress: Vec<ProstCreateMviewProgress>,
-
-    pub synced_sstables: Vec<LocalSstableInfo>,
 }
 
 enum BarrierState {

--- a/src/stream/src/task/barrier_manager/managed_state.rs
+++ b/src/stream/src/task/barrier_manager/managed_state.rs
@@ -94,7 +94,6 @@ impl ManagedBarrierState {
                     // Notify about barrier finishing.
                     let result = CollectResult {
                         create_mview_progress,
-                        synced_sstables: vec![],
                     };
                     if collect_notifier.send(result).is_err() {
                         warn!(

--- a/src/stream/src/task/stream_manager.rs
+++ b/src/stream/src/task/stream_manager.rs
@@ -25,6 +25,7 @@ use risingwave_common::error::{ErrorCode, Result, RwError};
 use risingwave_common::try_match_expand;
 use risingwave_common::util::addr::{is_local_address, HostAddr};
 use risingwave_common::util::compress::decompress_data;
+use risingwave_hummock_sdk::LocalSstableInfo;
 use risingwave_pb::common::ActorInfo;
 use risingwave_pb::stream_plan::stream_node::NodeBody;
 use risingwave_pb::{stream_plan, stream_service};
@@ -181,40 +182,36 @@ impl LocalStreamManager {
         barrier_manager.drain_collect_rx(prev_epoch);
     }
 
-    /// Use `prev_epoch` to find collect rx. And wait for all actor to be collected before
+    /// Use `epoch` to find collect rx. And wait for all actor to be collected before
     /// returning.
-    pub async fn collect_barrier_and_sync(
-        &self,
-        prev_epoch: u64,
-        need_sync: bool,
-    ) -> CollectResult {
+    pub async fn collect_barrier(&self, epoch: u64) -> CollectResult {
         let rx = {
             let core = self.core.lock();
             let mut barrier_manager = core.context.lock_barrier_manager();
-            barrier_manager.remove_collect_rx(prev_epoch)
+            barrier_manager.remove_collect_rx(epoch)
         };
         // Wait for all actors finishing this barrier.
-        let mut collect_result = rx.await.unwrap();
+        rx.await.unwrap()
+    }
 
-        // Sync states from shared buffer to S3 before telling meta service we've done.
-        if need_sync {
-            dispatch_state_store!(self.state_store(), store, {
-                match store.sync(Some(prev_epoch)).await {
-                    Ok(_) => {
-                        collect_result.synced_sstables =
-                        store.get_uncommitted_ssts(prev_epoch);
-                    }
-                    // TODO: Handle sync failure by propagating it
-                    // back to global barrier manager
-                    Err(e) => panic!(
-                        "Failed to sync state store after receiving barrier prev_epoch {:?} due to {}",
-                        prev_epoch, e
-                    ),
-                }
-            });
-        }
+    pub async fn sync_epoch(&self, epoch: u64) -> Vec<LocalSstableInfo> {
+        dispatch_state_store!(self.state_store(), store, {
+            match store.sync(Some(epoch)).await {
+                Ok(_) => store.get_uncommitted_ssts(epoch),
+                // TODO: Handle sync failure by propagating it
+                // back to global barrier manager
+                Err(e) => panic!(
+                    "Failed to sync state store after receiving barrier prev_epoch {:?} due to {}",
+                    epoch, e
+                ),
+            }
+        })
+    }
 
-        collect_result
+    pub fn clear_storage_buffer(&self) {
+        dispatch_state_store!(self.state_store(), store, {
+            store.clear_shared_buffer().unwrap();
+        });
     }
 
     /// Broadcast a barrier to all senders. Returns immediately, and caller won't be notified when
@@ -259,8 +256,9 @@ impl LocalStreamManager {
 
         self.drain_collect_rx(barrier.epoch.prev);
         self.send_barrier(barrier, actor_ids_to_send, actor_ids_to_collect)?;
-        self.collect_barrier_and_sync(barrier.epoch.prev, false)
-            .await;
+        self.collect_barrier(barrier.epoch.prev).await;
+        // Clear shared buffer in storage to release memory
+        self.clear_storage_buffer();
         self.core.lock().drop_all_actors();
 
         Ok(())

--- a/src/stream/src/task/stream_manager.rs
+++ b/src/stream/src/task/stream_manager.rs
@@ -208,9 +208,9 @@ impl LocalStreamManager {
         })
     }
 
-    pub fn clear_storage_buffer(&self) {
+    pub async fn clear_storage_buffer(&self) {
         dispatch_state_store!(self.state_store(), store, {
-            store.clear_shared_buffer().unwrap();
+            store.clear_shared_buffer().await.unwrap();
         });
     }
 
@@ -258,7 +258,7 @@ impl LocalStreamManager {
         self.send_barrier(barrier, actor_ids_to_send, actor_ids_to_collect)?;
         self.collect_barrier(barrier.epoch.prev).await;
         // Clear shared buffer in storage to release memory
-        self.clear_storage_buffer();
+        self.clear_storage_buffer().await;
         self.core.lock().drop_all_actors();
 
         Ok(())


### PR DESCRIPTION
I hereby agree to the terms of the [Singularity Data, Inc. Contributor License Agreement](https://gist.github.com/skyzh/0663682a70b0edde7ae991492f2314cb#file-s9y_cla).

## What's changed and what's your intention?

During the recovery process, we stop all actors in the compute node but we miss to clear buffers in storage, which keeps the memory unreleased. This PR fixes the problem by adding a method to clear shared buffer and calling it on stop_all_actors.

## Checklist

- [x] I have written necessary docs and comments
- [x] I have added necessary unit tests and integration tests
- [x] All checks passed in `./risedev check` (or alias, `./risedev c`)

## Refer to a related PR or issue link (optional)
