### PR TITLE
test: set sortmode rowsort

### DIFF
--- a/e2e_test/batch/basic/generate_series.slt
+++ b/e2e_test/batch/basic/generate_series.slt
@@ -1,3 +1,5 @@
+control sortmode rowsort
+
 statement ok
 SET RW_IMPLICIT_FLUSH TO true;
 

--- a/e2e_test/batch/config.slt
+++ b/e2e_test/batch/config.slt
@@ -1,2 +1,4 @@
+control sortmode rowsort
+
 statement ok
 set extra_float_digits = 3;

--- a/e2e_test/batch/distribution_mode.slt
+++ b/e2e_test/batch/distribution_mode.slt
@@ -1,3 +1,5 @@
+control sortmode rowsort
+
 statement ok
 SET RW_IMPLICIT_FLUSH TO true;
 

--- a/e2e_test/batch/explain.slt
+++ b/e2e_test/batch/explain.slt
@@ -1,3 +1,5 @@
+control sortmode rowsort
+
 statement ok
 create table t(v int);
 

--- a/e2e_test/batch/local_mode.slt
+++ b/e2e_test/batch/local_mode.slt
@@ -1,3 +1,5 @@
+control sortmode rowsort
+
 statement ok
 SET RW_IMPLICIT_FLUSH TO true;
 

--- a/e2e_test/batch/tpch.slt
+++ b/e2e_test/batch/tpch.slt
@@ -1,3 +1,5 @@
+control sortmode rowsort
+
 statement ok
 SET RW_IMPLICIT_FLUSH TO true;
 

--- a/e2e_test/database/prepare.slt
+++ b/e2e_test/database/prepare.slt
@@ -1,3 +1,5 @@
+control sortmode rowsort
+
 # Create a test database.
 statement ok
 create database test;

--- a/e2e_test/database/test.slt
+++ b/e2e_test/database/test.slt
@@ -1,3 +1,5 @@
+control sortmode rowsort
+
 query T rowsort
 show schemas;
 ----

--- a/e2e_test/ddl/database.slt
+++ b/e2e_test/ddl/database.slt
@@ -1,3 +1,5 @@
+control sortmode rowsort
+
 # Create a database.
 statement ok
 create database ddl_database;

--- a/e2e_test/ddl/index.slt
+++ b/e2e_test/ddl/index.slt
@@ -1,3 +1,5 @@
+control sortmode rowsort
+
 # Create a table.
 statement ok
 create table ddl_t (v1 int not null);

--- a/e2e_test/ddl/privilege.slt
+++ b/e2e_test/ddl/privilege.slt
@@ -1,3 +1,5 @@
+control sortmode rowsort
+
 # Create a super user.
 statement ok
 CREATE USER user WITH SUPERUSER PASSWORD 'password';

--- a/e2e_test/ddl/schema.slt
+++ b/e2e_test/ddl/schema.slt
@@ -1,3 +1,5 @@
+control sortmode rowsort
+
 # Create a table under the default schema.
 statement ok
 create table ddl_table;

--- a/e2e_test/ddl/show.slt
+++ b/e2e_test/ddl/show.slt
@@ -1,3 +1,5 @@
+control sortmode rowsort
+
 statement ok
 create table t3 (v1 int not null, v2 int not null, v3 int not null);
 

--- a/e2e_test/ddl/table.slt
+++ b/e2e_test/ddl/table.slt
@@ -1,3 +1,5 @@
+control sortmode rowsort
+
 # Create a table.
 statement ok
 create table ddl_t (v1 int not null);

--- a/e2e_test/ddl/user.slt
+++ b/e2e_test/ddl/user.slt
@@ -1,3 +1,5 @@
+control sortmode rowsort
+
 # Create a user.
 statement ok
 CREATE USER ddl_user WITH NOSUPERUSER CREATEDB PASSWORD 'md5827ccb0eea8a706c4c34a16891f84e7b';

--- a/e2e_test/source/basic_test.slt
+++ b/e2e_test/source/basic_test.slt
@@ -1,3 +1,5 @@
+control sortmode rowsort
+
 statement ok
 create materialized source s1 (v1 int, v2 varchar) with ( 'connector' = 'kafka', 'kafka.topic' = 'kafka_1_partition_topic', 'kafka.brokers' = '127.0.0.1:29092', 'kafka.scan.startup.mode'='earliest' ) row format json
 

--- a/e2e_test/source/ddl.slt
+++ b/e2e_test/source/ddl.slt
@@ -1,3 +1,5 @@
+control sortmode rowsort
+
 statement ok
 create materialized source s with ( 'connector' = 'kafka', 'kafka.topic' = 'kafka_1_partition_topic', 'kafka.brokers' = '127.0.0.1:29092' ) row format json;
 

--- a/e2e_test/streaming/append_only.slt
+++ b/e2e_test/streaming/append_only.slt
@@ -1,3 +1,5 @@
+control sortmode rowsort
+
 statement ok
 create table t1 (v1 int not null, v2 int not null) with ('appendonly' = true);
 

--- a/e2e_test/streaming/basic.slt
+++ b/e2e_test/streaming/basic.slt
@@ -1,3 +1,5 @@
+control sortmode rowsort
+
 statement ok
 create table t1 (v1 int not null, v2 int not null, v3 int not null);
 

