### PR TITLE
refactor(proto): simplify ColumnOrder

### DIFF
--- a/proto/plan_common.proto
+++ b/proto/plan_common.proto
@@ -82,7 +82,6 @@ message ColumnOrder {
   // maybe other name
   OrderType order_type = 1;
   expr.InputRefExpr input_ref = 2;
-  data.DataType return_type = 3;
 }
 
 enum RowFormatType {

--- a/proto/plan_common.proto
+++ b/proto/plan_common.proto
@@ -3,7 +3,6 @@ syntax = "proto3";
 package plan_common;
 
 import "data.proto";
-import "expr.proto";
 
 option optimize_for = SPEED;
 

--- a/proto/plan_common.proto
+++ b/proto/plan_common.proto
@@ -81,7 +81,7 @@ enum OrderType {
 message ColumnOrder {
   // maybe other name
   OrderType order_type = 1;
-  expr.InputRefExpr input_ref = 2;
+  uint32 index = 2;
 }
 
 enum RowFormatType {

--- a/proto/stream_plan.proto
+++ b/proto/stream_plan.proto
@@ -40,11 +40,12 @@ message FilterNode {
   expr.ExprNode search_condition = 1;
 }
 
-// A materialized view is regarded as a table,
-// hence we copy the CreateTableNode definition in OLAP PlanNode.
+// A materialized view is regarded as a table.
 // In addition, we also specify primary key to MV for efficient point lookup during update and deletion.
-// The node will be used for both create mv and create index. When creating mv,
-// `pk == distribution_keys == column_orders`. When creating index, `column_orders` will contain both
+//
+// The node will be used for both create mv and create index. 
+// When creating mv, `pk == distribution_keys == column_orders`. 
+// When creating index, `column_orders` will contain both
 // arrange columns and pk columns, while distribution keys will be arrange columns.
 message MaterializeNode {
   plan_common.TableRefId table_ref_id = 1;

--- a/proto/stream_plan.proto
+++ b/proto/stream_plan.proto
@@ -43,10 +43,10 @@ message FilterNode {
 // A materialized view is regarded as a table.
 // In addition, we also specify primary key to MV for efficient point lookup during update and deletion.
 //
-// The node will be used for both create mv and create index. 
-// When creating mv, `pk == distribution_keys == column_orders`. 
-// When creating index, `column_orders` will contain both
-// arrange columns and pk columns, while distribution keys will be arrange columns.
+// The node will be used for both create mv and create index.
+// - When creating mv, `pk == distribution_keys == column_orders`.
+// - When creating index, `column_orders` will contain both
+//   arrange columns and pk columns, while distribution keys will be arrange columns.
 message MaterializeNode {
   plan_common.TableRefId table_ref_id = 1;
   plan_common.TableRefId associated_table_ref_id = 2;

--- a/src/common/src/catalog/physical_table.rs
+++ b/src/common/src/catalog/physical_table.rs
@@ -53,7 +53,6 @@ impl TableDesc {
                 input_ref: Some(InputRefExpr {
                     column_idx: x.column_desc.column_id.get_id(),
                 }),
-                return_type: None,
             })
             .collect()
     }

--- a/src/common/src/catalog/physical_table.rs
+++ b/src/common/src/catalog/physical_table.rs
@@ -12,7 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use risingwave_pb::expr::InputRefExpr;
 use risingwave_pb::plan_common::{CellBasedTableDesc, ColumnOrder};
 
 use super::{ColumnDesc, OrderedColumnDesc, TableId};
@@ -50,9 +49,7 @@ impl TableDesc {
             .iter()
             .map(|x| ColumnOrder {
                 order_type: x.order.to_prost() as i32,
-                input_ref: Some(InputRefExpr {
-                    column_idx: x.column_desc.column_id.get_id(),
-                }),
+                index: x.column_desc.column_id.get_id() as u32,
             })
             .collect()
     }

--- a/src/common/src/util/sort_util.rs
+++ b/src/common/src/util/sort_util.rs
@@ -15,7 +15,6 @@
 use std::cmp::{Ord, Ordering};
 use std::sync::Arc;
 
-use risingwave_pb::expr::InputRefExpr;
 use risingwave_pb::plan_common::{ColumnOrder, OrderType as ProstOrderType};
 
 use crate::array::{Array, ArrayImpl, DataChunk};
@@ -63,10 +62,9 @@ impl OrderPair {
 
     pub fn from_prost(column_order: &ColumnOrder) -> Self {
         let order_type: ProstOrderType = ProstOrderType::from_i32(column_order.order_type).unwrap();
-        let input_ref: &InputRefExpr = column_order.get_input_ref().unwrap();
         OrderPair {
             order_type: OrderType::from_prost(&order_type),
-            column_idx: input_ref.column_idx as usize,
+            column_idx: column_order.index as usize,
         }
     }
 }

--- a/src/frontend/src/optimizer/plan_node/stream_materialize.rs
+++ b/src/frontend/src/optimizer/plan_node/stream_materialize.rs
@@ -263,7 +263,6 @@ impl ToStreamProst for StreamMaterialize {
                         input_ref: Some(InputRefExpr {
                             column_idx: idx as i32,
                         }),
-                        return_type: Some(col.column_desc.data_type.to_protobuf()),
                     }
                 })
                 .collect(),

--- a/src/frontend/src/optimizer/plan_node/stream_materialize.rs
+++ b/src/frontend/src/optimizer/plan_node/stream_materialize.rs
@@ -21,7 +21,6 @@ use risingwave_common::catalog::{ColumnDesc, OrderedColumnDesc, TableId};
 use risingwave_common::error::ErrorCode::InternalError;
 use risingwave_common::error::Result;
 use risingwave_common::util::sort_util::OrderType;
-use risingwave_pb::expr::InputRefExpr;
 use risingwave_pb::plan_common::ColumnOrder;
 use risingwave_pb::stream_plan::stream_node::NodeBody as ProstStreamNode;
 
@@ -260,9 +259,7 @@ impl ToStreamProst for StreamMaterialize {
                     let idx = self.col_id_to_idx(col.column_desc.column_id);
                     ColumnOrder {
                         order_type: col.order.to_prost() as i32,
-                        input_ref: Some(InputRefExpr {
-                            column_idx: idx as i32,
-                        }),
+                        index: idx as u32,
                     }
                 })
                 .collect(),

--- a/src/frontend/src/optimizer/plan_node/stream_topn.rs
+++ b/src/frontend/src/optimizer/plan_node/stream_topn.rs
@@ -88,7 +88,6 @@ impl ToStreamProst for StreamTopN {
                 input_ref: Some(InputRefExpr {
                     column_idx: f.index as i32,
                 }),
-                return_type: Some(self.input().schema()[f.index].data_type().to_protobuf()),
             })
             .collect();
 

