### PR TITLE
perf(hummock manager): apply version delta from version checkpoint

### DIFF
--- a/src/meta/src/hummock/hummock_manager.rs
+++ b/src/meta/src/hummock/hummock_manager.rs
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use std::collections::{BTreeMap, HashSet, VecDeque};
+use std::collections::{BTreeMap, BTreeSet, HashSet, VecDeque};
 use std::future::Future;
 use std::ops::DerefMut;
 use std::sync::atomic::{AtomicU64, Ordering};
@@ -220,9 +220,10 @@ where
             .await?
             .unwrap_or_else(CurrentHummockVersionId::new);
 
-        let mut version_ids: HashSet<_> = HummockVersion::list(self.env.meta_store())
+        let versions = HummockVersion::list(self.env.meta_store()).await?;
+        let mut version_ids: BTreeSet<_> = HummockVersion::list(self.env.meta_store())
             .await?
-            .into_iter()
+            .iter()
             .map(|version| version.id)
             .collect();
 
@@ -234,7 +235,7 @@ where
                 .collect();
 
         // Insert the initial version.
-        if versioning_guard.hummock_versions.is_empty() {
+        let mut redo_state = if version_ids.is_empty() {
             let mut init_version = HummockVersion {
                 id: FIRST_VERSION_ID,
                 levels: Default::default(),
@@ -261,18 +262,18 @@ where
                     .levels
                     .insert(compaction_group.group_id(), Levels { levels });
             }
-            if version_ids.is_empty() {
-                version_ids.insert(init_version.id);
-            }
-            let mut redo_state = init_version.clone();
-            if version_ids.contains(&init_version.id) {
-                init_version.insert(self.env.meta_store()).await?;
-                versioning_guard
-                    .hummock_versions
-                    .insert(init_version.id, init_version);
-            }
+            version_ids.insert(init_version.id);
+            init_version.insert(self.env.meta_store()).await?;
+            init_version
+        } else {
+            versions.first().unwrap().clone()
+        };
+        versioning_guard
+            .hummock_versions
+            .insert(redo_state.id, redo_state.clone());
 
-            for (id, version_delta) in &hummock_version_deltas {
+        for (id, version_delta) in &hummock_version_deltas {
+            if version_delta.prev_id == redo_state.id {
                 for (compaction_group_id, level_deltas) in &version_delta.level_deltas {
                     let mut delete_sst_levels = Vec::with_capacity(level_deltas.level_deltas.len());
                     let mut delete_sst_ids_set = HashSet::new();
@@ -303,12 +304,9 @@ where
                 redo_state.max_committed_epoch = version_delta.max_committed_epoch;
                 redo_state.safe_epoch = version_delta.safe_epoch;
 
-                if version_ids.contains(&redo_state.id) {
-                    redo_state.insert(self.env.meta_store()).await?;
-                    versioning_guard
-                        .hummock_versions
-                        .insert(redo_state.id, redo_state.clone());
-                }
+                versioning_guard
+                    .hummock_versions
+                    .insert(redo_state.id, redo_state.clone());
             }
         }
         self.max_committed_epoch.store(
@@ -836,11 +834,11 @@ where
                 compact_status,
                 compact_task_assignment,
                 current_version_id,
-                hummock_versions,
                 hummock_version_deltas,
                 version_stale_sstables,
                 sstable_id_infos
             )?;
+            hummock_versions.commit();
         } else {
             // The compaction task is cancelled.
             commit_multi_var!(
@@ -1009,11 +1007,11 @@ where
         commit_multi_var!(
             self,
             None,
-            new_hummock_version,
             new_version_delta,
             current_version_id,
             sstable_id_infos
         )?;
+        new_hummock_version.commit();
         self.max_committed_epoch.store(epoch, Ordering::Release);
 
         // Update metrics
@@ -1147,6 +1145,18 @@ where
         Ok(version_ids)
     }
 
+    pub async fn proceed_version_checkpoint(&self) -> risingwave_common::error::Result<()> {
+        let versioning_guard = self.versioning.read().await;
+        let new_checkpoint = versioning_guard
+            .hummock_versions
+            .first_key_value()
+            .unwrap()
+            .1
+            .clone();
+        new_checkpoint.insert(self.env.meta_store()).await?;
+        Ok(())
+    }
+
     /// Get the reference count of given version id
     pub async fn get_version_pin_count(
         &self,
@@ -1257,7 +1267,7 @@ where
             let compact_statuses_copy = compaction_guard.compaction_statuses.clone();
             let compact_task_assignment_copy = compaction_guard.compact_task_assignment.clone();
             let current_version_id_copy = versioning_guard.current_version_id.clone();
-            let hummmock_versions_copy = versioning_guard.hummock_versions.clone();
+            // let hummmock_versions_copy = versioning_guard.hummock_versions.clone();
             let pinned_versions_copy = versioning_guard.pinned_versions.clone();
             let pinned_snapshots_copy = versioning_guard.pinned_snapshots.clone();
             let stale_sstables_copy = versioning_guard.stale_sstables.clone();
@@ -1266,7 +1276,7 @@ where
                 compact_statuses_copy,
                 compact_task_assignment_copy,
                 current_version_id_copy,
-                hummmock_versions_copy,
+                // hummmock_versions_copy,
                 pinned_versions_copy,
                 pinned_snapshots_copy,
                 stale_sstables_copy,
@@ -1426,6 +1436,16 @@ where
     /// Gets current version without pinning it.
     pub async fn get_current_version(&self) -> HummockVersion {
         self.versioning.read().await.current_version()
+    }
+
+    pub async fn get_version(&self, version_id: HummockVersionId) -> HummockVersion {
+        self.versioning
+            .read()
+            .await
+            .hummock_versions
+            .get(&version_id)
+            .unwrap()
+            .clone()
     }
 
     pub fn set_compaction_scheduler(&self, sender: CompactionRequestChannelRef) {

--- a/src/meta/src/hummock/hummock_manager_tests.rs
+++ b/src/meta/src/hummock/hummock_manager_tests.rs
@@ -26,7 +26,7 @@ use risingwave_hummock_sdk::{
 };
 use risingwave_pb::common::{HostAddress, ParallelUnitType, WorkerType};
 use risingwave_pb::hummock::{
-    HummockPinnedSnapshot, HummockPinnedVersion, HummockSnapshot, HummockVersion, KeyRange,
+    HummockPinnedSnapshot, HummockPinnedVersion, HummockSnapshot, KeyRange,
 };
 
 use crate::hummock::compaction::ManualCompactionOption;
@@ -192,10 +192,7 @@ async fn test_hummock_compaction_task() {
         .await
         .unwrap()
         .unwrap();
-    let hummock_version1 = HummockVersion::select(env.meta_store(), &version_id1.id())
-        .await
-        .unwrap()
-        .unwrap();
+    let hummock_version1 = hummock_manager.get_version(version_id1.id()).await;
 
     // safe epoch should be INVALID before success compaction
     assert_eq!(INVALID_EPOCH, hummock_version1.safe_epoch);
@@ -242,10 +239,7 @@ async fn test_hummock_compaction_task() {
         .unwrap()
         .unwrap();
 
-    let hummock_version2 = HummockVersion::select(env.meta_store(), &version_id2.id())
-        .await
-        .unwrap()
-        .unwrap();
+    let hummock_version2 = hummock_manager.get_version(version_id2.id()).await;
 
     // safe epoch should still be INVALID since comapction task is canceled
     assert_eq!(INVALID_EPOCH, hummock_version2.safe_epoch);
@@ -280,10 +274,7 @@ async fn test_hummock_compaction_task() {
         .unwrap()
         .unwrap();
 
-    let hummock_version3 = HummockVersion::select(env.meta_store(), &version_id3.id())
-        .await
-        .unwrap()
-        .unwrap();
+    let hummock_version3 = hummock_manager.get_version(version_id3.id()).await;
 
     // Since there is no pinned epochs, the safe epoch in version should be max_committed_epoch
     assert_eq!(epoch, hummock_version3.safe_epoch);
@@ -642,10 +633,6 @@ async fn test_hummock_manager_basic() {
         .delete_versions(&[FIRST_VERSION_ID])
         .await
         .unwrap();
-    assert_eq!(
-        hummock_manager.list_version_ids_asc().await.unwrap(),
-        vec![FIRST_VERSION_ID + 1]
-    );
 }
 
 #[tokio::test]
@@ -1026,10 +1013,7 @@ async fn test_trigger_manual_compaction() {
         .await
         .unwrap()
         .unwrap();
-    let hummock_version1 = HummockVersion::select(env.meta_store(), &version_id1.id())
-        .await
-        .unwrap()
-        .unwrap();
+    let hummock_version1 = hummock_manager.get_version(version_id1.id()).await;
 
     // safe epoch should be INVALID before success compaction
     assert_eq!(INVALID_EPOCH, hummock_version1.safe_epoch);

--- a/src/meta/src/hummock/model/version.rs
+++ b/src/meta/src/hummock/model/version.rs
@@ -44,6 +44,6 @@ impl MetadataModel for HummockVersion {
     }
 
     fn key(&self) -> risingwave_common::error::Result<Self::KeyType> {
-        Ok(self.id)
+        Ok(0)
     }
 }


### PR DESCRIPTION
I hereby agree to the terms of the [Singularity Data, Inc. Contributor License Agreement](https://gist.github.com/skyzh/0663682a70b0edde7ae991492f2314cb#file-s9y_cla).

## What's changed and what's your intention?

apply version delta from version checkpoint
this PR is successor of https://github.com/singularity-data/risingwave/pull/3503 and #3529

## Checklist

## Refer to a related PR or issue link (optional)
