### PR TITLE
refactor(simple-agg): use fe generated table catalog for simple agg + some code-reuse refactor

### DIFF
--- a/src/stream/src/executor/aggregation/mod.rs
+++ b/src/stream/src/executor/aggregation/mod.rs
@@ -498,3 +498,53 @@ pub fn get_key_len(agg_call: &AggCall) -> usize {
         _ => unimplemented!("{:?} do not implemented!", agg_call.kind),
     }
 }
+
+/// Parse from stream proto plan internal tables, generate state tables used by agg.
+pub fn generate_state_tables_from_proto(
+    store: impl StateStore,
+    internal_tables: &[risingwave_pb::catalog::Table],
+) -> Vec<StateTable<impl StateStore>> {
+    let mut state_tables = Vec::with_capacity(internal_tables.len());
+    for table_catalog in internal_tables {
+        // Parse info from proto and create state table.
+        let state_table = {
+            let table_columns = table_catalog
+                .columns
+                .iter()
+                .map(|col| col.column_desc.as_ref().unwrap().into())
+                .collect();
+            let order_types = table_catalog
+                .orders
+                .iter()
+                .map(|order_type| {
+                    OrderType::from_prost(
+                        &risingwave_pb::plan_common::OrderType::from_i32(*order_type).unwrap(),
+                    )
+                })
+                .collect();
+            let dist_key_indices = table_catalog
+                .distribution_keys
+                .iter()
+                .map(|dist_index| *dist_index as usize)
+                .collect();
+            let pk_indices = table_catalog
+                .pk
+                .iter()
+                .map(|pk_index| *pk_index as usize)
+                .collect();
+            StateTable::new(
+                Keyspace::table_root(
+                    store.clone(),
+                    &risingwave_common::catalog::TableId::new(table_catalog.id),
+                ),
+                table_columns,
+                order_types,
+                Some(dist_key_indices),
+                pk_indices,
+            )
+        };
+
+        state_tables.push(state_table)
+    }
+    state_tables
+}

--- a/src/stream/src/executor/aggregation/mod.rs
+++ b/src/stream/src/executor/aggregation/mod.rs
@@ -26,7 +26,7 @@ use risingwave_common::array::{
     NaiveDateTimeArray, NaiveTimeArray, Row, StructArray, Utf8Array,
 };
 use risingwave_common::buffer::Bitmap;
-use risingwave_common::catalog::{ColumnDesc, ColumnId, Field, Schema};
+use risingwave_common::catalog::{Field, Schema};
 use risingwave_common::hash::HashCode;
 use risingwave_common::types::{DataType, Datum};
 use risingwave_common::util::sort_util::OrderType;
@@ -350,89 +350,6 @@ pub fn generate_agg_schema(
     Schema { fields }
 }
 
