### PR TITLE
fix(batch): remove async_trait from ExchangeSource(#1463)

### DIFF
--- a/src/batch/src/exchange_source.rs
+++ b/src/batch/src/exchange_source.rs
@@ -1,0 +1,39 @@
+use std::fmt::Debug;
+use std::future::Future;
+
+use risingwave_common::array::DataChunk;
+
+use crate::execution::grpc_exchange::GrpcExchangeSource;
+use crate::execution::local_exchange::LocalExchangeSource;
+#[cfg(test)]
+use crate::executor::test_utils::FakeExchangeSource;
+
+/// Each `ExchangeSource` maps to one task, it takes the execution result from task chunk by chunk.
+pub trait ExchangeSource: Send + Debug {
+    type TakeDataFuture<'a>: Future<Output = risingwave_common::error::Result<Option<DataChunk>>>
+        + 'a
+    where
+        Self: 'a;
+    fn take_data(&mut self) -> Self::TakeDataFuture<'_>;
+}
+
+#[derive(Debug)]
+pub enum ExchangeSourceImpl {
+    Grpc(GrpcExchangeSource),
+    Local(LocalExchangeSource),
+    #[cfg(test)]
+    Fake(FakeExchangeSource),
+}
+
+impl ExchangeSourceImpl {
+    pub(crate) async fn take_data(
+        &mut self,
+    ) -> risingwave_common::error::Result<Option<DataChunk>> {
+        match self {
+            ExchangeSourceImpl::Grpc(grpc) => grpc.take_data().await,
+            ExchangeSourceImpl::Local(local) => local.take_data().await,
+            #[cfg(test)]
+            ExchangeSourceImpl::Fake(fake) => fake.take_data().await,
+        }
+    }
+}

--- a/src/batch/src/execution/grpc_exchange.rs
+++ b/src/batch/src/execution/grpc_exchange.rs
@@ -87,6 +87,7 @@ impl ExchangeSource for GrpcExchangeSource {
                 data
             );
 
-        Ok(Some(data))
+            Ok(Some(data))
+        }
     }
 }

--- a/src/batch/src/executor/merge_sort_exchange.rs
+++ b/src/batch/src/executor/merge_sort_exchange.rs
@@ -24,8 +24,8 @@ use risingwave_common::types::ToOwnedDatum;
 use risingwave_common::util::sort_util::{HeapElem, OrderPair, K_PROCESSING_WINDOW_SIZE};
 use risingwave_pb::batch_plan::plan_node::NodeBody;
 use risingwave_pb::batch_plan::ExchangeSource as ProstExchangeSource;
-use risingwave_rpc_client::ExchangeSource;
 
