### PR TITLE
feat(storage):   iterator support min_epoch check

### DIFF
--- a/src/batch/src/executor/insert.rs
+++ b/src/batch/src/executor/insert.rs
@@ -306,6 +306,7 @@ mod tests {
                 ReadOptions {
                     epoch,
                     table_id: Default::default(),
+                    ttl: None,
                 },
             )
             .await?;

--- a/src/bench/ss_bench/operations/get.rs
+++ b/src/bench/ss_bench/operations/get.rs
@@ -107,6 +107,7 @@ impl Operations {
                             ReadOptions {
                                 epoch: u64::MAX,
                                 table_id: None,
+                                ttl: None,
                             },
                         )
                         .await

--- a/src/bench/ss_bench/operations/prefix_scan_random.rs
+++ b/src/bench/ss_bench/operations/prefix_scan_random.rs
@@ -67,6 +67,7 @@ impl Operations {
                             ReadOptions {
                                 epoch: u64::MAX,
                                 table_id: None,
+                                ttl: None,
                             },
                         )
                         .await

--- a/src/common/src/catalog/mod.rs
+++ b/src/common/src/catalog/mod.rs
@@ -19,6 +19,7 @@ mod schema;
 pub mod test_utils;
 
 use core::fmt;
+use std::collections::HashMap;
 use std::sync::Arc;
 
 use async_trait::async_trait;
@@ -28,6 +29,7 @@ pub use physical_table::*;
 pub use schema::{test_utils as schema_test_utils, Field, Schema};
 
 use crate::array::Row;
+pub use crate::config::constant::hummock;
 use crate::error::Result;
 
 pub const DEFAULT_DATABASE_NAME: &str = "dev";
@@ -207,6 +209,59 @@ impl From<&TableId> for risingwave_pb::plan_common::TableRefId {
             schema_ref_id: None,
             table_id: table_id.table_id as i32,
         }
+    }
+}
+
+// TODO: TableOption is deplicated with the properties in table catalog, We can refactor later to
+// directly fetch such options from catalog when creating compaction jobs.
+#[derive(Clone, Debug, PartialEq, Default, Copy)]
+pub struct TableOption {
+    pub ttl: Option<u32>,
+}
+
+impl From<&risingwave_pb::hummock::TableOption> for TableOption {
+    fn from(table_option: &risingwave_pb::hummock::TableOption) -> Self {
+        let ttl = if table_option.ttl == hummock::TABLE_OPTION_DUMMY_TTL {
+            None
+        } else {
+            Some(table_option.ttl)
+        };
+
+        Self { ttl }
+    }
+}
+
+impl From<&TableOption> for risingwave_pb::hummock::TableOption {
+    fn from(table_option: &TableOption) -> Self {
+        Self {
+            ttl: table_option.ttl.unwrap_or(0),
+        }
+    }
+}
+
+impl TableOption {
+    pub fn build_table_option(table_properties: &HashMap<String, String>) -> Self {
+        // now we only support ttl for TableOption
+        let mut result = TableOption::default();
+        match table_properties.get(hummock::PROPERTIES_TTL_KEY) {
+            Some(ttl_string) => {
+                match ttl_string.trim().parse::<u32>() {
+                    Ok(ttl_u32) => result.ttl = Some(ttl_u32),
+                    Err(e) => {
+                        tracing::info!(
+                            "build_table_option parse option ttl_string {} fail {}",
+                            ttl_string,
+                            e
+                        );
+                        result.ttl = None;
+                    }
+                };
+            }
+
+            None => {}
+        }
+
+        result
     }
 }
 

