### PR TITLE
test(batch): add micro benchmark for NestedLoopJoinExecutor

### DIFF
--- a/src/batch/Cargo.toml
+++ b/src/batch/Cargo.toml
@@ -69,3 +69,8 @@ tikv-jemallocator = "0.5"
 [[bench]]
 name = "filter"
 harness = false
+
+[[bench]]
+name = "nested_loop_join"
+harness = false
+

--- a/src/batch/benches/filter.rs
+++ b/src/batch/benches/filter.rs
@@ -12,16 +12,11 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use std::sync::Arc;
-
 use criterion::{black_box, criterion_group, criterion_main, BatchSize, BenchmarkId, Criterion};
 use futures::StreamExt;
-use risingwave_batch::executor::test_utils::MockExecutor;
+use risingwave_batch::executor::test_utils::{gen_data, MockExecutor};
 use risingwave_batch::executor::{BoxedExecutor, FilterExecutor};
-use risingwave_common::array::column::Column;
-use risingwave_common::array::DataChunk;
 use risingwave_common::catalog::schema_test_utils::field_n;
-use risingwave_common::field_generator::FieldGeneratorImpl;
 use risingwave_common::types::{DataType, ScalarImpl};
 use risingwave_expr::expr::build_from_prost;
 use risingwave_pb::data::data_type::TypeName;
@@ -35,37 +30,6 @@ use tokio::runtime::Runtime;
 
 #[global_allocator]
 static GLOBAL: Jemalloc = Jemalloc;