--- a/e2e_test/streaming/count_star.slt
+++ b/e2e_test/streaming/count_star.slt
@@ -1,3 +1,5 @@
+control sortmode rowsort
+
 statement ok
 create table t (v int);
 

--- a/e2e_test/streaming/datagen.slt
+++ b/e2e_test/streaming/datagen.slt
@@ -1,3 +1,5 @@
+control sortmode rowsort
+
 statement ok
 create materialized source s1 (v1 int, v2 float) with ( 'connector' = 'datagen' ,'fields.v1.kind' = 'sequence',
 'fields.v1.start' = '1','fields.v1.end'  = '10','fields.v2.kind' = 'sequence',

--- a/e2e_test/streaming/demo/ad_ctr.slt
+++ b/e2e_test/streaming/demo/ad_ctr.slt
@@ -1,3 +1,5 @@
+control sortmode rowsort
+
 statement ok
 SET RW_IMPLICIT_FLUSH TO true;
 

--- a/e2e_test/streaming/demo/metric_analysis.slt
+++ b/e2e_test/streaming/demo/metric_analysis.slt
@@ -1,3 +1,5 @@
+control sortmode rowsort
+
 statement ok
 CREATE TABLE nics_metrics (
     device_id VARCHAR,

--- a/e2e_test/streaming/extreme_null.slt
+++ b/e2e_test/streaming/extreme_null.slt
@@ -1,3 +1,5 @@
+control sortmode rowsort
+
 statement ok
 SET RW_IMPLICIT_FLUSH TO true;
 

--- a/e2e_test/streaming/join-3way.slt
+++ b/e2e_test/streaming/join-3way.slt
@@ -1,3 +1,5 @@
+control sortmode rowsort
+
 statement ok
 create table t1 (v1 int, v2 int);
 

--- a/e2e_test/streaming/join.slt
+++ b/e2e_test/streaming/join.slt
@@ -1,3 +1,5 @@
+control sortmode rowsort
+
 # INNER JOIN
 statement ok
 create table t1 (v1 int not null, v2 int not null, v3 int not null);

--- a/e2e_test/streaming/mv_on_mv.slt
+++ b/e2e_test/streaming/mv_on_mv.slt
@@ -1,3 +1,5 @@
+control sortmode rowsort
+
 statement ok
 create table t1(v1 int not null, v2 int not null);
 

--- a/e2e_test/streaming/nexmark_snapshot.slt
+++ b/e2e_test/streaming/nexmark_snapshot.slt
@@ -1,3 +1,5 @@
+control sortmode rowsort
+
 include ../nexmark/create_tables.slt.part
 
 include ../nexmark/insert_person.slt.part

--- a/e2e_test/streaming/nexmark_upstream.slt
+++ b/e2e_test/streaming/nexmark_upstream.slt
@@ -1,3 +1,5 @@
+control sortmode rowsort
+
 include ../nexmark/create_tables.slt.part
 
 include ./nexmark/create_views.slt.part

--- a/e2e_test/streaming/order_by.slt
+++ b/e2e_test/streaming/order_by.slt
@@ -1,3 +1,5 @@
+control sortmode rowsort
+
 statement ok
 SET RW_IMPLICIT_FLUSH TO true;
 

--- a/e2e_test/streaming/struct_table.slt
+++ b/e2e_test/streaming/struct_table.slt
@@ -1,3 +1,5 @@
+control sortmode rowsort
+
 statement ok
 SET RW_IMPLICIT_FLUSH TO true;
 

--- a/e2e_test/streaming/tpch_snapshot.slt
+++ b/e2e_test/streaming/tpch_snapshot.slt
@@ -1,3 +1,5 @@
+control sortmode rowsort
+
 include ../tpch/create_tables.slt.part
 
 include ../tpch/insert_customer.slt.part

--- a/e2e_test/streaming/tpch_upstream.slt
+++ b/e2e_test/streaming/tpch_upstream.slt
@@ -1,3 +1,5 @@
+control sortmode rowsort
+
 include ../tpch/create_tables.slt.part
 
 include ../tpch/insert_customer.slt.part

--- a/e2e_test/streaming_delta_join/join-3way.slt
+++ b/e2e_test/streaming_delta_join/join-3way.slt
@@ -1,3 +1,5 @@
+control sortmode rowsort
+
 statement ok
 SET RW_FORCE_DELTA_JOIN TO true;
 

--- a/e2e_test/streaming_delta_join/tpch_snapshot.slt
+++ b/e2e_test/streaming_delta_join/tpch_snapshot.slt
@@ -1,3 +1,5 @@
+control sortmode rowsort
+
 statement ok
 SET RW_FORCE_DELTA_JOIN TO true;
 


### PR DESCRIPTION
I hereby agree to the terms of the [Singularity Data, Inc. Contributor License Agreement](https://gist.github.com/skyzh/0663682a70b0edde7ae991492f2314cb#file-s9y_cla).

## What's changed and what's your intention?

Problem occured in https://github.com/singularity-data/risingwave/pull/3251. After we have parralel batch scan, the results from each partition is not ordered. 

I think sorting results by default makes sense. `nosort` should be added explicitly for special cases.

This PR added `control sortmode rowsort` to all `slt` files. Tell me if some files should use `nosort`
