### PR TITLE
feat(risectl): list tables and scan by id

### DIFF
--- a/proto/ddl_service.proto
+++ b/proto/ddl_service.proto
@@ -109,10 +109,10 @@ message DropMaterializedSourceResponse {
 }
 
 // Used by risectl (and in the future, dashboard)
-message ListMaterializedViewRequest {}
+message ListStateTablesRequest {}
 
 // Used by risectl (and in the future, dashboard)
-message ListMaterializedViewResponse {
+message ListStateTablesResponse {
   repeated catalog.Table tables = 1;
 }
 
@@ -127,5 +127,5 @@ service DdlService {
   rpc DropMaterializedView(DropMaterializedViewRequest) returns (DropMaterializedViewResponse);
   rpc CreateMaterializedSource(CreateMaterializedSourceRequest) returns (CreateMaterializedSourceResponse);
   rpc DropMaterializedSource(DropMaterializedSourceRequest) returns (DropMaterializedSourceResponse);
-  rpc ListMaterializedView(ListMaterializedViewRequest) returns (ListMaterializedViewResponse);
+  rpc RisectlListStateTables(ListStateTablesRequest) returns (ListStateTablesResponse);
 }

--- a/src/ctl/src/cmd_impl/table/list.rs
+++ b/src/ctl/src/cmd_impl/table/list.rs
@@ -12,8 +12,16 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-mod scan;
-pub use scan::*;
+use anyhow::Result;
 
-mod list;
-pub use list::*;
+use crate::common::MetaServiceOpts;
+
+pub async fn list() -> Result<()> {
+    let meta_opts = MetaServiceOpts::from_env()?;
+    let meta = meta_opts.create_meta_client().await?;
+    let mvs = meta.risectl_list_state_tables().await?;
+    for mv in mvs {
+        println!("#{}: {}", mv.id, mv.name);
+    }
+    Ok(())
+}

--- a/src/ctl/src/cmd_impl/table/scan.rs
+++ b/src/ctl/src/cmd_impl/table/scan.rs
@@ -16,16 +16,28 @@ use anyhow::{anyhow, Result};
 use futures::{pin_mut, StreamExt};
 use risingwave_frontend::catalog::TableCatalog;
 use risingwave_rpc_client::MetaClient;
+use risingwave_storage::hummock::HummockStorage;
+use risingwave_storage::monitor::MonitoredStateStore;
 use risingwave_storage::table::state_table::StateTable;
 use risingwave_storage::StateStore;
 
 use crate::common::HummockServiceOpts;
 
-pub async fn get_table_catalog(meta: MetaClient, table_id: String) -> Result<TableCatalog> {
-    let mvs = meta.list_materialize_view().await?;
+pub async fn get_table_catalog(meta: MetaClient, mv_name: String) -> Result<TableCatalog> {
+    let mvs = meta.risectl_list_state_tables().await?;
     let mv = mvs
         .iter()
-        .find(|x| x.name == table_id)
+        .find(|x| x.name == mv_name)
+        .ok_or_else(|| anyhow!("mv not found"))?
+        .clone();
+    Ok(TableCatalog::from(&mv))
+}
+
+pub async fn get_table_catalog_by_id(meta: MetaClient, table_id: u32) -> Result<TableCatalog> {
+    let mvs = meta.risectl_list_state_tables().await?;
+    let mv = mvs
+        .iter()
+        .find(|x| x.id == table_id)
         .ok_or_else(|| anyhow!("mv not found"))?
         .clone();
     Ok(TableCatalog::from(&mv))
@@ -52,10 +64,25 @@ pub fn make_state_table<S: StateStore>(hummock: S, table: &TableCatalog) -> Stat
     )
 }
 
-pub async fn scan(table_id: String) -> Result<()> {
+pub async fn scan(mv_name: String) -> Result<()> {
     let mut hummock_opts = HummockServiceOpts::from_env()?;
     let (meta, hummock) = hummock_opts.create_hummock_store().await?;
-    let table = get_table_catalog(meta.clone(), table_id).await?;
+    let table = get_table_catalog(meta.clone(), mv_name).await?;
+    do_scan(table, hummock, hummock_opts).await
+}
+
+pub async fn scan_id(table_id: u32) -> Result<()> {
+    let mut hummock_opts = HummockServiceOpts::from_env()?;
+    let (meta, hummock) = hummock_opts.create_hummock_store().await?;
+    let table = get_table_catalog_by_id(meta.clone(), table_id).await?;
+    do_scan(table, hummock, hummock_opts).await
+}
+
+async fn do_scan(
+    table: TableCatalog,
+    hummock: MonitoredStateStore<HummockStorage>,
+    mut hummock_opts: HummockServiceOpts,
+) -> Result<()> {
     print_table_catalog(&table);
     let state_table = make_state_table(hummock.clone(), &table);
     let stream = state_table.iter(u64::MAX).await?;

--- a/src/ctl/src/lib.rs
+++ b/src/ctl/src/lib.rs
@@ -74,11 +74,18 @@ enum HummockCommands {
 
 #[derive(Subcommand)]
 enum TableCommands {
-    /// benchmark state table
+    /// scan a state table with MV name
     Scan {
         /// name of the materialized view to operate on
         mv_name: String,
     },
+    /// scan a state table using Id
+    ScanById {
+        /// id of the state table to operate on
+        table_id: u32,
+    },
+    /// list all state tables
+    List,
 }
 
 pub async fn start(opts: CliOpts) -> Result<()> {
@@ -105,6 +112,10 @@ pub async fn start(opts: CliOpts) -> Result<()> {
         Commands::Table(TableCommands::Scan { mv_name }) => {
             tokio::spawn(cmd_impl::table::scan(mv_name)).await??
         }
+        Commands::Table(TableCommands::ScanById { table_id }) => {
+            tokio::spawn(cmd_impl::table::scan_id(table_id)).await??
+        }
+        Commands::Table(TableCommands::List) => tokio::spawn(cmd_impl::table::list()).await??,
         Commands::Bench(cmd) => tokio::spawn(cmd_impl::bench::do_bench(cmd)).await??,
     }
     Ok(())

--- a/src/meta/src/rpc/service/ddl_service.rs
+++ b/src/meta/src/rpc/service/ddl_service.rs
@@ -398,15 +398,15 @@ where
         }))
     }
 
-    async fn list_materialized_view(
+    async fn risectl_list_state_tables(
         &self,
-        _request: Request<ListMaterializedViewRequest>,
-    ) -> Result<Response<ListMaterializedViewResponse>, Status> {
+        _request: Request<ListStateTablesRequest>,
+    ) -> Result<Response<ListStateTablesResponse>, Status> {
         use crate::model::MetadataModel;
         let tables = Table::list(self.env.meta_store())
             .await
             .map_err(tonic_err)?;
-        Ok(Response::new(ListMaterializedViewResponse { tables }))
+        Ok(Response::new(ListStateTablesResponse { tables }))
     }
 }
 

--- a/src/rpc_client/src/meta_client.rs
+++ b/src/rpc_client/src/meta_client.rs
@@ -319,9 +319,9 @@ impl MetaClient {
         (join_handle, shutdown_tx)
     }
 
-    pub async fn list_materialize_view(&self) -> Result<Vec<ProstTable>> {
-        let request = ListMaterializedViewRequest {};
-        let resp = self.inner.list_materialized_view(request).await?;
+    pub async fn risectl_list_state_tables(&self) -> Result<Vec<ProstTable>> {
+        let request = ListStateTablesRequest {};
+        let resp = self.inner.risectl_list_state_tables(request).await?;
         Ok(resp.tables)
     }
 
@@ -563,7 +563,7 @@ macro_rules! for_all_meta_rpc {
             ,{ ddl_client, drop_source, DropSourceRequest, DropSourceResponse }
             ,{ ddl_client, drop_database, DropDatabaseRequest, DropDatabaseResponse }
             ,{ ddl_client, drop_schema, DropSchemaRequest, DropSchemaResponse }
-            ,{ ddl_client, list_materialized_view, ListMaterializedViewRequest, ListMaterializedViewResponse }
+            ,{ ddl_client, risectl_list_state_tables, ListStateTablesRequest, ListStateTablesResponse }
             ,{ hummock_client, pin_version, PinVersionRequest, PinVersionResponse }
             ,{ hummock_client, unpin_version, UnpinVersionRequest, UnpinVersionResponse }
             ,{ hummock_client, pin_snapshot, PinSnapshotRequest, PinSnapshotResponse }


### PR DESCRIPTION
Signed-off-by: Alex Chi <iskyzh@gmail.com>

I hereby agree to the terms of the [Singularity Data, Inc. Contributor License Agreement](https://gist.github.com/skyzh/0663682a70b0edde7ae991492f2314cb#file-s9y_cla).

## What's changed and what's your intention?

Support two more commands:

```
./risedev ctl table scan-by-id 1002
./risedev ctl table list
```

Note that internal state table is not in catalog, and could not be scanned for now.

## Checklist

- [x] I have written necessary docs and comments
- [x] I have added necessary unit tests and integration tests
- [x] All checks passed in `./risedev check` (or alias, `./risedev c`)

## Refer to a related PR or issue link (optional)

related to https://github.com/singularity-data/risingwave/issues/3609