### PR TITLE
feat(batch): enforce order for parallel scan on ordered mv

### DIFF
--- a/e2e_test/batch/basic/array.slt.part
+++ b/e2e_test/batch/basic/array.slt.part
@@ -1,3 +1,5 @@
+control sortmode rowsort
+
 statement ok
 SET RW_IMPLICIT_FLUSH TO true;
 

--- a/e2e_test/batch/basic/boolean.slt.part
+++ b/e2e_test/batch/basic/boolean.slt.part
@@ -1,3 +1,5 @@
+control sortmode rowsort
+
 statement ok
 SET RW_IMPLICIT_FLUSH TO true;
 

--- a/e2e_test/streaming/append_only.slt
+++ b/e2e_test/streaming/append_only.slt
@@ -15,7 +15,7 @@ insert into t2 values (1,5), (2,6), (3, 7);
 statement ok
 create materialized view mv1 as select t1.v1 as id, v2, v3 from t1 join t2 on t1.v1=t2.v1;
 
-query I
+query I rowsort
 select * from mv1;
 ----
 1 2 5
@@ -27,7 +27,7 @@ insert into t1 values (3,4), (7,7);
 statement ok
 flush;
 
-query II
+query II rowsort
 select * from mv1;
 ----
 1 2 5
@@ -45,7 +45,7 @@ insert into t4 values (1,1,4), (5,1,4), (1,9,1), (9,8,1), (0,2,3);
 statement ok
 create materialized view mv3 as select v3, sum(v1) as sum_v1, min(v1) as min_v1, max(v1) as max_v1 from t4 group by v3;
 
-query III
+query III nosort
 select sum_v1, min_v1, max_v1, v3 from mv3 order by sum_v1;
 ----
 0  0 0 3
@@ -57,7 +57,7 @@ select sum_v1, min_v1, max_v1, v3 from mv3 order by sum_v1;
 statement ok
 create materialized view mv4 as select v1, v3 from t4 order by v1 limit 3 offset 3;
 
-query IV
+query IV nosort
 select * from mv4;
 ----
 5 4