+use crate::exchange_source::ExchangeSourceImpl;
 use crate::executor::{
     BoxedDataChunkStream, BoxedExecutor, BoxedExecutorBuilder, CreateSource, DefaultCreateSource,
     Executor, ExecutorBuilder,
@@ -45,7 +45,7 @@ pub struct MergeSortExchangeExecutorImpl<CS, C> {
     order_pairs: Arc<Vec<OrderPair>>,
     min_heap: BinaryHeap<HeapElem>,
     proto_sources: Vec<ProstExchangeSource>,
-    sources: Vec<Box<dyn ExchangeSource>>,
+    sources: Vec<ExchangeSourceImpl>, // impl
     /// Mock-able CreateSource.
     source_creators: Vec<CS>,
     schema: Schema,

--- a/src/batch/src/executor/test_utils.rs
+++ b/src/batch/src/executor/test_utils.rs
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 use std::collections::VecDeque;
+use std::future::Future;
 
 use assert_matches::assert_matches;
 use futures_async_stream::{for_await, try_stream};
@@ -20,8 +21,9 @@ use itertools::Itertools;
 use risingwave_common::array::DataChunk;
 use risingwave_common::catalog::Schema;
 use risingwave_common::error::{Result, RwError};
-use risingwave_rpc_client::ExchangeSource;
+use risingwave_pb::batch_plan::ExchangeSource as ProstExchangeSource;
 
+use crate::exchange_source::{ExchangeSource, ExchangeSourceImpl};
 use crate::executor::{BoxedDataChunkStream, BoxedExecutor, CreateSource, Executor};
 use crate::task::BatchTaskContext;
 
@@ -146,7 +148,7 @@ fn is_data_chunk_eq(left: &DataChunk, right: &DataChunk) {
 }
 
 #[derive(Debug, Clone)]
-pub(super) struct FakeExchangeSource {
+pub struct FakeExchangeSource {
     chunks: Vec<Option<DataChunk>>,
 }
 
@@ -156,13 +158,15 @@ impl FakeExchangeSource {
     }
 }
 
-#[async_trait::async_trait]
 impl ExchangeSource for FakeExchangeSource {
-    async fn take_data(&mut self) -> Result<Option<DataChunk>> {
-        if let Some(chunk) = self.chunks.pop() {
-            Ok(chunk)
-        } else {
-            Ok(None)
+    type TakeDataFuture<'a> = impl Future<Output = Result<Option<DataChunk>>>;
+    fn take_data(&mut self) -> Self::TakeDataFuture<'_> {
+        async {
+            if let Some(chunk) = self.chunks.pop() {
+                Ok(chunk)
+            } else {
+                Ok(None)
+            }
         }
     }
 }
@@ -180,15 +184,13 @@ impl FakeCreateSource {
     }
 }
 
-use risingwave_pb::batch_plan::ExchangeSource as ProstExchangeSource;
-
 #[async_trait::async_trait]
 impl CreateSource for FakeCreateSource {
     async fn create_source(
         &self,
         _: impl BatchTaskContext,
         _: &ProstExchangeSource,
-    ) -> Result<Box<dyn ExchangeSource>> {
-        Ok(Box::new(self.fake_exchange_source.clone()))
+    ) -> Result<ExchangeSourceImpl> {
+        Ok(ExchangeSourceImpl::Fake(self.fake_exchange_source.clone()))
     }
 }

--- a/src/batch/src/lib.rs
+++ b/src/batch/src/lib.rs
@@ -38,6 +38,7 @@
 #![feature(iterator_try_collect)]
 #![feature(lint_reasons)]
 
+pub mod exchange_source;
 pub mod execution;
 pub mod executor;
 pub mod rpc;

--- a/src/rpc_client/src/compute_client.rs
+++ b/src/rpc_client/src/compute_client.rs
@@ -12,10 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use std::fmt::Debug;
 use std::time::Duration;
 
-use risingwave_common::array::DataChunk;
 use risingwave_common::util::addr::HostAddr;
 use risingwave_pb::batch_plan::exchange_info::DistributionMode;
 use risingwave_pb::batch_plan::{ExchangeInfo, PlanFragment, PlanNode, TaskId, TaskOutputId};
@@ -134,10 +132,4 @@ impl ComputeClient {
     pub async fn execute(&self, req: ExecuteRequest) -> Result<Streaming<GetDataResponse>> {
         Ok(self.task_client.to_owned().execute(req).await?.into_inner())
     }
-}
-
-/// Each ExchangeSource maps to one task, it takes the execution result from task chunk by chunk.
-#[async_trait::async_trait]
-pub trait ExchangeSource: Send + Debug {
-    async fn take_data(&mut self) -> risingwave_common::error::Result<Option<DataChunk>>;
 }

--- a/src/rpc_client/src/lib.rs
+++ b/src/rpc_client/src/lib.rs
@@ -28,11 +28,13 @@
 #![feature(generic_associated_types)]
 #![feature(binary_heap_drain_sorted)]
 #![feature(result_option_inspect)]
+#![feature(type_alias_impl_trait)]
+#![feature(associated_type_defaults)]
 
 mod meta_client;
 pub use meta_client::{GrpcMetaClient, MetaClient, NotificationStream};
 mod compute_client;
-pub use compute_client::{ComputeClient, ExchangeSource};
+pub use compute_client::ComputeClient;
 mod compute_client_pool;
 pub use compute_client_pool::{ComputeClientPool, ComputeClientPoolRef};
 mod hummock_meta_client;


### PR DESCRIPTION
I hereby agree to the terms of the [Singularity Data, Inc. Contributor License Agreement](https://gist.github.com/skyzh/0663682a70b0edde7ae991492f2314cb#file-s9y_cla).

## Overview

This PR resolves #1463 by introducing associated types to eliminate `async_trait` for `ExchangeSource`

- Refactor `ExchangeSource` and move it to `batch`, where its downstream impls are defined.
- Fix downstream implementations (`GrpcExchangeSource`, `LocalExchangeSource` and `FakeExchangeSource`)
- Fix lifecycles and imports.

## Checklist

- [x] I have written necessary docs and comments
- [x] I have added necessary unit tests and integration tests
- [x] All checks passed in `./risedev check` (or alias, `./risedev c`)

## Related issue
#1463 
