### PR TITLE
updated the grafana ip from 127.0.0.1 to 0.0.0.0

### DIFF
--- a/risedev.yml
+++ b/risedev.yml
@@ -503,7 +503,7 @@ template:
     listen-address: ${address}
 
     # Advertise address of Grafana
-    address: "127.0.0.1"
+    address: "0.0.0.0"
 
     # Listen port of Grafana
     port: 3001


### PR DESCRIPTION
I hereby agree to the terms of the [Singularity Data, Inc. Contributor License Agreement](https://gist.github.com/skyzh/0663682a70b0edde7ae991492f2314cb#file-s9y_cla).

## Updated the Grafana ip from 127.0.0.1 to 0.0.0.0 to allow the other IPs also apart from localhost.

***PLEASE DO NOT LEAVE THIS EMPTY !!!***

Please explain **IN DETAIL** what the changes are in this PR and why they are needed:

- Updated the Grafana ip from 127.0.0.1 to 0.0.0.0
- It is required to run the Grafana dashboard for benchmarking run 
- As we run the benchmarks on various machines, it will be useful to access the Grafana matrices from our machine


## Checklist

- [x] I have written necessary docs and comments
- [x] I have added necessary unit tests and integration tests
- [x] All checks passed in `./risedev check` (or alias, `./risedev c`)

## Refer to a related PR or issue link (optional)