-/// Infer column desc for state table.
-/// The column desc layout is
-/// [ `group_key` (only for hash agg) / `sort_key` (only for extreme) /
-/// `value`(the agg call return type)].
-/// This is the Row layout insert into state table.
-/// For different agg call, different executor (hash agg or simple agg), the layout will be
-/// different.
-pub fn generate_column_descs(
-    agg_call: &AggCall,
-    group_keys: &[usize],
-    pk_indices: &[usize],
-    agg_schema: &Schema,
-    input_ref: &dyn Executor,
-) -> Vec<ColumnDesc> {
-    let mut column_descs = Vec::with_capacity(group_keys.len() + 1);
-    let mut next_column_id = 0;
-
-    // Define a closure for DRY.
-    let mut add_column_desc = |data_type: DataType| {
-        column_descs.push(ColumnDesc::unnamed(
-            ColumnId::new(next_column_id),
-            data_type,
-        ));
-        next_column_id += 1;
-    };
-
-    for (idx, _) in group_keys.iter().enumerate() {
-        add_column_desc(agg_schema.fields[idx].data_type.clone());
-    }
-
-    // For max, min, the table descs should include sort key.
-    // The added columns should be (sort_key, pk from input data).
-    if (agg_call.kind == AggKind::Max || agg_call.kind == AggKind::Min) && !agg_call.append_only {
-        // Add value as part of sort key.
-        add_column_desc(agg_call.return_type.clone());
-
-        for pk_idx in pk_indices {
-            add_column_desc(input_ref.schema().fields[*pk_idx].data_type.clone());
-        }
-    }
-
-    // Agg value should also be part of state table.
-    add_column_desc(agg_call.return_type.clone());
-
-    column_descs
-}
-
-/// Generate state table for agg executor.
-/// Relational pk = `table_desc.len` - 1.
-/// After finished the refactor of frontend infer table catalog, should mark it as unit test only.
-pub fn generate_state_table<S: StateStore>(
-    ks: Keyspace<S>,
-    agg_call: &AggCall,
-    group_keys: &[usize],
-    pk_indices: &[usize],
-    agg_schema: &Schema,
-    input_ref: &dyn Executor,
-) -> StateTable<S> {
-    let table_desc = generate_column_descs(agg_call, group_keys, pk_indices, agg_schema, input_ref);
-    // Always leave 1 space for agg call value.
-    let relational_pk_len = table_desc.len() - 1;
-    let dist_keys: Vec<usize> = (0..group_keys.len()).collect();
-    StateTable::new(
-        ks,
-        table_desc,
-        // Primary key do not includes group key.
-        vec![
-            // Now we only infer order type for min/max in a naive way.
-            if agg_call.kind == AggKind::Max {
-                OrderType::Descending
-            } else {
-                OrderType::Ascending
-            };
-            relational_pk_len
-        ],
-        if dist_keys.is_empty() {
-            None
-        } else {
-            Some(dist_keys)
-        },
-        (0..relational_pk_len).collect(),
-    )
-}
 /// Generate initial [`AggState`] from `agg_calls`. For [`crate::executor::HashAggExecutor`], the
 /// group key should be provided.
 pub async fn generate_managed_agg_state<S: StateStore>(
@@ -474,29 +391,6 @@ pub async fn generate_managed_agg_state<S: StateStore>(
         managed_states,
         prev_states: None,
     })
-}
-
-/// Get the pk keys len (Do not count group key).
-/// For hash agg, add with group key to get internal table primary key len.
-/// For simple agg,
-pub fn get_key_len(agg_call: &AggCall) -> usize {
-    match agg_call.kind {
-        // If append_only, do not need order key.
-        AggKind::Min | AggKind::Max => {
-            if agg_call.append_only {
-                0
-            } else {
-                1
-            }
-        }
-        // These agg call do not have keys besides group key.
-        AggKind::Sum
-        | AggKind::Count
-        | AggKind::SingleValue
-        | AggKind::RowCount
-        | AggKind::ApproxCountDistinct => 0,
-        _ => unimplemented!("{:?} do not implemented!", agg_call.kind),
-    }
 }
 
 /// Parse from stream proto plan internal tables, generate state tables used by agg.

