### PR TITLE
fix(storage): allow accessing other vnodes from batch scan

### DIFF
--- a/src/storage/src/table/cell_based_table.rs
+++ b/src/storage/src/table/cell_based_table.rs
@@ -261,6 +261,28 @@ impl<S: StateStore, SER: RowSerializer, const T: AccessType> CellBasedTableBase<
 
 /// Get
 impl<S: StateStore, SER: RowSerializer, const T: AccessType> CellBasedTableBase<S, SER, T> {
+    /// Check whether the given `vnode` is set in the `vnodes` of this table.
+    ///
+    /// - For `READ_WRITE` or streaming usages, this will panic on `false` and always return `true`
+    ///   since the table should only be used to access entries with vnode specified in
+    ///   `self.vnodes`.
+    /// - For `READ_ONLY` or batch usages, this will return the result verbatim. The caller may
+    ///   filter out the scanned row according to the result.
+    fn check_vnode_is_set(&self, vnode: VirtualNode) -> bool {
+        let is_set = self.vnodes.is_set(vnode as usize).unwrap();
+        match T {
+            READ_WRITE => {
+                assert!(
+                    is_set,
+                    "vnode {} should not be accessed by this table: {:#?}, dist key {:?}",
+                    vnode, self.table_columns, self.dist_key_indices
+                );
+            }
+            READ_ONLY => {}
+        }
+        is_set
+    }
+
     /// Get vnode value with `indices` on the given `row`. Should not be used directly.
     fn compute_vnode(&self, row: &Row, indices: &[usize]) -> VirtualNode {
         let vnode = if indices.is_empty() {
@@ -272,14 +294,7 @@ impl<S: StateStore, SER: RowSerializer, const T: AccessType> CellBasedTableBase<
 
         tracing::trace!(target: "events::storage::cell_based_table", "compute vnode: {:?} keys {:?} => {}", row, indices, vnode);
 
-        // This table should only be used to access entries with vnode specified in `self.vnodes`.
-        assert!(
-            self.vnodes.is_set(vnode as usize).unwrap(),
-            "vnode {} should not be accessed by this table: {:#?}, dist key {:?}",
-            vnode,
-            self.table_columns,
-            self.dist_key_indices
-        );
+        let _ = self.check_vnode_is_set(vnode);
         vnode
     }
 
@@ -318,12 +333,7 @@ impl<S: StateStore, SER: RowSerializer, const T: AccessType> CellBasedTableBase<
         }
 
         let result = deserializer.take();
-        Ok(result.map(|(vnode, _pk, row)| {
-            // This table should only to used to access entries with vnode specified in
-            // `self.vnodes`.
-            assert!(self.vnodes.is_set(vnode as usize).unwrap());
-            row
-        }))
+        Ok(result.and_then(|(vnode, _pk, row)| self.check_vnode_is_set(vnode).then_some(row)))
     }
 
     /// Get a single row by range scan
@@ -342,12 +352,7 @@ impl<S: StateStore, SER: RowSerializer, const T: AccessType> CellBasedTableBase<
         }
 
         let result = deserializer.take();
-        Ok(result.map(|(vnode, _pk, row)| {
-            // This table should only be used to access entries with vnode specified in
-            // `self.vnodes`.
-            assert!(self.vnodes.is_set(vnode as usize).unwrap());
-            row
-        }))
+        Ok(result.and_then(|(vnode, _pk, row)| self.check_vnode_is_set(vnode).then_some(row)))
     }
 }
 


### PR DESCRIPTION
Signed-off-by: Bugen Zhao <i@bugenzhao.com>

I hereby agree to the terms of the [Singularity Data, Inc. Contributor License Agreement](https://gist.github.com/skyzh/0663682a70b0edde7ae991492f2314cb#file-s9y_cla).

## What's changed and what's your intention?

As title. For `READ_ONLY` tables, accessing other vnodes is allowed and the row from point-get will be filtered out. This will make #3251 much cleaner.

## Checklist

- [x] I have written necessary docs and comments
- [x] I have added necessary unit tests and integration tests
- [x] All checks passed in `./risedev check` (or alias, `./risedev c`)

## Refer to a related PR or issue link (optional)