-
-const SEED: u64 = 0xFF67FEABBAEF76FF;
-
-/// Generate [`batch_num`] data chunks, each data chunk has cardinality of [`batch_size`].
-fn gen_data(data_type: DataType, batch_size: usize, batch_num: usize) -> Vec<DataChunk> {
-    let mut data_gen =
-        FieldGeneratorImpl::with_random(data_type.clone(), None, None, None, None, SEED).unwrap();
-    let mut ret = Vec::<DataChunk>::with_capacity(batch_num);
-
-    for _ in 0..batch_num {
-        let mut array_builder = data_type.create_array_builder(batch_size);
-
-        for _ in 0..batch_size {
-            array_builder
-                .append_datum(&Some(ScalarImpl::Int64(
-                    // TODO: We should remove this later when generator supports generate Datum,
-                    // see https://github.com/singularity-data/risingwave/issues/3519
-                    data_gen.generate(0).as_i64().unwrap(),
-                )))
-                .unwrap();
-        }
-
-        let array = array_builder.finish().unwrap();
-        ret.push(DataChunk::new(
-            vec![Column::new(Arc::new(array))],
-            batch_size,
-        ));
-    }
-
-    ret
-}
 
 fn create_filter_executor(chunk_size: usize, chunk_num: usize) -> BoxedExecutor {
     let input_data = gen_data(DataType::Int64, chunk_size, chunk_num);

--- a/src/batch/benches/nested_loop_join.rs
+++ b/src/batch/benches/nested_loop_join.rs
@@ -162,8 +162,8 @@ async fn execute_nested_loop_join_executor(executor: BoxedExecutor) {
 }
 
 fn bench_nested_loop_join(c: &mut Criterion) {
-    const LEFT_SIZE: usize = 1024;
-    const RIGHT_SIZE: usize = 1024;
+    const LEFT_SIZE: usize = 2 * 1024;
+    const RIGHT_SIZE: usize = 2 * 1024;
     let rt = Runtime::new().unwrap();
     for join_type in &[
         JoinType::Inner,

--- a/src/batch/benches/nested_loop_join.rs
+++ b/src/batch/benches/nested_loop_join.rs
@@ -1,0 +1,207 @@
+// Copyright 2022 Singularity Data
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use criterion::{black_box, criterion_group, criterion_main, BatchSize, BenchmarkId, Criterion};
+use futures::StreamExt;
+use risingwave_batch::executor::test_utils::{gen_data, MockExecutor};
+use risingwave_batch::executor::{BoxedExecutor, Executor, JoinType, NestedLoopJoinExecutor};
+use risingwave_common::catalog::schema_test_utils::field_n;
+use risingwave_common::catalog::Schema;
+use risingwave_common::types::{DataType, ScalarImpl};
+use risingwave_expr::expr::build_from_prost;
+use risingwave_pb::data::data_type::TypeName;
+use risingwave_pb::expr::expr_node::RexNode;
+use risingwave_pb::expr::expr_node::Type::{
+    ConstantValue as TConstValue, Equal, InputRef, Modulus,
+};
+use risingwave_pb::expr::{ConstantValue, ExprNode, FunctionCall, InputRefExpr};
+use tikv_jemallocator::Jemalloc;
+use tokio::runtime::Runtime;
+
+#[global_allocator]
+static GLOBAL: Jemalloc = Jemalloc;
+
+fn create_nested_loop_join_executor(
+    join_type: JoinType,
+    left_chunk_size: usize,
+    left_chunk_num: usize,
+    right_chunk_size: usize,
+    right_chunk_num: usize,
+) -> BoxedExecutor {
+    let left_input = gen_data(DataType::Int64, left_chunk_size, left_chunk_num);
+    let right_input = gen_data(DataType::Int64, right_chunk_size, right_chunk_num);
+
+    let mut left_child = Box::new(MockExecutor::new(field_n::<1>(DataType::Int64)));
+    left_input.into_iter().for_each(|c| left_child.add(c));
+
+    let mut right_child = Box::new(MockExecutor::new(field_n::<1>(DataType::Int64)));
+    right_input.into_iter().for_each(|c| right_child.add(c));
+
+    // Expression: $1 % 2 == $2 % 3
+    let join_expr = {
+        let left_input_ref = ExprNode {
+            expr_type: InputRef as i32,
+            return_type: Some(risingwave_pb::data::DataType {
+                type_name: TypeName::Int64 as i32,
+                ..Default::default()
+            }),
+            rex_node: Some(RexNode::InputRef(InputRefExpr { column_idx: 0 })),
+        };
+
+        let right_input_ref = ExprNode {
+            expr_type: InputRef as i32,
+            return_type: Some(risingwave_pb::data::DataType {
+                type_name: TypeName::Int64 as i32,
+                ..Default::default()
+            }),
+            rex_node: Some(RexNode::InputRef(InputRefExpr { column_idx: 1 })),
+        };
+
+        let literal2 = ExprNode {
+            expr_type: TConstValue as i32,
+            return_type: Some(risingwave_pb::data::DataType {
+                type_name: TypeName::Int64 as i32,
+                ..Default::default()
+            }),
+            rex_node: Some(RexNode::Constant(ConstantValue {
+                body: ScalarImpl::Int64(2).to_protobuf(),
+            })),
+        };
+
+        let literal3 = ExprNode {
+            expr_type: TConstValue as i32,
+            return_type: Some(risingwave_pb::data::DataType {
+                type_name: TypeName::Int64 as i32,
+                ..Default::default()
+            }),
+            rex_node: Some(RexNode::Constant(ConstantValue {
+                body: ScalarImpl::Int64(3).to_protobuf(),
+            })),
+        };
+
+        // $1 % 2
+        let left_mod2 = ExprNode {
+            expr_type: Modulus as i32,
+            return_type: Some(risingwave_pb::data::DataType {
+                type_name: TypeName::Int64 as i32,
+                ..Default::default()
+            }),
+            rex_node: Some(RexNode::FuncCall(FunctionCall {
+                children: vec![left_input_ref, literal2],
+            })),
+        };
+
+        // $2 % 3
+        let right_mod3 = ExprNode {
+            expr_type: Modulus as i32,
+            return_type: Some(risingwave_pb::data::DataType {
+                type_name: TypeName::Int64 as i32,
+                ..Default::default()
+            }),
+            rex_node: Some(RexNode::FuncCall(FunctionCall {
+                children: vec![right_input_ref, literal3],
+            })),
+        };
+
+        // $1 % 2 == $2 % 3
+        ExprNode {
+            expr_type: Equal as i32,
+            return_type: Some(risingwave_pb::data::DataType {
+                type_name: TypeName::Boolean as i32,
+                ..Default::default()
+            }),
+            rex_node: Some(RexNode::FuncCall(FunctionCall {
+                children: vec![left_mod2, right_mod3],
+            })),
+        }
+    };
+
+    let schema = Schema::new(match join_type {
+        JoinType::LeftSemi => left_child.schema().fields.clone(),
+        JoinType::LeftAnti => left_child.schema().fields.clone(),
+        JoinType::RightSemi => right_child.schema().fields.clone(),
+        JoinType::RightAnti => right_child.schema().fields.clone(),
+        _ => left_child
+            .schema()
+            .fields
+            .iter()
+            .chain(right_child.schema().fields.iter())
+            .cloned()
+            .collect(),
+    });
+
+    let output_indices = (0..schema.fields().len()).collect();
+
+    Box::new(NestedLoopJoinExecutor::new(
+        build_from_prost(&join_expr).unwrap(),
+        join_type,
+        schema,
+        output_indices,
+        left_child,
+        right_child,
+        "NestedLoopJoinBenchmarkExecutor".into(),
+    ))
+}
+
+async fn execute_nested_loop_join_executor(executor: BoxedExecutor) {
+    let mut stream = executor.execute();
+    while let Some(ret) = stream.next().await {
+        black_box(ret.unwrap());
+    }
+}
+
+fn bench_nested_loop_join(c: &mut Criterion) {
+    const LEFT_SIZE: usize = 1024;
+    const RIGHT_SIZE: usize = 1024;
+    let rt = Runtime::new().unwrap();
+    for join_type in &[
+        JoinType::Inner,
+        JoinType::LeftOuter,
+        JoinType::LeftSemi,
+        JoinType::LeftAnti,
+        JoinType::RightOuter,
+        JoinType::RightSemi,
+        JoinType::RightAnti,
+    ] {
+        for chunk_size in &[32, 128, 512, 1024] {
+            c.bench_with_input(
+                BenchmarkId::new(
+                    "NestedLoopJoinExecutor",
+                    format!("{}({:?})", chunk_size, join_type),
+                ),
+                chunk_size,
+                |b, &chunk_size| {
+                    let left_chunk_num = LEFT_SIZE / chunk_size;
+                    let right_chunk_num = RIGHT_SIZE / chunk_size;
+                    b.to_async(&rt).iter_batched(
+                        || {
+                            create_nested_loop_join_executor(
+                                *join_type,
+                                chunk_size,
+                                left_chunk_num,
+                                chunk_size,
+                                right_chunk_num,
+                            )
+                        },
+                        |e| execute_nested_loop_join_executor(e),
+                        BatchSize::SmallInput,
+                    );
+                },
+            );
+        }
+    }
+}
+
+criterion_group!(benches, bench_nested_loop_join);
+criterion_main!(benches);

--- a/src/batch/src/executor/join/mod.rs
+++ b/src/batch/src/executor/join/mod.rs
@@ -27,7 +27,7 @@ pub use sort_merge_join::*;
 
 use crate::executor::join::JoinType::Inner;
 #[derive(Copy, Clone, Debug, PartialEq)]
-pub(super) enum JoinType {
+pub enum JoinType {
     Inner,
     LeftOuter,
     /// Semi join when probe side should output when matched

--- a/src/batch/src/executor/join/nested_loop_join.rs
+++ b/src/batch/src/executor/join/nested_loop_join.rs
@@ -210,7 +210,6 @@ impl BoxedExecutorBuilder for NestedLoopJoinExecutor {
         let join_expr = expr_build_from_prost(nested_loop_join_node.get_join_cond()?)?;
 
         let left_child = inputs.remove(0);
-        let probe_side_schema = left_child.schema().data_types();
         let right_child = inputs.remove(0);
 
         // TODO(Bowen): Merge this with derive schema in Logical Join (#790).
@@ -233,10 +232,6 @@ impl BoxedExecutorBuilder for NestedLoopJoinExecutor {
             .map(|&x| x as usize)
             .collect();
         let original_schema = Schema { fields };
-        let actual_schema = output_indices
-            .iter()
-            .map(|&idx| original_schema[idx].clone())
-            .collect();
         match join_type {
             JoinType::Inner
             | JoinType::LeftOuter
@@ -246,24 +241,16 @@ impl BoxedExecutorBuilder for NestedLoopJoinExecutor {
             | JoinType::RightSemi
             | JoinType::RightAnti => {
                 // TODO: Support FULL OUTER.
-                let outer_table_source = RowLevelIter::new(left_child);
 
-                Ok(Box::new(Self {
+                Ok(Box::new(Self::new(
                     join_expr,
                     join_type,
-                    chunk_builder: DataChunkBuilder::with_default_size(
-                        original_schema.data_types(),
-                    ),
-                    schema: actual_schema,
+                    original_schema,
                     output_indices,
-                    last_chunk: None,
-                    probe_side_schema,
-                    probe_side_source: outer_table_source,
-                    build_table: RowLevelIter::new(right_child),
-                    probe_remain_chunk_idx: 0,
-                    probe_remain_row_idx: 0,
-                    identity: "NestedLoopJoinExecutor2".to_string(),
-                }))
+                    left_child,
+                    right_child,
+                    "NestedLoopJoinExecutor2".to_string(),
+                )))
             }
             _ => Err(ErrorCode::NotImplemented(
                 format!("Do not support {:?} join type now.", join_type),
@@ -273,7 +260,37 @@ impl BoxedExecutorBuilder for NestedLoopJoinExecutor {
         }
     }
 }
+
 impl NestedLoopJoinExecutor {
+    pub fn new(
+        join_expr: BoxedExpression,
+        join_type: JoinType,
+        original_schema: Schema,
+        output_indices: Vec<usize>,
+        left_child: BoxedExecutor,
+        right_child: BoxedExecutor,
+        identity: String,
+    ) -> Self {
+        let schema = output_indices
+            .iter()
+            .map(|&idx| original_schema[idx].clone())
+            .collect();
+        Self {
+            join_expr,
+            join_type,
+            schema,
+            output_indices,
+            chunk_builder: DataChunkBuilder::with_default_size(original_schema.data_types()),
+            last_chunk: None,
+            probe_side_schema: left_child.schema().data_types(),
+            probe_side_source: RowLevelIter::new(left_child),
+            build_table: RowLevelIter::new(right_child),
+            probe_remain_chunk_idx: 0,
+            probe_remain_row_idx: 0,
+            identity,
+        }
+    }
+
     /// Probe matched rows in `probe_table`.
     /// # Arguments
     /// * `first_probe`: whether the first probing. Init outer source if yes.

--- a/src/batch/src/executor/join/row_level_iter.rs
+++ b/src/batch/src/executor/join/row_level_iter.rs
@@ -94,11 +94,7 @@ impl RowLevelIter {
     }
 
     pub fn get_current_chunk(&self) -> Option<&DataChunk> {
-        if self.chunk_idx < self.data.len() {
-            Some(&self.data[self.chunk_idx])
-        } else {
-            None
-        }
+        self.data.get(self.chunk_idx)
     }
 
     pub fn get_current_row_ref(&self) -> Option<RowRef<'_>> {

--- a/src/batch/src/executor/test_utils.rs
+++ b/src/batch/src/executor/test_utils.rs
@@ -14,18 +14,56 @@
 
 use std::collections::VecDeque;
 use std::future::Future;
+use std::sync::Arc;
 
 use assert_matches::assert_matches;
 use futures_async_stream::{for_await, try_stream};
 use itertools::Itertools;
+use risingwave_common::array::column::Column;
 use risingwave_common::array::DataChunk;
 use risingwave_common::catalog::Schema;
 use risingwave_common::error::{Result, RwError};
+use risingwave_common::field_generator::FieldGeneratorImpl;
+use risingwave_common::types::{DataType, ScalarImpl};
 use risingwave_pb::batch_plan::ExchangeSource as ProstExchangeSource;
 
 use crate::exchange_source::{ExchangeSource, ExchangeSourceImpl};
 use crate::executor::{BoxedDataChunkStream, BoxedExecutor, CreateSource, Executor};
 use crate::task::BatchTaskContext;
+
+const SEED: u64 = 0xFF67FEABBAEF76FF;
+
+/// Generate [`batch_num`] data chunks, each data chunk has cardinality of [`batch_size`].
+pub fn gen_data(data_type: DataType, batch_size: usize, batch_num: usize) -> Vec<DataChunk> {
+    let mut data_gen =
+        FieldGeneratorImpl::with_random(data_type.clone(), None, None, None, None, SEED).unwrap();
+    let mut ret = Vec::<DataChunk>::with_capacity(batch_num);
+
+    for i in 0..batch_num {
+        let mut array_builder = data_type.create_array_builder(batch_size);
+
+        for j in 0..batch_size {
+            array_builder
+                .append_datum(&Some(ScalarImpl::Int64(
+                    // TODO: We should remove this later when generator supports generate Datum,
+                    // see https://github.com/singularity-data/risingwave/issues/3519
+                    data_gen
+                        .generate(((i + 1) * (j + 1)) as u64)
+                        .as_i64()
+                        .unwrap(),
+                )))
+                .unwrap();
+        }
+
+        let array = array_builder.finish().unwrap();
+        ret.push(DataChunk::new(
+            vec![Column::new(Arc::new(array))],
+            batch_size,
+        ));
+    }
+
+    ret
+}
 
 /// Mock the input of executor.
 /// You can bind one or more `MockExecutor` as the children of the executor to test,

--- a/src/batch/src/executor/test_utils.rs
+++ b/src/batch/src/executor/test_utils.rs
@@ -33,7 +33,7 @@ use crate::task::BatchTaskContext;
 
 const SEED: u64 = 0xFF67FEABBAEF76FF;
 
-/// Generate [`batch_num`] data chunks, each data chunk has cardinality of [`batch_size`].
+/// Generate `batch_num` data chunks, each data chunk has cardinality of `batch_size`.
 pub fn gen_data(data_type: DataType, batch_size: usize, batch_num: usize) -> Vec<DataChunk> {
     let mut data_gen =
         FieldGeneratorImpl::with_random(data_type.clone(), None, None, None, None, SEED).unwrap();


### PR DESCRIPTION
I hereby agree to the terms of the [Singularity Data, Inc. Contributor License Agreement](https://gist.github.com/skyzh/0663682a70b0edde7ae991492f2314cb#file-s9y_cla).

## What's changed and what's your intention?

Add micro benchmark for NestedLoopJoinExecutor and some minor changes.

Part of the benchmark results on ec2 c4.4xlarge instance:
```bash
NestedLoopJoinExecutor/32(Inner)                                                                            
                        time:   [449.19 ms 449.29 ms 449.39 ms]

NestedLoopJoinExecutor/128(Inner)                                                                            
                        time:   [355.96 ms 355.98 ms 356.00 ms]

NestedLoopJoinExecutor/512(Inner)                                                                            
                        time:   [333.32 ms 333.33 ms 333.35 ms]

NestedLoopJoinExecutor/1024(Inner)                                                                            
                        time:   [329.74 ms 329.76 ms 329.78 ms]

```

## Checklist

- [x] I have written necessary rustdoc comments
- [x] I have added necessary unit tests and integration tests
- [x] All checks passed in `./risedev check` (or alias, `./risedev c`)

## Refer to a related PR or issue link (optional)
