### PR TITLE
chore(doc): add documentation-specific instructions

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -10,12 +10,29 @@ Please explain **IN DETAIL** what the changes are in this PR and why they are ne
 - How does this PR work? Need a brief introduction for the changed logic (optional)
 - Describe clearly one logical change and avoid lazy messages (optional)
 - Describe any limitations of the current code (optional)
-- Add the 'user-facing changes' label if your PR contains changes that are visible to users (optional)
 
 ## Checklist
 
-- [ ] I have written necessary docs and comments
+- [ ] I have written necessary rustdocs and comments
 - [ ] I have added necessary unit tests and integration tests
 - [ ] All checks passed in `./risedev check` (or alias, `./risedev c`)
+
+## Documentation
+
+If your pull request contains user-facing changes, please specify the types of the changes, and create a release note. Otherwise, please feel free to remove this section.
+
+### Types of user-facing changes
+
+Please keep the types that apply to your changes, and remove those that do not apply.
+
+* Installation and deployment 
+* Connector (sources & sinks)
+* SQL commands, functions, and operators
+* RisingWave cluster configuration changes
+* Other (please specify in the release note below)
+
+### Release note
+
+Please create a release note for your changes. In the release note, focus on the impact on users, and mention the environment or conditions where the impact may occur.
 
 ## Refer to a related PR or issue link (optional)

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -13,7 +13,7 @@ Please explain **IN DETAIL** what the changes are in this PR and why they are ne
 
 ## Checklist
 
-- [ ] I have written necessary rustdocs and comments
+- [ ] I have written necessary rustdoc comments
 - [ ] I have added necessary unit tests and integration tests
 - [ ] All checks passed in `./risedev check` (or alias, `./risedev c`)
 


### PR DESCRIPTION
I hereby agree to the terms of the [Singularity Data, Inc. Contributor License Agreement](https://gist.github.com/skyzh/0663682a70b0edde7ae991492f2314cb#file-s9y_cla).

## What's changed and what's your intention?

Added documentation-specific instructions so that developers can specify whether their PR contains user-facing changes, categorize the changes if so, and create a release note draft. The purpose of this template change is to make it easier for all to locate user-facing changes, and easier for tech writers to create official release notes. 

***PLEASE DO NOT LEAVE THIS EMPTY !!!***

Please explain **IN DETAIL** what the changes are in this PR and why they are needed:

- Summarize your change (**mandatory**)
- How does this PR work? Need a brief introduction for the changed logic (optional)
- Describe clearly one logical change and avoid lazy messages (optional)
- Describe any limitations of the current code (optional)
- Add the 'user-facing changes' label if your PR contains changes that are visible to users (optional)

## Checklist

- [x] I have written necessary docs and comments
- [x] I have added necessary unit tests and integration tests
- [x] All checks passed in `./risedev check` (or alias, `./risedev c`)

## Refer to a related PR or issue link (optional)