--- a/src/stream/src/executor/hash_agg.rs
+++ b/src/stream/src/executor/hash_agg.rs
@@ -455,9 +455,8 @@ mod tests {
     use risingwave_storage::table::state_table::StateTable;
     use risingwave_storage::{Keyspace, StateStore};
 
-    use crate::executor::aggregation::{
-        generate_agg_schema, generate_state_table, AggArgs, AggCall,
-    };
+    use crate::executor::aggregation::{generate_agg_schema, AggArgs, AggCall};
+    use crate::executor::test_utils::global_simple_agg::generate_state_table;
     use crate::executor::test_utils::*;
     use crate::executor::{Executor, HashAggExecutor, Message, PkIndices};
 

--- a/src/stream/src/executor/integration_tests.rs
+++ b/src/stream/src/executor/integration_tests.rs
@@ -30,9 +30,8 @@ use crate::executor::dispatch::*;
 use crate::executor::monitor::StreamingMetrics;
 use crate::executor::receiver::ReceiverExecutor;
 use crate::executor::test_utils::create_in_memory_keyspace_agg;
-use crate::executor::{
-    Executor, LocalSimpleAggExecutor, MergeExecutor, ProjectExecutor, SimpleAggExecutor,
-};
+use crate::executor::test_utils::global_simple_agg::new_boxed_simple_agg_executor;
+use crate::executor::{Executor, LocalSimpleAggExecutor, MergeExecutor, ProjectExecutor};
 use crate::task::SharedContext;
 
 /// This test creates a merger-dispatcher pair, and run a sum. Each chunk
@@ -159,7 +158,8 @@ async fn test_merger_sum_aggr() {
 
     // for global aggregator, we need to sum data and sum row count
     let append_only = false;
-    let aggregator = SimpleAggExecutor::new(
+    let aggregator = new_boxed_simple_agg_executor(
+        create_in_memory_keyspace_agg(2),
         merger.boxed(),
         vec![
             AggCall {
@@ -175,15 +175,13 @@ async fn test_merger_sum_aggr() {
                 append_only,
             },
         ],
-        create_in_memory_keyspace_agg(2),
         vec![],
         2,
         vec![],
-    )
-    .unwrap();
+    );
 
     let projection = ProjectExecutor::new(
-        aggregator.boxed(),
+        aggregator,
         vec![],
         vec![
             // TODO: use the new streaming_if_null expression here, and add `None` tests

--- a/src/stream/src/executor/test_utils.rs
+++ b/src/stream/src/executor/test_utils.rs
@@ -162,10 +162,100 @@ pub fn create_in_memory_keyspace_agg(num_ks: usize) -> Vec<Keyspace<MemoryStateS
 }
 
 pub mod global_simple_agg {
+    /// Infer column desc for state table.
+    /// The column desc layout is
+    /// [ `group_key` (only for hash agg) / `sort_key` (only for extreme) /
+    /// `value`(the agg call return type)].
+    /// This is the Row layout insert into state table.
+    /// For different agg call, different executor (hash agg or simple agg), the layout will be
+    /// different.
+    pub fn generate_column_descs(
+        agg_call: &AggCall,
+        group_keys: &[usize],
+        pk_indices: &[usize],
+        agg_schema: &Schema,
+        input_ref: &dyn Executor,
+    ) -> Vec<ColumnDesc> {
+        let mut column_descs = Vec::with_capacity(group_keys.len() + 1);
+        let mut next_column_id = 0;
+
+        // Define a closure for DRY.
+        let mut add_column_desc = |data_type: DataType| {
+            column_descs.push(ColumnDesc::unnamed(
+                ColumnId::new(next_column_id),
+                data_type,
+            ));
+            next_column_id += 1;
+        };
+
+        for (idx, _) in group_keys.iter().enumerate() {
+            add_column_desc(agg_schema.fields[idx].data_type.clone());
+        }
+
+        // For max, min, the table descs should include sort key.
+        // The added columns should be (sort_key, pk from input data).
+        if (agg_call.kind == AggKind::Max || agg_call.kind == AggKind::Min) && !agg_call.append_only
+        {
+            // Add value as part of sort key.
+            add_column_desc(agg_call.return_type.clone());
+
+            for pk_idx in pk_indices {
+                add_column_desc(input_ref.schema().fields[*pk_idx].data_type.clone());
+            }
+        }
+
+        // Agg value should also be part of state table.
+        add_column_desc(agg_call.return_type.clone());
+
+        column_descs
+    }
+
+    /// Generate state table for agg executor.
+    /// Relational pk = `table_desc.len` - 1.
+    /// it's test only.
+    pub fn generate_state_table<S: StateStore>(
+        ks: Keyspace<S>,
+        agg_call: &AggCall,
+        group_keys: &[usize],
+        pk_indices: &[usize],
+        agg_schema: &Schema,
+        input_ref: &dyn Executor,
+    ) -> StateTable<S> {
+        let table_desc =
+            generate_column_descs(agg_call, group_keys, pk_indices, agg_schema, input_ref);
+        // Always leave 1 space for agg call value.
+        let relational_pk_len = table_desc.len() - 1;
+        let dist_keys: Vec<usize> = (0..group_keys.len()).collect();
+        StateTable::new(
+            ks,
+            table_desc,
+            // Primary key do not includes group key.
+            vec![
+                // Now we only infer order type for min/max in a naive way.
+                if agg_call.kind == AggKind::Max {
+                    OrderType::Descending
+                } else {
+                    OrderType::Ascending
+                };
+                relational_pk_len
+            ],
+            if dist_keys.is_empty() {
+                None
+            } else {
+                Some(dist_keys)
+            },
+            (0..relational_pk_len).collect(),
+        )
+    }
     use itertools::Itertools;
+    use risingwave_common::catalog::{ColumnDesc, ColumnId, Schema};
+    use risingwave_common::types::DataType;
+    use risingwave_common::util::sort_util::OrderType;
+    use risingwave_expr::expr::AggKind;
+    use risingwave_storage::table::state_table::StateTable;
     use risingwave_storage::{Keyspace, StateStore};
 
-    use crate::executor::aggregation::{generate_agg_schema, generate_state_table, AggCall};
+    use crate::executor::aggregation::{generate_agg_schema, AggCall};
     use crate::executor::{BoxedExecutor, Executor, PkIndices, SimpleAggExecutor};
 
     pub fn new_boxed_simple_agg_executor(

--- a/src/stream/src/from_proto/hash_agg.rs
+++ b/src/stream/src/from_proto/hash_agg.rs
@@ -16,13 +16,11 @@
 
 use std::marker::PhantomData;
 
-use risingwave_common::catalog::TableId;
 use risingwave_common::hash::{calc_hash_key_kind, HashKey, HashKeyDispatcher};
-use risingwave_common::util::sort_util::OrderType;
 use risingwave_storage::table::state_table::StateTable;
 
 use super::*;
-use crate::executor::aggregation::AggCall;
+use crate::executor::aggregation::{generate_state_tables_from_proto, AggCall};
 use crate::executor::{HashAggExecutor, PkIndices};
 
 struct HashAggExecutorDispatcher<S: StateStore>(PhantomData<S>);
@@ -73,55 +71,13 @@ impl ExecutorBuilder for HashAggExecutorBuilder {
             .iter()
             .map(|agg_call| build_agg_call_from_prost(node.is_append_only, agg_call))
             .try_collect()?;
-        // Build vector of keyspace via table ids.
-        // One keyspace for one agg call.
         let input = params.input.remove(0);
         let keys = key_indices
             .iter()
             .map(|idx| input.schema().fields[*idx].data_type())
             .collect_vec();
         let kind = calc_hash_key_kind(&keys);
-        let agg_calls_len = agg_calls.len();
-        // Create internal tables used by hash agg.
-        let mut state_tables = Vec::with_capacity(agg_calls_len);
-        for table_catalog in &node.internal_tables {
-            // Parse info from proto and create state table.
-            let state_table = {
-                let table_columns = table_catalog
-                    .columns
-                    .iter()
-                    .map(|col| col.column_desc.as_ref().unwrap().into())
-                    .collect();
-                let order_types = table_catalog
-                    .orders
-                    .iter()
-                    .map(|order_type| {
-                        OrderType::from_prost(
-                            &risingwave_pb::plan_common::OrderType::from_i32(*order_type).unwrap(),
-                        )
-                    })
-                    .collect();
-                let dist_key_indices = table_catalog
-                    .distribution_keys
-                    .iter()
-                    .map(|dist_index| *dist_index as usize)
-                    .collect();
-                let pk_indices = table_catalog
-                    .pk
-                    .iter()
-                    .map(|pk_index| *pk_index as usize)
-                    .collect();
-                StateTable::new(
-                    Keyspace::table_root(store.clone(), &TableId::new(table_catalog.id)),
-                    table_columns,
-                    order_types,
-                    Some(dist_key_indices),
-                    pk_indices,
-                )
-            };
-
-            state_tables.push(state_table)
-        }
+        let state_tables = generate_state_tables_from_proto(store, &node.internal_tables);
 
         let args = HashAggExecutorDispatcherArgs {
             input,


### PR DESCRIPTION
…nd some simple refactor

I hereby agree to the terms of the [Singularity Data, Inc. Contributor License Agreement](https://gist.github.com/skyzh/0663682a70b0edde7ae991492f2314cb#file-s9y_cla).

## What's changed and what's your intention?
* Add a method in mod.rs `generate_state_table_from_proto`. Currently reused by global agg and simple agg. 
* Add a method in test_util.rs `new_boxed_simple_agg_executor`. Currently used by tests in simple agg.

## Checklist

- [x] I have written necessary docs and comments
- [x] I have added necessary unit tests and integration tests
- [x] All checks passed in `./risedev check` (or alias, `./risedev c`)

## Refer to a related PR or issue link (optional)