--- a/src/common/src/catalog/mod.rs
+++ b/src/common/src/catalog/mod.rs
@@ -216,7 +216,7 @@ impl From<&TableId> for risingwave_pb::plan_common::TableRefId {
 // directly fetch such options from catalog when creating compaction jobs.
 #[derive(Clone, Debug, PartialEq, Default, Copy)]
 pub struct TableOption {
-    pub ttl: Option<u32>,
+    pub ttl: Option<u32>, // second
 }
 
 impl From<&risingwave_pb::hummock::TableOption> for TableOption {
@@ -234,7 +234,7 @@ impl From<&risingwave_pb::hummock::TableOption> for TableOption {
 impl From<&TableOption> for risingwave_pb::hummock::TableOption {
     fn from(table_option: &TableOption) -> Self {
         Self {
-            ttl: table_option.ttl.unwrap_or(0),
+            ttl: table_option.ttl.unwrap_or(hummock::TABLE_OPTION_DUMMY_TTL),
         }
     }
 }

--- a/src/ctl/src/cmd_impl/hummock/list_kv.rs
+++ b/src/ctl/src/cmd_impl/hummock/list_kv.rs
@@ -36,6 +36,7 @@ pub async fn list_kv(epoch: u64, table_id: Option<u32>) -> anyhow::Result<()> {
                     ReadOptions {
                         epoch: u64::MAX,
                         table_id: None,
+                        ttl: None,
                     },
                 )
                 .await?
@@ -52,6 +53,7 @@ pub async fn list_kv(epoch: u64, table_id: Option<u32>) -> anyhow::Result<()> {
                     ReadOptions {
                         epoch: u64::MAX,
                         table_id: Some(TableId { table_id }),
+                        ttl: None,
                     },
                 )
                 .await?

--- a/src/meta/src/hummock/compaction_group/manager.rs
+++ b/src/meta/src/hummock/compaction_group/manager.rs
@@ -91,7 +91,7 @@ impl<S: MetaStore> CompactionGroupManager<S> {
             // `StateDefault`.
             CompactionGroupId::from(StaticCompactionGroupId::StateDefault),
             // CompactionGroupId::from(StaticCompactionGroupId::MaterializedView),
-            table_option.clone(),
+            table_option,
         ));
         // internal states
         for table_id in table_fragments.internal_table_ids() {
@@ -99,7 +99,7 @@ impl<S: MetaStore> CompactionGroupManager<S> {
             pairs.push((
                 Prefix::from(table_id),
                 CompactionGroupId::from(StaticCompactionGroupId::StateDefault),
-                table_option.clone(),
+                table_option,
             ));
         }
         self.inner
@@ -270,7 +270,7 @@ impl CompactionGroupManagerInner {
             compaction_group.member_prefixes.insert(*prefix);
             compaction_group
                 .table_id_to_options
-                .insert(prefix.into(), table_option.clone());
+                .insert(prefix.into(), *table_option);
         }
         let mut trx = Transaction::default();
         compaction_groups.apply_to_txn(&mut trx)?;
@@ -338,7 +338,7 @@ impl CompactionGroupManagerInner {
     ) -> Result<TableOption> {
         let compaction_group = self.compaction_group(compaction_group_id)?;
         match compaction_group.table_id_to_options().get(&table_id) {
-            Some(table_option) => Ok(table_option.clone()),
+            Some(table_option) => Ok(*table_option),
 
             None => Ok(TableOption::default()),
         }
@@ -396,7 +396,7 @@ mod tests {
                 &[(
                     Prefix::from(1u32),
                     StaticCompactionGroupId::StateDefault.into(),
-                    table_option.clone(),
+                    table_option,
                 )],
                 env.meta_store(),
             )
@@ -409,7 +409,7 @@ mod tests {
                 &[(
                     Prefix::from(2u32),
                     StaticCompactionGroupId::MaterializedView.into(),
-                    table_option.clone(),
+                    table_option,
                 )],
                 env.meta_store(),
             )

--- a/src/meta/src/hummock/compaction_group/manager.rs
+++ b/src/meta/src/hummock/compaction_group/manager.rs
@@ -16,13 +16,14 @@ use std::collections::{BTreeMap, HashMap, HashSet};
 use std::sync::Arc;
 
 use itertools::Itertools;
+use risingwave_common::catalog::TableOption;
 use risingwave_hummock_sdk::compaction_group::{Prefix, StaticCompactionGroupId};
 use risingwave_hummock_sdk::CompactionGroupId;
 use risingwave_pb::hummock::CompactionConfig;
 use tokio::sync::RwLock;
 
 use crate::hummock::compaction::compaction_config::CompactionConfigBuilder;
-use crate::hummock::compaction_group::{CompactionGroup, TableOption};
+use crate::hummock::compaction_group::CompactionGroup;
 use crate::hummock::error::{Error, Result};
 use crate::manager::{MetaSrvEnv, SourceId};
 use crate::model::{MetadataModel, TableFragments, ValTransaction, VarTransaction};
@@ -81,7 +82,7 @@ impl<S: MetaStore> CompactionGroupManager<S> {
         table_fragments: &TableFragments,
         table_properties: &HashMap<String, String>,
     ) -> Result<()> {
-        let table_option = CompactionGroup::build_table_option(table_properties);
+        let table_option = TableOption::build_table_option(table_properties);
         let mut pairs = vec![];
         // materialized_view or materialized_source
         pairs.push((
@@ -129,7 +130,7 @@ impl<S: MetaStore> CompactionGroupManager<S> {
         source_id: u32,
         table_properties: &HashMap<String, String>,
     ) -> Result<()> {
-        let table_option = CompactionGroup::build_table_option(table_properties);
+        let table_option = TableOption::build_table_option(table_properties);
         self.inner
             .write()
             .await
@@ -350,11 +351,11 @@ mod tests {
     use std::collections::HashMap;
     use std::ops::Deref;
 
-    use risingwave_common::catalog::TableId;
+    use risingwave_common::catalog::{TableId, TableOption};
     use risingwave_hummock_sdk::compaction_group::{Prefix, StaticCompactionGroupId};
 
     use crate::hummock::compaction_group::manager::{
-        CompactionGroup, CompactionGroupManager, CompactionGroupManagerInner,
+        CompactionGroupManager, CompactionGroupManagerInner,
     };
     use crate::hummock::test_utils::setup_compute_env;
     use crate::model::TableFragments;
@@ -385,7 +386,7 @@ mod tests {
         assert_eq!(registered_number(inner.read().await.deref()), 0);
 
         let table_properties = HashMap::from([(String::from("ttl"), String::from("300"))]);
-        let table_option = CompactionGroup::build_table_option(&table_properties);
+        let table_option = TableOption::build_table_option(&table_properties);
 
         // Test register
         inner

--- a/src/meta/src/hummock/compaction_group/mod.rs
+++ b/src/meta/src/hummock/compaction_group/mod.rs
@@ -58,30 +58,6 @@ impl CompactionGroup {
     pub fn table_id_to_options(&self) -> &HashMap<u32, TableOption> {
         &self.table_id_to_options
     }
-
-    // pub fn build_table_option(table_properties: &HashMap<String, String>) -> TableOption {
-    //     // now we only support ttl for TableOption
-    //     let mut result = TableOption::default();
-    //     match table_properties.get(hummock::PROPERTIES_TTL_KEY) {
-    //         Some(ttl_string) => {
-    //             match ttl_string.trim().parse::<u32>() {
-    //                 Ok(ttl_u32) => result.ttl = Some(ttl_u32),
-    //                 Err(e) => {
-    //                     tracing::info!(
-    //                         "build_table_option parse option ttl_string {} fail {}",
-    //                         ttl_string,
-    //                         e
-    //                     );
-    //                     result.ttl = None;
-    //                 }
-    //             };
-    //         }
-
-    //         None => {}
-    //     }
-
-    //     result
-    // }
 }
 
 impl From<&risingwave_pb::hummock::CompactionGroup> for CompactionGroup {

--- a/src/meta/src/hummock/compaction_group/mod.rs
+++ b/src/meta/src/hummock/compaction_group/mod.rs
@@ -18,7 +18,7 @@ use std::borrow::Borrow;
 use std::collections::{HashMap, HashSet};
 
 use itertools::Itertools;
-use risingwave_common::config::constant::hummock;
+use risingwave_common::catalog::TableOption;
 use risingwave_hummock_sdk::compaction_group::Prefix;
 use risingwave_hummock_sdk::CompactionGroupId;
 use risingwave_pb::hummock::CompactionConfig;
@@ -59,29 +59,29 @@ impl CompactionGroup {
         &self.table_id_to_options
     }
 
-    pub fn build_table_option(table_properties: &HashMap<String, String>) -> TableOption {
-        // now we only support ttl for TableOption
-        let mut result = TableOption::default();
-        match table_properties.get(hummock::PROPERTIES_TTL_KEY) {
-            Some(ttl_string) => {
-                match ttl_string.trim().parse::<u32>() {
-                    Ok(ttl_u32) => result.ttl = Some(ttl_u32),
-                    Err(e) => {
-                        tracing::info!(
-                            "build_table_option parse option ttl_string {} fail {}",
-                            ttl_string,
-                            e
-                        );
-                        result.ttl = None;
-                    }
-                };
-            }
+    // pub fn build_table_option(table_properties: &HashMap<String, String>) -> TableOption {
+    //     // now we only support ttl for TableOption
+    //     let mut result = TableOption::default();
+    //     match table_properties.get(hummock::PROPERTIES_TTL_KEY) {
+    //         Some(ttl_string) => {
+    //             match ttl_string.trim().parse::<u32>() {
+    //                 Ok(ttl_u32) => result.ttl = Some(ttl_u32),
+    //                 Err(e) => {
+    //                     tracing::info!(
+    //                         "build_table_option parse option ttl_string {} fail {}",
+    //                         ttl_string,
+    //                         e
+    //                     );
+    //                     result.ttl = None;
+    //                 }
+    //             };
+    //         }
 
-            None => {}
-        }
+    //         None => {}
+    //     }
 
-        result
-    }
+    //     result
+    // }
 }
 
 impl From<&risingwave_pb::hummock::CompactionGroup> for CompactionGroup {
@@ -145,32 +145,5 @@ impl MetadataModel for CompactionGroup {
 
     fn key(&self) -> risingwave_common::error::Result<Self::KeyType> {
         Ok(self.group_id)
-    }
-}
-
-// TODO: TableOption is deplicated with the properties in table catalog, We can refactor later to
-// directly fetch such options from catalog when creating compaction jobs.
-#[derive(Clone, Debug, PartialEq, Default)]
-pub struct TableOption {
-    ttl: Option<u32>,
-}
-
-impl From<&risingwave_pb::hummock::TableOption> for TableOption {
-    fn from(table_option: &risingwave_pb::hummock::TableOption) -> Self {
-        let ttl = if table_option.ttl == hummock::TABLE_OPTION_DUMMY_TTL {
-            None
-        } else {
-            Some(table_option.ttl)
-        };
-
-        Self { ttl }
-    }
-}
-
-impl From<&TableOption> for risingwave_pb::hummock::TableOption {
-    fn from(table_option: &TableOption) -> Self {
-        Self {
-            ttl: table_option.ttl.unwrap_or(0),
-        }
     }
 }

--- a/src/storage/src/hummock/compactor_tests.rs
+++ b/src/storage/src/hummock/compactor_tests.rs
@@ -173,6 +173,7 @@ mod tests {
                 ReadOptions {
                     epoch,
                     table_id: Default::default(),
+                    ttl: None,
                 },
             )
             .await
@@ -408,6 +409,7 @@ mod tests {
                 ReadOptions {
                     epoch,
                     table_id: Default::default(),
+                    ttl: None,
                 },
             )
             .await
@@ -548,6 +550,7 @@ mod tests {
                 ReadOptions {
                     epoch,
                     table_id: Default::default(),
+                    ttl: None,
                 },
             )
             .await

--- a/src/storage/src/hummock/compactor_tests.rs
+++ b/src/storage/src/hummock/compactor_tests.rs
@@ -15,7 +15,7 @@
 #[cfg(test)]
 mod tests {
 
-    use std::collections::HashMap;
+    use std::collections::{BTreeSet, HashMap};
     use std::sync::Arc;
 
     use bytes::Bytes;
@@ -23,6 +23,7 @@ mod tests {
     use risingwave_common::catalog::TableId;
     use risingwave_common::config::constant::hummock::CompactionFilterFlag;
     use risingwave_common::config::StorageConfig;
+    use risingwave_common::util::epoch::Epoch;
     use risingwave_hummock_sdk::compaction_group::hummock_version_ext::HummockVersionExt;
     use risingwave_hummock_sdk::compaction_group::StaticCompactionGroupId;
     use risingwave_hummock_sdk::key::{get_epoch, get_table_id};
@@ -304,7 +305,7 @@ mod tests {
 
         let drop_table_id = 1;
         let existing_table_ids = 2;
-        let kv_count = 1024;
+        let kv_count = 128;
         let mut epoch: u64 = 1;
         for index in 0..kv_count {
             let table_id = if index % 2 == 0 {
@@ -425,6 +426,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_compaction_drop_key_by_ttl() {
+        // TODO: reduce cost time of test (which cause by commit_epoch 1000 times)
         let (_env, hummock_manager_ref, _cluster_manager_ref, worker_node) =
             setup_compute_env(8080).await;
         let hummock_meta_client = Arc::new(MockHummockMetaClient::new(
@@ -443,14 +445,18 @@ mod tests {
         };
 
         // 1. add sstables
-        let val = Bytes::from(b"0"[..].repeat(1 << 10)); // 1024 Byte value
+        let val = Bytes::from(b"0"[..].to_vec()); // 1 Byte value
 
         let existing_table_id = 2;
-        let kv_count = 128;
-        let mut epoch: u64 = 1;
+        let kv_count = 1001;
+        let base_epoch = Epoch::now();
+        let mut epoch: u64 = base_epoch.0;
+        let millisec_for_epoch: u64 = 1 << 16;
         let keyspace = Keyspace::table_root(storage.clone(), &TableId::new(existing_table_id));
+        let mut epoch_set = BTreeSet::new();
         for _ in 0..kv_count {
-            epoch += 1;
+            epoch += millisec_for_epoch;
+            epoch_set.insert(epoch);
             let mut write_batch = keyspace.state_store().start_write_batch(WriteOptions {
                 epoch,
                 table_id: Default::default(),
@@ -460,8 +466,10 @@ mod tests {
             let ramdom_key = rand::thread_rng().gen::<[u8; 32]>();
             local.put(ramdom_key, StorageValue::new_default_put(val.clone()));
             write_batch.ingest().await.unwrap();
+        }
 
-            storage.sync(Some(epoch)).await.unwrap();
+        storage.sync(None).await.unwrap();
+        for epoch in epoch_set {
             hummock_meta_client
                 .commit_epoch(
                     epoch,
@@ -488,9 +496,13 @@ mod tests {
         compact_task.existing_table_ids.push(existing_table_id);
         let compaction_filter_flag = CompactionFilterFlag::STATE_CLEAN | CompactionFilterFlag::TTL;
         compact_task.compaction_filter_mask = compaction_filter_flag.bits();
-        let ttl_expire = 60;
-        compact_task.table_options =
-            HashMap::from_iter([(existing_table_id, TableOption { ttl: ttl_expire })]);
+        let ttl_expire_second = 1;
+        compact_task.table_options = HashMap::from_iter([(
+            existing_table_id,
+            TableOption {
+                ttl: ttl_expire_second,
+            },
+        )]);
         let watermark = compact_task.watermark;
 
         hummock_manager_ref
@@ -501,7 +513,7 @@ mod tests {
         // assert compact_task
         assert_eq!(
             compact_task.input_ssts.first().unwrap().table_infos.len(),
-            kv_count
+            kv_count,
         );
 
         // 3. compact
@@ -527,7 +539,7 @@ mod tests {
                 .meta
                 .key_count;
         }
-        assert_eq!(ttl_expire, key_count); // ttl will clean the key (which epoch < epoch - ttl)
+        assert_eq!(ttl_expire_second * 1000, key_count); // ttl will clean the key (which epoch < epoch - ttl)
 
         // 5. get compact task and there should be none
         let compact_task = hummock_manager_ref
@@ -556,11 +568,12 @@ mod tests {
             .await
             .unwrap();
         let mut scan_count = 0;
+        let min_epoch = Epoch(watermark).subtract_ms(ttl_expire_second as u64 * 1000);
         for (k, _) in scan_result {
             let table_id = get_table_id(&k).unwrap();
             let epoch = get_epoch(&k);
             assert_eq!(table_id, existing_table_id);
-            assert!(epoch >= (watermark - ttl_expire as u64));
+            assert!(epoch >= min_epoch.0);
             scan_count += 1;
         }
         assert_eq!(key_count, scan_count);

--- a/src/storage/src/hummock/iterator/backward_user.rs
+++ b/src/storage/src/hummock/iterator/backward_user.rs
@@ -53,6 +53,7 @@ pub struct BackwardUserIterator {
     /// Only reads values if `epoch <= self.read_epoch`.
     read_epoch: Epoch,
 
+    /// Only reads values if `ts > self.min_epoch`. use for ttl
     min_epoch: Epoch,
 
     /// Ensures the SSTs needed by `iterator` won't be vacuumed.

--- a/src/storage/src/hummock/iterator/forward_user.rs
+++ b/src/storage/src/hummock/iterator/forward_user.rs
@@ -116,7 +116,7 @@ pub struct UserIterator {
     /// Only reads values if `ts <= self.read_epoch`.
     read_epoch: Epoch,
 
-    /// Only reads values if `ts >= self.min_epoch`.
+    /// Only reads values if `ts > self.min_epoch`.
     min_epoch: Epoch,
 
     /// Ensures the SSTs needed by `iterator` won't be vacuumed.
@@ -132,6 +132,16 @@ impl UserIterator {
         key_range: (Bound<Vec<u8>>, Bound<Vec<u8>>),
     ) -> Self {
         Self::new(iterator, key_range, Epoch::MAX, 0, None)
+    }
+
+    #[cfg(test)]
+    pub(crate) fn for_test_with_epoch(
+        iterator: MergeIterator,
+        key_range: (Bound<Vec<u8>>, Bound<Vec<u8>>),
+        read_epoch: u64,
+        min_epoch: u64,
+    ) -> Self {
+        Self::new(iterator, key_range, read_epoch, min_epoch, None)
     }
 
     /// Create [`UserIterator`] with given `read_epoch`.
@@ -185,6 +195,7 @@ impl UserIterator {
                             Excluded(end_key) => self.out_of_range = key >= end_key.as_slice(),
                             Unbounded => {}
                         };
+
                         return Ok(());
                     }
                     // It means that the key is deleted from the storage.
@@ -299,8 +310,9 @@ mod tests {
     use super::*;
     use crate::hummock::iterator::test_utils::{
         default_builder_opt_for_test, gen_iterator_test_sstable_base,
-        gen_iterator_test_sstable_from_kv_pair, iterator_test_key_of, iterator_test_key_of_epoch,
-        iterator_test_value_of, mock_sstable_store, TEST_KEYS_COUNT,
+        gen_iterator_test_sstable_from_kv_pair, gen_iterator_test_sstable_with_incr_epoch,
+        iterator_test_key_of, iterator_test_key_of_epoch, iterator_test_value_of,
+        mock_sstable_store, TEST_KEYS_COUNT,
     };
     use crate::hummock::iterator::{BoxedForwardHummockIterator, ReadOptions};
     use crate::hummock::sstable::{SSTableIterator, SSTableIteratorType};
@@ -505,6 +517,7 @@ mod tests {
                 read_options,
             )),
         ];
+
         let mi = MergeIterator::new(iters, Arc::new(StateStoreMetrics::unused()));
         let mut ui = UserIterator::for_test(mi, (Unbounded, Unbounded));
         ui.rewind().await.unwrap();
@@ -861,5 +874,45 @@ mod tests {
             .await
             .unwrap();
         assert!(!ui.is_valid());
+    }
+
+    #[tokio::test]
+    async fn test_min_epoch() {
+        let sstable_store = mock_sstable_store();
+        let read_options = Arc::new(ReadOptions::default());
+        let table0 = gen_iterator_test_sstable_with_incr_epoch(
+            0,
+            default_builder_opt_for_test(),
+            |x| x * 3,
+            sstable_store.clone(),
+            TEST_KEYS_COUNT,
+            1,
+        )
+        .await;
+        let cache = create_small_table_cache();
+        let iters: Vec<BoxedForwardHummockIterator> = vec![Box::new(SSTableIterator::create(
+            cache.insert(table0.id, table0.id, 1, Box::new(table0)),
+            sstable_store.clone(),
+            read_options.clone(),
+        ))];
+
+        let min_epoch = (TEST_KEYS_COUNT / 5) as u64;
+        let mi = MergeIterator::new(iters, Arc::new(StateStoreMetrics::unused()));
+        let mut ui =
+            UserIterator::for_test_with_epoch(mi, (Unbounded, Unbounded), u64::MAX, min_epoch);
+        ui.rewind().await.unwrap();
+
+        let mut i = 0;
+        while ui.is_valid() {
+            let key = ui.key();
+            let key_epoch = get_epoch(key);
+            assert!(key_epoch > min_epoch);
+
+            i += 1;
+            ui.next().await.unwrap();
+        }
+
+        let expect_count = TEST_KEYS_COUNT - min_epoch as usize;
+        assert_eq!(i, expect_count);
     }
 }

--- a/src/storage/src/hummock/iterator/forward_user.rs
+++ b/src/storage/src/hummock/iterator/forward_user.rs
@@ -116,7 +116,7 @@ pub struct UserIterator {
     /// Only reads values if `ts <= self.read_epoch`.
     read_epoch: Epoch,
 
-    /// Only reads values if `ts > self.min_epoch`.
+    /// Only reads values if `ts > self.min_epoch`. use for ttl
     min_epoch: Epoch,
 
     /// Ensures the SSTs needed by `iterator` won't be vacuumed.

--- a/src/storage/src/hummock/iterator/test_utils.rs
+++ b/src/storage/src/hummock/iterator/test_utils.rs
@@ -142,3 +142,25 @@ pub fn gen_merge_iterator_interleave_test_sstable_iters(
         })
         .collect_vec()
 }
+
+pub async fn gen_iterator_test_sstable_with_incr_epoch(
+    sst_id: HummockSSTableId,
+    opts: SSTableBuilderOptions,
+    idx_mapping: impl Fn(usize) -> usize,
+    sstable_store: SstableStoreRef,
+    total: usize,
+    epoch_base: u64,
+) -> Sstable {
+    gen_test_sstable(
+        opts,
+        sst_id,
+        (0..total).map(|i| {
+            (
+                iterator_test_key_of_epoch(idx_mapping(i), epoch_base + i as u64),
+                HummockValue::put(iterator_test_value_of(idx_mapping(i))),
+            )
+        }),
+        sstable_store,
+    )
+    .await
+}

--- a/src/storage/src/hummock/snapshot_tests.rs
+++ b/src/storage/src/hummock/snapshot_tests.rs
@@ -33,6 +33,7 @@ macro_rules! assert_count_range_scan {
                 ReadOptions {
                     epoch: $epoch,
                     table_id: Default::default(),
+                    ttl: None,
                 },
             )
             .await
@@ -56,6 +57,7 @@ macro_rules! assert_count_backward_range_scan {
                 ReadOptions {
                     epoch: $epoch,
                     table_id: Default::default(),
+                    ttl: None,
                 },
             )
             .await

--- a/src/storage/src/hummock/state_store.rs
+++ b/src/storage/src/hummock/state_store.rs
@@ -81,6 +81,7 @@ impl HummockStorage {
         T: HummockIteratorType,
     {
         let epoch = read_options.epoch;
+        let min_epoch = read_options.min_epoch();
         let iter_read_options = Arc::new(IterReadOptions::default());
         let mut overlapped_iters = vec![];
 
@@ -170,6 +171,7 @@ impl HummockStorage {
             self.stats.clone(),
             key_range,
             epoch,
+            min_epoch,
             Some(pinned_version),
         );
 

--- a/src/storage/src/hummock/state_store_tests.rs
+++ b/src/storage/src/hummock/state_store_tests.rs
@@ -99,6 +99,7 @@ async fn test_basic() {
             ReadOptions {
                 epoch: epoch1,
                 table_id: Default::default(),
+                ttl: None,
             },
         )
         .await
@@ -111,6 +112,7 @@ async fn test_basic() {
             ReadOptions {
                 epoch: epoch1,
                 table_id: Default::default(),
+                ttl: None,
             },
         )
         .await
@@ -125,6 +127,7 @@ async fn test_basic() {
             ReadOptions {
                 epoch: epoch1,
                 table_id: Default::default(),
+                ttl: None,
             },
         )
         .await
@@ -151,6 +154,7 @@ async fn test_basic() {
             ReadOptions {
                 epoch: epoch2,
                 table_id: Default::default(),
+                ttl: None,
             },
         )
         .await
@@ -178,6 +182,7 @@ async fn test_basic() {
             ReadOptions {
                 epoch: epoch3,
                 table_id: Default::default(),
+                ttl: None,
             },
         )
         .await
@@ -191,6 +196,7 @@ async fn test_basic() {
             ReadOptions {
                 epoch: epoch3,
                 table_id: Default::default(),
+                ttl: None,
             },
         )
         .await
@@ -204,6 +210,7 @@ async fn test_basic() {
             ReadOptions {
                 epoch: epoch1,
                 table_id: Default::default(),
+                ttl: None,
             },
         )
         .await
@@ -218,6 +225,7 @@ async fn test_basic() {
             ReadOptions {
                 epoch: epoch1,
                 table_id: Default::default(),
+                ttl: None,
             },
         )
         .await
@@ -232,6 +240,7 @@ async fn test_basic() {
             ReadOptions {
                 epoch: epoch2,
                 table_id: Default::default(),
+                ttl: None,
             },
         )
         .await
@@ -245,6 +254,7 @@ async fn test_basic() {
             ReadOptions {
                 epoch: epoch2,
                 table_id: Default::default(),
+                ttl: None,
             },
         )
         .await
@@ -259,6 +269,7 @@ async fn test_basic() {
             ReadOptions {
                 epoch: epoch3,
                 table_id: Default::default(),
+                ttl: None,
             },
         )
         .await
@@ -282,6 +293,7 @@ async fn test_basic() {
             ReadOptions {
                 epoch: epoch2,
                 table_id: Default::default(),
+                ttl: None,
             },
         )
         .await
@@ -294,6 +306,7 @@ async fn test_basic() {
             ReadOptions {
                 epoch: epoch2,
                 table_id: Default::default(),
+                ttl: None,
             },
         )
         .await
@@ -492,6 +505,7 @@ async fn test_reload_storage() {
             ReadOptions {
                 epoch: epoch1,
                 table_id: Default::default(),
+                ttl: None,
             },
         )
         .await
@@ -506,6 +520,7 @@ async fn test_reload_storage() {
             ReadOptions {
                 epoch: epoch1,
                 table_id: Default::default(),
+                ttl: None,
             },
         )
         .await
@@ -532,6 +547,7 @@ async fn test_reload_storage() {
             ReadOptions {
                 epoch: epoch2,
                 table_id: Default::default(),
+                ttl: None,
             },
         )
         .await
@@ -546,6 +562,7 @@ async fn test_reload_storage() {
             ReadOptions {
                 epoch: epoch1,
                 table_id: Default::default(),
+                ttl: None,
             },
         )
         .await
@@ -560,6 +577,7 @@ async fn test_reload_storage() {
             ReadOptions {
                 epoch: epoch1,
                 table_id: Default::default(),
+                ttl: None,
             },
         )
         .await
@@ -574,6 +592,7 @@ async fn test_reload_storage() {
             ReadOptions {
                 epoch: epoch2,
                 table_id: Default::default(),
+                ttl: None,
             },
         )
         .await
@@ -587,6 +606,7 @@ async fn test_reload_storage() {
             ReadOptions {
                 epoch: epoch2,
                 table_id: Default::default(),
+                ttl: None,
             },
         )
         .await
@@ -630,7 +650,8 @@ async fn test_write_anytime() {
                 "aa".as_bytes(),
                 ReadOptions {
                     epoch,
-                    table_id: Default::default()
+                    table_id: Default::default(),
+                    ttl: None,
                 }
             ))
             .unwrap()
@@ -642,7 +663,8 @@ async fn test_write_anytime() {
                 "bb".as_bytes(),
                 ReadOptions {
                     epoch,
-                    table_id: Default::default()
+                    table_id: Default::default(),
+                    ttl: None,
                 }
             ))
             .unwrap()
@@ -654,7 +676,8 @@ async fn test_write_anytime() {
                 "cc".as_bytes(),
                 ReadOptions {
                     epoch,
-                    table_id: Default::default()
+                    table_id: Default::default(),
+                    ttl: None,
                 }
             ))
             .unwrap()
@@ -666,6 +689,7 @@ async fn test_write_anytime() {
             ReadOptions {
                 epoch,
                 table_id: Default::default(),
+                ttl: None,
             },
         ))
         .unwrap();
@@ -710,7 +734,8 @@ async fn test_write_anytime() {
                 "aa".as_bytes(),
                 ReadOptions {
                     epoch,
-                    table_id: Default::default()
+                    table_id: Default::default(),
+                    ttl: None,
                 }
             ))
             .unwrap()
@@ -720,7 +745,8 @@ async fn test_write_anytime() {
             "bb".as_bytes(),
             ReadOptions {
                 epoch,
-                table_id: Default::default()
+                table_id: Default::default(),
+                ttl: None,
             }
         ))
         .unwrap()
@@ -731,7 +757,8 @@ async fn test_write_anytime() {
                 "cc".as_bytes(),
                 ReadOptions {
                     epoch,
-                    table_id: Default::default()
+                    table_id: Default::default(),
+                    ttl: None,
                 }
             ))
             .unwrap()
@@ -742,6 +769,7 @@ async fn test_write_anytime() {
             ReadOptions {
                 epoch,
                 table_id: Default::default(),
+                ttl: None,
             },
         ))
         .unwrap();
@@ -874,7 +902,8 @@ async fn test_delete_get() {
             "bb".as_bytes(),
             ReadOptions {
                 epoch: epoch2,
-                table_id: Default::default()
+                table_id: Default::default(),
+                ttl: None,
             }
         )
         .await

--- a/src/storage/src/memory.rs
+++ b/src/storage/src/memory.rs
@@ -313,7 +313,8 @@ mod tests {
                     None,
                     ReadOptions {
                         epoch: 0,
-                        table_id: Default::default()
+                        table_id: Default::default(),
+                        ttl: None,
                     }
                 )
                 .await
@@ -330,7 +331,8 @@ mod tests {
                     Some(1),
                     ReadOptions {
                         epoch: 0,
-                        table_id: Default::default()
+                        table_id: Default::default(),
+                        ttl: None,
                     }
                 )
                 .await
@@ -344,7 +346,8 @@ mod tests {
                     None,
                     ReadOptions {
                         epoch: 1,
-                        table_id: Default::default()
+                        table_id: Default::default(),
+                        ttl: None,
                     }
                 )
                 .await
@@ -357,7 +360,8 @@ mod tests {
                     b"a",
                     ReadOptions {
                         epoch: 0,
-                        table_id: Default::default()
+                        table_id: Default::default(),
+                        ttl: None,
                     }
                 )
                 .await
@@ -370,7 +374,8 @@ mod tests {
                     b"b",
                     ReadOptions {
                         epoch: 0,
-                        table_id: Default::default()
+                        table_id: Default::default(),
+                        ttl: None,
                     }
                 )
                 .await
@@ -383,7 +388,8 @@ mod tests {
                     b"c",
                     ReadOptions {
                         epoch: 0,
-                        table_id: Default::default()
+                        table_id: Default::default(),
+                        ttl: None,
                     }
                 )
                 .await
@@ -396,7 +402,8 @@ mod tests {
                     b"a",
                     ReadOptions {
                         epoch: 1,
-                        table_id: Default::default()
+                        table_id: Default::default(),
+                        ttl: None,
                     }
                 )
                 .await
@@ -409,7 +416,8 @@ mod tests {
                     b"b",
                     ReadOptions {
                         epoch: 1,
-                        table_id: Default::default()
+                        table_id: Default::default(),
+                        ttl: None,
                     }
                 )
                 .await
@@ -422,7 +430,8 @@ mod tests {
                     b"c",
                     ReadOptions {
                         epoch: 1,
-                        table_id: Default::default()
+                        table_id: Default::default(),
+                        ttl: None,
                     }
                 )
                 .await

--- a/src/storage/src/storage_failpoints/test_hummock.rs
+++ b/src/storage/src/storage_failpoints/test_hummock.rs
@@ -82,6 +82,7 @@ async fn test_failpoints_state_store_read_upload() {
             ReadOptions {
                 epoch: 1,
                 table_id: Default::default(),
+                ttl: None,
             },
         )
         .await
@@ -124,6 +125,7 @@ async fn test_failpoints_state_store_read_upload() {
             ReadOptions {
                 epoch: 2,
                 table_id: Default::default(),
+                ttl: None,
             },
         )
         .await;
@@ -134,6 +136,7 @@ async fn test_failpoints_state_store_read_upload() {
             ReadOptions {
                 epoch: 2,
                 table_id: Default::default(),
+                ttl: None,
             },
         )
         .await;
@@ -145,6 +148,7 @@ async fn test_failpoints_state_store_read_upload() {
             ReadOptions {
                 epoch: 2,
                 table_id: Default::default(),
+                ttl: None,
             },
         )
         .await
@@ -176,6 +180,7 @@ async fn test_failpoints_state_store_read_upload() {
             ReadOptions {
                 epoch: 5,
                 table_id: Default::default(),
+                ttl: None,
             },
         )
         .await
@@ -188,6 +193,7 @@ async fn test_failpoints_state_store_read_upload() {
             ReadOptions {
                 epoch: 5,
                 table_id: Default::default(),
+                ttl: None,
             },
         )
         .await

--- a/src/storage/src/store.rs
+++ b/src/storage/src/store.rs
@@ -183,10 +183,20 @@ pub trait StateStoreIter: Send + 'static {
 pub struct ReadOptions {
     pub epoch: u64,
     pub table_id: Option<TableId>,
+    pub ttl: Option<u32>,
 }
 
 #[derive(Default, Clone)]
 pub struct WriteOptions {
     pub epoch: u64,
     pub table_id: TableId,
+}
+
+impl ReadOptions {
+    pub fn min_epoch(&self) -> u64 {
+        match self.ttl {
+            Some(ttl_u32) => self.epoch - ttl_u32 as u64,
+            None => 0,
+        }
+    }
 }

--- a/src/stream/src/executor/lookup/tests.rs
+++ b/src/stream/src/executor/lookup/tests.rs
@@ -247,6 +247,7 @@ async fn test_lookup_this_epoch() {
             ReadOptions {
                 epoch: u64::MAX,
                 table_id: Default::default(),
+                ttl: None,
             },
         )
         .await


### PR DESCRIPTION
I hereby agree to the terms of the [Singularity Data, Inc. Contributor License Agreement](https://gist.github.com/skyzh/0663682a70b0edde7ae991492f2314cb#file-s9y_cla).

## What's changed and what's your intention?
Some change about TTL as title

Please explain **IN DETAIL** what the changes are in this PR and why they are needed:
- ~`keyspace` adapt table properties with `CatalogTable`~
-  `UserIterator` add check through min_epoch
- `ReadOptions` add Option<ttl> and support to calculate min_epoch for iterator


## Checklist

- [x] I have written necessary docs and comments
- [x] I have added necessary unit tests and integration tests

## Refer to a related PR or issue link (optional)
- https://github.com/singularity-data/risingwave/issues/3298