### PR TITLE
chore(binder): add descriptions to some NotImplemented error

### DIFF
--- a/src/frontend/src/binder/expr/binary_op.rs
+++ b/src/frontend/src/binder/expr/binary_op.rs
@@ -51,7 +51,13 @@ impl Binder {
             BinaryOperator::PGBitwiseShiftRight => ExprType::BitwiseShiftRight,
             BinaryOperator::Concat => return self.bind_concat_op(bound_left, bound_right),
 
-            _ => return Err(ErrorCode::NotImplemented(format!("{:?}", op), 112.into()).into()),
+            _ => {
+                return Err(ErrorCode::NotImplemented(
+                    format!("unsuported binary op: {:?}", op),
+                    112.into(),
+                )
+                .into())
+            }
         };
         Ok(FunctionCall::new(func_type, vec![bound_left, bound_right])?.into())
     }

--- a/src/frontend/src/binder/expr/binary_op.rs
+++ b/src/frontend/src/binder/expr/binary_op.rs
@@ -52,11 +52,9 @@ impl Binder {
             BinaryOperator::Concat => return self.bind_concat_op(bound_left, bound_right),
 
             _ => {
-                return Err(ErrorCode::NotImplemented(
-                    format!("binary op: {:?}", op),
-                    112.into(),
+                return Err(
+                    ErrorCode::NotImplemented(format!("binary op: {:?}", op), 112.into()).into(),
                 )
-                .into())
             }
         };
         Ok(FunctionCall::new(func_type, vec![bound_left, bound_right])?.into())

--- a/src/frontend/src/binder/expr/binary_op.rs
+++ b/src/frontend/src/binder/expr/binary_op.rs
@@ -53,7 +53,7 @@ impl Binder {
 
             _ => {
                 return Err(ErrorCode::NotImplemented(
-                    format!("unsuported binary op: {:?}", op),
+                    format!("binary op: {:?}", op),
                     112.into(),
                 )
                 .into())

--- a/src/frontend/src/binder/expr/value.rs
+++ b/src/frontend/src/binder/expr/value.rs
@@ -39,7 +39,7 @@ impl Binder {
                 fractional_seconds_precision: None,
             } => self.bind_interval(value, leading_field),
             _ => Err(ErrorCode::NotImplemented(
-                format!("unsupported value: {:?}", value),
+                format!("value: {:?}", value),
                 None.into(),
             )
             .into()),

--- a/src/frontend/src/binder/expr/value.rs
+++ b/src/frontend/src/binder/expr/value.rs
@@ -38,7 +38,11 @@ impl Binder {
                 last_field: None,
                 fractional_seconds_precision: None,
             } => self.bind_interval(value, leading_field),
-            _ => Err(ErrorCode::NotImplemented(format!("{:?}", value), None.into()).into()),
+            _ => Err(ErrorCode::NotImplemented(
+                format!("unsupported value: {:?}", value),
+                None.into(),
+            )
+            .into()),
         }
     }
 

--- a/src/frontend/src/binder/expr/value.rs
+++ b/src/frontend/src/binder/expr/value.rs
@@ -38,11 +38,7 @@ impl Binder {
                 last_field: None,
                 fractional_seconds_precision: None,
             } => self.bind_interval(value, leading_field),
-            _ => Err(ErrorCode::NotImplemented(
-                format!("value: {:?}", value),
-                None.into(),
-            )
-            .into()),
+            _ => Err(ErrorCode::NotImplemented(format!("value: {:?}", value), None.into()).into()),
         }
     }
 

--- a/src/frontend/src/binder/set_expr.rs
+++ b/src/frontend/src/binder/set_expr.rs
@@ -49,7 +49,16 @@ impl Binder {
         match set_expr {
             SetExpr::Select(s) => Ok(BoundSetExpr::Select(Box::new(self.bind_select(*s)?))),
             SetExpr::Values(v) => Ok(BoundSetExpr::Values(Box::new(self.bind_values(v, None)?))),
-            _ => Err(ErrorCode::NotImplemented(format!("{:?}", set_expr), None.into()).into()),
+            SetExpr::Query(q) => Err(ErrorCode::NotImplemented(
+                format!("Parenthesized SELECT subquery: ({:})\nYou can try to remove the parentheses if they are optional", q),
+                3584.into(),
+            )
+            .into()),
+            _ => Err(ErrorCode::NotImplemented(
+                format!("unsupported set expr: {:}", set_expr),
+                None.into(),
+            )
+            .into()),
         }
     }
 }

--- a/src/frontend/src/binder/set_expr.rs
+++ b/src/frontend/src/binder/set_expr.rs
@@ -55,7 +55,7 @@ impl Binder {
             )
             .into()),
             _ => Err(ErrorCode::NotImplemented(
-                format!("unsupported set expr: {:}", set_expr),
+                format!("set expr: {:}", set_expr),
                 None.into(),
             )
             .into()),


### PR DESCRIPTION
I hereby agree to the terms of the [Singularity Data, Inc. Contributor License Agreement](https://gist.github.com/skyzh/0663682a70b0edde7ae991492f2314cb#file-s9y_cla).

## What's changed and what's your intention?
as title

old error for create mv with parentheses is confusing
<img width="1134" alt="image" src="https://user-images.githubusercontent.com/37948597/176762073-b8f8e718-b368-452e-90f9-37ac570bb718.png">

new
<img width="1105" alt="image" src="https://user-images.githubusercontent.com/37948597/176762292-62c7da52-090d-4f45-bc8a-eb19e333bf0f.png">
