### PR TITLE
refactor(optimizer): cleanup LogicalAgg::prune_col

### DIFF
--- a/src/frontend/src/utils/column_index_mapping.rs
+++ b/src/frontend/src/utils/column_index_mapping.rs
@@ -218,21 +218,6 @@ impl ColIndexMapping {
         Self::with_target_size(map, self.source_size())
     }
 
-    /// inverse the mapping with required columns in the source, if a target corresponds more than
-    /// one source, it will choose the required columns.
-    #[must_use]
-    pub fn inverse_with_required(&self, required: &FixedBitSet) -> Self {
-        let mut map = vec![None; self.target_size()];
-        for (src, dst) in self.mapping_pairs() {
-            if let Some(other_src) = map[dst] && required.contains(other_src) {
-                // do nothing
-            } else {
-                map[dst] = Some(src);
-            }
-        }
-        Self::with_target_size(map, self.source_size())
-    }
-
     /// return iter of (src, dst) order by src
     pub fn mapping_pairs(&self) -> impl Iterator<Item = (usize, usize)> + '_ {
         self.map

--- a/src/frontend/test_runner/tests/testdata/agg.yaml
+++ b/src/frontend/test_runner/tests/testdata/agg.yaml
@@ -481,3 +481,18 @@
     create table t(a int, b int);
     select abs(a) FILTER (WHERE a > 0) AS avga from t;
   binder_error: 'Invalid input syntax: filter clause is only allowed in aggregation functions, but `abs` is not an aggregation function'
+- sql: |
+    /* prune column before filter */
+    create table t(v1 int, v2 int);
+    with sub(a, b) as (select min(v1), sum(v2) filter (where v2 < 5) from t) select b from sub;
+  batch_plan: |
+    BatchSimpleAgg { aggs: [sum($0)] }
+      BatchExchange { order: [], dist: Single }
+        BatchSimpleAgg { aggs: [sum($0) filter(($0 < 5:Int32))] }
+          BatchScan { table: t, columns: [v2] }
+  stream_plan: |
+    StreamMaterialize { columns: [agg#0(hidden), b], pk_columns: [] }
+      StreamGlobalSimpleAgg { aggs: [sum($0), sum($1)] }
+        StreamExchange { dist: Single }
+          StreamLocalSimpleAgg { aggs: [count, sum($0) filter(($0 < 5:Int32))] }
+            StreamTableScan { table: t, columns: [v2, _row_id], pk_indices: [1] }


### PR DESCRIPTION
I hereby agree to the terms of the [Singularity Data, Inc. Contributor License Agreement](https://gist.github.com/skyzh/0663682a70b0edde7ae991492f2314cb#file-s9y_cla).

## What's changed and what's your intention?

Removes unnecessary helpers (`inverse_with_required`, `i2o_col_mapping_with_required_out`) after the fix #3632

Also extracts the common part of `rewrite_with_input` and `prune_col` into `rewrite_with_input_agg`, which also fixes the following bug introduced by #3626:
```
dev=> create table t(v1 int, v2 int);
CREATE_TABLE
dev=> explain with sub(a, b) as (select min(v1), sum(v2) filter (where v2 < 5) from t) select b from sub;
                          QUERY PLAN                           
---------------------------------------------------------------
 BatchSimpleAgg { aggs: [sum($0)] }
   BatchExchange { order: [], dist: Single }
     BatchSimpleAgg { aggs: [sum($0) filter(($1 < 5:Int32))] }  -- index inside filter is not updated
       BatchScan { table: t, columns: [v2] }
(4 rows)
```

## Checklist

- [x] I have written necessary rustdoc comments
- [x] I have added necessary unit tests and integration tests
- [x] All checks passed in `./risedev check` (or alias, `./risedev c`)

## Refer to a related PR or issue link (optional)
