### PR TITLE
refactor(storage): remove arc in shared buffer event sender

### DIFF
--- a/src/storage/benches/bench_merge_iter.rs
+++ b/src/storage/benches/bench_merge_iter.rs
@@ -43,7 +43,7 @@ fn gen_interleave_shared_buffer_batch_iter(
         let batch = SharedBufferBatch::new(
             batch_data,
             2333,
-            Arc::new(mpsc::unbounded_channel().0),
+            mpsc::unbounded_channel().0,
             StaticCompactionGroupId::StateDefault.into(),
         );
         iterators.push(Box::new(batch.into_forward_iter()) as BoxedForwardHummockIterator);

--- a/src/storage/src/hummock/local_version_manager.rs
+++ b/src/storage/src/hummock/local_version_manager.rs
@@ -61,14 +61,14 @@ struct BufferTracker {
     global_buffer_size: Arc<AtomicUsize>,
     global_upload_task_size: Arc<AtomicUsize>,
 
-    buffer_event_sender: Arc<mpsc::UnboundedSender<SharedBufferEvent>>,
+    buffer_event_sender: mpsc::UnboundedSender<SharedBufferEvent>,
 }
 
 impl BufferTracker {
     pub fn new(
         flush_threshold: usize,
         block_write_threshold: usize,
-        buffer_event_sender: Arc<mpsc::UnboundedSender<SharedBufferEvent>>,
+        buffer_event_sender: mpsc::UnboundedSender<SharedBufferEvent>,
     ) -> Self {
         assert!(
             flush_threshold <= block_write_threshold,
@@ -177,7 +177,7 @@ impl LocalVersionManager {
                 // TODO: enable setting the ratio with config
                 capacity * 4 / 5,
                 capacity,
-                Arc::new(buffer_event_sender),
+                buffer_event_sender,
             ),
             write_conflict_detector: write_conflict_detector.clone(),
             shared_buffer_uploader: Arc::new(SharedBufferUploader::new(
@@ -936,7 +936,7 @@ mod tests {
             let batch = SharedBufferBatch::new(
                 LocalVersionManager::build_shared_buffer_item_batches(kvs[i].clone(), epochs[i]),
                 epochs[i],
-                Arc::new(mpsc::unbounded_channel().0),
+                mpsc::unbounded_channel().0,
                 StaticCompactionGroupId::StateDefault.into(),
             );
             assert_eq!(

--- a/src/storage/src/hummock/shared_buffer/mod.rs
+++ b/src/storage/src/hummock/shared_buffer/mod.rs
@@ -501,7 +501,6 @@ impl SharedBuffer {
 mod tests {
     use std::cell::RefCell;
     use std::ops::DerefMut;
-    use std::sync::Arc;
 
     use bytes::Bytes;
     use risingwave_hummock_sdk::compaction_group::StaticCompactionGroupId;
@@ -540,7 +539,7 @@ mod tests {
         let batch = SharedBufferBatch::new(
             shared_buffer_items,
             epoch,
-            Arc::new(mpsc::unbounded_channel().0),
+            mpsc::unbounded_channel().0,
             StaticCompactionGroupId::StateDefault.into(),
         );
         if is_replicate {

--- a/src/storage/src/hummock/shared_buffer/shared_buffer_batch.rs
+++ b/src/storage/src/hummock/shared_buffer/shared_buffer_batch.rs
@@ -37,7 +37,7 @@ pub(crate) type SharedBufferItem = (Bytes, HummockValue<Bytes>);
 pub(crate) struct SharedBufferBatchInner {
     payload: Vec<SharedBufferItem>,
     size: usize,
-    buffer_release_notifier: Arc<mpsc::UnboundedSender<SharedBufferEvent>>,
+    buffer_release_notifier: mpsc::UnboundedSender<SharedBufferEvent>,
 }
 
 impl Deref for SharedBufferBatchInner {
@@ -87,7 +87,7 @@ impl SharedBufferBatch {
     pub fn new(
         sorted_items: Vec<SharedBufferItem>,
         epoch: HummockEpoch,
-        buffer_release_notifier: Arc<mpsc::UnboundedSender<SharedBufferEvent>>,
+        buffer_release_notifier: mpsc::UnboundedSender<SharedBufferEvent>,
         compaction_group_id: CompactionGroupId,
     ) -> Self {
         let size: usize = Self::measure_batch_size(&sorted_items);
@@ -312,7 +312,7 @@ mod tests {
         let shared_buffer_batch = SharedBufferBatch::new(
             transform_shared_buffer(shared_buffer_items.clone()),
             epoch,
-            Arc::new(mpsc::unbounded_channel().0),
+            mpsc::unbounded_channel().0,
             StaticCompactionGroupId::StateDefault.into(),
         );
 
@@ -389,7 +389,7 @@ mod tests {
         let shared_buffer_batch = SharedBufferBatch::new(
             transform_shared_buffer(shared_buffer_items.clone()),
             epoch,
-            Arc::new(mpsc::unbounded_channel().0),
+            mpsc::unbounded_channel().0,
             StaticCompactionGroupId::StateDefault.into(),
         );
 


### PR DESCRIPTION
I hereby agree to the terms of the [Singularity Data, Inc. Contributor License Agreement](https://gist.github.com/skyzh/0663682a70b0edde7ae991492f2314cb#file-s9y_cla).

## What's changed and what's your intention?
As title. Our current code use an `Arc` to wrap the shared buffer event sender, which is of type `mpsc::UnboundedSender`. But it seems that the type support `Clone` trait and it implements reference counting internally. Therefore, we don't need the `Arc` any more and we can clone from the raw sender.

## Checklist

- [x] I have written necessary docs and comments
- [x] I have added necessary unit tests and integration tests
- [x] All checks passed in `./risedev check` (or alias, `./risedev c`)

## Refer to a related PR or issue link (optional)