--- a/src/frontend/src/optimizer/plan_node/stream_topn.rs
+++ b/src/frontend/src/optimizer/plan_node/stream_topn.rs
@@ -14,12 +14,10 @@
 
 use std::fmt;
 
-use risingwave_pb::expr::InputRefExpr;
-use risingwave_pb::plan_common::ColumnOrder;
 use risingwave_pb::stream_plan::stream_node::NodeBody as ProstStreamNode;
 
 use super::{LogicalTopN, PlanBase, PlanRef, PlanTreeNodeUnary, ToStreamProst};
-use crate::optimizer::property::Distribution;
+use crate::optimizer::property::{Distribution, FieldOrder};
 
 /// `StreamTopN` implements [`super::LogicalTopN`] to find the top N elements with a heap
 #[derive(Debug, Clone)]
@@ -83,12 +81,7 @@ impl ToStreamProst for StreamTopN {
             .topn_order()
             .field_order
             .iter()
-            .map(|f| ColumnOrder {
-                order_type: f.direct.to_protobuf() as i32,
-                input_ref: Some(InputRefExpr {
-                    column_idx: f.index as i32,
-                }),
-            })
+            .map(FieldOrder::to_protobuf)
             .collect();
 
         let topn_node = TopNNode {

--- a/src/frontend/src/optimizer/property/order.rs
+++ b/src/frontend/src/optimizer/property/order.rs
@@ -18,7 +18,6 @@ use itertools::Itertools;
 use risingwave_common::catalog::Schema;
 use risingwave_common::error::Result;
 use risingwave_common::util::sort_util::OrderType;
-use risingwave_pb::expr::InputRefExpr;
 use risingwave_pb::plan_common::{ColumnOrder, OrderType as ProstOrderType};
 
 use super::super::plan_node::*;
@@ -38,13 +37,7 @@ impl Order {
     pub fn to_protobuf(&self, _schema: &Schema) -> Vec<ColumnOrder> {
         self.field_order
             .iter()
-            .map(|f| {
-                let (input_ref, order_type) = f.to_protobuf();
-                ColumnOrder {
-                    order_type: order_type as i32,
-                    input_ref: Some(input_ref),
-                }
-            })
+            .map(FieldOrder::to_protobuf)
             .collect_vec()
     }
 }
@@ -89,12 +82,11 @@ impl FieldOrder {
         }
     }
 
-    pub fn to_protobuf(&self) -> (InputRefExpr, ProstOrderType) {
-        let input_ref_expr = InputRefExpr {
-            column_idx: self.index as i32,
-        };
-        let order_type = self.direct.to_protobuf();
-        (input_ref_expr, order_type)
+    pub fn to_protobuf(&self) -> ColumnOrder {
+        ColumnOrder {
+            order_type: self.direct.to_protobuf() as i32,
+            index: self.index as u32,
+        }
     }
 }
 

--- a/src/frontend/src/optimizer/property/order.rs
+++ b/src/frontend/src/optimizer/property/order.rs
@@ -35,16 +35,14 @@ impl Order {
     }
 
     /// Convert into protobuf.
-    pub fn to_protobuf(&self, schema: &Schema) -> Vec<ColumnOrder> {
+    pub fn to_protobuf(&self, _schema: &Schema) -> Vec<ColumnOrder> {
         self.field_order
             .iter()
             .map(|f| {
                 let (input_ref, order_type) = f.to_protobuf();
-                let data_type = schema.fields[f.index].data_type.to_protobuf();
                 ColumnOrder {
                     order_type: order_type as i32,
                     input_ref: Some(input_ref),
-                    return_type: Some(data_type),
                 }
             })
             .collect_vec()

--- a/src/frontend/src/stream_fragmenter/rewrite/delta_join.rs
+++ b/src/frontend/src/stream_fragmenter/rewrite/delta_join.rs
@@ -16,7 +16,6 @@ use itertools::Itertools;
 use risingwave_common::catalog::{ColumnDesc, ColumnId, Field};
 use risingwave_common::error::Result;
 use risingwave_common::util::sort_util::{OrderPair, OrderType};
-use risingwave_pb::expr::InputRefExpr;
 use risingwave_pb::plan_common::{ColumnOrder, Field as ProstField};
 use risingwave_pb::stream_plan::lookup_node::ArrangementTableId;
 use risingwave_pb::stream_plan::stream_node::NodeBody;
@@ -126,9 +125,7 @@ impl StreamFragmenter {
             )
             .map(|x| ColumnOrder {
                 order_type: x.order_type.to_prost() as i32,
-                input_ref: Some(InputRefExpr {
-                    column_idx: x.column_idx as i32,
-                }),
+                index: x.column_idx as u32,
             })
             .collect();
 

--- a/src/frontend/src/stream_fragmenter/rewrite/delta_join.rs
+++ b/src/frontend/src/stream_fragmenter/rewrite/delta_join.rs
@@ -129,7 +129,6 @@ impl StreamFragmenter {
                 input_ref: Some(InputRefExpr {
                     column_idx: x.column_idx as i32,
                 }),
-                return_type: None,
             })
             .collect();
 

--- a/src/frontend/test_runner/tests/testdata/stream_proto.yaml
+++ b/src/frontend/test_runner/tests/testdata/stream_proto.yaml
@@ -109,11 +109,7 @@
     materialize:
       columnOrders:
         - orderType: ASCENDING
-          inputRef:
-            columnIdx: 1
-          returnType:
-            typeName: INT64
-            isNullable: true
+          index: 1
       columnIds:
         - 0
         - 1
@@ -224,11 +220,7 @@
     materialize:
       columnOrders:
         - orderType: ASCENDING
-          inputRef:
-            columnIdx: 1
-          returnType:
-            typeName: INT64
-            isNullable: true
+          index: 1
       columnIds:
         - 0
         - 1
@@ -348,11 +340,7 @@
     materialize:
       columnOrders:
         - orderType: ASCENDING
-          inputRef:
-            columnIdx: 1
-          returnType:
-            typeName: INT64
-            isNullable: true
+          index: 1
       columnIds:
         - 0
         - 1
@@ -849,11 +837,7 @@
     materialize:
       columnOrders:
         - orderType: ASCENDING
-          inputRef:
-            columnIdx: 1
-          returnType:
-            typeName: INT32
-            isNullable: true
+          index: 1
       columnIds:
         - 0
         - 1

--- a/src/meta/src/stream/test_fragmenter.rs
+++ b/src/meta/src/stream/test_fragmenter.rs
@@ -90,10 +90,10 @@ fn make_field(type_name: TypeName) -> Field {
     }
 }
 
-fn make_column_order(idx: i32) -> ColumnOrder {
+fn make_column_order(index: u32) -> ColumnOrder {
     ColumnOrder {
         order_type: OrderType::Ascending as i32,
-        input_ref: Some(InputRefExpr { column_idx: idx }),
+        index,
     }
 }
 

--- a/src/meta/src/stream/test_fragmenter.rs
+++ b/src/meta/src/stream/test_fragmenter.rs
@@ -94,10 +94,6 @@ fn make_column_order(idx: i32) -> ColumnOrder {
     ColumnOrder {
         order_type: OrderType::Ascending as i32,
         input_ref: Some(InputRefExpr { column_idx: idx }),
-        return_type: Some(DataType {
-            type_name: TypeName::Int64 as i32,
-            ..Default::default()
-        }),
     }
 }
 


### PR DESCRIPTION
I hereby agree to the terms of the [Singularity Data, Inc. Contributor License Agreement](https://gist.github.com/skyzh/0663682a70b0edde7ae991492f2314cb#file-s9y_cla).

## What's changed and what's your intention?

Trying to dedup `OrderedColumnDesc`, and use `FieldOrder` instead (https://github.com/singularity-data/risingwave/issues/3638). But found it difficult. Simplify `ColumnOrder` proto first 