--- a/e2e_test/streaming/datagen.slt
+++ b/e2e_test/streaming/datagen.slt
@@ -7,7 +7,7 @@ create materialized source s1 (v1 int, v2 float) with ( 'connector' = 'datagen' 
 # Wait enough time to ensure Datagen connector generate data
 sleep 2s
 
-query II
+query II rowsort
 select v1, v2 from s1 limit 15;
 ----
 1 11
@@ -36,7 +36,7 @@ create materialized source s1 (v1 int)  with ( 'connector' = 'datagen' ,'fields.
 # Wait enough time to ensure Datagen connector generate data
 sleep 2s
 
-query II
+query II nosort
 select v1 from s1 order by v1 limit 10;
 ----
 1

--- a/e2e_test/streaming/demo/ad_ctr.slt
+++ b/e2e_test/streaming/demo/ad_ctr.slt
@@ -101,7 +101,7 @@ FROM
     ) AS ac ON ai.ad_id = ac.ad_id
     AND ai.window_end = ac.window_end;
 
-query TTT
+query TTT rowsort
 SELECT ad_id, ROUND(ctr, 2), window_end FROM ad_ctr_5min;
 ----
 7  0.33      2022-06-10 12:21:00

--- a/e2e_test/streaming/struct_table.slt
+++ b/e2e_test/streaming/struct_table.slt
@@ -13,7 +13,7 @@ insert into st values(1,(1,(1,2)));
 statement ok
 insert into st values(1,(1,(1,3)));
 
-query I
+query I rowsort
 select * from mv1;
 ----
 (1,2)

--- a/e2e_test/streaming/time_window.slt
+++ b/e2e_test/streaming/time_window.slt
@@ -110,7 +110,7 @@ select * from mv_hop_agg_1 order by window_start;
  8 2022-01-01 11:00:00
 
 query IIT
-select * from mv_hop_agg_2 order by window_start;
+select * from mv_hop_agg_2 order by window_start, uid;
 ----
 1 4 2022-01-01 09:45:00
 2 2 2022-01-01 09:45:00

--- a/proto/catalog.proto
+++ b/proto/catalog.proto
@@ -51,7 +51,10 @@ message Table {
   string name = 4;
   repeated plan_common.ColumnCatalog columns = 5;
   repeated plan_common.ColumnOrder order_keys = 6;
-  repeated plan_common.ColumnOrder user_order_by = 7;
+  message Order {
+    repeated plan_common.ColumnOrder field_order = 1;
+  }
+  Order user_order_by = 7;
   repeated uint32 dependent_relations = 8;
   oneof optional_associated_source_id {
     uint32 associated_source_id = 9;

--- a/proto/catalog.proto
+++ b/proto/catalog.proto
@@ -51,6 +51,7 @@ message Table {
   string name = 4;
   repeated plan_common.ColumnCatalog columns = 5;
   repeated plan_common.ColumnOrder order_keys = 6;
+  repeated plan_common.ColumnOrder user_order_by = 7;
   repeated uint32 dependent_relations = 8;
   oneof optional_associated_source_id {
     uint32 associated_source_id = 9;

--- a/src/common/src/catalog/physical_table.rs
+++ b/src/common/src/catalog/physical_table.rs
@@ -71,4 +71,11 @@ impl TableDesc {
             dist_key_indices: self.distribution_keys.iter().map(|&k| k as u32).collect(),
         }
     }
+
+    pub fn is_ordered(&self) -> bool {
+        match &self.user_order_by {
+            Some(vec) => !vec.is_empty(),
+            None => false,
+        }
+    }
 }

--- a/src/common/src/catalog/physical_table.rs
+++ b/src/common/src/catalog/physical_table.rs
@@ -26,6 +26,9 @@ pub struct TableDesc {
     pub table_id: TableId,
     /// The keys used to sort in storage.
     pub order_keys: Vec<OrderPair>,
+    /// The ORDER BY specified by the user. Describes how the MV is logically ordered.
+    /// Only used for MV table.
+    pub user_order_by: Option<Vec<OrderPair>>,
     /// All columns in the table, noticed it is NOT sorted by columnId in the vec.
     pub columns: Vec<ColumnDesc>,
     /// Distribution keys of this table, which corresponds to the corresponding column of the

--- a/src/frontend/src/catalog/table_catalog.rs
+++ b/src/frontend/src/catalog/table_catalog.rs
@@ -97,6 +97,10 @@ impl TableCatalog {
                 .iter()
                 .map(FieldOrder::to_order_pair)
                 .collect(),
+            user_order_by: self
+                .user_order_by
+                .as_ref()
+                .map(|vec| vec.iter().map(FieldOrder::to_order_pair).collect()),
             pks: self.pks.clone(),
             columns: self.columns.iter().map(|c| c.column_desc.clone()).collect(),
             distribution_keys: self.distribution_keys.clone(),

--- a/src/frontend/src/optimizer/plan_node/batch_seq_scan.rs
+++ b/src/frontend/src/optimizer/plan_node/batch_seq_scan.rs
@@ -23,7 +23,7 @@ use risingwave_pb::batch_plan::plan_node::NodeBody;
 use risingwave_pb::batch_plan::{RowSeqScanNode, SysRowSeqScanNode};
 use risingwave_pb::plan_common::ColumnDesc as ProstColumnDesc;
 
-use super::{PlanBase, PlanRef, ToBatchProst, ToDistributedBatch};
+use super::{PlanBase, PlanRef, ToBatchProst, ToDistributedBatch, BatchExchange};
 use crate::catalog::ColumnId;
 use crate::optimizer::plan_node::{LogicalScan, ToLocalBatch};
 use crate::optimizer::property::{Direction, Distribution, FieldOrder, Order};
@@ -102,7 +102,7 @@ impl BatchSeqScan {
                     })
                     .collect(),
             };
-            order.enforce(plan)
+            BatchExchange::new(order.enforce(plan), order, Distribution::Single).into() 
         } else {
             plan
         }

--- a/src/frontend/src/optimizer/plan_node/batch_sort.rs
+++ b/src/frontend/src/optimizer/plan_node/batch_sort.rs
@@ -20,7 +20,7 @@ use risingwave_pb::batch_plan::OrderByNode;
 
 use super::{PlanBase, PlanRef, PlanTreeNodeUnary, ToBatchProst, ToDistributedBatch};
 use crate::optimizer::plan_node::ToLocalBatch;
-use crate::optimizer::property::Order;
+use crate::optimizer::property::{Distribution, Order};
 
 /// `BatchSort` buffers all data from input and sort these rows by specified order, providing the
 /// collation required by user or parent plan node.
@@ -35,7 +35,7 @@ impl BatchSort {
         assert!(!order.field_order.is_empty());
         let ctx = input.ctx();
         let schema = input.schema().clone();
-        let dist = input.distribution().clone();
+        let dist = Distribution::Single;
         let base = PlanBase::new_batch(ctx, schema, dist, order);
         BatchSort { base, input }
     }

--- a/src/frontend/src/optimizer/plan_node/batch_sort.rs
+++ b/src/frontend/src/optimizer/plan_node/batch_sort.rs
@@ -20,7 +20,7 @@ use risingwave_pb::batch_plan::OrderByNode;
 
 use super::{PlanBase, PlanRef, PlanTreeNodeUnary, ToBatchProst, ToDistributedBatch};
 use crate::optimizer::plan_node::ToLocalBatch;
-use crate::optimizer::property::{Distribution, Order};
+use crate::optimizer::property::Order;
 
 /// `BatchSort` buffers all data from input and sort these rows by specified order, providing the
 /// collation required by user or parent plan node.
@@ -32,10 +32,9 @@ pub struct BatchSort {
 
 impl BatchSort {
     pub fn new(input: PlanRef, order: Order) -> Self {
-        assert!(!order.field_order.is_empty());
         let ctx = input.ctx();
         let schema = input.schema().clone();
-        let dist = Distribution::Single;
+        let dist = input.distribution().clone();
         let base = PlanBase::new_batch(ctx, schema, dist, order);
         BatchSort { base, input }
     }

--- a/src/frontend/src/optimizer/plan_node/batch_sort.rs
+++ b/src/frontend/src/optimizer/plan_node/batch_sort.rs
@@ -32,6 +32,7 @@ pub struct BatchSort {
 
 impl BatchSort {
     pub fn new(input: PlanRef, order: Order) -> Self {
+        assert!(!order.field_order.is_empty());
         let ctx = input.ctx();
         let schema = input.schema().clone();
         let dist = input.distribution().clone();

--- a/src/frontend/src/optimizer/plan_node/logical_scan.rs
+++ b/src/frontend/src/optimizer/plan_node/logical_scan.rs
@@ -175,6 +175,10 @@ impl LogicalScan {
             .collect()
     }
 
+    pub fn output_column_indices(&self) -> &[usize] {
+        self.output_col_idx.as_ref()
+    }
+
     /// Get all indexes on this table
     pub fn indexes(&self) -> &[(String, Rc<TableDesc>)] {
         &self.indexes

--- a/src/frontend/src/optimizer/plan_node/stream_hash_join.rs
+++ b/src/frontend/src/optimizer/plan_node/stream_hash_join.rs
@@ -271,6 +271,7 @@ fn infer_internal_table_catalog(input: PlanRef) -> TableCatalog {
         name: String::new(),
         columns,
         order_keys: order_desc,
+        user_order_by: None,
         pks: pk_indices.clone(),
         distribution_keys: base.dist.dist_column_indices().to_vec(),
         is_index_on: None,

--- a/src/frontend/src/optimizer/plan_node/stream_materialize.rs
+++ b/src/frontend/src/optimizer/plan_node/stream_materialize.rs
@@ -214,6 +214,13 @@ impl fmt::Display for StreamMaterialize {
         if pk_column_names != order_descs {
             builder.field("order_descs", &format_args!("[{}]", order_descs));
         }
+        if let Some(order) = &table.user_order_by && !order.is_empty() {
+            let order_names = order
+                .iter()
+                .map(|o| format!("{} {}", &table.columns[o.index].column_desc.name, o.direct))
+                .join(", ");
+            builder.field("order", &format_args!("[{}]", order_names));
+        }
         builder.finish()
     }
 }

--- a/src/frontend/src/optimizer/plan_node/stream_materialize.rs
+++ b/src/frontend/src/optimizer/plan_node/stream_materialize.rs
@@ -153,6 +153,7 @@ impl StreamMaterialize {
             name: mv_name,
             columns,
             order_keys,
+            user_order_by: Some(user_order_by.field_order.clone()),
             pks: pk_indices.clone(),
             is_index_on,
             distribution_keys: base.dist.dist_column_indices().to_vec(),

--- a/src/frontend/src/optimizer/plan_node/stream_materialize.rs
+++ b/src/frontend/src/optimizer/plan_node/stream_materialize.rs
@@ -153,7 +153,7 @@ impl StreamMaterialize {
             name: mv_name,
             columns,
             order_keys,
-            user_order_by: Some(user_order_by.field_order.clone()),
+            user_order_by: Some(user_order_by.field_order),
             pks: pk_indices.clone(),
             is_index_on,
             distribution_keys: base.dist.dist_column_indices().to_vec(),

--- a/src/frontend/src/optimizer/plan_node/utils.rs
+++ b/src/frontend/src/optimizer/plan_node/utils.rs
@@ -112,6 +112,7 @@ impl TableCatalogBuilder {
             name: String::new(),
             columns: self.columns,
             order_keys: self.order_keys,
+            user_order_by: None,
             pks: self.pk_indices,
             is_index_on: None,
             distribution_keys,

--- a/src/frontend/src/scheduler/distributed/query.rs
+++ b/src/frontend/src/scheduler/distributed/query.rs
@@ -402,6 +402,7 @@ mod tests {
                 table_id: 0.into(),
                 pks: vec![],
                 order_keys: vec![],
+                user_order_by: None,
                 columns: vec![
                     ColumnDesc {
                         data_type: DataType::Int32,

--- a/src/frontend/src/scheduler/plan_fragmenter.rs
+++ b/src/frontend/src/scheduler/plan_fragmenter.rs
@@ -397,8 +397,7 @@ impl BatchPlanFragmenter {
                     // FIXME: workaround because batch parallel scan on ordered mv may have unorderd
                     // results. should do a merge sort after parallel scan.
                     // Tracking issue: <https://github.com/singularity-data/risingwave/issues/3583>
-                    let is_singleton = true;
-                    // let is_singleton = builder.parallelism == 1;
+                    let is_singleton = builder.parallelism == 1 || table_desc.is_ordered();
 
                     assert!(
                         builder.table_scan_info.is_none()
@@ -507,6 +506,7 @@ mod tests {
                 table_id: 0.into(),
                 pks: vec![],
                 order_keys: vec![],
+                user_order_by: None,
                 columns: vec![
                     ColumnDesc {
                         data_type: DataType::Int32,

--- a/src/frontend/src/scheduler/plan_fragmenter.rs
+++ b/src/frontend/src/scheduler/plan_fragmenter.rs
@@ -394,10 +394,7 @@ impl BatchPlanFragmenter {
                 if let Some(scan_node) = node.as_batch_seq_scan() {
                     let table_desc = scan_node.logical().table_desc();
 
-                    // FIXME: workaround because batch parallel scan on ordered mv may have unorderd
-                    // results. should do a merge sort after parallel scan.
-                    // Tracking issue: <https://github.com/singularity-data/risingwave/issues/3583>
-                    let is_singleton = builder.parallelism == 1 || table_desc.is_ordered();
+                    let is_singleton = builder.parallelism == 1;
 
                     assert!(
                         builder.table_scan_info.is_none()

--- a/src/frontend/test_runner/tests/testdata/append_only.yaml
+++ b/src/frontend/test_runner/tests/testdata/append_only.yaml
@@ -23,7 +23,7 @@
     create table t1 (v1 int, v2 int) with ('appendonly' = true);
     select v1 from t1 order by v1 limit 3 offset 3;
   stream_plan: |
-    StreamMaterialize { columns: [v1, _row_id(hidden)], pk_columns: [_row_id], order_descs: [v1, _row_id] }
+    StreamMaterialize { columns: [v1, _row_id(hidden)], pk_columns: [_row_id], order_descs: [v1, _row_id], order: [v1 ASC] }
       StreamAppendOnlyTopN { order: [$0 ASC], limit: 3, offset: 3 }
         StreamExchange { dist: Single }
           StreamTableScan { table: t1, columns: [v1, _row_id], pk_indices: [1] }

--- a/src/frontend/test_runner/tests/testdata/order_by.yaml
+++ b/src/frontend/test_runner/tests/testdata/order_by.yaml
@@ -4,8 +4,9 @@
     create table t (v1 bigint, v2 double precision);
     select * from t order by v1 desc;
   batch_plan: |
-    BatchSort { order: [$0 DESC] }
-      BatchScan { table: t, columns: [v1, v2] }
+    BatchExchange { order: [$0 DESC], dist: Single }
+      BatchSort { order: [$0 DESC] }
+        BatchScan { table: t, columns: [v1, v2] }
   stream_plan: |
     StreamMaterialize { columns: [v1, v2, _row_id(hidden)], pk_columns: [_row_id], order_descs: [v1, _row_id], order: [v1 DESC] }
       StreamTableScan { table: t, columns: [v1, v2, _row_id], pk_indices: [2] }
@@ -14,28 +15,32 @@
     create table t (v1 bigint, v2 double precision);
     select t.* from t order by v1;
   batch_plan: |
-    BatchSort { order: [$1 ASC] }
-      BatchScan { table: t, columns: [_row_id, v1, v2] }
+    BatchExchange { order: [$1 ASC], dist: Single }
+      BatchSort { order: [$1 ASC] }
+        BatchScan { table: t, columns: [_row_id, v1, v2] }
 - sql: |
     create table t (v1 bigint, v2 double precision);
     select v1, v1+1 from t order by v1;
   batch_plan: |
-    BatchSort { order: [$0 ASC] }
-      BatchProject { exprs: [$0, ($0 + 1:Int32)] }
-        BatchScan { table: t, columns: [v1] }
+    BatchExchange { order: [$0 ASC], dist: Single }
+      BatchSort { order: [$0 ASC] }
+        BatchProject { exprs: [$0, ($0 + 1:Int32)] }
+          BatchScan { table: t, columns: [v1] }
 - sql: |
     create table t (v1 bigint, v2 double precision);
     select t.v1 from t order by v1;
   batch_plan: |
-    BatchSort { order: [$0 ASC] }
-      BatchScan { table: t, columns: [v1] }
+    BatchExchange { order: [$0 ASC], dist: Single }
+      BatchSort { order: [$0 ASC] }
+        BatchScan { table: t, columns: [v1] }
 - sql: |
     /* order by output alias */
     create table t (v1 bigint, v2 double precision);
     select v1 as a1 from t order by a1;
   batch_plan: |
-    BatchSort { order: [$0 ASC] }
-      BatchScan { table: t, columns: [v1] }
+    BatchExchange { order: [$0 ASC], dist: Single }
+      BatchSort { order: [$0 ASC] }
+        BatchScan { table: t, columns: [v1] }
 - sql: |
     /* order by ambiguous */
     create table t (v1 bigint, v2 double precision);
@@ -46,16 +51,18 @@
     create table t (v1 bigint, v2 double precision);
     select v1 as a, v2 as a from t order by 2;
   batch_plan: |
-    BatchSort { order: [$1 ASC] }
-      BatchScan { table: t, columns: [v1, v2] }
+    BatchExchange { order: [$1 ASC], dist: Single }
+      BatchSort { order: [$1 ASC] }
+        BatchScan { table: t, columns: [v1, v2] }
 - sql: |
     create table t (v1 bigint, v2 double precision);
     select * from t order by 1+1;
   batch_plan: |
     BatchProject { exprs: [$0, $1] }
-      BatchSort { order: [$2 ASC] }
-        BatchProject { exprs: [$0, $1, (1:Int32 + 1:Int32)] }
-          BatchScan { table: t, columns: [v1, v2] }
+      BatchExchange { order: [$2 ASC], dist: Single }
+        BatchSort { order: [$2 ASC] }
+          BatchProject { exprs: [$0, $1, (1:Int32 + 1:Int32)] }
+            BatchScan { table: t, columns: [v1, v2] }
   stream_plan: |
     StreamMaterialize { columns: [v1, v2, expr#2(hidden), _row_id(hidden)], pk_columns: [_row_id], order_descs: [expr#2, _row_id], order: [expr#2 ASC] }
       StreamProject { exprs: [$0, $1, (1:Int32 + 1:Int32), $2] }
@@ -97,9 +104,10 @@
       LogicalScan { table: t, columns: [x, y, z] }
   batch_plan: |
     BatchProject { exprs: [$0, $1] }
-      BatchSort { order: [$2 ASC, $3 ASC] }
-        BatchProject { exprs: [$0, $1, ($0 + $1), $2] }
-          BatchScan { table: t, columns: [x, y, z] }
+      BatchExchange { order: [$2 ASC, $3 ASC], dist: Single }
+        BatchSort { order: [$2 ASC, $3 ASC] }
+          BatchProject { exprs: [$0, $1, ($0 + $1), $2] }
+            BatchScan { table: t, columns: [x, y, z] }
   stream_plan: |
     StreamMaterialize { columns: [x, y, expr#2(hidden), z(hidden), _row_id(hidden)], pk_columns: [_row_id], order_descs: [expr#2, z, _row_id], order: [expr#2 ASC, z ASC] }
       StreamProject { exprs: [$0, $1, ($0 + $1), $2, $3] }
@@ -111,8 +119,9 @@
   optimized_logical_plan: |
     LogicalScan { table: t, columns: [x, y] }
   batch_plan: |
-    BatchSort { order: [$1 ASC] }
-      BatchScan { table: t, columns: [x, y] }
+    BatchExchange { order: [$1 ASC], dist: Single }
+      BatchSort { order: [$1 ASC] }
+        BatchScan { table: t, columns: [x, y] }
 - sql: |
     /* index exceeds the number of select items */
     create table t (x int, y int);

--- a/src/frontend/test_runner/tests/testdata/order_by.yaml
+++ b/src/frontend/test_runner/tests/testdata/order_by.yaml
@@ -8,7 +8,7 @@
       BatchSort { order: [$0 DESC] }
         BatchScan { table: t, columns: [v1, v2] }
   stream_plan: |
-    StreamMaterialize { columns: [v1, v2, _row_id(hidden)], pk_columns: [_row_id], order_descs: [v1, _row_id] }
+    StreamMaterialize { columns: [v1, v2, _row_id(hidden)], pk_columns: [_row_id], order_descs: [v1, _row_id], order: [v1 DESC] }
       StreamTableScan { table: t, columns: [v1, v2, _row_id], pk_indices: [2] }
 - sql: |
     /* output names are not quailified after table names */
@@ -64,7 +64,7 @@
           BatchProject { exprs: [$0, $1, (1:Int32 + 1:Int32)] }
             BatchScan { table: t, columns: [v1, v2] }
   stream_plan: |
-    StreamMaterialize { columns: [v1, v2, expr#2(hidden), _row_id(hidden)], pk_columns: [_row_id], order_descs: [expr#2, _row_id] }
+    StreamMaterialize { columns: [v1, v2, expr#2(hidden), _row_id(hidden)], pk_columns: [_row_id], order_descs: [expr#2, _row_id], order: [expr#2 ASC] }
       StreamProject { exprs: [$0, $1, (1:Int32 + 1:Int32), $2] }
         StreamTableScan { table: t, columns: [v1, v2, _row_id], pk_indices: [2] }
 - sql: |
@@ -79,7 +79,7 @@
       BatchExchange { order: [], dist: Single }
         BatchScan { table: t, columns: [v1, v2] }
   stream_plan: |
-    StreamMaterialize { columns: [v1, v2, _row_id(hidden)], pk_columns: [_row_id], order_descs: [v1, _row_id] }
+    StreamMaterialize { columns: [v1, v2, _row_id(hidden)], pk_columns: [_row_id], order_descs: [v1, _row_id], order: [v1 DESC] }
       StreamTopN { order: [$0 DESC], limit: 5, offset: 0 }
         StreamExchange { dist: Single }
           StreamTableScan { table: t, columns: [v1, v2, _row_id], pk_indices: [2] }
@@ -91,7 +91,7 @@
       BatchExchange { order: [], dist: Single }
         BatchScan { table: t, columns: [v1, v2] }
   stream_plan: |
-    StreamMaterialize { columns: [v1, v2, _row_id(hidden)], pk_columns: [_row_id], order_descs: [v1, _row_id] }
+    StreamMaterialize { columns: [v1, v2, _row_id(hidden)], pk_columns: [_row_id], order_descs: [v1, _row_id], order: [v1 DESC] }
       StreamTopN { order: [$0 DESC], limit: 5, offset: 7 }
         StreamExchange { dist: Single }
           StreamTableScan { table: t, columns: [v1, v2, _row_id], pk_indices: [2] }
@@ -109,7 +109,7 @@
           BatchProject { exprs: [$0, $1, ($0 + $1), $2] }
             BatchScan { table: t, columns: [x, y, z] }
   stream_plan: |
-    StreamMaterialize { columns: [x, y, expr#2(hidden), z(hidden), _row_id(hidden)], pk_columns: [_row_id], order_descs: [expr#2, z, _row_id] }
+    StreamMaterialize { columns: [x, y, expr#2(hidden), z(hidden), _row_id(hidden)], pk_columns: [_row_id], order_descs: [expr#2, z, _row_id], order: [expr#2 ASC, z ASC] }
       StreamProject { exprs: [$0, $1, ($0 + $1), $2, $3] }
         StreamTableScan { table: t, columns: [x, y, z, _row_id], pk_indices: [3] }
 - sql: |

--- a/src/frontend/test_runner/tests/testdata/order_by.yaml
+++ b/src/frontend/test_runner/tests/testdata/order_by.yaml
@@ -4,9 +4,8 @@
     create table t (v1 bigint, v2 double precision);
     select * from t order by v1 desc;
   batch_plan: |
-    BatchExchange { order: [$0 DESC], dist: Single }
-      BatchSort { order: [$0 DESC] }
-        BatchScan { table: t, columns: [v1, v2] }
+    BatchSort { order: [$0 DESC] }
+      BatchScan { table: t, columns: [v1, v2] }
   stream_plan: |
     StreamMaterialize { columns: [v1, v2, _row_id(hidden)], pk_columns: [_row_id], order_descs: [v1, _row_id], order: [v1 DESC] }
       StreamTableScan { table: t, columns: [v1, v2, _row_id], pk_indices: [2] }
@@ -15,32 +14,28 @@
     create table t (v1 bigint, v2 double precision);
     select t.* from t order by v1;
   batch_plan: |
-    BatchExchange { order: [$1 ASC], dist: Single }
-      BatchSort { order: [$1 ASC] }
-        BatchScan { table: t, columns: [_row_id, v1, v2] }
+    BatchSort { order: [$1 ASC] }
+      BatchScan { table: t, columns: [_row_id, v1, v2] }
 - sql: |
     create table t (v1 bigint, v2 double precision);
     select v1, v1+1 from t order by v1;
   batch_plan: |
-    BatchExchange { order: [$0 ASC], dist: Single }
-      BatchSort { order: [$0 ASC] }
-        BatchProject { exprs: [$0, ($0 + 1:Int32)] }
-          BatchScan { table: t, columns: [v1] }
+    BatchSort { order: [$0 ASC] }
+      BatchProject { exprs: [$0, ($0 + 1:Int32)] }
+        BatchScan { table: t, columns: [v1] }
 - sql: |
     create table t (v1 bigint, v2 double precision);
     select t.v1 from t order by v1;
   batch_plan: |
-    BatchExchange { order: [$0 ASC], dist: Single }
-      BatchSort { order: [$0 ASC] }
-        BatchScan { table: t, columns: [v1] }
+    BatchSort { order: [$0 ASC] }
+      BatchScan { table: t, columns: [v1] }
 - sql: |
     /* order by output alias */
     create table t (v1 bigint, v2 double precision);
     select v1 as a1 from t order by a1;
   batch_plan: |
-    BatchExchange { order: [$0 ASC], dist: Single }
-      BatchSort { order: [$0 ASC] }
-        BatchScan { table: t, columns: [v1] }
+    BatchSort { order: [$0 ASC] }
+      BatchScan { table: t, columns: [v1] }
 - sql: |
     /* order by ambiguous */
     create table t (v1 bigint, v2 double precision);
@@ -51,18 +46,16 @@
     create table t (v1 bigint, v2 double precision);
     select v1 as a, v2 as a from t order by 2;
   batch_plan: |
-    BatchExchange { order: [$1 ASC], dist: Single }
-      BatchSort { order: [$1 ASC] }
-        BatchScan { table: t, columns: [v1, v2] }
+    BatchSort { order: [$1 ASC] }
+      BatchScan { table: t, columns: [v1, v2] }
 - sql: |
     create table t (v1 bigint, v2 double precision);
     select * from t order by 1+1;
   batch_plan: |
     BatchProject { exprs: [$0, $1] }
-      BatchExchange { order: [$2 ASC], dist: Single }
-        BatchSort { order: [$2 ASC] }
-          BatchProject { exprs: [$0, $1, (1:Int32 + 1:Int32)] }
-            BatchScan { table: t, columns: [v1, v2] }
+      BatchSort { order: [$2 ASC] }
+        BatchProject { exprs: [$0, $1, (1:Int32 + 1:Int32)] }
+          BatchScan { table: t, columns: [v1, v2] }
   stream_plan: |
     StreamMaterialize { columns: [v1, v2, expr#2(hidden), _row_id(hidden)], pk_columns: [_row_id], order_descs: [expr#2, _row_id], order: [expr#2 ASC] }
       StreamProject { exprs: [$0, $1, (1:Int32 + 1:Int32), $2] }
@@ -104,10 +97,9 @@
       LogicalScan { table: t, columns: [x, y, z] }
   batch_plan: |
     BatchProject { exprs: [$0, $1] }
-      BatchExchange { order: [$2 ASC, $3 ASC], dist: Single }
-        BatchSort { order: [$2 ASC, $3 ASC] }
-          BatchProject { exprs: [$0, $1, ($0 + $1), $2] }
-            BatchScan { table: t, columns: [x, y, z] }
+      BatchSort { order: [$2 ASC, $3 ASC] }
+        BatchProject { exprs: [$0, $1, ($0 + $1), $2] }
+          BatchScan { table: t, columns: [x, y, z] }
   stream_plan: |
     StreamMaterialize { columns: [x, y, expr#2(hidden), z(hidden), _row_id(hidden)], pk_columns: [_row_id], order_descs: [expr#2, z, _row_id], order: [expr#2 ASC, z ASC] }
       StreamProject { exprs: [$0, $1, ($0 + $1), $2, $3] }
@@ -119,9 +111,8 @@
   optimized_logical_plan: |
     LogicalScan { table: t, columns: [x, y] }
   batch_plan: |
-    BatchExchange { order: [$1 ASC], dist: Single }
-      BatchSort { order: [$1 ASC] }
-        BatchScan { table: t, columns: [x, y] }
+    BatchSort { order: [$1 ASC] }
+      BatchScan { table: t, columns: [x, y] }
 - sql: |
     /* index exceeds the number of select items */
     create table t (x int, y int);

--- a/src/frontend/test_runner/tests/testdata/range_scan.yaml
+++ b/src/frontend/test_runner/tests/testdata/range_scan.yaml
@@ -91,20 +91,23 @@
   sql: |
     SELECT * FROM orders_count_by_user_ordered WHERE user_id = 42
   batch_plan: |
-    BatchFilter { predicate: ($0 = 42:Int32) }
-      BatchSort { order: [$2 ASC] }
-        BatchScan { table: orders_count_by_user_ordered, columns: [user_id, date, orders_count] }
+    BatchExchange { order: [], dist: Single }
+      BatchFilter { predicate: ($0 = 42:Int32) }
+        BatchSort { order: [$2 ASC] }
+          BatchScan { table: orders_count_by_user_ordered, columns: [user_id, date, orders_count] }
 - before:
     - create_table_and_mv_ordered
   sql: |
     SELECT * FROM orders_count_by_user_ordered WHERE user_id > 42 AND orders_count = 10
   batch_plan: |
-    BatchSort { order: [$2 ASC] }
-      BatchScan { table: orders_count_by_user_ordered, columns: [user_id, date, orders_count], scan_range: [orders_count = Int64(10), user_id > Int32(42)] }
+    BatchExchange { order: [], dist: Single }
+      BatchSort { order: [$2 ASC] }
+        BatchScan { table: orders_count_by_user_ordered, columns: [user_id, date, orders_count], scan_range: [orders_count = Int64(10), user_id > Int32(42)] }
 - before:
     - create_table_and_mv_ordered
   sql: |
     SELECT * FROM orders_count_by_user_ordered WHERE orders_count = 10
   batch_plan: |
-    BatchSort { order: [$2 ASC] }
-      BatchScan { table: orders_count_by_user_ordered, columns: [user_id, date, orders_count], scan_range: [orders_count = Int64(10)] }
+    BatchExchange { order: [], dist: Single }
+      BatchSort { order: [$2 ASC] }
+        BatchScan { table: orders_count_by_user_ordered, columns: [user_id, date, orders_count], scan_range: [orders_count = Int64(10)] }

--- a/src/frontend/test_runner/tests/testdata/range_scan.yaml
+++ b/src/frontend/test_runner/tests/testdata/range_scan.yaml
@@ -91,23 +91,20 @@
   sql: |
     SELECT * FROM orders_count_by_user_ordered WHERE user_id = 42
   batch_plan: |
-    BatchExchange { order: [], dist: Single }
-      BatchFilter { predicate: ($0 = 42:Int32) }
-        BatchSort { order: [$2 ASC] }
-          BatchScan { table: orders_count_by_user_ordered, columns: [user_id, date, orders_count] }
+    BatchFilter { predicate: ($0 = 42:Int32) }
+      BatchSort { order: [$2 ASC] }
+        BatchScan { table: orders_count_by_user_ordered, columns: [user_id, date, orders_count] }
 - before:
     - create_table_and_mv_ordered
   sql: |
     SELECT * FROM orders_count_by_user_ordered WHERE user_id > 42 AND orders_count = 10
   batch_plan: |
-    BatchExchange { order: [], dist: Single }
-      BatchSort { order: [$2 ASC] }
-        BatchScan { table: orders_count_by_user_ordered, columns: [user_id, date, orders_count], scan_range: [orders_count = Int64(10), user_id > Int32(42)] }
+    BatchSort { order: [$2 ASC] }
+      BatchScan { table: orders_count_by_user_ordered, columns: [user_id, date, orders_count], scan_range: [orders_count = Int64(10), user_id > Int32(42)] }
 - before:
     - create_table_and_mv_ordered
   sql: |
     SELECT * FROM orders_count_by_user_ordered WHERE orders_count = 10
   batch_plan: |
-    BatchExchange { order: [], dist: Single }
-      BatchSort { order: [$2 ASC] }
-        BatchScan { table: orders_count_by_user_ordered, columns: [user_id, date, orders_count], scan_range: [orders_count = Int64(10)] }
+    BatchSort { order: [$2 ASC] }
+      BatchScan { table: orders_count_by_user_ordered, columns: [user_id, date, orders_count], scan_range: [orders_count = Int64(10)] }

--- a/src/frontend/test_runner/tests/testdata/range_scan.yaml
+++ b/src/frontend/test_runner/tests/testdata/range_scan.yaml
@@ -93,18 +93,21 @@
   batch_plan: |
     BatchExchange { order: [], dist: Single }
       BatchFilter { predicate: ($0 = 42:Int32) }
-        BatchScan { table: orders_count_by_user_ordered, columns: [user_id, date, orders_count] }
+        BatchSort { order: [$2 ASC] }
+          BatchScan { table: orders_count_by_user_ordered, columns: [user_id, date, orders_count] }
 - before:
     - create_table_and_mv_ordered
   sql: |
     SELECT * FROM orders_count_by_user_ordered WHERE user_id > 42 AND orders_count = 10
   batch_plan: |
     BatchExchange { order: [], dist: Single }
-      BatchScan { table: orders_count_by_user_ordered, columns: [user_id, date, orders_count], scan_range: [orders_count = Int64(10), user_id > Int32(42)] }
+      BatchSort { order: [$2 ASC] }
+        BatchScan { table: orders_count_by_user_ordered, columns: [user_id, date, orders_count], scan_range: [orders_count = Int64(10), user_id > Int32(42)] }
 - before:
     - create_table_and_mv_ordered
   sql: |
     SELECT * FROM orders_count_by_user_ordered WHERE orders_count = 10
   batch_plan: |
     BatchExchange { order: [], dist: Single }
-      BatchScan { table: orders_count_by_user_ordered, columns: [user_id, date, orders_count], scan_range: [orders_count = Int64(10)] }
+      BatchSort { order: [$2 ASC] }
+        BatchScan { table: orders_count_by_user_ordered, columns: [user_id, date, orders_count], scan_range: [orders_count = Int64(10)] }

--- a/src/frontend/test_runner/tests/testdata/range_scan.yaml
+++ b/src/frontend/test_runner/tests/testdata/range_scan.yaml
@@ -91,8 +91,8 @@
   sql: |
     SELECT * FROM orders_count_by_user_ordered WHERE user_id = 42
   batch_plan: |
-    BatchExchange { order: [], dist: Single }
-      BatchFilter { predicate: ($0 = 42:Int32) }
+    BatchFilter { predicate: ($0 = 42:Int32) }
+      BatchExchange { order: [$2 ASC], dist: Single }
         BatchSort { order: [$2 ASC] }
           BatchScan { table: orders_count_by_user_ordered, columns: [user_id, date, orders_count] }
 - before:
@@ -100,7 +100,7 @@
   sql: |
     SELECT * FROM orders_count_by_user_ordered WHERE user_id > 42 AND orders_count = 10
   batch_plan: |
-    BatchExchange { order: [], dist: Single }
+    BatchExchange { order: [$2 ASC], dist: Single }
       BatchSort { order: [$2 ASC] }
         BatchScan { table: orders_count_by_user_ordered, columns: [user_id, date, orders_count], scan_range: [orders_count = Int64(10), user_id > Int32(42)] }
 - before:
@@ -108,6 +108,6 @@
   sql: |
     SELECT * FROM orders_count_by_user_ordered WHERE orders_count = 10
   batch_plan: |
-    BatchExchange { order: [], dist: Single }
+    BatchExchange { order: [$2 ASC], dist: Single }
       BatchSort { order: [$2 ASC] }
         BatchScan { table: orders_count_by_user_ordered, columns: [user_id, date, orders_count], scan_range: [orders_count = Int64(10)] }

--- a/src/frontend/test_runner/tests/testdata/stream_proto.yaml
+++ b/src/frontend/test_runner/tests/testdata/stream_proto.yaml
@@ -128,6 +128,7 @@
     orderKeys:
       - orderType: ASCENDING
         index: 1
+    userOrderBy: {}
     distributionKeys:
       - 1
     pk:
@@ -231,6 +232,7 @@
     orderKeys:
       - orderType: ASCENDING
         index: 1
+    userOrderBy: {}
     distributionKeys:
       - 1
     pk:
@@ -343,6 +345,7 @@
     orderKeys:
       - orderType: ASCENDING
         index: 1
+    userOrderBy: {}
     distributionKeys:
       - 1
     pk:
@@ -549,6 +552,7 @@
             isNullable: true
           columnId: 1
           name: sum
+    userOrderBy: {}
     owner: root
 - sql: |
     /* test simple agg */
@@ -821,6 +825,7 @@
     orderKeys:
       - orderType: ASCENDING
         index: 1
+    userOrderBy: {}
     distributionKeys:
       - 1
     pk:

--- a/src/frontend/test_runner/tests/testdata/tpch.yaml
+++ b/src/frontend/test_runner/tests/testdata/tpch.yaml
@@ -114,13 +114,14 @@
         LogicalProject { exprs: [$4, $5, $0, $1, ($1 * (1:Int32 - $2)), (($1 * (1:Int32 - $2)) * (1:Int32 + $3)), $2] }
           LogicalScan { table: lineitem, output_columns: [l_quantity, l_extendedprice, l_discount, l_tax, l_returnflag, l_linestatus], required_columns: [$5:l_quantity, $6:l_extendedprice, $7:l_discount, $8:l_tax, $9:l_returnflag, $10:l_linestatus, $11:l_shipdate], predicate: ($11 <= ('1998-12-01':Varchar::Date - '71 days 00:00:00':Interval)) }
   batch_plan: |
-    BatchSort { order: [$0 ASC, $1 ASC] }
-      BatchProject { exprs: [$0, $1, $2, $3, $4, $5, RoundDigit(($6 / $7), 4:Int32), RoundDigit(($8 / $9), 4:Int32), RoundDigit(($10 / $11), 4:Int32), $12] }
-        BatchHashAgg { group_keys: [$0, $1], aggs: [sum($2), sum($3), sum($4), sum($5), sum($2), count($2), sum($3), count($3), sum($6), count($6), count] }
-          BatchExchange { order: [], dist: HashShard([0, 1]) }
-            BatchProject { exprs: [$4, $5, $0, $1, ($1 * (1:Int32 - $2)), (($1 * (1:Int32 - $2)) * (1:Int32 + $3)), $2] }
-              BatchFilter { predicate: ($6 <= ('1998-12-01':Varchar::Date - '71 days 00:00:00':Interval)) }
-                BatchScan { table: lineitem, columns: [l_quantity, l_extendedprice, l_discount, l_tax, l_returnflag, l_linestatus, l_shipdate] }
+    BatchExchange { order: [$0 ASC, $1 ASC], dist: Single }
+      BatchSort { order: [$0 ASC, $1 ASC] }
+        BatchProject { exprs: [$0, $1, $2, $3, $4, $5, RoundDigit(($6 / $7), 4:Int32), RoundDigit(($8 / $9), 4:Int32), RoundDigit(($10 / $11), 4:Int32), $12] }
+          BatchHashAgg { group_keys: [$0, $1], aggs: [sum($2), sum($3), sum($4), sum($5), sum($2), count($2), sum($3), count($3), sum($6), count($6), count] }
+            BatchExchange { order: [], dist: HashShard([0, 1]) }
+              BatchProject { exprs: [$4, $5, $0, $1, ($1 * (1:Int32 - $2)), (($1 * (1:Int32 - $2)) * (1:Int32 + $3)), $2] }
+                BatchFilter { predicate: ($6 <= ('1998-12-01':Varchar::Date - '71 days 00:00:00':Interval)) }
+                  BatchScan { table: lineitem, columns: [l_quantity, l_extendedprice, l_discount, l_tax, l_returnflag, l_linestatus, l_shipdate] }
   stream_plan: |
     StreamMaterialize { columns: [l_returnflag, l_linestatus, sum_qty, sum_base_price, sum_disc_price, sum_charge, avg_qty, avg_price, avg_disc, count_order], pk_columns: [l_returnflag, l_linestatus], order: [l_returnflag ASC, l_linestatus ASC] }
       StreamProject { exprs: [$0, $1, $3, $4, $5, $6, RoundDigit(($7 / $8), 4:Int32), RoundDigit(($9 / $10), 4:Int32), RoundDigit(($11 / $12), 4:Int32), $13] }
@@ -446,18 +447,19 @@
         LogicalScan { table: orders, output_columns: [o_orderkey, o_orderpriority], required_columns: [$1:o_orderkey, $6:o_orderpriority, $5:o_orderdate], predicate: ($5 >= '1997-07-01':Varchar::Date) AND ($5 < ('1997-07-01':Varchar::Date + '3 mons 00:00:00':Interval)) }
         LogicalScan { table: lineitem, output_columns: [l_orderkey], required_columns: [$1:l_orderkey, $12:l_commitdate, $13:l_receiptdate], predicate: ($12 < $13) }
   batch_plan: |
-    BatchSort { order: [$0 ASC] }
-      BatchHashAgg { group_keys: [$0], aggs: [count] }
-        BatchExchange { order: [], dist: HashShard([0]) }
-          BatchHashJoin { type: LeftSemi, predicate: $0 = $2, output_indices: [1] }
-            BatchExchange { order: [], dist: HashShard([0]) }
-              BatchProject { exprs: [$0, $1] }
-                BatchFilter { predicate: ($2 >= '1997-07-01':Varchar::Date) AND ($2 < ('1997-07-01':Varchar::Date + '3 mons 00:00:00':Interval)) }
-                  BatchScan { table: orders, columns: [o_orderkey, o_orderpriority, o_orderdate] }
-            BatchExchange { order: [], dist: HashShard([0]) }
-              BatchProject { exprs: [$0] }
-                BatchFilter { predicate: ($1 < $2) }
-                  BatchScan { table: lineitem, columns: [l_orderkey, l_commitdate, l_receiptdate] }
+    BatchExchange { order: [$0 ASC], dist: Single }
+      BatchSort { order: [$0 ASC] }
+        BatchHashAgg { group_keys: [$0], aggs: [count] }
+          BatchExchange { order: [], dist: HashShard([0]) }
+            BatchHashJoin { type: LeftSemi, predicate: $0 = $2, output_indices: [1] }
+              BatchExchange { order: [], dist: HashShard([0]) }
+                BatchProject { exprs: [$0, $1] }
+                  BatchFilter { predicate: ($2 >= '1997-07-01':Varchar::Date) AND ($2 < ('1997-07-01':Varchar::Date + '3 mons 00:00:00':Interval)) }
+                    BatchScan { table: orders, columns: [o_orderkey, o_orderpriority, o_orderdate] }
+              BatchExchange { order: [], dist: HashShard([0]) }
+                BatchProject { exprs: [$0] }
+                  BatchFilter { predicate: ($1 < $2) }
+                    BatchScan { table: lineitem, columns: [l_orderkey, l_commitdate, l_receiptdate] }
   stream_plan: |
     StreamMaterialize { columns: [o_orderpriority, agg#0(hidden), order_count], pk_columns: [o_orderpriority], order: [o_orderpriority ASC] }
       StreamHashAgg { group_keys: [$0], aggs: [count, count] }
@@ -530,35 +532,36 @@
             LogicalScan { table: nation, columns: [n_nationkey, n_name, n_regionkey] }
           LogicalScan { table: region, output_columns: [r_regionkey], required_columns: [$1:r_regionkey, $2:r_name], predicate: ($2 = 'MIDDLE EAST':Varchar) }
   batch_plan: |
-    BatchSort { order: [$1 DESC] }
-      BatchHashAgg { group_keys: [$0], aggs: [sum($1)] }
-        BatchExchange { order: [], dist: HashShard([0]) }
-          BatchProject { exprs: [$2, ($0 * (1:Int32 - $1))] }
-            BatchHashJoin { type: Inner, predicate: $3 = $4, output_indices: [0, 1, 2] }
-              BatchExchange { order: [], dist: HashShard([3]) }
-                BatchHashJoin { type: Inner, predicate: $2 = $3, output_indices: [0, 1, 4, 5] }
-                  BatchExchange { order: [], dist: HashShard([2]) }
-                    BatchHashJoin { type: Inner, predicate: $1 = $4 AND $0 = $5, output_indices: [2, 3, 5] }
-                      BatchExchange { order: [], dist: HashShard([1, 0]) }
-                        BatchHashJoin { type: Inner, predicate: $1 = $2, output_indices: [0, 3, 4, 5] }
-                          BatchExchange { order: [], dist: HashShard([1]) }
-                            BatchHashJoin { type: Inner, predicate: $0 = $3, output_indices: [1, 2] }
-                              BatchExchange { order: [], dist: HashShard([0]) }
-                                BatchScan { table: customer, columns: [c_custkey, c_nationkey] }
-                              BatchExchange { order: [], dist: HashShard([1]) }
-                                BatchProject { exprs: [$0, $1] }
-                                  BatchFilter { predicate: ($2 >= '1994-01-01':Varchar::Date) AND ($2 < ('1994-01-01':Varchar::Date + '1 year 00:00:00':Interval)) }
-                                    BatchScan { table: orders, columns: [o_orderkey, o_custkey, o_orderdate] }
-                          BatchExchange { order: [], dist: HashShard([0]) }
-                            BatchScan { table: lineitem, columns: [l_orderkey, l_suppkey, l_extendedprice, l_discount] }
-                      BatchExchange { order: [], dist: HashShard([0, 1]) }
-                        BatchScan { table: supplier, columns: [s_suppkey, s_nationkey] }
-                  BatchExchange { order: [], dist: HashShard([0]) }
-                    BatchScan { table: nation, columns: [n_nationkey, n_name, n_regionkey] }
-              BatchExchange { order: [], dist: HashShard([0]) }
-                BatchProject { exprs: [$0] }
-                  BatchFilter { predicate: ($1 = 'MIDDLE EAST':Varchar) }
-                    BatchScan { table: region, columns: [r_regionkey, r_name] }
+    BatchExchange { order: [$1 DESC], dist: Single }
+      BatchSort { order: [$1 DESC] }
+        BatchHashAgg { group_keys: [$0], aggs: [sum($1)] }
+          BatchExchange { order: [], dist: HashShard([0]) }
+            BatchProject { exprs: [$2, ($0 * (1:Int32 - $1))] }
+              BatchHashJoin { type: Inner, predicate: $3 = $4, output_indices: [0, 1, 2] }
+                BatchExchange { order: [], dist: HashShard([3]) }
+                  BatchHashJoin { type: Inner, predicate: $2 = $3, output_indices: [0, 1, 4, 5] }
+                    BatchExchange { order: [], dist: HashShard([2]) }
+                      BatchHashJoin { type: Inner, predicate: $1 = $4 AND $0 = $5, output_indices: [2, 3, 5] }
+                        BatchExchange { order: [], dist: HashShard([1, 0]) }
+                          BatchHashJoin { type: Inner, predicate: $1 = $2, output_indices: [0, 3, 4, 5] }
+                            BatchExchange { order: [], dist: HashShard([1]) }
+                              BatchHashJoin { type: Inner, predicate: $0 = $3, output_indices: [1, 2] }
+                                BatchExchange { order: [], dist: HashShard([0]) }
+                                  BatchScan { table: customer, columns: [c_custkey, c_nationkey] }
+                                BatchExchange { order: [], dist: HashShard([1]) }
+                                  BatchProject { exprs: [$0, $1] }
+                                    BatchFilter { predicate: ($2 >= '1994-01-01':Varchar::Date) AND ($2 < ('1994-01-01':Varchar::Date + '1 year 00:00:00':Interval)) }
+                                      BatchScan { table: orders, columns: [o_orderkey, o_custkey, o_orderdate] }
+                            BatchExchange { order: [], dist: HashShard([0]) }
+                              BatchScan { table: lineitem, columns: [l_orderkey, l_suppkey, l_extendedprice, l_discount] }
+                        BatchExchange { order: [], dist: HashShard([0, 1]) }
+                          BatchScan { table: supplier, columns: [s_suppkey, s_nationkey] }
+                    BatchExchange { order: [], dist: HashShard([0]) }
+                      BatchScan { table: nation, columns: [n_nationkey, n_name, n_regionkey] }
+                BatchExchange { order: [], dist: HashShard([0]) }
+                  BatchProject { exprs: [$0] }
+                    BatchFilter { predicate: ($1 = 'MIDDLE EAST':Varchar) }
+                      BatchScan { table: region, columns: [r_regionkey, r_name] }
   stream_plan: |
     StreamMaterialize { columns: [n_name, agg#0(hidden), revenue], pk_columns: [n_name], order_descs: [revenue, n_name], order: [revenue DESC] }
       StreamHashAgg { group_keys: [$0], aggs: [count, sum($1)] }
@@ -702,33 +705,34 @@
             LogicalScan { table: nation, columns: [n_nationkey, n_name] }
           LogicalScan { table: nation, columns: [n_nationkey, n_name] }
   batch_plan: |
-    BatchSort { order: [$0 ASC, $1 ASC, $2 ASC] }
-      BatchHashAgg { group_keys: [$0, $1, $2], aggs: [sum($3)] }
-        BatchExchange { order: [], dist: HashShard([0, 1, 2]) }
-          BatchProject { exprs: [$4, $6, Extract('YEAR':Varchar, $2), ($0 * (1:Int32 - $1))] }
-            BatchFilter { predicate: ((($4 = 'ROMANIA':Varchar) AND ($6 = 'IRAN':Varchar)) OR (($4 = 'IRAN':Varchar) AND ($6 = 'ROMANIA':Varchar))) }
-              BatchHashJoin { type: Inner, predicate: $3 = $5, output_indices: all }
-                BatchExchange { order: [], dist: HashShard([3]) }
-                  BatchHashJoin { type: Inner, predicate: $0 = $5, output_indices: [1, 2, 3, 4, 6] }
-                    BatchExchange { order: [], dist: HashShard([0]) }
-                      BatchHashJoin { type: Inner, predicate: $4 = $5, output_indices: [0, 1, 2, 3, 6] }
-                        BatchExchange { order: [], dist: HashShard([4]) }
-                          BatchHashJoin { type: Inner, predicate: $1 = $5, output_indices: [0, 2, 3, 4, 6] }
-                            BatchExchange { order: [], dist: HashShard([1]) }
-                              BatchHashJoin { type: Inner, predicate: $0 = $3, output_indices: [1, 2, 4, 5, 6] }
-                                BatchExchange { order: [], dist: HashShard([0]) }
-                                  BatchScan { table: supplier, columns: [s_suppkey, s_nationkey] }
-                                BatchExchange { order: [], dist: HashShard([1]) }
-                                  BatchFilter { predicate: ($4 >= '1983-01-01':Varchar::Date) AND ($4 <= '2000-12-31':Varchar::Date) }
-                                    BatchScan { table: lineitem, columns: [l_orderkey, l_suppkey, l_extendedprice, l_discount, l_shipdate] }
-                            BatchExchange { order: [], dist: HashShard([0]) }
-                              BatchScan { table: orders, columns: [o_orderkey, o_custkey] }
-                        BatchExchange { order: [], dist: HashShard([0]) }
-                          BatchScan { table: customer, columns: [c_custkey, c_nationkey] }
-                    BatchExchange { order: [], dist: HashShard([0]) }
-                      BatchScan { table: nation, columns: [n_nationkey, n_name] }
-                BatchExchange { order: [], dist: HashShard([0]) }
-                  BatchScan { table: nation, columns: [n_nationkey, n_name] }
+    BatchExchange { order: [$0 ASC, $1 ASC, $2 ASC], dist: Single }
+      BatchSort { order: [$0 ASC, $1 ASC, $2 ASC] }
+        BatchHashAgg { group_keys: [$0, $1, $2], aggs: [sum($3)] }
+          BatchExchange { order: [], dist: HashShard([0, 1, 2]) }
+            BatchProject { exprs: [$4, $6, Extract('YEAR':Varchar, $2), ($0 * (1:Int32 - $1))] }
+              BatchFilter { predicate: ((($4 = 'ROMANIA':Varchar) AND ($6 = 'IRAN':Varchar)) OR (($4 = 'IRAN':Varchar) AND ($6 = 'ROMANIA':Varchar))) }
+                BatchHashJoin { type: Inner, predicate: $3 = $5, output_indices: all }
+                  BatchExchange { order: [], dist: HashShard([3]) }
+                    BatchHashJoin { type: Inner, predicate: $0 = $5, output_indices: [1, 2, 3, 4, 6] }
+                      BatchExchange { order: [], dist: HashShard([0]) }
+                        BatchHashJoin { type: Inner, predicate: $4 = $5, output_indices: [0, 1, 2, 3, 6] }
+                          BatchExchange { order: [], dist: HashShard([4]) }
+                            BatchHashJoin { type: Inner, predicate: $1 = $5, output_indices: [0, 2, 3, 4, 6] }
+                              BatchExchange { order: [], dist: HashShard([1]) }
+                                BatchHashJoin { type: Inner, predicate: $0 = $3, output_indices: [1, 2, 4, 5, 6] }
+                                  BatchExchange { order: [], dist: HashShard([0]) }
+                                    BatchScan { table: supplier, columns: [s_suppkey, s_nationkey] }
+                                  BatchExchange { order: [], dist: HashShard([1]) }
+                                    BatchFilter { predicate: ($4 >= '1983-01-01':Varchar::Date) AND ($4 <= '2000-12-31':Varchar::Date) }
+                                      BatchScan { table: lineitem, columns: [l_orderkey, l_suppkey, l_extendedprice, l_discount, l_shipdate] }
+                              BatchExchange { order: [], dist: HashShard([0]) }
+                                BatchScan { table: orders, columns: [o_orderkey, o_custkey] }
+                          BatchExchange { order: [], dist: HashShard([0]) }
+                            BatchScan { table: customer, columns: [c_custkey, c_nationkey] }
+                      BatchExchange { order: [], dist: HashShard([0]) }
+                        BatchScan { table: nation, columns: [n_nationkey, n_name] }
+                  BatchExchange { order: [], dist: HashShard([0]) }
+                    BatchScan { table: nation, columns: [n_nationkey, n_name] }
   stream_plan: |
     StreamMaterialize { columns: [supp_nation, cust_nation, l_year, agg#0(hidden), revenue], pk_columns: [supp_nation, cust_nation, l_year], order: [supp_nation ASC, cust_nation ASC, l_year ASC] }
       StreamHashAgg { group_keys: [$0, $1, $2], aggs: [count, sum($3)] }
@@ -841,45 +845,46 @@
               LogicalScan { table: nation, columns: [n_nationkey, n_name] }
             LogicalScan { table: region, output_columns: [r_regionkey], required_columns: [$1:r_regionkey, $2:r_name], predicate: ($2 = 'ASIA':Varchar) }
   batch_plan: |
-    BatchSort { order: [$0 ASC] }
-      BatchProject { exprs: [$0, RoundDigit(($1 / $2), 6:Int32)] }
-        BatchHashAgg { group_keys: [$0], aggs: [sum($1), sum($2)] }
-          BatchExchange { order: [], dist: HashShard([0]) }
-            BatchProject { exprs: [Extract('YEAR':Varchar, $2), Case(($3 = 'IRAN':Varchar), ($0 * (1:Int32 - $1)), 0:Int32::Decimal), ($0 * (1:Int32 - $1))] }
-              BatchHashJoin { type: Inner, predicate: $3 = $5, output_indices: [0, 1, 2, 4] }
-                BatchExchange { order: [], dist: HashShard([3]) }
-                  BatchHashJoin { type: Inner, predicate: $2 = $5, output_indices: [0, 1, 3, 4, 6] }
-                    BatchExchange { order: [], dist: HashShard([2]) }
-                      BatchHashJoin { type: Inner, predicate: $4 = $5, output_indices: [0, 1, 2, 3, 6] }
-                        BatchExchange { order: [], dist: HashShard([4]) }
-                          BatchHashJoin { type: Inner, predicate: $3 = $5, output_indices: [0, 1, 2, 4, 6] }
-                            BatchExchange { order: [], dist: HashShard([3]) }
-                              BatchHashJoin { type: Inner, predicate: $0 = $4, output_indices: [1, 2, 3, 5, 6] }
-                                BatchExchange { order: [], dist: HashShard([0]) }
-                                  BatchHashJoin { type: Inner, predicate: $1 = $4, output_indices: [0, 2, 3, 5] }
-                                    BatchExchange { order: [], dist: HashShard([1]) }
-                                      BatchHashJoin { type: Inner, predicate: $1 = $5, output_indices: [0, 2, 3, 4] }
-                                        BatchExchange { order: [], dist: HashShard([1]) }
-                                          BatchScan { table: lineitem, columns: [l_orderkey, l_partkey, l_suppkey, l_extendedprice, l_discount] }
-                                        BatchExchange { order: [], dist: HashShard([0]) }
-                                          BatchProject { exprs: [$0] }
-                                            BatchFilter { predicate: ($1 = 'PROMO ANODIZED STEEL':Varchar) }
-                                              BatchScan { table: part, columns: [p_partkey, p_type] }
-                                    BatchExchange { order: [], dist: HashShard([0]) }
-                                      BatchScan { table: supplier, columns: [s_suppkey, s_nationkey] }
-                                BatchExchange { order: [], dist: HashShard([0]) }
-                                  BatchFilter { predicate: ($2 >= '1995-01-01':Varchar::Date) AND ($2 <= '1996-12-31':Varchar::Date) }
-                                    BatchScan { table: orders, columns: [o_orderkey, o_custkey, o_orderdate] }
-                            BatchExchange { order: [], dist: HashShard([0]) }
-                              BatchScan { table: customer, columns: [c_custkey, c_nationkey] }
-                        BatchExchange { order: [], dist: HashShard([0]) }
-                          BatchScan { table: nation, columns: [n_nationkey, n_regionkey] }
-                    BatchExchange { order: [], dist: HashShard([0]) }
-                      BatchScan { table: nation, columns: [n_nationkey, n_name] }
-                BatchExchange { order: [], dist: HashShard([0]) }
-                  BatchProject { exprs: [$0] }
-                    BatchFilter { predicate: ($1 = 'ASIA':Varchar) }
-                      BatchScan { table: region, columns: [r_regionkey, r_name] }
+    BatchExchange { order: [$0 ASC], dist: Single }
+      BatchSort { order: [$0 ASC] }
+        BatchProject { exprs: [$0, RoundDigit(($1 / $2), 6:Int32)] }
+          BatchHashAgg { group_keys: [$0], aggs: [sum($1), sum($2)] }
+            BatchExchange { order: [], dist: HashShard([0]) }
+              BatchProject { exprs: [Extract('YEAR':Varchar, $2), Case(($3 = 'IRAN':Varchar), ($0 * (1:Int32 - $1)), 0:Int32::Decimal), ($0 * (1:Int32 - $1))] }
+                BatchHashJoin { type: Inner, predicate: $3 = $5, output_indices: [0, 1, 2, 4] }
+                  BatchExchange { order: [], dist: HashShard([3]) }
+                    BatchHashJoin { type: Inner, predicate: $2 = $5, output_indices: [0, 1, 3, 4, 6] }
+                      BatchExchange { order: [], dist: HashShard([2]) }
+                        BatchHashJoin { type: Inner, predicate: $4 = $5, output_indices: [0, 1, 2, 3, 6] }
+                          BatchExchange { order: [], dist: HashShard([4]) }
+                            BatchHashJoin { type: Inner, predicate: $3 = $5, output_indices: [0, 1, 2, 4, 6] }
+                              BatchExchange { order: [], dist: HashShard([3]) }
+                                BatchHashJoin { type: Inner, predicate: $0 = $4, output_indices: [1, 2, 3, 5, 6] }
+                                  BatchExchange { order: [], dist: HashShard([0]) }
+                                    BatchHashJoin { type: Inner, predicate: $1 = $4, output_indices: [0, 2, 3, 5] }
+                                      BatchExchange { order: [], dist: HashShard([1]) }
+                                        BatchHashJoin { type: Inner, predicate: $1 = $5, output_indices: [0, 2, 3, 4] }
+                                          BatchExchange { order: [], dist: HashShard([1]) }
+                                            BatchScan { table: lineitem, columns: [l_orderkey, l_partkey, l_suppkey, l_extendedprice, l_discount] }
+                                          BatchExchange { order: [], dist: HashShard([0]) }
+                                            BatchProject { exprs: [$0] }
+                                              BatchFilter { predicate: ($1 = 'PROMO ANODIZED STEEL':Varchar) }
+                                                BatchScan { table: part, columns: [p_partkey, p_type] }
+                                      BatchExchange { order: [], dist: HashShard([0]) }
+                                        BatchScan { table: supplier, columns: [s_suppkey, s_nationkey] }
+                                  BatchExchange { order: [], dist: HashShard([0]) }
+                                    BatchFilter { predicate: ($2 >= '1995-01-01':Varchar::Date) AND ($2 <= '1996-12-31':Varchar::Date) }
+                                      BatchScan { table: orders, columns: [o_orderkey, o_custkey, o_orderdate] }
+                              BatchExchange { order: [], dist: HashShard([0]) }
+                                BatchScan { table: customer, columns: [c_custkey, c_nationkey] }
+                          BatchExchange { order: [], dist: HashShard([0]) }
+                            BatchScan { table: nation, columns: [n_nationkey, n_regionkey] }
+                      BatchExchange { order: [], dist: HashShard([0]) }
+                        BatchScan { table: nation, columns: [n_nationkey, n_name] }
+                  BatchExchange { order: [], dist: HashShard([0]) }
+                    BatchProject { exprs: [$0] }
+                      BatchFilter { predicate: ($1 = 'ASIA':Varchar) }
+                        BatchScan { table: region, columns: [r_regionkey, r_name] }
   stream_plan: |
     StreamMaterialize { columns: [o_year, mkt_share], pk_columns: [o_year], order: [o_year ASC] }
       StreamProject { exprs: [$0, RoundDigit(($2 / $3), 6:Int32)] }
@@ -991,34 +996,35 @@
               LogicalScan { table: orders, columns: [o_orderkey, o_orderdate] }
             LogicalScan { table: nation, columns: [n_nationkey, n_name] }
   batch_plan: |
-    BatchSort { order: [$0 ASC, $1 DESC] }
-      BatchProject { exprs: [$0, $1, RoundDigit($2, 2:Int32)] }
-        BatchHashAgg { group_keys: [$0, $1], aggs: [sum($2)] }
-          BatchExchange { order: [], dist: HashShard([0, 1]) }
-            BatchProject { exprs: [$5, Extract('YEAR':Varchar, $4), (($1 * (1:Int32 - $2)) - ($3 * $0))] }
-              BatchHashJoin { type: Inner, predicate: $3 = $6, output_indices: [0, 1, 2, 4, 5, 7] }
-                BatchExchange { order: [], dist: HashShard([3]) }
-                  BatchHashJoin { type: Inner, predicate: $0 = $6, output_indices: [1, 2, 3, 4, 5, 7] }
-                    BatchExchange { order: [], dist: HashShard([0]) }
-                      BatchHashJoin { type: Inner, predicate: $2 = $8 AND $1 = $7, output_indices: [0, 3, 4, 5, 6, 9] }
-                        BatchExchange { order: [], dist: HashShard([1, 2]) }
-                          BatchHashJoin { type: Inner, predicate: $2 = $6, output_indices: [0, 1, 2, 3, 4, 5, 7] }
-                            BatchExchange { order: [], dist: HashShard([2]) }
-                              BatchHashJoin { type: Inner, predicate: $1 = $6, output_indices: [0, 1, 2, 3, 4, 5] }
-                                BatchExchange { order: [], dist: HashShard([1]) }
-                                  BatchScan { table: lineitem, columns: [l_orderkey, l_partkey, l_suppkey, l_quantity, l_extendedprice, l_discount] }
-                                BatchExchange { order: [], dist: HashShard([0]) }
-                                  BatchProject { exprs: [$0] }
-                                    BatchFilter { predicate: Like($1, '%yellow%':Varchar) }
-                                      BatchScan { table: part, columns: [p_partkey, p_name] }
-                            BatchExchange { order: [], dist: HashShard([0]) }
-                              BatchScan { table: supplier, columns: [s_suppkey, s_nationkey] }
-                        BatchExchange { order: [], dist: HashShard([0, 1]) }
-                          BatchScan { table: partsupp, columns: [ps_partkey, ps_suppkey, ps_supplycost] }
-                    BatchExchange { order: [], dist: HashShard([0]) }
-                      BatchScan { table: orders, columns: [o_orderkey, o_orderdate] }
-                BatchExchange { order: [], dist: HashShard([0]) }
-                  BatchScan { table: nation, columns: [n_nationkey, n_name] }
+    BatchExchange { order: [$0 ASC, $1 DESC], dist: Single }
+      BatchSort { order: [$0 ASC, $1 DESC] }
+        BatchProject { exprs: [$0, $1, RoundDigit($2, 2:Int32)] }
+          BatchHashAgg { group_keys: [$0, $1], aggs: [sum($2)] }
+            BatchExchange { order: [], dist: HashShard([0, 1]) }
+              BatchProject { exprs: [$5, Extract('YEAR':Varchar, $4), (($1 * (1:Int32 - $2)) - ($3 * $0))] }
+                BatchHashJoin { type: Inner, predicate: $3 = $6, output_indices: [0, 1, 2, 4, 5, 7] }
+                  BatchExchange { order: [], dist: HashShard([3]) }
+                    BatchHashJoin { type: Inner, predicate: $0 = $6, output_indices: [1, 2, 3, 4, 5, 7] }
+                      BatchExchange { order: [], dist: HashShard([0]) }
+                        BatchHashJoin { type: Inner, predicate: $2 = $8 AND $1 = $7, output_indices: [0, 3, 4, 5, 6, 9] }
+                          BatchExchange { order: [], dist: HashShard([1, 2]) }
+                            BatchHashJoin { type: Inner, predicate: $2 = $6, output_indices: [0, 1, 2, 3, 4, 5, 7] }
+                              BatchExchange { order: [], dist: HashShard([2]) }
+                                BatchHashJoin { type: Inner, predicate: $1 = $6, output_indices: [0, 1, 2, 3, 4, 5] }
+                                  BatchExchange { order: [], dist: HashShard([1]) }
+                                    BatchScan { table: lineitem, columns: [l_orderkey, l_partkey, l_suppkey, l_quantity, l_extendedprice, l_discount] }
+                                  BatchExchange { order: [], dist: HashShard([0]) }
+                                    BatchProject { exprs: [$0] }
+                                      BatchFilter { predicate: Like($1, '%yellow%':Varchar) }
+                                        BatchScan { table: part, columns: [p_partkey, p_name] }
+                              BatchExchange { order: [], dist: HashShard([0]) }
+                                BatchScan { table: supplier, columns: [s_suppkey, s_nationkey] }
+                          BatchExchange { order: [], dist: HashShard([0, 1]) }
+                            BatchScan { table: partsupp, columns: [ps_partkey, ps_suppkey, ps_supplycost] }
+                      BatchExchange { order: [], dist: HashShard([0]) }
+                        BatchScan { table: orders, columns: [o_orderkey, o_orderdate] }
+                  BatchExchange { order: [], dist: HashShard([0]) }
+                    BatchScan { table: nation, columns: [n_nationkey, n_name] }
   stream_plan: |
     StreamMaterialize { columns: [nation, o_year, sum_profit], pk_columns: [nation, o_year], order: [nation ASC, o_year DESC] }
       StreamProject { exprs: [$0, $1, RoundDigit($3, 2:Int32)] }
@@ -1346,17 +1352,18 @@
           LogicalScan { table: orders, columns: [o_orderkey, o_orderpriority] }
           LogicalScan { table: lineitem, output_columns: [l_orderkey, l_shipmode], required_columns: [$1:l_orderkey, $15:l_shipmode, $11:l_shipdate, $12:l_commitdate, $13:l_receiptdate], predicate: In($15, 'FOB':Varchar, 'SHIP':Varchar) AND ($12 < $13) AND ($11 < $12) AND ($13 >= '1994-01-01':Varchar::Date) AND ($13 < ('1994-01-01':Varchar::Date + '1 year 00:00:00':Interval)) }
   batch_plan: |
-    BatchSort { order: [$0 ASC] }
-      BatchHashAgg { group_keys: [$0], aggs: [sum($1), sum($2)] }
-        BatchExchange { order: [], dist: HashShard([0]) }
-          BatchProject { exprs: [$1, Case((($0 = '1-URGENT':Varchar) OR ($0 = '2-HIGH':Varchar)), 1:Int32, 0:Int32), Case((($0 <> '1-URGENT':Varchar) AND ($0 <> '2-HIGH':Varchar)), 1:Int32, 0:Int32)] }
-            BatchHashJoin { type: Inner, predicate: $0 = $2, output_indices: [1, 3] }
-              BatchExchange { order: [], dist: HashShard([0]) }
-                BatchScan { table: orders, columns: [o_orderkey, o_orderpriority] }
-              BatchExchange { order: [], dist: HashShard([0]) }
-                BatchProject { exprs: [$0, $1] }
-                  BatchFilter { predicate: In($1, 'FOB':Varchar, 'SHIP':Varchar) AND ($3 < $4) AND ($2 < $3) AND ($4 >= '1994-01-01':Varchar::Date) AND ($4 < ('1994-01-01':Varchar::Date + '1 year 00:00:00':Interval)) }
-                    BatchScan { table: lineitem, columns: [l_orderkey, l_shipmode, l_shipdate, l_commitdate, l_receiptdate] }
+    BatchExchange { order: [$0 ASC], dist: Single }
+      BatchSort { order: [$0 ASC] }
+        BatchHashAgg { group_keys: [$0], aggs: [sum($1), sum($2)] }
+          BatchExchange { order: [], dist: HashShard([0]) }
+            BatchProject { exprs: [$1, Case((($0 = '1-URGENT':Varchar) OR ($0 = '2-HIGH':Varchar)), 1:Int32, 0:Int32), Case((($0 <> '1-URGENT':Varchar) AND ($0 <> '2-HIGH':Varchar)), 1:Int32, 0:Int32)] }
+              BatchHashJoin { type: Inner, predicate: $0 = $2, output_indices: [1, 3] }
+                BatchExchange { order: [], dist: HashShard([0]) }
+                  BatchScan { table: orders, columns: [o_orderkey, o_orderpriority] }
+                BatchExchange { order: [], dist: HashShard([0]) }
+                  BatchProject { exprs: [$0, $1] }
+                    BatchFilter { predicate: In($1, 'FOB':Varchar, 'SHIP':Varchar) AND ($3 < $4) AND ($2 < $3) AND ($4 >= '1994-01-01':Varchar::Date) AND ($4 < ('1994-01-01':Varchar::Date + '1 year 00:00:00':Interval)) }
+                      BatchScan { table: lineitem, columns: [l_orderkey, l_shipmode, l_shipdate, l_commitdate, l_receiptdate] }
   stream_plan: |
     StreamMaterialize { columns: [l_shipmode, agg#0(hidden), high_line_count, low_line_count], pk_columns: [l_shipmode], order: [l_shipmode ASC] }
       StreamHashAgg { group_keys: [$0], aggs: [count, sum($1), sum($2)] }
@@ -1411,18 +1418,19 @@
             LogicalScan { table: customer, columns: [c_custkey] }
             LogicalScan { table: orders, output_columns: [o_orderkey, o_custkey], required_columns: [$1:o_orderkey, $2:o_custkey, $9:o_comment], predicate: Not(Like($9, '%:1%:2%':Varchar)) }
   batch_plan: |
-    BatchSort { order: [$1 DESC, $0 DESC] }
-      BatchHashAgg { group_keys: [$0], aggs: [count] }
-        BatchExchange { order: [], dist: HashShard([0]) }
-          BatchProject { exprs: [$1] }
-            BatchHashAgg { group_keys: [$0], aggs: [count($1)] }
-              BatchHashJoin { type: LeftOuter, predicate: $0 = $2, output_indices: [0, 1] }
-                BatchExchange { order: [], dist: HashShard([0]) }
-                  BatchScan { table: customer, columns: [c_custkey] }
-                BatchExchange { order: [], dist: HashShard([1]) }
-                  BatchProject { exprs: [$0, $1] }
-                    BatchFilter { predicate: Not(Like($2, '%:1%:2%':Varchar)) }
-                      BatchScan { table: orders, columns: [o_orderkey, o_custkey, o_comment] }
+    BatchExchange { order: [$1 DESC, $0 DESC], dist: Single }
+      BatchSort { order: [$1 DESC, $0 DESC] }
+        BatchHashAgg { group_keys: [$0], aggs: [count] }
+          BatchExchange { order: [], dist: HashShard([0]) }
+            BatchProject { exprs: [$1] }
+              BatchHashAgg { group_keys: [$0], aggs: [count($1)] }
+                BatchHashJoin { type: LeftOuter, predicate: $0 = $2, output_indices: [0, 1] }
+                  BatchExchange { order: [], dist: HashShard([0]) }
+                    BatchScan { table: customer, columns: [c_custkey] }
+                  BatchExchange { order: [], dist: HashShard([1]) }
+                    BatchProject { exprs: [$0, $1] }
+                      BatchFilter { predicate: Not(Like($2, '%:1%:2%':Varchar)) }
+                        BatchScan { table: orders, columns: [o_orderkey, o_custkey, o_comment] }
   stream_plan: |
     StreamMaterialize { columns: [c_count, agg#0(hidden), custdist], pk_columns: [c_count], order_descs: [custdist, c_count], order: [custdist DESC, c_count DESC] }
       StreamHashAgg { group_keys: [$0], aggs: [count, count] }
@@ -1562,27 +1570,28 @@
             LogicalProject { exprs: [$0, ($1 * (1:Int32 - $2))] }
               LogicalScan { table: lineitem, output_columns: [l_suppkey, l_extendedprice, l_discount], required_columns: [$3:l_suppkey, $6:l_extendedprice, $7:l_discount, $11:l_shipdate], predicate: ($11 >= '1993-01-01':Varchar::Date) AND ($11 < ('1993-01-01':Varchar::Date + '3 mons 00:00:00':Interval)) }
   batch_plan: |
-    BatchSort { order: [$0 ASC] }
-      BatchHashJoin { type: Inner, predicate: $4 = $5, output_indices: [0, 1, 2, 3, 4] }
-        BatchExchange { order: [], dist: HashShard([4]) }
-          BatchHashJoin { type: Inner, predicate: $0 = $4, output_indices: [0, 1, 2, 3, 5] }
-            BatchExchange { order: [], dist: HashShard([0]) }
-              BatchScan { table: supplier, columns: [s_suppkey, s_name, s_address, s_phone] }
-            BatchHashAgg { group_keys: [$0], aggs: [sum($1)] }
+    BatchExchange { order: [$0 ASC], dist: Single }
+      BatchSort { order: [$0 ASC] }
+        BatchHashJoin { type: Inner, predicate: $4 = $5, output_indices: [0, 1, 2, 3, 4] }
+          BatchExchange { order: [], dist: HashShard([4]) }
+            BatchHashJoin { type: Inner, predicate: $0 = $4, output_indices: [0, 1, 2, 3, 5] }
               BatchExchange { order: [], dist: HashShard([0]) }
-                BatchProject { exprs: [$0, ($1 * (1:Int32 - $2))] }
-                  BatchFilter { predicate: ($3 >= '1993-01-01':Varchar::Date) AND ($3 < ('1993-01-01':Varchar::Date + '3 mons 00:00:00':Interval)) }
-                    BatchScan { table: lineitem, columns: [l_suppkey, l_extendedprice, l_discount, l_shipdate] }
-        BatchExchange { order: [], dist: HashShard([0]) }
-          BatchSimpleAgg { aggs: [max($0)] }
-            BatchExchange { order: [], dist: Single }
-              BatchSimpleAgg { aggs: [max($0)] }
-                BatchProject { exprs: [$1] }
-                  BatchHashAgg { group_keys: [$0], aggs: [sum($1)] }
-                    BatchExchange { order: [], dist: HashShard([0]) }
-                      BatchProject { exprs: [$0, ($1 * (1:Int32 - $2))] }
-                        BatchFilter { predicate: ($3 >= '1993-01-01':Varchar::Date) AND ($3 < ('1993-01-01':Varchar::Date + '3 mons 00:00:00':Interval)) }
-                          BatchScan { table: lineitem, columns: [l_suppkey, l_extendedprice, l_discount, l_shipdate] }
+                BatchScan { table: supplier, columns: [s_suppkey, s_name, s_address, s_phone] }
+              BatchHashAgg { group_keys: [$0], aggs: [sum($1)] }
+                BatchExchange { order: [], dist: HashShard([0]) }
+                  BatchProject { exprs: [$0, ($1 * (1:Int32 - $2))] }
+                    BatchFilter { predicate: ($3 >= '1993-01-01':Varchar::Date) AND ($3 < ('1993-01-01':Varchar::Date + '3 mons 00:00:00':Interval)) }
+                      BatchScan { table: lineitem, columns: [l_suppkey, l_extendedprice, l_discount, l_shipdate] }
+          BatchExchange { order: [], dist: HashShard([0]) }
+            BatchSimpleAgg { aggs: [max($0)] }
+              BatchExchange { order: [], dist: Single }
+                BatchSimpleAgg { aggs: [max($0)] }
+                  BatchProject { exprs: [$1] }
+                    BatchHashAgg { group_keys: [$0], aggs: [sum($1)] }
+                      BatchExchange { order: [], dist: HashShard([0]) }
+                        BatchProject { exprs: [$0, ($1 * (1:Int32 - $2))] }
+                          BatchFilter { predicate: ($3 >= '1993-01-01':Varchar::Date) AND ($3 < ('1993-01-01':Varchar::Date + '3 mons 00:00:00':Interval)) }
+                            BatchScan { table: lineitem, columns: [l_suppkey, l_extendedprice, l_discount, l_shipdate] }
   stream_plan: |
     StreamMaterialize { columns: [s_suppkey, s_name, s_address, s_phone, total_revenue, _row_id(hidden), l_suppkey(hidden)], pk_columns: [_row_id, l_suppkey], order_descs: [s_suppkey, _row_id, l_suppkey], order: [s_suppkey ASC] }
       StreamExchange { dist: HashShard([5, 6]) }
@@ -1660,22 +1669,23 @@
             LogicalScan { table: part, output_columns: [p_partkey, p_brand, p_type, p_size], required_columns: [$1:p_partkey, $4:p_brand, $5:p_type, $6:p_size], predicate: ($4 <> 'Brand#45':Varchar) AND Not(Like($5, 'SMALL PLATED%':Varchar)) AND In($6, 19:Int32, 17:Int32, 16:Int32, 23:Int32, 10:Int32, 4:Int32, 38:Int32, 11:Int32) }
           LogicalScan { table: supplier, output_columns: [s_suppkey], required_columns: [$1:s_suppkey, $7:s_comment], predicate: Like($7, '%Customer%Complaints%':Varchar) }
   batch_plan: |
-    BatchSort { order: [$3 DESC, $0 ASC, $1 ASC, $2 ASC] }
-      BatchHashAgg { group_keys: [$0, $1, $2], aggs: [count(distinct $3)] }
-        BatchExchange { order: [], dist: HashShard([0, 1, 2]) }
-          BatchProject { exprs: [$1, $2, $3, $0] }
-            BatchHashJoin { type: LeftAnti, predicate: $0 = $4, output_indices: all }
-              BatchExchange { order: [], dist: HashShard([0]) }
-                BatchHashJoin { type: Inner, predicate: $0 = $2, output_indices: [1, 3, 4, 5] }
-                  BatchExchange { order: [], dist: HashShard([0]) }
-                    BatchScan { table: partsupp, columns: [ps_partkey, ps_suppkey] }
-                  BatchExchange { order: [], dist: HashShard([0]) }
-                    BatchFilter { predicate: ($1 <> 'Brand#45':Varchar) AND Not(Like($2, 'SMALL PLATED%':Varchar)) AND In($3, 19:Int32, 17:Int32, 16:Int32, 23:Int32, 10:Int32, 4:Int32, 38:Int32, 11:Int32) }
-                      BatchScan { table: part, columns: [p_partkey, p_brand, p_type, p_size] }
-              BatchExchange { order: [], dist: HashShard([0]) }
-                BatchProject { exprs: [$0] }
-                  BatchFilter { predicate: Like($1, '%Customer%Complaints%':Varchar) }
-                    BatchScan { table: supplier, columns: [s_suppkey, s_comment] }
+    BatchExchange { order: [$3 DESC, $0 ASC, $1 ASC, $2 ASC], dist: Single }
+      BatchSort { order: [$3 DESC, $0 ASC, $1 ASC, $2 ASC] }
+        BatchHashAgg { group_keys: [$0, $1, $2], aggs: [count(distinct $3)] }
+          BatchExchange { order: [], dist: HashShard([0, 1, 2]) }
+            BatchProject { exprs: [$1, $2, $3, $0] }
+              BatchHashJoin { type: LeftAnti, predicate: $0 = $4, output_indices: all }
+                BatchExchange { order: [], dist: HashShard([0]) }
+                  BatchHashJoin { type: Inner, predicate: $0 = $2, output_indices: [1, 3, 4, 5] }
+                    BatchExchange { order: [], dist: HashShard([0]) }
+                      BatchScan { table: partsupp, columns: [ps_partkey, ps_suppkey] }
+                    BatchExchange { order: [], dist: HashShard([0]) }
+                      BatchFilter { predicate: ($1 <> 'Brand#45':Varchar) AND Not(Like($2, 'SMALL PLATED%':Varchar)) AND In($3, 19:Int32, 17:Int32, 16:Int32, 23:Int32, 10:Int32, 4:Int32, 38:Int32, 11:Int32) }
+                        BatchScan { table: part, columns: [p_partkey, p_brand, p_type, p_size] }
+                BatchExchange { order: [], dist: HashShard([0]) }
+                  BatchProject { exprs: [$0] }
+                    BatchFilter { predicate: Like($1, '%Customer%Complaints%':Varchar) }
+                      BatchScan { table: supplier, columns: [s_suppkey, s_comment] }
   stream_plan: |
     StreamMaterialize { columns: [p_brand, p_type, p_size, agg#0(hidden), supplier_cnt], pk_columns: [p_brand, p_type, p_size], order_descs: [supplier_cnt, p_brand, p_type, p_size], order: [supplier_cnt DESC, p_brand ASC, p_type ASC, p_size ASC] }
       StreamHashAgg { group_keys: [$0, $1, $2], aggs: [count, count(distinct $3)] }
@@ -2045,34 +2055,35 @@
           LogicalAgg { group_keys: [0, 1], agg_calls: [sum($2)] }
             LogicalScan { table: lineitem, output_columns: [l_partkey, l_suppkey, l_quantity], required_columns: [$2:l_partkey, $3:l_suppkey, $5:l_quantity, $11:l_shipdate], predicate: ($11 >= '1994-01-01':Varchar::Date) AND ($11 < ('1994-01-01':Varchar::Date + '1 year 00:00:00':Interval)) }
   batch_plan: |
-    BatchSort { order: [$0 ASC] }
-      BatchHashJoin { type: LeftSemi, predicate: $0 = $3, output_indices: [1, 2] }
-        BatchExchange { order: [], dist: HashShard([0]) }
-          BatchHashJoin { type: Inner, predicate: $3 = $4, output_indices: [0, 1, 2] }
-            BatchExchange { order: [], dist: HashShard([3]) }
-              BatchScan { table: supplier, columns: [s_suppkey, s_name, s_address, s_nationkey] }
-            BatchExchange { order: [], dist: HashShard([0]) }
-              BatchProject { exprs: [$0] }
-                BatchFilter { predicate: ($1 = 'KENYA':Varchar) }
-                  BatchScan { table: nation, columns: [n_nationkey, n_name] }
-        BatchExchange { order: [], dist: HashShard([0]) }
-          BatchProject { exprs: [$1] }
-            BatchFilter { predicate: ($2 > $5) }
-              BatchHashJoin { type: Inner, predicate: $0 = $3 AND $1 = $4, output_indices: all }
-                BatchExchange { order: [], dist: HashShard([0, 1]) }
-                  BatchHashJoin { type: LeftSemi, predicate: $0 = $3, output_indices: all }
-                    BatchExchange { order: [], dist: HashShard([0]) }
-                      BatchScan { table: partsupp, columns: [ps_partkey, ps_suppkey, ps_availqty] }
-                    BatchExchange { order: [], dist: HashShard([0]) }
-                      BatchProject { exprs: [$0] }
-                        BatchFilter { predicate: Like($1, 'forest%':Varchar) }
-                          BatchScan { table: part, columns: [p_partkey, p_name] }
-                BatchProject { exprs: [$0, $1, (0.5:Decimal * $2)] }
-                  BatchHashAgg { group_keys: [$0, $1], aggs: [sum($2)] }
-                    BatchExchange { order: [], dist: HashShard([0, 1]) }
-                      BatchProject { exprs: [$0, $1, $2] }
-                        BatchFilter { predicate: ($3 >= '1994-01-01':Varchar::Date) AND ($3 < ('1994-01-01':Varchar::Date + '1 year 00:00:00':Interval)) }
-                          BatchScan { table: lineitem, columns: [l_partkey, l_suppkey, l_quantity, l_shipdate] }
+    BatchExchange { order: [$0 ASC], dist: Single }
+      BatchSort { order: [$0 ASC] }
+        BatchHashJoin { type: LeftSemi, predicate: $0 = $3, output_indices: [1, 2] }
+          BatchExchange { order: [], dist: HashShard([0]) }
+            BatchHashJoin { type: Inner, predicate: $3 = $4, output_indices: [0, 1, 2] }
+              BatchExchange { order: [], dist: HashShard([3]) }
+                BatchScan { table: supplier, columns: [s_suppkey, s_name, s_address, s_nationkey] }
+              BatchExchange { order: [], dist: HashShard([0]) }
+                BatchProject { exprs: [$0] }
+                  BatchFilter { predicate: ($1 = 'KENYA':Varchar) }
+                    BatchScan { table: nation, columns: [n_nationkey, n_name] }
+          BatchExchange { order: [], dist: HashShard([0]) }
+            BatchProject { exprs: [$1] }
+              BatchFilter { predicate: ($2 > $5) }
+                BatchHashJoin { type: Inner, predicate: $0 = $3 AND $1 = $4, output_indices: all }
+                  BatchExchange { order: [], dist: HashShard([0, 1]) }
+                    BatchHashJoin { type: LeftSemi, predicate: $0 = $3, output_indices: all }
+                      BatchExchange { order: [], dist: HashShard([0]) }
+                        BatchScan { table: partsupp, columns: [ps_partkey, ps_suppkey, ps_availqty] }
+                      BatchExchange { order: [], dist: HashShard([0]) }
+                        BatchProject { exprs: [$0] }
+                          BatchFilter { predicate: Like($1, 'forest%':Varchar) }
+                            BatchScan { table: part, columns: [p_partkey, p_name] }
+                  BatchProject { exprs: [$0, $1, (0.5:Decimal * $2)] }
+                    BatchHashAgg { group_keys: [$0, $1], aggs: [sum($2)] }
+                      BatchExchange { order: [], dist: HashShard([0, 1]) }
+                        BatchProject { exprs: [$0, $1, $2] }
+                          BatchFilter { predicate: ($3 >= '1994-01-01':Varchar::Date) AND ($3 < ('1994-01-01':Varchar::Date + '1 year 00:00:00':Interval)) }
+                            BatchScan { table: lineitem, columns: [l_partkey, l_suppkey, l_quantity, l_shipdate] }
   stream_plan: |
     StreamMaterialize { columns: [s_name, s_address, _row_id(hidden), _row_id#1(hidden)], pk_columns: [_row_id, _row_id#1], order_descs: [s_name, _row_id, _row_id#1], order: [s_name ASC] }
       StreamExchange { dist: HashShard([2, 3]) }
@@ -2318,22 +2329,23 @@
             LogicalAgg { group_keys: [], agg_calls: [sum($0), count($0)] }
               LogicalScan { table: customer, output_columns: [c_acctbal], required_columns: [$6:c_acctbal, $5:c_phone], predicate: ($6 > 0.00:Decimal) AND In(Substr($5, 1:Int32, 2:Int32), '30':Varchar, '24':Varchar, '31':Varchar, '38':Varchar, '25':Varchar, '34':Varchar, '37':Varchar) }
   batch_plan: |
-    BatchSort { order: [$0 ASC] }
-      BatchHashAgg { group_keys: [$0], aggs: [count, sum($1)] }
-        BatchExchange { order: [], dist: HashShard([0]) }
-          BatchProject { exprs: [Substr($0, 1:Int32, 2:Int32), $1] }
-            BatchNestedLoopJoin { type: Inner, predicate: ($1 > $2), output_indices: [0, 1] }
-              BatchExchange { order: [], dist: Single }
-                BatchHashJoin { type: LeftAnti, predicate: $0 = $3, output_indices: [1, 2] }
-                  BatchExchange { order: [], dist: HashShard([0]) }
-                    BatchFilter { predicate: In(Substr($1, 1:Int32, 2:Int32), '30':Varchar, '24':Varchar, '31':Varchar, '38':Varchar, '25':Varchar, '34':Varchar, '37':Varchar) }
-                      BatchScan { table: customer, columns: [c_custkey, c_phone, c_acctbal] }
-                  BatchExchange { order: [], dist: HashShard([0]) }
-                    BatchScan { table: orders, columns: [o_custkey] }
-              BatchProject { exprs: [($0 / $1)] }
-                BatchSimpleAgg { aggs: [sum($0), sum($1)] }
-                  BatchExchange { order: [], dist: Single }
-                    BatchSimpleAgg { aggs: [sum($0), count($0)] }
-                      BatchProject { exprs: [$0] }
-                        BatchFilter { predicate: ($0 > 0.00:Decimal) AND In(Substr($1, 1:Int32, 2:Int32), '30':Varchar, '24':Varchar, '31':Varchar, '38':Varchar, '25':Varchar, '34':Varchar, '37':Varchar) }
-                          BatchScan { table: customer, columns: [c_acctbal, c_phone] }
+    BatchExchange { order: [$0 ASC], dist: Single }
+      BatchSort { order: [$0 ASC] }
+        BatchHashAgg { group_keys: [$0], aggs: [count, sum($1)] }
+          BatchExchange { order: [], dist: HashShard([0]) }
+            BatchProject { exprs: [Substr($0, 1:Int32, 2:Int32), $1] }
+              BatchNestedLoopJoin { type: Inner, predicate: ($1 > $2), output_indices: [0, 1] }
+                BatchExchange { order: [], dist: Single }
+                  BatchHashJoin { type: LeftAnti, predicate: $0 = $3, output_indices: [1, 2] }
+                    BatchExchange { order: [], dist: HashShard([0]) }
+                      BatchFilter { predicate: In(Substr($1, 1:Int32, 2:Int32), '30':Varchar, '24':Varchar, '31':Varchar, '38':Varchar, '25':Varchar, '34':Varchar, '37':Varchar) }
+                        BatchScan { table: customer, columns: [c_custkey, c_phone, c_acctbal] }
+                    BatchExchange { order: [], dist: HashShard([0]) }
+                      BatchScan { table: orders, columns: [o_custkey] }
+                BatchProject { exprs: [($0 / $1)] }
+                  BatchSimpleAgg { aggs: [sum($0), sum($1)] }
+                    BatchExchange { order: [], dist: Single }
+                      BatchSimpleAgg { aggs: [sum($0), count($0)] }
+                        BatchProject { exprs: [$0] }
+                          BatchFilter { predicate: ($0 > 0.00:Decimal) AND In(Substr($1, 1:Int32, 2:Int32), '30':Varchar, '24':Varchar, '31':Varchar, '38':Varchar, '25':Varchar, '34':Varchar, '37':Varchar) }
+                            BatchScan { table: customer, columns: [c_acctbal, c_phone] }

--- a/src/frontend/test_runner/tests/testdata/tpch.yaml
+++ b/src/frontend/test_runner/tests/testdata/tpch.yaml
@@ -114,14 +114,13 @@
         LogicalProject { exprs: [$4, $5, $0, $1, ($1 * (1:Int32 - $2)), (($1 * (1:Int32 - $2)) * (1:Int32 + $3)), $2] }
           LogicalScan { table: lineitem, output_columns: [l_quantity, l_extendedprice, l_discount, l_tax, l_returnflag, l_linestatus], required_columns: [$5:l_quantity, $6:l_extendedprice, $7:l_discount, $8:l_tax, $9:l_returnflag, $10:l_linestatus, $11:l_shipdate], predicate: ($11 <= ('1998-12-01':Varchar::Date - '71 days 00:00:00':Interval)) }
   batch_plan: |
-    BatchExchange { order: [$0 ASC, $1 ASC], dist: Single }
-      BatchSort { order: [$0 ASC, $1 ASC] }
-        BatchProject { exprs: [$0, $1, $2, $3, $4, $5, RoundDigit(($6 / $7), 4:Int32), RoundDigit(($8 / $9), 4:Int32), RoundDigit(($10 / $11), 4:Int32), $12] }
-          BatchHashAgg { group_keys: [$0, $1], aggs: [sum($2), sum($3), sum($4), sum($5), sum($2), count($2), sum($3), count($3), sum($6), count($6), count] }
-            BatchExchange { order: [], dist: HashShard([0, 1]) }
-              BatchProject { exprs: [$4, $5, $0, $1, ($1 * (1:Int32 - $2)), (($1 * (1:Int32 - $2)) * (1:Int32 + $3)), $2] }
-                BatchFilter { predicate: ($6 <= ('1998-12-01':Varchar::Date - '71 days 00:00:00':Interval)) }
-                  BatchScan { table: lineitem, columns: [l_quantity, l_extendedprice, l_discount, l_tax, l_returnflag, l_linestatus, l_shipdate] }
+    BatchSort { order: [$0 ASC, $1 ASC] }
+      BatchProject { exprs: [$0, $1, $2, $3, $4, $5, RoundDigit(($6 / $7), 4:Int32), RoundDigit(($8 / $9), 4:Int32), RoundDigit(($10 / $11), 4:Int32), $12] }
+        BatchHashAgg { group_keys: [$0, $1], aggs: [sum($2), sum($3), sum($4), sum($5), sum($2), count($2), sum($3), count($3), sum($6), count($6), count] }
+          BatchExchange { order: [], dist: HashShard([0, 1]) }
+            BatchProject { exprs: [$4, $5, $0, $1, ($1 * (1:Int32 - $2)), (($1 * (1:Int32 - $2)) * (1:Int32 + $3)), $2] }
+              BatchFilter { predicate: ($6 <= ('1998-12-01':Varchar::Date - '71 days 00:00:00':Interval)) }
+                BatchScan { table: lineitem, columns: [l_quantity, l_extendedprice, l_discount, l_tax, l_returnflag, l_linestatus, l_shipdate] }
   stream_plan: |
     StreamMaterialize { columns: [l_returnflag, l_linestatus, sum_qty, sum_base_price, sum_disc_price, sum_charge, avg_qty, avg_price, avg_disc, count_order], pk_columns: [l_returnflag, l_linestatus], order: [l_returnflag ASC, l_linestatus ASC] }
       StreamProject { exprs: [$0, $1, $3, $4, $5, $6, RoundDigit(($7 / $8), 4:Int32), RoundDigit(($9 / $10), 4:Int32), RoundDigit(($11 / $12), 4:Int32), $13] }
@@ -447,19 +446,18 @@
         LogicalScan { table: orders, output_columns: [o_orderkey, o_orderpriority], required_columns: [$1:o_orderkey, $6:o_orderpriority, $5:o_orderdate], predicate: ($5 >= '1997-07-01':Varchar::Date) AND ($5 < ('1997-07-01':Varchar::Date + '3 mons 00:00:00':Interval)) }
         LogicalScan { table: lineitem, output_columns: [l_orderkey], required_columns: [$1:l_orderkey, $12:l_commitdate, $13:l_receiptdate], predicate: ($12 < $13) }
   batch_plan: |
-    BatchExchange { order: [$0 ASC], dist: Single }
-      BatchSort { order: [$0 ASC] }
-        BatchHashAgg { group_keys: [$0], aggs: [count] }
-          BatchExchange { order: [], dist: HashShard([0]) }
-            BatchHashJoin { type: LeftSemi, predicate: $0 = $2, output_indices: [1] }
-              BatchExchange { order: [], dist: HashShard([0]) }
-                BatchProject { exprs: [$0, $1] }
-                  BatchFilter { predicate: ($2 >= '1997-07-01':Varchar::Date) AND ($2 < ('1997-07-01':Varchar::Date + '3 mons 00:00:00':Interval)) }
-                    BatchScan { table: orders, columns: [o_orderkey, o_orderpriority, o_orderdate] }
-              BatchExchange { order: [], dist: HashShard([0]) }
-                BatchProject { exprs: [$0] }
-                  BatchFilter { predicate: ($1 < $2) }
-                    BatchScan { table: lineitem, columns: [l_orderkey, l_commitdate, l_receiptdate] }
+    BatchSort { order: [$0 ASC] }
+      BatchHashAgg { group_keys: [$0], aggs: [count] }
+        BatchExchange { order: [], dist: HashShard([0]) }
+          BatchHashJoin { type: LeftSemi, predicate: $0 = $2, output_indices: [1] }
+            BatchExchange { order: [], dist: HashShard([0]) }
+              BatchProject { exprs: [$0, $1] }
+                BatchFilter { predicate: ($2 >= '1997-07-01':Varchar::Date) AND ($2 < ('1997-07-01':Varchar::Date + '3 mons 00:00:00':Interval)) }
+                  BatchScan { table: orders, columns: [o_orderkey, o_orderpriority, o_orderdate] }
+            BatchExchange { order: [], dist: HashShard([0]) }
+              BatchProject { exprs: [$0] }
+                BatchFilter { predicate: ($1 < $2) }
+                  BatchScan { table: lineitem, columns: [l_orderkey, l_commitdate, l_receiptdate] }
   stream_plan: |
     StreamMaterialize { columns: [o_orderpriority, agg#0(hidden), order_count], pk_columns: [o_orderpriority], order: [o_orderpriority ASC] }
       StreamHashAgg { group_keys: [$0], aggs: [count, count] }
@@ -532,36 +530,35 @@
             LogicalScan { table: nation, columns: [n_nationkey, n_name, n_regionkey] }
           LogicalScan { table: region, output_columns: [r_regionkey], required_columns: [$1:r_regionkey, $2:r_name], predicate: ($2 = 'MIDDLE EAST':Varchar) }
   batch_plan: |
-    BatchExchange { order: [$1 DESC], dist: Single }
-      BatchSort { order: [$1 DESC] }
-        BatchHashAgg { group_keys: [$0], aggs: [sum($1)] }
-          BatchExchange { order: [], dist: HashShard([0]) }
-            BatchProject { exprs: [$2, ($0 * (1:Int32 - $1))] }
-              BatchHashJoin { type: Inner, predicate: $3 = $4, output_indices: [0, 1, 2] }
-                BatchExchange { order: [], dist: HashShard([3]) }
-                  BatchHashJoin { type: Inner, predicate: $2 = $3, output_indices: [0, 1, 4, 5] }
-                    BatchExchange { order: [], dist: HashShard([2]) }
-                      BatchHashJoin { type: Inner, predicate: $1 = $4 AND $0 = $5, output_indices: [2, 3, 5] }
-                        BatchExchange { order: [], dist: HashShard([1, 0]) }
-                          BatchHashJoin { type: Inner, predicate: $1 = $2, output_indices: [0, 3, 4, 5] }
-                            BatchExchange { order: [], dist: HashShard([1]) }
-                              BatchHashJoin { type: Inner, predicate: $0 = $3, output_indices: [1, 2] }
-                                BatchExchange { order: [], dist: HashShard([0]) }
-                                  BatchScan { table: customer, columns: [c_custkey, c_nationkey] }
-                                BatchExchange { order: [], dist: HashShard([1]) }
-                                  BatchProject { exprs: [$0, $1] }
-                                    BatchFilter { predicate: ($2 >= '1994-01-01':Varchar::Date) AND ($2 < ('1994-01-01':Varchar::Date + '1 year 00:00:00':Interval)) }
-                                      BatchScan { table: orders, columns: [o_orderkey, o_custkey, o_orderdate] }
-                            BatchExchange { order: [], dist: HashShard([0]) }
-                              BatchScan { table: lineitem, columns: [l_orderkey, l_suppkey, l_extendedprice, l_discount] }
-                        BatchExchange { order: [], dist: HashShard([0, 1]) }
-                          BatchScan { table: supplier, columns: [s_suppkey, s_nationkey] }
-                    BatchExchange { order: [], dist: HashShard([0]) }
-                      BatchScan { table: nation, columns: [n_nationkey, n_name, n_regionkey] }
-                BatchExchange { order: [], dist: HashShard([0]) }
-                  BatchProject { exprs: [$0] }
-                    BatchFilter { predicate: ($1 = 'MIDDLE EAST':Varchar) }
-                      BatchScan { table: region, columns: [r_regionkey, r_name] }
+    BatchSort { order: [$1 DESC] }
+      BatchHashAgg { group_keys: [$0], aggs: [sum($1)] }
+        BatchExchange { order: [], dist: HashShard([0]) }
+          BatchProject { exprs: [$2, ($0 * (1:Int32 - $1))] }
+            BatchHashJoin { type: Inner, predicate: $3 = $4, output_indices: [0, 1, 2] }
+              BatchExchange { order: [], dist: HashShard([3]) }
+                BatchHashJoin { type: Inner, predicate: $2 = $3, output_indices: [0, 1, 4, 5] }
+                  BatchExchange { order: [], dist: HashShard([2]) }
+                    BatchHashJoin { type: Inner, predicate: $1 = $4 AND $0 = $5, output_indices: [2, 3, 5] }
+                      BatchExchange { order: [], dist: HashShard([1, 0]) }
+                        BatchHashJoin { type: Inner, predicate: $1 = $2, output_indices: [0, 3, 4, 5] }
+                          BatchExchange { order: [], dist: HashShard([1]) }
+                            BatchHashJoin { type: Inner, predicate: $0 = $3, output_indices: [1, 2] }
+                              BatchExchange { order: [], dist: HashShard([0]) }
+                                BatchScan { table: customer, columns: [c_custkey, c_nationkey] }
+                              BatchExchange { order: [], dist: HashShard([1]) }
+                                BatchProject { exprs: [$0, $1] }
+                                  BatchFilter { predicate: ($2 >= '1994-01-01':Varchar::Date) AND ($2 < ('1994-01-01':Varchar::Date + '1 year 00:00:00':Interval)) }
+                                    BatchScan { table: orders, columns: [o_orderkey, o_custkey, o_orderdate] }
+                          BatchExchange { order: [], dist: HashShard([0]) }
+                            BatchScan { table: lineitem, columns: [l_orderkey, l_suppkey, l_extendedprice, l_discount] }
+                      BatchExchange { order: [], dist: HashShard([0, 1]) }
+                        BatchScan { table: supplier, columns: [s_suppkey, s_nationkey] }
+                  BatchExchange { order: [], dist: HashShard([0]) }
+                    BatchScan { table: nation, columns: [n_nationkey, n_name, n_regionkey] }
+              BatchExchange { order: [], dist: HashShard([0]) }
+                BatchProject { exprs: [$0] }
+                  BatchFilter { predicate: ($1 = 'MIDDLE EAST':Varchar) }
+                    BatchScan { table: region, columns: [r_regionkey, r_name] }
   stream_plan: |
     StreamMaterialize { columns: [n_name, agg#0(hidden), revenue], pk_columns: [n_name], order_descs: [revenue, n_name], order: [revenue DESC] }
       StreamHashAgg { group_keys: [$0], aggs: [count, sum($1)] }
@@ -705,34 +702,33 @@
             LogicalScan { table: nation, columns: [n_nationkey, n_name] }
           LogicalScan { table: nation, columns: [n_nationkey, n_name] }
   batch_plan: |
-    BatchExchange { order: [$0 ASC, $1 ASC, $2 ASC], dist: Single }
-      BatchSort { order: [$0 ASC, $1 ASC, $2 ASC] }
-        BatchHashAgg { group_keys: [$0, $1, $2], aggs: [sum($3)] }
-          BatchExchange { order: [], dist: HashShard([0, 1, 2]) }
-            BatchProject { exprs: [$4, $6, Extract('YEAR':Varchar, $2), ($0 * (1:Int32 - $1))] }
-              BatchFilter { predicate: ((($4 = 'ROMANIA':Varchar) AND ($6 = 'IRAN':Varchar)) OR (($4 = 'IRAN':Varchar) AND ($6 = 'ROMANIA':Varchar))) }
-                BatchHashJoin { type: Inner, predicate: $3 = $5, output_indices: all }
-                  BatchExchange { order: [], dist: HashShard([3]) }
-                    BatchHashJoin { type: Inner, predicate: $0 = $5, output_indices: [1, 2, 3, 4, 6] }
-                      BatchExchange { order: [], dist: HashShard([0]) }
-                        BatchHashJoin { type: Inner, predicate: $4 = $5, output_indices: [0, 1, 2, 3, 6] }
-                          BatchExchange { order: [], dist: HashShard([4]) }
-                            BatchHashJoin { type: Inner, predicate: $1 = $5, output_indices: [0, 2, 3, 4, 6] }
-                              BatchExchange { order: [], dist: HashShard([1]) }
-                                BatchHashJoin { type: Inner, predicate: $0 = $3, output_indices: [1, 2, 4, 5, 6] }
-                                  BatchExchange { order: [], dist: HashShard([0]) }
-                                    BatchScan { table: supplier, columns: [s_suppkey, s_nationkey] }
-                                  BatchExchange { order: [], dist: HashShard([1]) }
-                                    BatchFilter { predicate: ($4 >= '1983-01-01':Varchar::Date) AND ($4 <= '2000-12-31':Varchar::Date) }
-                                      BatchScan { table: lineitem, columns: [l_orderkey, l_suppkey, l_extendedprice, l_discount, l_shipdate] }
-                              BatchExchange { order: [], dist: HashShard([0]) }
-                                BatchScan { table: orders, columns: [o_orderkey, o_custkey] }
-                          BatchExchange { order: [], dist: HashShard([0]) }
-                            BatchScan { table: customer, columns: [c_custkey, c_nationkey] }
-                      BatchExchange { order: [], dist: HashShard([0]) }
-                        BatchScan { table: nation, columns: [n_nationkey, n_name] }
-                  BatchExchange { order: [], dist: HashShard([0]) }
-                    BatchScan { table: nation, columns: [n_nationkey, n_name] }
+    BatchSort { order: [$0 ASC, $1 ASC, $2 ASC] }
+      BatchHashAgg { group_keys: [$0, $1, $2], aggs: [sum($3)] }
+        BatchExchange { order: [], dist: HashShard([0, 1, 2]) }
+          BatchProject { exprs: [$4, $6, Extract('YEAR':Varchar, $2), ($0 * (1:Int32 - $1))] }
+            BatchFilter { predicate: ((($4 = 'ROMANIA':Varchar) AND ($6 = 'IRAN':Varchar)) OR (($4 = 'IRAN':Varchar) AND ($6 = 'ROMANIA':Varchar))) }
+              BatchHashJoin { type: Inner, predicate: $3 = $5, output_indices: all }
+                BatchExchange { order: [], dist: HashShard([3]) }
+                  BatchHashJoin { type: Inner, predicate: $0 = $5, output_indices: [1, 2, 3, 4, 6] }
+                    BatchExchange { order: [], dist: HashShard([0]) }
+                      BatchHashJoin { type: Inner, predicate: $4 = $5, output_indices: [0, 1, 2, 3, 6] }
+                        BatchExchange { order: [], dist: HashShard([4]) }
+                          BatchHashJoin { type: Inner, predicate: $1 = $5, output_indices: [0, 2, 3, 4, 6] }
+                            BatchExchange { order: [], dist: HashShard([1]) }
+                              BatchHashJoin { type: Inner, predicate: $0 = $3, output_indices: [1, 2, 4, 5, 6] }
+                                BatchExchange { order: [], dist: HashShard([0]) }
+                                  BatchScan { table: supplier, columns: [s_suppkey, s_nationkey] }
+                                BatchExchange { order: [], dist: HashShard([1]) }
+                                  BatchFilter { predicate: ($4 >= '1983-01-01':Varchar::Date) AND ($4 <= '2000-12-31':Varchar::Date) }
+                                    BatchScan { table: lineitem, columns: [l_orderkey, l_suppkey, l_extendedprice, l_discount, l_shipdate] }
+                            BatchExchange { order: [], dist: HashShard([0]) }
+                              BatchScan { table: orders, columns: [o_orderkey, o_custkey] }
+                        BatchExchange { order: [], dist: HashShard([0]) }
+                          BatchScan { table: customer, columns: [c_custkey, c_nationkey] }
+                    BatchExchange { order: [], dist: HashShard([0]) }
+                      BatchScan { table: nation, columns: [n_nationkey, n_name] }
+                BatchExchange { order: [], dist: HashShard([0]) }
+                  BatchScan { table: nation, columns: [n_nationkey, n_name] }
   stream_plan: |
     StreamMaterialize { columns: [supp_nation, cust_nation, l_year, agg#0(hidden), revenue], pk_columns: [supp_nation, cust_nation, l_year], order: [supp_nation ASC, cust_nation ASC, l_year ASC] }
       StreamHashAgg { group_keys: [$0, $1, $2], aggs: [count, sum($3)] }
@@ -845,46 +841,45 @@
               LogicalScan { table: nation, columns: [n_nationkey, n_name] }
             LogicalScan { table: region, output_columns: [r_regionkey], required_columns: [$1:r_regionkey, $2:r_name], predicate: ($2 = 'ASIA':Varchar) }
   batch_plan: |
-    BatchExchange { order: [$0 ASC], dist: Single }
-      BatchSort { order: [$0 ASC] }
-        BatchProject { exprs: [$0, RoundDigit(($1 / $2), 6:Int32)] }
-          BatchHashAgg { group_keys: [$0], aggs: [sum($1), sum($2)] }
-            BatchExchange { order: [], dist: HashShard([0]) }
-              BatchProject { exprs: [Extract('YEAR':Varchar, $2), Case(($3 = 'IRAN':Varchar), ($0 * (1:Int32 - $1)), 0:Int32::Decimal), ($0 * (1:Int32 - $1))] }
-                BatchHashJoin { type: Inner, predicate: $3 = $5, output_indices: [0, 1, 2, 4] }
-                  BatchExchange { order: [], dist: HashShard([3]) }
-                    BatchHashJoin { type: Inner, predicate: $2 = $5, output_indices: [0, 1, 3, 4, 6] }
-                      BatchExchange { order: [], dist: HashShard([2]) }
-                        BatchHashJoin { type: Inner, predicate: $4 = $5, output_indices: [0, 1, 2, 3, 6] }
-                          BatchExchange { order: [], dist: HashShard([4]) }
-                            BatchHashJoin { type: Inner, predicate: $3 = $5, output_indices: [0, 1, 2, 4, 6] }
-                              BatchExchange { order: [], dist: HashShard([3]) }
-                                BatchHashJoin { type: Inner, predicate: $0 = $4, output_indices: [1, 2, 3, 5, 6] }
-                                  BatchExchange { order: [], dist: HashShard([0]) }
-                                    BatchHashJoin { type: Inner, predicate: $1 = $4, output_indices: [0, 2, 3, 5] }
-                                      BatchExchange { order: [], dist: HashShard([1]) }
-                                        BatchHashJoin { type: Inner, predicate: $1 = $5, output_indices: [0, 2, 3, 4] }
-                                          BatchExchange { order: [], dist: HashShard([1]) }
-                                            BatchScan { table: lineitem, columns: [l_orderkey, l_partkey, l_suppkey, l_extendedprice, l_discount] }
-                                          BatchExchange { order: [], dist: HashShard([0]) }
-                                            BatchProject { exprs: [$0] }
-                                              BatchFilter { predicate: ($1 = 'PROMO ANODIZED STEEL':Varchar) }
-                                                BatchScan { table: part, columns: [p_partkey, p_type] }
-                                      BatchExchange { order: [], dist: HashShard([0]) }
-                                        BatchScan { table: supplier, columns: [s_suppkey, s_nationkey] }
-                                  BatchExchange { order: [], dist: HashShard([0]) }
-                                    BatchFilter { predicate: ($2 >= '1995-01-01':Varchar::Date) AND ($2 <= '1996-12-31':Varchar::Date) }
-                                      BatchScan { table: orders, columns: [o_orderkey, o_custkey, o_orderdate] }
-                              BatchExchange { order: [], dist: HashShard([0]) }
-                                BatchScan { table: customer, columns: [c_custkey, c_nationkey] }
-                          BatchExchange { order: [], dist: HashShard([0]) }
-                            BatchScan { table: nation, columns: [n_nationkey, n_regionkey] }
-                      BatchExchange { order: [], dist: HashShard([0]) }
-                        BatchScan { table: nation, columns: [n_nationkey, n_name] }
-                  BatchExchange { order: [], dist: HashShard([0]) }
-                    BatchProject { exprs: [$0] }
-                      BatchFilter { predicate: ($1 = 'ASIA':Varchar) }
-                        BatchScan { table: region, columns: [r_regionkey, r_name] }
+    BatchSort { order: [$0 ASC] }
+      BatchProject { exprs: [$0, RoundDigit(($1 / $2), 6:Int32)] }
+        BatchHashAgg { group_keys: [$0], aggs: [sum($1), sum($2)] }
+          BatchExchange { order: [], dist: HashShard([0]) }
+            BatchProject { exprs: [Extract('YEAR':Varchar, $2), Case(($3 = 'IRAN':Varchar), ($0 * (1:Int32 - $1)), 0:Int32::Decimal), ($0 * (1:Int32 - $1))] }
+              BatchHashJoin { type: Inner, predicate: $3 = $5, output_indices: [0, 1, 2, 4] }
+                BatchExchange { order: [], dist: HashShard([3]) }
+                  BatchHashJoin { type: Inner, predicate: $2 = $5, output_indices: [0, 1, 3, 4, 6] }
+                    BatchExchange { order: [], dist: HashShard([2]) }
+                      BatchHashJoin { type: Inner, predicate: $4 = $5, output_indices: [0, 1, 2, 3, 6] }
+                        BatchExchange { order: [], dist: HashShard([4]) }
+                          BatchHashJoin { type: Inner, predicate: $3 = $5, output_indices: [0, 1, 2, 4, 6] }
+                            BatchExchange { order: [], dist: HashShard([3]) }
+                              BatchHashJoin { type: Inner, predicate: $0 = $4, output_indices: [1, 2, 3, 5, 6] }
+                                BatchExchange { order: [], dist: HashShard([0]) }
+                                  BatchHashJoin { type: Inner, predicate: $1 = $4, output_indices: [0, 2, 3, 5] }
+                                    BatchExchange { order: [], dist: HashShard([1]) }
+                                      BatchHashJoin { type: Inner, predicate: $1 = $5, output_indices: [0, 2, 3, 4] }
+                                        BatchExchange { order: [], dist: HashShard([1]) }
+                                          BatchScan { table: lineitem, columns: [l_orderkey, l_partkey, l_suppkey, l_extendedprice, l_discount] }
+                                        BatchExchange { order: [], dist: HashShard([0]) }
+                                          BatchProject { exprs: [$0] }
+                                            BatchFilter { predicate: ($1 = 'PROMO ANODIZED STEEL':Varchar) }
+                                              BatchScan { table: part, columns: [p_partkey, p_type] }
+                                    BatchExchange { order: [], dist: HashShard([0]) }
+                                      BatchScan { table: supplier, columns: [s_suppkey, s_nationkey] }
+                                BatchExchange { order: [], dist: HashShard([0]) }
+                                  BatchFilter { predicate: ($2 >= '1995-01-01':Varchar::Date) AND ($2 <= '1996-12-31':Varchar::Date) }
+                                    BatchScan { table: orders, columns: [o_orderkey, o_custkey, o_orderdate] }
+                            BatchExchange { order: [], dist: HashShard([0]) }
+                              BatchScan { table: customer, columns: [c_custkey, c_nationkey] }
+                        BatchExchange { order: [], dist: HashShard([0]) }
+                          BatchScan { table: nation, columns: [n_nationkey, n_regionkey] }
+                    BatchExchange { order: [], dist: HashShard([0]) }
+                      BatchScan { table: nation, columns: [n_nationkey, n_name] }
+                BatchExchange { order: [], dist: HashShard([0]) }
+                  BatchProject { exprs: [$0] }
+                    BatchFilter { predicate: ($1 = 'ASIA':Varchar) }
+                      BatchScan { table: region, columns: [r_regionkey, r_name] }
   stream_plan: |
     StreamMaterialize { columns: [o_year, mkt_share], pk_columns: [o_year], order: [o_year ASC] }
       StreamProject { exprs: [$0, RoundDigit(($2 / $3), 6:Int32)] }
@@ -996,35 +991,34 @@
               LogicalScan { table: orders, columns: [o_orderkey, o_orderdate] }
             LogicalScan { table: nation, columns: [n_nationkey, n_name] }
   batch_plan: |
-    BatchExchange { order: [$0 ASC, $1 DESC], dist: Single }
-      BatchSort { order: [$0 ASC, $1 DESC] }
-        BatchProject { exprs: [$0, $1, RoundDigit($2, 2:Int32)] }
-          BatchHashAgg { group_keys: [$0, $1], aggs: [sum($2)] }
-            BatchExchange { order: [], dist: HashShard([0, 1]) }
-              BatchProject { exprs: [$5, Extract('YEAR':Varchar, $4), (($1 * (1:Int32 - $2)) - ($3 * $0))] }
-                BatchHashJoin { type: Inner, predicate: $3 = $6, output_indices: [0, 1, 2, 4, 5, 7] }
-                  BatchExchange { order: [], dist: HashShard([3]) }
-                    BatchHashJoin { type: Inner, predicate: $0 = $6, output_indices: [1, 2, 3, 4, 5, 7] }
-                      BatchExchange { order: [], dist: HashShard([0]) }
-                        BatchHashJoin { type: Inner, predicate: $2 = $8 AND $1 = $7, output_indices: [0, 3, 4, 5, 6, 9] }
-                          BatchExchange { order: [], dist: HashShard([1, 2]) }
-                            BatchHashJoin { type: Inner, predicate: $2 = $6, output_indices: [0, 1, 2, 3, 4, 5, 7] }
-                              BatchExchange { order: [], dist: HashShard([2]) }
-                                BatchHashJoin { type: Inner, predicate: $1 = $6, output_indices: [0, 1, 2, 3, 4, 5] }
-                                  BatchExchange { order: [], dist: HashShard([1]) }
-                                    BatchScan { table: lineitem, columns: [l_orderkey, l_partkey, l_suppkey, l_quantity, l_extendedprice, l_discount] }
-                                  BatchExchange { order: [], dist: HashShard([0]) }
-                                    BatchProject { exprs: [$0] }
-                                      BatchFilter { predicate: Like($1, '%yellow%':Varchar) }
-                                        BatchScan { table: part, columns: [p_partkey, p_name] }
-                              BatchExchange { order: [], dist: HashShard([0]) }
-                                BatchScan { table: supplier, columns: [s_suppkey, s_nationkey] }
-                          BatchExchange { order: [], dist: HashShard([0, 1]) }
-                            BatchScan { table: partsupp, columns: [ps_partkey, ps_suppkey, ps_supplycost] }
-                      BatchExchange { order: [], dist: HashShard([0]) }
-                        BatchScan { table: orders, columns: [o_orderkey, o_orderdate] }
-                  BatchExchange { order: [], dist: HashShard([0]) }
-                    BatchScan { table: nation, columns: [n_nationkey, n_name] }
+    BatchSort { order: [$0 ASC, $1 DESC] }
+      BatchProject { exprs: [$0, $1, RoundDigit($2, 2:Int32)] }
+        BatchHashAgg { group_keys: [$0, $1], aggs: [sum($2)] }
+          BatchExchange { order: [], dist: HashShard([0, 1]) }
+            BatchProject { exprs: [$5, Extract('YEAR':Varchar, $4), (($1 * (1:Int32 - $2)) - ($3 * $0))] }
+              BatchHashJoin { type: Inner, predicate: $3 = $6, output_indices: [0, 1, 2, 4, 5, 7] }
+                BatchExchange { order: [], dist: HashShard([3]) }
+                  BatchHashJoin { type: Inner, predicate: $0 = $6, output_indices: [1, 2, 3, 4, 5, 7] }
+                    BatchExchange { order: [], dist: HashShard([0]) }
+                      BatchHashJoin { type: Inner, predicate: $2 = $8 AND $1 = $7, output_indices: [0, 3, 4, 5, 6, 9] }
+                        BatchExchange { order: [], dist: HashShard([1, 2]) }
+                          BatchHashJoin { type: Inner, predicate: $2 = $6, output_indices: [0, 1, 2, 3, 4, 5, 7] }
+                            BatchExchange { order: [], dist: HashShard([2]) }
+                              BatchHashJoin { type: Inner, predicate: $1 = $6, output_indices: [0, 1, 2, 3, 4, 5] }
+                                BatchExchange { order: [], dist: HashShard([1]) }
+                                  BatchScan { table: lineitem, columns: [l_orderkey, l_partkey, l_suppkey, l_quantity, l_extendedprice, l_discount] }
+                                BatchExchange { order: [], dist: HashShard([0]) }
+                                  BatchProject { exprs: [$0] }
+                                    BatchFilter { predicate: Like($1, '%yellow%':Varchar) }
+                                      BatchScan { table: part, columns: [p_partkey, p_name] }
+                            BatchExchange { order: [], dist: HashShard([0]) }
+                              BatchScan { table: supplier, columns: [s_suppkey, s_nationkey] }
+                        BatchExchange { order: [], dist: HashShard([0, 1]) }
+                          BatchScan { table: partsupp, columns: [ps_partkey, ps_suppkey, ps_supplycost] }
+                    BatchExchange { order: [], dist: HashShard([0]) }
+                      BatchScan { table: orders, columns: [o_orderkey, o_orderdate] }
+                BatchExchange { order: [], dist: HashShard([0]) }
+                  BatchScan { table: nation, columns: [n_nationkey, n_name] }
   stream_plan: |
     StreamMaterialize { columns: [nation, o_year, sum_profit], pk_columns: [nation, o_year], order: [nation ASC, o_year DESC] }
       StreamProject { exprs: [$0, $1, RoundDigit($3, 2:Int32)] }
@@ -1315,18 +1309,17 @@
           LogicalScan { table: orders, columns: [o_orderkey, o_orderpriority] }
           LogicalScan { table: lineitem, output_columns: [l_orderkey, l_shipmode], required_columns: [$1:l_orderkey, $15:l_shipmode, $11:l_shipdate, $12:l_commitdate, $13:l_receiptdate], predicate: In($15, 'FOB':Varchar, 'SHIP':Varchar) AND ($12 < $13) AND ($11 < $12) AND ($13 >= '1994-01-01':Varchar::Date) AND ($13 < ('1994-01-01':Varchar::Date + '1 year 00:00:00':Interval)) }
   batch_plan: |
-    BatchExchange { order: [$0 ASC], dist: Single }
-      BatchSort { order: [$0 ASC] }
-        BatchHashAgg { group_keys: [$0], aggs: [sum($1), sum($2)] }
-          BatchExchange { order: [], dist: HashShard([0]) }
-            BatchProject { exprs: [$1, Case((($0 = '1-URGENT':Varchar) OR ($0 = '2-HIGH':Varchar)), 1:Int32, 0:Int32), Case((($0 <> '1-URGENT':Varchar) AND ($0 <> '2-HIGH':Varchar)), 1:Int32, 0:Int32)] }
-              BatchHashJoin { type: Inner, predicate: $0 = $2, output_indices: [1, 3] }
-                BatchExchange { order: [], dist: HashShard([0]) }
-                  BatchScan { table: orders, columns: [o_orderkey, o_orderpriority] }
-                BatchExchange { order: [], dist: HashShard([0]) }
-                  BatchProject { exprs: [$0, $1] }
-                    BatchFilter { predicate: In($1, 'FOB':Varchar, 'SHIP':Varchar) AND ($3 < $4) AND ($2 < $3) AND ($4 >= '1994-01-01':Varchar::Date) AND ($4 < ('1994-01-01':Varchar::Date + '1 year 00:00:00':Interval)) }
-                      BatchScan { table: lineitem, columns: [l_orderkey, l_shipmode, l_shipdate, l_commitdate, l_receiptdate] }
+    BatchSort { order: [$0 ASC] }
+      BatchHashAgg { group_keys: [$0], aggs: [sum($1), sum($2)] }
+        BatchExchange { order: [], dist: HashShard([0]) }
+          BatchProject { exprs: [$1, Case((($0 = '1-URGENT':Varchar) OR ($0 = '2-HIGH':Varchar)), 1:Int32, 0:Int32), Case((($0 <> '1-URGENT':Varchar) AND ($0 <> '2-HIGH':Varchar)), 1:Int32, 0:Int32)] }
+            BatchHashJoin { type: Inner, predicate: $0 = $2, output_indices: [1, 3] }
+              BatchExchange { order: [], dist: HashShard([0]) }
+                BatchScan { table: orders, columns: [o_orderkey, o_orderpriority] }
+              BatchExchange { order: [], dist: HashShard([0]) }
+                BatchProject { exprs: [$0, $1] }
+                  BatchFilter { predicate: In($1, 'FOB':Varchar, 'SHIP':Varchar) AND ($3 < $4) AND ($2 < $3) AND ($4 >= '1994-01-01':Varchar::Date) AND ($4 < ('1994-01-01':Varchar::Date + '1 year 00:00:00':Interval)) }
+                    BatchScan { table: lineitem, columns: [l_orderkey, l_shipmode, l_shipdate, l_commitdate, l_receiptdate] }
   stream_plan: |
     StreamMaterialize { columns: [l_shipmode, agg#0(hidden), high_line_count, low_line_count], pk_columns: [l_shipmode], order: [l_shipmode ASC] }
       StreamHashAgg { group_keys: [$0], aggs: [count, sum($1), sum($2)] }
@@ -1381,19 +1374,18 @@
             LogicalScan { table: customer, columns: [c_custkey] }
             LogicalScan { table: orders, output_columns: [o_orderkey, o_custkey], required_columns: [$1:o_orderkey, $2:o_custkey, $9:o_comment], predicate: Not(Like($9, '%:1%:2%':Varchar)) }
   batch_plan: |
-    BatchExchange { order: [$1 DESC, $0 DESC], dist: Single }
-      BatchSort { order: [$1 DESC, $0 DESC] }
-        BatchHashAgg { group_keys: [$0], aggs: [count] }
-          BatchExchange { order: [], dist: HashShard([0]) }
-            BatchProject { exprs: [$1] }
-              BatchHashAgg { group_keys: [$0], aggs: [count($1)] }
-                BatchHashJoin { type: LeftOuter, predicate: $0 = $2, output_indices: [0, 1] }
-                  BatchExchange { order: [], dist: HashShard([0]) }
-                    BatchScan { table: customer, columns: [c_custkey] }
-                  BatchExchange { order: [], dist: HashShard([1]) }
-                    BatchProject { exprs: [$0, $1] }
-                      BatchFilter { predicate: Not(Like($2, '%:1%:2%':Varchar)) }
-                        BatchScan { table: orders, columns: [o_orderkey, o_custkey, o_comment] }
+    BatchSort { order: [$1 DESC, $0 DESC] }
+      BatchHashAgg { group_keys: [$0], aggs: [count] }
+        BatchExchange { order: [], dist: HashShard([0]) }
+          BatchProject { exprs: [$1] }
+            BatchHashAgg { group_keys: [$0], aggs: [count($1)] }
+              BatchHashJoin { type: LeftOuter, predicate: $0 = $2, output_indices: [0, 1] }
+                BatchExchange { order: [], dist: HashShard([0]) }
+                  BatchScan { table: customer, columns: [c_custkey] }
+                BatchExchange { order: [], dist: HashShard([1]) }
+                  BatchProject { exprs: [$0, $1] }
+                    BatchFilter { predicate: Not(Like($2, '%:1%:2%':Varchar)) }
+                      BatchScan { table: orders, columns: [o_orderkey, o_custkey, o_comment] }
   stream_plan: |
     StreamMaterialize { columns: [c_count, agg#0(hidden), custdist], pk_columns: [c_count], order_descs: [custdist, c_count], order: [custdist DESC, c_count DESC] }
       StreamHashAgg { group_keys: [$0], aggs: [count, count] }
@@ -1533,28 +1525,27 @@
             LogicalProject { exprs: [$0, ($1 * (1:Int32 - $2))] }
               LogicalScan { table: lineitem, output_columns: [l_suppkey, l_extendedprice, l_discount], required_columns: [$3:l_suppkey, $6:l_extendedprice, $7:l_discount, $11:l_shipdate], predicate: ($11 >= '1993-01-01':Varchar::Date) AND ($11 < ('1993-01-01':Varchar::Date + '3 mons 00:00:00':Interval)) }
   batch_plan: |
-    BatchExchange { order: [$0 ASC], dist: Single }
-      BatchSort { order: [$0 ASC] }
-        BatchHashJoin { type: Inner, predicate: $4 = $5, output_indices: [0, 1, 2, 3, 4] }
-          BatchExchange { order: [], dist: HashShard([4]) }
-            BatchHashJoin { type: Inner, predicate: $0 = $4, output_indices: [0, 1, 2, 3, 5] }
+    BatchSort { order: [$0 ASC] }
+      BatchHashJoin { type: Inner, predicate: $4 = $5, output_indices: [0, 1, 2, 3, 4] }
+        BatchExchange { order: [], dist: HashShard([4]) }
+          BatchHashJoin { type: Inner, predicate: $0 = $4, output_indices: [0, 1, 2, 3, 5] }
+            BatchExchange { order: [], dist: HashShard([0]) }
+              BatchScan { table: supplier, columns: [s_suppkey, s_name, s_address, s_phone] }
+            BatchHashAgg { group_keys: [$0], aggs: [sum($1)] }
               BatchExchange { order: [], dist: HashShard([0]) }
-                BatchScan { table: supplier, columns: [s_suppkey, s_name, s_address, s_phone] }
-              BatchHashAgg { group_keys: [$0], aggs: [sum($1)] }
-                BatchExchange { order: [], dist: HashShard([0]) }
-                  BatchProject { exprs: [$0, ($1 * (1:Int32 - $2))] }
-                    BatchFilter { predicate: ($3 >= '1993-01-01':Varchar::Date) AND ($3 < ('1993-01-01':Varchar::Date + '3 mons 00:00:00':Interval)) }
-                      BatchScan { table: lineitem, columns: [l_suppkey, l_extendedprice, l_discount, l_shipdate] }
-          BatchExchange { order: [], dist: HashShard([0]) }
-            BatchSimpleAgg { aggs: [max($0)] }
-              BatchExchange { order: [], dist: Single }
-                BatchSimpleAgg { aggs: [max($0)] }
-                  BatchProject { exprs: [$1] }
-                    BatchHashAgg { group_keys: [$0], aggs: [sum($1)] }
-                      BatchExchange { order: [], dist: HashShard([0]) }
-                        BatchProject { exprs: [$0, ($1 * (1:Int32 - $2))] }
-                          BatchFilter { predicate: ($3 >= '1993-01-01':Varchar::Date) AND ($3 < ('1993-01-01':Varchar::Date + '3 mons 00:00:00':Interval)) }
-                            BatchScan { table: lineitem, columns: [l_suppkey, l_extendedprice, l_discount, l_shipdate] }
+                BatchProject { exprs: [$0, ($1 * (1:Int32 - $2))] }
+                  BatchFilter { predicate: ($3 >= '1993-01-01':Varchar::Date) AND ($3 < ('1993-01-01':Varchar::Date + '3 mons 00:00:00':Interval)) }
+                    BatchScan { table: lineitem, columns: [l_suppkey, l_extendedprice, l_discount, l_shipdate] }
+        BatchExchange { order: [], dist: HashShard([0]) }
+          BatchSimpleAgg { aggs: [max($0)] }
+            BatchExchange { order: [], dist: Single }
+              BatchSimpleAgg { aggs: [max($0)] }
+                BatchProject { exprs: [$1] }
+                  BatchHashAgg { group_keys: [$0], aggs: [sum($1)] }
+                    BatchExchange { order: [], dist: HashShard([0]) }
+                      BatchProject { exprs: [$0, ($1 * (1:Int32 - $2))] }
+                        BatchFilter { predicate: ($3 >= '1993-01-01':Varchar::Date) AND ($3 < ('1993-01-01':Varchar::Date + '3 mons 00:00:00':Interval)) }
+                          BatchScan { table: lineitem, columns: [l_suppkey, l_extendedprice, l_discount, l_shipdate] }
   stream_plan: |
     StreamMaterialize { columns: [s_suppkey, s_name, s_address, s_phone, total_revenue, _row_id(hidden), l_suppkey(hidden)], pk_columns: [_row_id, l_suppkey], order_descs: [s_suppkey, _row_id, l_suppkey], order: [s_suppkey ASC] }
       StreamExchange { dist: HashShard([5, 6]) }
@@ -1632,23 +1623,22 @@
             LogicalScan { table: part, output_columns: [p_partkey, p_brand, p_type, p_size], required_columns: [$1:p_partkey, $4:p_brand, $5:p_type, $6:p_size], predicate: ($4 <> 'Brand#45':Varchar) AND Not(Like($5, 'SMALL PLATED%':Varchar)) AND In($6, 19:Int32, 17:Int32, 16:Int32, 23:Int32, 10:Int32, 4:Int32, 38:Int32, 11:Int32) }
           LogicalScan { table: supplier, output_columns: [s_suppkey], required_columns: [$1:s_suppkey, $7:s_comment], predicate: Like($7, '%Customer%Complaints%':Varchar) }
   batch_plan: |
-    BatchExchange { order: [$3 DESC, $0 ASC, $1 ASC, $2 ASC], dist: Single }
-      BatchSort { order: [$3 DESC, $0 ASC, $1 ASC, $2 ASC] }
-        BatchHashAgg { group_keys: [$0, $1, $2], aggs: [count(distinct $3)] }
-          BatchExchange { order: [], dist: HashShard([0, 1, 2]) }
-            BatchProject { exprs: [$1, $2, $3, $0] }
-              BatchHashJoin { type: LeftAnti, predicate: $0 = $4, output_indices: all }
-                BatchExchange { order: [], dist: HashShard([0]) }
-                  BatchHashJoin { type: Inner, predicate: $0 = $2, output_indices: [1, 3, 4, 5] }
-                    BatchExchange { order: [], dist: HashShard([0]) }
-                      BatchScan { table: partsupp, columns: [ps_partkey, ps_suppkey] }
-                    BatchExchange { order: [], dist: HashShard([0]) }
-                      BatchFilter { predicate: ($1 <> 'Brand#45':Varchar) AND Not(Like($2, 'SMALL PLATED%':Varchar)) AND In($3, 19:Int32, 17:Int32, 16:Int32, 23:Int32, 10:Int32, 4:Int32, 38:Int32, 11:Int32) }
-                        BatchScan { table: part, columns: [p_partkey, p_brand, p_type, p_size] }
-                BatchExchange { order: [], dist: HashShard([0]) }
-                  BatchProject { exprs: [$0] }
-                    BatchFilter { predicate: Like($1, '%Customer%Complaints%':Varchar) }
-                      BatchScan { table: supplier, columns: [s_suppkey, s_comment] }
+    BatchSort { order: [$3 DESC, $0 ASC, $1 ASC, $2 ASC] }
+      BatchHashAgg { group_keys: [$0, $1, $2], aggs: [count(distinct $3)] }
+        BatchExchange { order: [], dist: HashShard([0, 1, 2]) }
+          BatchProject { exprs: [$1, $2, $3, $0] }
+            BatchHashJoin { type: LeftAnti, predicate: $0 = $4, output_indices: all }
+              BatchExchange { order: [], dist: HashShard([0]) }
+                BatchHashJoin { type: Inner, predicate: $0 = $2, output_indices: [1, 3, 4, 5] }
+                  BatchExchange { order: [], dist: HashShard([0]) }
+                    BatchScan { table: partsupp, columns: [ps_partkey, ps_suppkey] }
+                  BatchExchange { order: [], dist: HashShard([0]) }
+                    BatchFilter { predicate: ($1 <> 'Brand#45':Varchar) AND Not(Like($2, 'SMALL PLATED%':Varchar)) AND In($3, 19:Int32, 17:Int32, 16:Int32, 23:Int32, 10:Int32, 4:Int32, 38:Int32, 11:Int32) }
+                      BatchScan { table: part, columns: [p_partkey, p_brand, p_type, p_size] }
+              BatchExchange { order: [], dist: HashShard([0]) }
+                BatchProject { exprs: [$0] }
+                  BatchFilter { predicate: Like($1, '%Customer%Complaints%':Varchar) }
+                    BatchScan { table: supplier, columns: [s_suppkey, s_comment] }
   stream_plan: |
     StreamMaterialize { columns: [p_brand, p_type, p_size, agg#0(hidden), supplier_cnt], pk_columns: [p_brand, p_type, p_size], order_descs: [supplier_cnt, p_brand, p_type, p_size], order: [supplier_cnt DESC, p_brand ASC, p_type ASC, p_size ASC] }
       StreamHashAgg { group_keys: [$0, $1, $2], aggs: [count, count(distinct $3)] }
@@ -2018,35 +2008,34 @@
           LogicalAgg { group_keys: [0, 1], agg_calls: [sum($2)] }
             LogicalScan { table: lineitem, output_columns: [l_partkey, l_suppkey, l_quantity], required_columns: [$2:l_partkey, $3:l_suppkey, $5:l_quantity, $11:l_shipdate], predicate: ($11 >= '1994-01-01':Varchar::Date) AND ($11 < ('1994-01-01':Varchar::Date + '1 year 00:00:00':Interval)) }
   batch_plan: |
-    BatchExchange { order: [$0 ASC], dist: Single }
-      BatchSort { order: [$0 ASC] }
-        BatchHashJoin { type: LeftSemi, predicate: $0 = $3, output_indices: [1, 2] }
-          BatchExchange { order: [], dist: HashShard([0]) }
-            BatchHashJoin { type: Inner, predicate: $3 = $4, output_indices: [0, 1, 2] }
-              BatchExchange { order: [], dist: HashShard([3]) }
-                BatchScan { table: supplier, columns: [s_suppkey, s_name, s_address, s_nationkey] }
-              BatchExchange { order: [], dist: HashShard([0]) }
-                BatchProject { exprs: [$0] }
-                  BatchFilter { predicate: ($1 = 'KENYA':Varchar) }
-                    BatchScan { table: nation, columns: [n_nationkey, n_name] }
-          BatchExchange { order: [], dist: HashShard([0]) }
-            BatchProject { exprs: [$1] }
-              BatchFilter { predicate: ($2 > $5) }
-                BatchHashJoin { type: Inner, predicate: $0 = $3 AND $1 = $4, output_indices: all }
-                  BatchExchange { order: [], dist: HashShard([0, 1]) }
-                    BatchHashJoin { type: LeftSemi, predicate: $0 = $3, output_indices: all }
-                      BatchExchange { order: [], dist: HashShard([0]) }
-                        BatchScan { table: partsupp, columns: [ps_partkey, ps_suppkey, ps_availqty] }
-                      BatchExchange { order: [], dist: HashShard([0]) }
-                        BatchProject { exprs: [$0] }
-                          BatchFilter { predicate: Like($1, 'forest%':Varchar) }
-                            BatchScan { table: part, columns: [p_partkey, p_name] }
-                  BatchProject { exprs: [$0, $1, (0.5:Decimal * $2)] }
-                    BatchHashAgg { group_keys: [$0, $1], aggs: [sum($2)] }
-                      BatchExchange { order: [], dist: HashShard([0, 1]) }
-                        BatchProject { exprs: [$0, $1, $2] }
-                          BatchFilter { predicate: ($3 >= '1994-01-01':Varchar::Date) AND ($3 < ('1994-01-01':Varchar::Date + '1 year 00:00:00':Interval)) }
-                            BatchScan { table: lineitem, columns: [l_partkey, l_suppkey, l_quantity, l_shipdate] }
+    BatchSort { order: [$0 ASC] }
+      BatchHashJoin { type: LeftSemi, predicate: $0 = $3, output_indices: [1, 2] }
+        BatchExchange { order: [], dist: HashShard([0]) }
+          BatchHashJoin { type: Inner, predicate: $3 = $4, output_indices: [0, 1, 2] }
+            BatchExchange { order: [], dist: HashShard([3]) }
+              BatchScan { table: supplier, columns: [s_suppkey, s_name, s_address, s_nationkey] }
+            BatchExchange { order: [], dist: HashShard([0]) }
+              BatchProject { exprs: [$0] }
+                BatchFilter { predicate: ($1 = 'KENYA':Varchar) }
+                  BatchScan { table: nation, columns: [n_nationkey, n_name] }
+        BatchExchange { order: [], dist: HashShard([0]) }
+          BatchProject { exprs: [$1] }
+            BatchFilter { predicate: ($2 > $5) }
+              BatchHashJoin { type: Inner, predicate: $0 = $3 AND $1 = $4, output_indices: all }
+                BatchExchange { order: [], dist: HashShard([0, 1]) }
+                  BatchHashJoin { type: LeftSemi, predicate: $0 = $3, output_indices: all }
+                    BatchExchange { order: [], dist: HashShard([0]) }
+                      BatchScan { table: partsupp, columns: [ps_partkey, ps_suppkey, ps_availqty] }
+                    BatchExchange { order: [], dist: HashShard([0]) }
+                      BatchProject { exprs: [$0] }
+                        BatchFilter { predicate: Like($1, 'forest%':Varchar) }
+                          BatchScan { table: part, columns: [p_partkey, p_name] }
+                BatchProject { exprs: [$0, $1, (0.5:Decimal * $2)] }
+                  BatchHashAgg { group_keys: [$0, $1], aggs: [sum($2)] }
+                    BatchExchange { order: [], dist: HashShard([0, 1]) }
+                      BatchProject { exprs: [$0, $1, $2] }
+                        BatchFilter { predicate: ($3 >= '1994-01-01':Varchar::Date) AND ($3 < ('1994-01-01':Varchar::Date + '1 year 00:00:00':Interval)) }
+                          BatchScan { table: lineitem, columns: [l_partkey, l_suppkey, l_quantity, l_shipdate] }
   stream_plan: |
     StreamMaterialize { columns: [s_name, s_address, _row_id(hidden), _row_id#1(hidden)], pk_columns: [_row_id, _row_id#1], order_descs: [s_name, _row_id, _row_id#1], order: [s_name ASC] }
       StreamExchange { dist: HashShard([2, 3]) }
@@ -2292,23 +2281,22 @@
             LogicalAgg { group_keys: [], agg_calls: [sum($0), count($0)] }
               LogicalScan { table: customer, output_columns: [c_acctbal], required_columns: [$6:c_acctbal, $5:c_phone], predicate: ($6 > 0.00:Decimal) AND In(Substr($5, 1:Int32, 2:Int32), '30':Varchar, '24':Varchar, '31':Varchar, '38':Varchar, '25':Varchar, '34':Varchar, '37':Varchar) }
   batch_plan: |
-    BatchExchange { order: [$0 ASC], dist: Single }
-      BatchSort { order: [$0 ASC] }
-        BatchHashAgg { group_keys: [$0], aggs: [count, sum($1)] }
-          BatchExchange { order: [], dist: HashShard([0]) }
-            BatchProject { exprs: [Substr($0, 1:Int32, 2:Int32), $1] }
-              BatchNestedLoopJoin { type: Inner, predicate: ($1 > $2), output_indices: [0, 1] }
-                BatchExchange { order: [], dist: Single }
-                  BatchHashJoin { type: LeftAnti, predicate: $0 = $3, output_indices: [1, 2] }
-                    BatchExchange { order: [], dist: HashShard([0]) }
-                      BatchFilter { predicate: In(Substr($1, 1:Int32, 2:Int32), '30':Varchar, '24':Varchar, '31':Varchar, '38':Varchar, '25':Varchar, '34':Varchar, '37':Varchar) }
-                        BatchScan { table: customer, columns: [c_custkey, c_phone, c_acctbal] }
-                    BatchExchange { order: [], dist: HashShard([0]) }
-                      BatchScan { table: orders, columns: [o_custkey] }
-                BatchProject { exprs: [($0 / $1)] }
-                  BatchSimpleAgg { aggs: [sum($0), sum($1)] }
-                    BatchExchange { order: [], dist: Single }
-                      BatchSimpleAgg { aggs: [sum($0), count($0)] }
-                        BatchProject { exprs: [$0] }
-                          BatchFilter { predicate: ($0 > 0.00:Decimal) AND In(Substr($1, 1:Int32, 2:Int32), '30':Varchar, '24':Varchar, '31':Varchar, '38':Varchar, '25':Varchar, '34':Varchar, '37':Varchar) }
-                            BatchScan { table: customer, columns: [c_acctbal, c_phone] }
+    BatchSort { order: [$0 ASC] }
+      BatchHashAgg { group_keys: [$0], aggs: [count, sum($1)] }
+        BatchExchange { order: [], dist: HashShard([0]) }
+          BatchProject { exprs: [Substr($0, 1:Int32, 2:Int32), $1] }
+            BatchNestedLoopJoin { type: Inner, predicate: ($1 > $2), output_indices: [0, 1] }
+              BatchExchange { order: [], dist: Single }
+                BatchHashJoin { type: LeftAnti, predicate: $0 = $3, output_indices: [1, 2] }
+                  BatchExchange { order: [], dist: HashShard([0]) }
+                    BatchFilter { predicate: In(Substr($1, 1:Int32, 2:Int32), '30':Varchar, '24':Varchar, '31':Varchar, '38':Varchar, '25':Varchar, '34':Varchar, '37':Varchar) }
+                      BatchScan { table: customer, columns: [c_custkey, c_phone, c_acctbal] }
+                  BatchExchange { order: [], dist: HashShard([0]) }
+                    BatchScan { table: orders, columns: [o_custkey] }
+              BatchProject { exprs: [($0 / $1)] }
+                BatchSimpleAgg { aggs: [sum($0), sum($1)] }
+                  BatchExchange { order: [], dist: Single }
+                    BatchSimpleAgg { aggs: [sum($0), count($0)] }
+                      BatchProject { exprs: [$0] }
+                        BatchFilter { predicate: ($0 > 0.00:Decimal) AND In(Substr($1, 1:Int32, 2:Int32), '30':Varchar, '24':Varchar, '31':Varchar, '38':Varchar, '25':Varchar, '34':Varchar, '37':Varchar) }
+                          BatchScan { table: customer, columns: [c_acctbal, c_phone] }

--- a/src/frontend/test_runner/tests/testdata/tpch.yaml
+++ b/src/frontend/test_runner/tests/testdata/tpch.yaml
@@ -123,7 +123,7 @@
                 BatchFilter { predicate: ($6 <= ('1998-12-01':Varchar::Date - '71 days 00:00:00':Interval)) }
                   BatchScan { table: lineitem, columns: [l_quantity, l_extendedprice, l_discount, l_tax, l_returnflag, l_linestatus, l_shipdate] }
   stream_plan: |
-    StreamMaterialize { columns: [l_returnflag, l_linestatus, sum_qty, sum_base_price, sum_disc_price, sum_charge, avg_qty, avg_price, avg_disc, count_order], pk_columns: [l_returnflag, l_linestatus] }
+    StreamMaterialize { columns: [l_returnflag, l_linestatus, sum_qty, sum_base_price, sum_disc_price, sum_charge, avg_qty, avg_price, avg_disc, count_order], pk_columns: [l_returnflag, l_linestatus], order: [l_returnflag ASC, l_linestatus ASC] }
       StreamProject { exprs: [$0, $1, $3, $4, $5, $6, RoundDigit(($7 / $8), 4:Int32), RoundDigit(($9 / $10), 4:Int32), RoundDigit(($11 / $12), 4:Int32), $13] }
         StreamHashAgg { group_keys: [$0, $1], aggs: [count, sum($2), sum($3), sum($4), sum($5), sum($2), count($2), sum($3), count($3), sum($6), count($6), count] }
           StreamExchange { dist: HashShard([0, 1]) }
@@ -271,7 +271,7 @@
                       BatchFilter { predicate: ($1 = 'AFRICA':Varchar) }
                         BatchScan { table: region, columns: [r_regionkey, r_name] }
   stream_plan: |
-    StreamMaterialize { columns: [s_acctbal, s_name, n_name, p_partkey, p_mfgr, s_address, s_phone, s_comment, _row_id(hidden), _row_id#1(hidden), _row_id#2(hidden), _row_id#3(hidden), _row_id#4(hidden), ps_partkey(hidden)], pk_columns: [_row_id, _row_id#1, _row_id#2, _row_id#3, _row_id#4, ps_partkey], order_descs: [s_acctbal, n_name, s_name, p_partkey, _row_id, _row_id#1, _row_id#2, _row_id#3, _row_id#4, ps_partkey] }
+    StreamMaterialize { columns: [s_acctbal, s_name, n_name, p_partkey, p_mfgr, s_address, s_phone, s_comment, _row_id(hidden), _row_id#1(hidden), _row_id#2(hidden), _row_id#3(hidden), _row_id#4(hidden), ps_partkey(hidden)], pk_columns: [_row_id, _row_id#1, _row_id#2, _row_id#3, _row_id#4, ps_partkey], order_descs: [s_acctbal, n_name, s_name, p_partkey, _row_id, _row_id#1, _row_id#2, _row_id#3, _row_id#4, ps_partkey], order: [s_acctbal DESC, n_name ASC, s_name ASC, p_partkey ASC] }
       StreamTopN { order: [$0 DESC, $2 ASC, $1 ASC, $3 ASC], limit: 100, offset: 0 }
         StreamExchange { dist: Single }
           StreamProject { exprs: [$5, $2, $7, $0, $1, $3, $4, $6, $8, $9, $10, $11, $12, $13] }
@@ -385,7 +385,7 @@
                       BatchFilter { predicate: ($3 > '1995-03-29':Varchar::Date) }
                         BatchScan { table: lineitem, columns: [l_orderkey, l_extendedprice, l_discount, l_shipdate] }
   stream_plan: |
-    StreamMaterialize { columns: [l_orderkey, revenue, o_orderdate, o_shippriority], pk_columns: [l_orderkey, o_orderdate, o_shippriority], order_descs: [revenue, o_orderdate, l_orderkey, o_shippriority] }
+    StreamMaterialize { columns: [l_orderkey, revenue, o_orderdate, o_shippriority], pk_columns: [l_orderkey, o_orderdate, o_shippriority], order_descs: [revenue, o_orderdate, l_orderkey, o_shippriority], order: [revenue DESC, o_orderdate ASC] }
       StreamTopN { order: [$1 DESC, $2 ASC], limit: 10, offset: 0 }
         StreamExchange { dist: Single }
           StreamProject { exprs: [$0, $4, $1, $2] }
@@ -461,7 +461,7 @@
                   BatchFilter { predicate: ($1 < $2) }
                     BatchScan { table: lineitem, columns: [l_orderkey, l_commitdate, l_receiptdate] }
   stream_plan: |
-    StreamMaterialize { columns: [o_orderpriority, agg#0(hidden), order_count], pk_columns: [o_orderpriority] }
+    StreamMaterialize { columns: [o_orderpriority, agg#0(hidden), order_count], pk_columns: [o_orderpriority], order: [o_orderpriority ASC] }
       StreamHashAgg { group_keys: [$0], aggs: [count, count] }
         StreamExchange { dist: HashShard([0]) }
           StreamHashJoin { type: LeftSemi, predicate: $0 = $3, output_indices: [1, 2] }
@@ -563,7 +563,7 @@
                     BatchFilter { predicate: ($1 = 'MIDDLE EAST':Varchar) }
                       BatchScan { table: region, columns: [r_regionkey, r_name] }
   stream_plan: |
-    StreamMaterialize { columns: [n_name, agg#0(hidden), revenue], pk_columns: [n_name], order_descs: [revenue, n_name] }
+    StreamMaterialize { columns: [n_name, agg#0(hidden), revenue], pk_columns: [n_name], order_descs: [revenue, n_name], order: [revenue DESC] }
       StreamHashAgg { group_keys: [$0], aggs: [count, sum($1)] }
         StreamExchange { dist: HashShard([0]) }
           StreamProject { exprs: [$2, ($0 * (1:Int32 - $1)), $3, $4, $5, $6, $7, $8] }
@@ -734,7 +734,7 @@
                   BatchExchange { order: [], dist: HashShard([0]) }
                     BatchScan { table: nation, columns: [n_nationkey, n_name] }
   stream_plan: |
-    StreamMaterialize { columns: [supp_nation, cust_nation, l_year, agg#0(hidden), revenue], pk_columns: [supp_nation, cust_nation, l_year] }
+    StreamMaterialize { columns: [supp_nation, cust_nation, l_year, agg#0(hidden), revenue], pk_columns: [supp_nation, cust_nation, l_year], order: [supp_nation ASC, cust_nation ASC, l_year ASC] }
       StreamHashAgg { group_keys: [$0, $1, $2], aggs: [count, sum($3)] }
         StreamExchange { dist: HashShard([0, 1, 2]) }
           StreamProject { exprs: [$4, $11, Extract('YEAR':Varchar, $2), ($0 * (1:Int32 - $1)), $5, $6, $7, $8, $9, $12] }
@@ -886,7 +886,7 @@
                       BatchFilter { predicate: ($1 = 'ASIA':Varchar) }
                         BatchScan { table: region, columns: [r_regionkey, r_name] }
   stream_plan: |
-    StreamMaterialize { columns: [o_year, mkt_share], pk_columns: [o_year] }
+    StreamMaterialize { columns: [o_year, mkt_share], pk_columns: [o_year], order: [o_year ASC] }
       StreamProject { exprs: [$0, RoundDigit(($2 / $3), 6:Int32)] }
         StreamHashAgg { group_keys: [$0], aggs: [count, sum($1), sum($2)] }
           StreamExchange { dist: HashShard([0]) }
@@ -1026,7 +1026,7 @@
                   BatchExchange { order: [], dist: HashShard([0]) }
                     BatchScan { table: nation, columns: [n_nationkey, n_name] }
   stream_plan: |
-    StreamMaterialize { columns: [nation, o_year, sum_profit], pk_columns: [nation, o_year] }
+    StreamMaterialize { columns: [nation, o_year, sum_profit], pk_columns: [nation, o_year], order: [nation ASC, o_year DESC] }
       StreamProject { exprs: [$0, $1, RoundDigit($3, 2:Int32)] }
         StreamHashAgg { group_keys: [$0, $1], aggs: [count, sum($2)] }
           StreamExchange { dist: HashShard([0, 1]) }
@@ -1140,7 +1140,7 @@
                   BatchExchange { order: [], dist: HashShard([0]) }
                     BatchScan { table: nation, columns: [n_nationkey, n_name] }
   stream_plan: |
-    StreamMaterialize { columns: [c_custkey, c_name, revenue, c_acctbal, n_name, c_address, c_phone, c_comment], pk_columns: [c_custkey, c_name, c_acctbal, c_phone, n_name, c_address, c_comment], order_descs: [revenue, c_custkey, c_name, c_acctbal, c_phone, n_name, c_address, c_comment] }
+    StreamMaterialize { columns: [c_custkey, c_name, revenue, c_acctbal, n_name, c_address, c_phone, c_comment], pk_columns: [c_custkey, c_name, c_acctbal, c_phone, n_name, c_address, c_comment], order_descs: [revenue, c_custkey, c_name, c_acctbal, c_phone, n_name, c_address, c_comment], order: [revenue DESC] }
       StreamTopN { order: [$2 DESC], limit: 20, offset: 0 }
         StreamExchange { dist: Single }
           StreamProject { exprs: [$0, $1, $8, $2, $4, $5, $3, $6] }
@@ -1328,7 +1328,7 @@
                     BatchFilter { predicate: In($1, 'FOB':Varchar, 'SHIP':Varchar) AND ($3 < $4) AND ($2 < $3) AND ($4 >= '1994-01-01':Varchar::Date) AND ($4 < ('1994-01-01':Varchar::Date + '1 year 00:00:00':Interval)) }
                       BatchScan { table: lineitem, columns: [l_orderkey, l_shipmode, l_shipdate, l_commitdate, l_receiptdate] }
   stream_plan: |
-    StreamMaterialize { columns: [l_shipmode, agg#0(hidden), high_line_count, low_line_count], pk_columns: [l_shipmode] }
+    StreamMaterialize { columns: [l_shipmode, agg#0(hidden), high_line_count, low_line_count], pk_columns: [l_shipmode], order: [l_shipmode ASC] }
       StreamHashAgg { group_keys: [$0], aggs: [count, sum($1), sum($2)] }
         StreamExchange { dist: HashShard([0]) }
           StreamProject { exprs: [$1, Case((($0 = '1-URGENT':Varchar) OR ($0 = '2-HIGH':Varchar)), 1:Int32, 0:Int32), Case((($0 <> '1-URGENT':Varchar) AND ($0 <> '2-HIGH':Varchar)), 1:Int32, 0:Int32), $2, $3] }
@@ -1395,7 +1395,7 @@
                       BatchFilter { predicate: Not(Like($2, '%:1%:2%':Varchar)) }
                         BatchScan { table: orders, columns: [o_orderkey, o_custkey, o_comment] }
   stream_plan: |
-    StreamMaterialize { columns: [c_count, agg#0(hidden), custdist], pk_columns: [c_count], order_descs: [custdist, c_count] }
+    StreamMaterialize { columns: [c_count, agg#0(hidden), custdist], pk_columns: [c_count], order_descs: [custdist, c_count], order: [custdist DESC, c_count DESC] }
       StreamHashAgg { group_keys: [$0], aggs: [count, count] }
         StreamExchange { dist: HashShard([0]) }
           StreamProject { exprs: [$2, $0] }
@@ -1556,7 +1556,7 @@
                           BatchFilter { predicate: ($3 >= '1993-01-01':Varchar::Date) AND ($3 < ('1993-01-01':Varchar::Date + '3 mons 00:00:00':Interval)) }
                             BatchScan { table: lineitem, columns: [l_suppkey, l_extendedprice, l_discount, l_shipdate] }
   stream_plan: |
-    StreamMaterialize { columns: [s_suppkey, s_name, s_address, s_phone, total_revenue, _row_id(hidden), l_suppkey(hidden)], pk_columns: [_row_id, l_suppkey], order_descs: [s_suppkey, _row_id, l_suppkey] }
+    StreamMaterialize { columns: [s_suppkey, s_name, s_address, s_phone, total_revenue, _row_id(hidden), l_suppkey(hidden)], pk_columns: [_row_id, l_suppkey], order_descs: [s_suppkey, _row_id, l_suppkey], order: [s_suppkey ASC] }
       StreamExchange { dist: HashShard([5, 6]) }
         StreamHashJoin { type: Inner, predicate: $4 = $8, output_indices: [0, 1, 2, 3, 4, 5, 6] }
           StreamExchange { dist: HashShard([4]) }
@@ -1650,7 +1650,7 @@
                     BatchFilter { predicate: Like($1, '%Customer%Complaints%':Varchar) }
                       BatchScan { table: supplier, columns: [s_suppkey, s_comment] }
   stream_plan: |
-    StreamMaterialize { columns: [p_brand, p_type, p_size, agg#0(hidden), supplier_cnt], pk_columns: [p_brand, p_type, p_size], order_descs: [supplier_cnt, p_brand, p_type, p_size] }
+    StreamMaterialize { columns: [p_brand, p_type, p_size, agg#0(hidden), supplier_cnt], pk_columns: [p_brand, p_type, p_size], order_descs: [supplier_cnt, p_brand, p_type, p_size], order: [supplier_cnt DESC, p_brand ASC, p_type ASC, p_size ASC] }
       StreamHashAgg { group_keys: [$0, $1, $2], aggs: [count, count(distinct $3)] }
         StreamExchange { dist: HashShard([0, 1, 2]) }
           StreamProject { exprs: [$1, $2, $3, $0, $4, $5] }
@@ -1842,7 +1842,7 @@
                     BatchExchange { order: [], dist: HashShard([0]) }
                       BatchScan { table: lineitem, columns: [l_orderkey, l_quantity] }
   stream_plan: |
-    StreamMaterialize { columns: [c_name, c_custkey, o_orderkey, o_orderdate, o_totalprice, agg#0(hidden), quantity], pk_columns: [c_name, c_custkey, o_orderkey, o_orderdate, o_totalprice], order_descs: [o_totalprice, o_orderdate, c_name, c_custkey, o_orderkey] }
+    StreamMaterialize { columns: [c_name, c_custkey, o_orderkey, o_orderdate, o_totalprice, agg#0(hidden), quantity], pk_columns: [c_name, c_custkey, o_orderkey, o_orderdate, o_totalprice], order_descs: [o_totalprice, o_orderdate, c_name, c_custkey, o_orderkey], order: [o_totalprice DESC, o_orderdate ASC] }
       StreamTopN { order: [$4 DESC, $3 ASC], limit: 100, offset: 0 }
         StreamExchange { dist: Single }
           StreamHashAgg { group_keys: [$0, $1, $2, $3, $4], aggs: [count, sum($5)] }
@@ -2048,7 +2048,7 @@
                           BatchFilter { predicate: ($3 >= '1994-01-01':Varchar::Date) AND ($3 < ('1994-01-01':Varchar::Date + '1 year 00:00:00':Interval)) }
                             BatchScan { table: lineitem, columns: [l_partkey, l_suppkey, l_quantity, l_shipdate] }
   stream_plan: |
-    StreamMaterialize { columns: [s_name, s_address, _row_id(hidden), _row_id#1(hidden)], pk_columns: [_row_id, _row_id#1], order_descs: [s_name, _row_id, _row_id#1] }
+    StreamMaterialize { columns: [s_name, s_address, _row_id(hidden), _row_id#1(hidden)], pk_columns: [_row_id, _row_id#1], order_descs: [s_name, _row_id, _row_id#1], order: [s_name ASC] }
       StreamExchange { dist: HashShard([2, 3]) }
         StreamHashJoin { type: LeftSemi, predicate: $0 = $5, output_indices: [1, 2, 3, 4] }
           StreamExchange { dist: HashShard([0]) }
@@ -2190,7 +2190,7 @@
                   BatchFilter { predicate: ($3 > $2) }
                     BatchScan { table: lineitem, columns: [l_orderkey, l_suppkey, l_commitdate, l_receiptdate] }
   stream_plan: |
-    StreamMaterialize { columns: [s_name, agg#0(hidden), numwait], pk_columns: [s_name], order_descs: [numwait, s_name] }
+    StreamMaterialize { columns: [s_name, agg#0(hidden), numwait], pk_columns: [s_name], order_descs: [numwait, s_name], order: [numwait DESC, s_name ASC] }
       StreamTopN { order: [$2 DESC, $0 ASC], limit: 100, offset: 0 }
         StreamExchange { dist: Single }
           StreamHashAgg { group_keys: [$0], aggs: [count, count] }


### PR DESCRIPTION
I hereby agree to the terms of the [Singularity Data, Inc. Contributor License Agreement](https://gist.github.com/skyzh/0663682a70b0edde7ae991492f2314cb#file-s9y_cla).

## What's changed and what's your intention?

As title
- add `user_order_by` in table catalog, so that we can know whether an mv is ordered
- if an mv is ordered, enforce order when batch scan on it

## Checklist

- [x] I have written necessary rustdoc comments
- [x] I have added necessary unit tests and integration tests
- [x] All checks passed in `./risedev check` (or alias, `./risedev c`)


## Refer to a related PR or issue link (optional)
#3583 
close #3237