### PR TITLE
feat: kafka json append only sink

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4236,6 +4236,7 @@ dependencies = [
  "static_assertions",
  "tempfile",
  "thiserror",
+ "tokio-retry",
  "tokio-stream",
  "tokio-util",
  "twox-hash",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4239,6 +4239,7 @@ dependencies = [
  "tokio-retry",
  "tokio-stream",
  "tokio-util",
+ "tracing",
  "twox-hash",
  "url",
  "urlencoding",

--- a/proto/stream_plan.proto
+++ b/proto/stream_plan.proto
@@ -81,6 +81,7 @@ message SourceNode {
 message SinkNode {
   uint32 table_id = 1;
   repeated int32 column_ids = 2;
+  map<string, string> properties = 3;
 }
 
 message ProjectNode {

--- a/src/common/src/error.rs
+++ b/src/common/src/error.rs
@@ -144,7 +144,7 @@ pub enum ErrorCode {
     },
     #[error("Invalid Parameter Value: {0}")]
     InvalidParameterValue(String),
-    #[error("MySQL error: {0}")]
+    #[error("Sink error: {0}")]
     SinkError(BoxedError),
 
     /// This error occurs when the meta node receives heartbeat from a previous removed worker

--- a/src/connector/Cargo.toml
+++ b/src/connector/Cargo.toml
@@ -57,6 +57,7 @@ tokio-retry = "0.3"
 tokio-stream = "0.1"
 tokio-util = { version = "0.7", features = ["codec", "io"] }
 tonic = { version = "=0.2.0-alpha.3", package = "madsim-tonic" }
+tracing = { version = "0.1" }
 twox-hash = "1"
 url = "2"
 urlencoding = "2"

--- a/src/connector/Cargo.toml
+++ b/src/connector/Cargo.toml
@@ -53,6 +53,7 @@ static_assertions = "1"
 tempfile = "3"
 thiserror = "1"
 tokio = { version = "=0.2.0-alpha.3", package = "madsim-tokio", features = ["rt", "rt-multi-thread", "sync", "macros", "time", "signal", "fs"] }
+tokio-retry = "0.3"
 tokio-stream = "0.1"
 tokio-util = { version = "0.7", features = ["codec", "io"] }
 tonic = { version = "=0.2.0-alpha.3", package = "madsim-tonic" }

--- a/src/connector/src/lib.rs
+++ b/src/connector/src/lib.rs
@@ -17,6 +17,7 @@
 #![feature(generators)]
 #![feature(proc_macro_hygiene)]
 #![feature(stmt_expr_attributes)]
+#![feature(box_patterns)]
 #![warn(clippy::dbg_macro)]
 #![warn(clippy::disallowed_methods)]
 #![warn(clippy::doc_markdown)]

--- a/src/connector/src/sink/kafka.rs
+++ b/src/connector/src/sink/kafka.rs
@@ -31,7 +31,7 @@ use serde_json::{json, Map, Value};
 use tokio::task;
 
 use super::{Sink, SinkError};
-use crate::sink::{Result, SinkState};
+use crate::sink::Result;
 
 pub const KAFKA_SINK: &str = "kafka";
 

--- a/src/connector/src/sink/kafka.rs
+++ b/src/connector/src/sink/kafka.rs
@@ -241,10 +241,6 @@ impl Sink for KafkaSink {
             .await
             .map_err(SinkError::Kafka)
     }
-
-    async fn take_snapshot(&self) -> Result<SinkState> {
-        todo!()
-    }
 }
 
 fn datum_to_json_object(field: &Field, datum: DatumRef) -> ArrayResult<Value> {

--- a/src/connector/src/sink/kafka.rs
+++ b/src/connector/src/sink/kafka.rs
@@ -1,0 +1,217 @@
+// Copyright 2022 Singularity Data
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::collections::HashMap;
+use std::sync::Arc;
+
+use aws_sdk_kinesis::model::record;
+use aws_sdk_s3::model::FilterRuleName;
+use rdkafka::config::RDKafkaLogLevel;
+use rdkafka::producer::{DefaultProducerContext, FutureProducer};
+use rdkafka::ClientConfig;
+use risingwave_common::array::{ArrayBuilder, StreamChunk, RowRef};
+use risingwave_common::catalog::{Schema, Field};
+use risingwave_common::error::{ErrorCode, RwError};
+use risingwave_common::types::DataType;
+use serde::Deserialize;
+use serde_json::{Value, Map, json};
+
+use risingwave_common::types::{OrderedF32, OrderedF64};
+
+use super::{Sink, SinkError};
+use crate::sink::Result;
+
+pub const KAFKA_SINK: &str = "kafka";
+
+#[derive(Debug, Clone, Deserialize)]
+pub struct KafkaConfig {
+    #[serde(rename = "kafka.brokers")]
+    pub brokers: String,
+
+    #[serde(rename = "kafka.topic")]
+    pub topic: String,
+}
+
+impl KafkaConfig {
+    pub fn from_hashmap(values: HashMap<String, String>) -> Result<Self> {
+        let brokers = values
+            .get("kafka.brokers")
+            .expect("kafka.brokers must be set");
+        let topic = values.get("kafka.topic").expect("kafka.topic must be set");
+
+        Ok(KafkaConfig {
+            brokers: brokers.to_string(),
+            topic: topic.to_string(),
+        })
+    }
+}
+
+pub struct KafkaSink {
+    pub properties: KafkaConfig,
+    pub producer: FutureProducer,
+}
+
+macro_rules! json_type_cast_impl {
+    ( [], $({ $original_type:ident, $scalar:ty })* ) => {
+        $( $original_type => { json!( $scalar::try_from(row.value_at(idx).unwrap()).map_err(|e| SinkError::JsonParse(e.to_string()))?) }, )*
+    };
+}
+
+fn record_to_json(row: RowRef, schema: Vec<Field>) -> Result<Map<String, Value>> {
+    let mut mappings = Map::with_capacity(schema.len());
+    for (idx, field) in schema.iter().enumerate() {
+        let key = field.name.clone();
+
+        let value: Value = match field.data_type {
+            DataType::Boolean => { json!(bool::try_from(row.value_at(idx).unwrap()).map_err(|e| SinkError::JsonParse(e.to_string()))?) },
+            DataType::Int16 => { json!(i16::try_from(row.value_at(idx).unwrap()).map_err(|e| SinkError::JsonParse(e.to_string()))?) },
+            DataType::Int32 => { json!(i32::try_from(row.value_at(idx).unwrap()).map_err(|e| SinkError::JsonParse(e.to_string()))?) },
+            DataType::Int64 => { json!(i64::try_from(row.value_at(idx).unwrap()).map_err(|e| SinkError::JsonParse(e.to_string()))?) },
+            DataType::Float32 => { json!(f32::from(OrderedF32::try_from(row.value_at(idx).unwrap()).map_err(|e| SinkError::JsonParse(e.to_string()))?)) },
+            DataType::Float64 => { json!(f64::from(OrderedF64::try_from(row.value_at(idx).unwrap()).map_err(|e| SinkError::JsonParse(e.to_string()))?)) },
+            DataType::Varchar => { json!(row.value_at(idx).unwrap().into_scalar_impl().to_string()) }
+            // DataType::List { datatype } => {}
+            // DataType::Struct { fields: _ } => {
+            //     let x = row.value_at(idx).unwrap().into_scalar_impl().to_string();
+            //     let obj_value = record_to_json(, field.sub_fields.clone())?;
+            //     Value::Object(obj_value)
+            // },
+            _ => unimplemented!(),
+        };
+        mappings.insert(key, value);
+    }
+    Ok(mappings)
+}
+
+pub fn chunk_to_json(chunk: StreamChunk, schema: &Schema) -> Result<Vec<String>> {
+    let mut records: Vec<String> = Vec::with_capacity(chunk.capacity());
+    for (_, row) in chunk.rows() {
+        let record = Value::Object(record_to_json(row, schema.fields.clone())?);
+        records.push(record.to_string());
+    }
+    
+    Ok(records)
+}
+
+impl KafkaSink {
+    async fn new(config: KafkaConfig) -> Result<Self> {
+        let producer = ClientConfig::new()
+            .set("bootstrap.servers", config.brokers.as_str())
+            .set("message.timeout.ms", "5000")
+            .create()
+            .expect("Producer creation error");
+
+        Ok(KafkaSink {
+            properties: config,
+            producer,
+        })
+    }
+
+    async fn flush(&mut self) -> Result<()> {
+        Ok(())
+    }
+}
+
+#[async_trait::async_trait]
+impl Sink for KafkaSink {
+    async fn write_batch(&mut self, chunk: StreamChunk, _schema: &Schema) -> Result<()> {
+        Ok(())
+    }
+}
+
+mod test {
+    use rdkafka::producer::FutureRecord;
+    use risingwave_common::array;
+    use risingwave_common::array::column::Column;
+    use risingwave_common::array::{
+        ArrayImpl, ArrayMeta, DataChunk, F32Array, F32ArrayBuilder, I32Array, I32ArrayBuilder,
+        PrimitiveArrayBuilder, StructArray, StructArrayBuilder, Vis,
+    };
+    use risingwave_common::types::{DataType, OrderedF32};
+
+    use super::*;
+
+    #[tokio::test]
+    async fn test_kafka_producer() -> Result<()> {
+        let kafka_config = KafkaConfig {
+            brokers: "127.0.0.1:29092".to_string(),
+            topic: "test_producer".to_string(),
+        };
+        let sink = KafkaSink::new(kafka_config).await.unwrap();
+
+        // let content = FutureRecord::to("test_producer").payload("1");
+
+        Ok(())
+    }
+
+    #[test]
+    fn test_chunk_to_json() -> Result<()> {
+        let mut column_i32_builder = I32ArrayBuilder::new(10);
+        for i in 0..10 {
+            column_i32_builder.append(Some(i)).unwrap();
+        }
+        let column_i32 = Column::new(Arc::new(ArrayImpl::from(
+            column_i32_builder.finish().unwrap(),
+        )));
+        let mut column_f32_builder = F32ArrayBuilder::new(10);
+        for i in 0..10 {
+            column_f32_builder
+                .append(Some(OrderedF32::from(i as f32)))
+                .unwrap();
+        }
+        let column_f32 = Column::new(Arc::new(ArrayImpl::from(
+            column_f32_builder.finish().unwrap(),
+        )));
+
+        let column_struct = Column::new(Arc::new(ArrayImpl::from(StructArray::from_slices(
+            &[true, true, true, true, true, true, true, true, true, true],
+            vec![
+                array! { I32Array, [Some(1), Some(2), Some(3), Some(4), Some(5), Some(6), Some(7), Some(8), Some(9), Some(10)] }.into(),
+                array! { F32Array, [Some(1.0), Some(2.0), Some(3.0), Some(4.0), Some(5.0), Some(6.0), Some(7.0), Some(8.0), Some(9.0), Some(10.0)] }.into(),
+            ],
+            vec![DataType::Int32, DataType::Float32],
+        )
+        .unwrap())));
+
+        let chunk = DataChunk::new(
+            vec![column_i32, column_f32],
+            Vis::Compact(10),
+        );
+
+        let chunk = StreamChunk {
+            
+        };
+
+        // let x = chunk.row_at(0).unwrap().0.value_at(2).unwrap().into_scalar_impl().into_struct();
+        // println!("{:?}", x);
+
+        let schema = Schema::new(vec![
+            Field {
+                data_type: DataType::Int32, 
+                name: "v1".into(),
+                sub_fields: vec![],
+                type_name: "".into(),
+            }, Field {
+                data_type: DataType::Float32, 
+                name: "v2".into(),
+                sub_fields: vec![],
+                type_name: "".into(),
+            }
+        ]);
+
+        println!("{:?}", chunk_to_json(chunk, &schema));
+
+        Ok(())
+    }
+}

--- a/src/connector/src/sink/kafka.rs
+++ b/src/connector/src/sink/kafka.rs
@@ -13,20 +13,21 @@
 // limitations under the License.
 
 use std::collections::HashMap;
+use std::sync::Arc;
+use std::time::Duration;
 
-
-
-
-
-use rdkafka::producer::{FutureProducer};
+use futures::{Future, TryFutureExt};
+use rdkafka::error::{KafkaError, KafkaResult};
+use rdkafka::message::ToBytes;
+use rdkafka::producer::{BaseRecord, DefaultProducerContext, Producer, ThreadedProducer};
 use rdkafka::ClientConfig;
-use risingwave_common::array::{ArrayBuilder, ArrayResult, RowRef, StreamChunk};
+use rdkafka::types::RDKafkaErrorCode;
+use risingwave_common::array::{ArrayResult, RowRef, StreamChunk};
 use risingwave_common::catalog::{Field, Schema};
-
-
-use risingwave_common::types::{DataType, DatumRef, OrderedF32, OrderedF64, ScalarRefImpl};
+use risingwave_common::types::{DataType, DatumRef, ScalarRefImpl};
 use serde::Deserialize;
 use serde_json::{json, Map, Value};
+use tokio::task;
 
 use super::{Sink, SinkError};
 use crate::sink::Result;
@@ -40,6 +41,16 @@ pub struct KafkaConfig {
 
     #[serde(rename = "kafka.topic")]
     pub topic: String,
+
+    // Optional. If not specified, the default value is None and messages are sent to random
+    // partition. if we want to guarantee exactly once delivery, we need to specify the
+    // partition number.
+    // (the partition number should set by meta)
+    pub partition: Option<i32>,
+
+    pub timeout: Duration,
+    pub max_retry_num: i32,
+    pub retry_interval: Duration,
 }
 
 impl KafkaConfig {
@@ -52,22 +63,102 @@ impl KafkaConfig {
         Ok(KafkaConfig {
             brokers: brokers.to_string(),
             topic: topic.to_string(),
+            partition: None,
+            timeout: Duration::from_secs(5), // default timeout is 5 seconds
+            max_retry_num: 3,                // default max retry num is 3
+            retry_interval: Duration::from_millis(100), // default retry interval is 100ms
         })
     }
 }
 
 pub struct KafkaSink {
-    pub properties: KafkaConfig,
-    pub producer: FutureProducer,
+    pub config: KafkaConfig,
+    pub conductor: KafkaTransactionConductor,
+    latest_epoch: u64,
 }
 
-macro_rules! json_type_cast_impl {
-    ( [], $({ $original_type:ident, $scalar:ty })* ) => {
-        $( $original_type => { json!( $scalar::try_from(row.value_at(idx).unwrap()).map_err(|e| SinkError::JsonParse(e.to_string()))?) }, )*
-    };
+impl KafkaSink {
+    pub async fn new(config: KafkaConfig) -> Result<Self> {
+        Ok(KafkaSink {
+            config: config.clone(),
+            conductor: KafkaTransactionConductor::new(config).await?,
+            latest_epoch: 0,
+        })
+    }
+
+    // any error should report to upper level and requires revert to previous epoch.
+    pub async fn do_with_retry<'a, F, FutKR, T>(&self, f: F) -> KafkaResult<T>
+    where
+        F: Fn(KafkaTransactionConductor) -> FutKR,
+        FutKR: Future<Output = KafkaResult<T>>,
+    {
+        let producer = self.conductor.clone();
+        let mut err_placeholder = KafkaError::Canceled;
+        for _ in 0..self.config.max_retry_num {
+            match f(producer.clone()).await {
+                Ok(res) => {
+                    return Ok(res);
+                }
+                Err(e) => {
+                    err_placeholder = e;
+                }
+            }
+            // a back off policy
+            tokio::time::sleep(self.config.retry_interval).await;
+        }
+
+        Err(err_placeholder)
+    }
+
+    async fn send<'a, K, P>(&self, mut record: BaseRecord<'a, K, P>) -> KafkaResult<()>
+    where
+        K: ToBytes + ?Sized,
+        P: ToBytes + ?Sized,
+    {
+        let mut err_placeholder = KafkaError::Canceled;
+        
+        for _ in 0..self.config.max_retry_num {
+            match self.conductor.send(record) {
+                Ok(()) => {
+                    return Ok(());
+                }
+                Err((e, rec)) => {
+                    err_placeholder = e;
+                    record = rec;
+                    if let KafkaError::MessageProduction(RDKafkaErrorCode::QueueFull) = err_placeholder {
+                        // if the queue is full, we need to wait for some time and retry.
+                        tokio::time::sleep(self.config.retry_interval).await;
+                        continue;
+                    } else {
+                        return Err(err_placeholder);
+                    }
+                }
+            }
+        }
+        Err(err_placeholder)
+    }
 }
 
-fn datum_to_json_object(datum: DatumRef, field: &Field) -> ArrayResult<Value> {
+#[async_trait::async_trait]
+impl Sink for KafkaSink {
+    async fn write_batch(&mut self, _chunk: StreamChunk, _schema: &Schema) -> Result<()> {
+        todo!()
+    }
+
+    async fn begin_epoch(&mut self, epoch: u64) -> Result<()> {
+        todo!()
+    }
+
+    async fn commit(&mut self) -> Result<()> {
+        todo!()
+    }
+
+    async fn abort(&mut self) -> Result<()> {
+        todo!()
+    }
+}
+
+fn datum_to_json_object(field: &Field, datum: DatumRef) -> ArrayResult<Value> {
     let scalar_ref = match datum {
         None => return Ok(Value::Null),
         Some(datum) => datum,
@@ -111,7 +202,7 @@ fn datum_to_json_object(datum: DatumRef, field: &Field) -> ArrayResult<Value> {
                 .into_iter()
                 .zip(field.sub_fields.iter())
             {
-                let value = datum_to_json_object(sub_datum_ref, sub_field)?;
+                let value = datum_to_json_object(sub_field, sub_datum_ref)?;
                 vec.push(value);
             }
             json!(vec)
@@ -123,7 +214,7 @@ fn datum_to_json_object(datum: DatumRef, field: &Field) -> ArrayResult<Value> {
                 .into_iter()
                 .zip(field.sub_fields.iter())
             {
-                let value = datum_to_json_object(sub_datum_ref, sub_field)?;
+                let value = datum_to_json_object(sub_field, sub_datum_ref)?;
                 map.insert(sub_field.name.clone(), value);
             }
             json!(map)
@@ -136,49 +227,10 @@ fn datum_to_json_object(datum: DatumRef, field: &Field) -> ArrayResult<Value> {
 
 fn record_to_json(row: RowRef, schema: Vec<Field>) -> Result<Map<String, Value>> {
     let mut mappings = Map::with_capacity(schema.len());
-    for (idx, field) in schema.iter().enumerate() {
+    for (field, datum_ref) in schema.iter().zip(row.values()) {
         let key = field.name.clone();
-
-        let value: Value = match field.data_type {
-            DataType::Boolean => {
-                json!(bool::try_from(row.value_at(idx).unwrap())
-                    .map_err(|e| SinkError::JsonParse(e.to_string()))?)
-            }
-            DataType::Int16 => {
-                json!(i16::try_from(row.value_at(idx).unwrap())
-                    .map_err(|e| SinkError::JsonParse(e.to_string()))?)
-            }
-            DataType::Int32 => {
-                json!(i32::try_from(row.value_at(idx).unwrap())
-                    .map_err(|e| SinkError::JsonParse(e.to_string()))?)
-            }
-            DataType::Int64 => {
-                json!(i64::try_from(row.value_at(idx).unwrap())
-                    .map_err(|e| SinkError::JsonParse(e.to_string()))?)
-            }
-            DataType::Float32 => {
-                json!(f32::from(
-                    OrderedF32::try_from(row.value_at(idx).unwrap())
-                        .map_err(|e| SinkError::JsonParse(e.to_string()))?
-                ))
-            }
-            DataType::Float64 => {
-                json!(f64::from(
-                    OrderedF64::try_from(row.value_at(idx).unwrap())
-                        .map_err(|e| SinkError::JsonParse(e.to_string()))?
-                ))
-            }
-            DataType::Varchar => {
-                json!(row.value_at(idx).unwrap().into_scalar_impl().to_string())
-            }
-            // DataType::List { datatype } => {}
-            // DataType::Struct { fields: _ } => {
-            //     let x = row.value_at(idx).unwrap().into_scalar_impl().to_string();
-            //     let obj_value = record_to_json(, field.sub_fields.clone())?;
-            //     Value::Object(obj_value)
-            // },
-            _ => unimplemented!(),
-        };
+        let value = datum_to_json_object(field, datum_ref)
+            .map_err(|e| SinkError::JsonParse(e.to_string()))?;
         mappings.insert(key, value);
     }
     Ok(mappings)
@@ -194,107 +246,150 @@ pub fn chunk_to_json(chunk: StreamChunk, schema: &Schema) -> Result<Vec<String>>
     Ok(records)
 }
 
-impl KafkaSink {
+/// the struct conducts all transactions with Kafka
+#[derive(Clone)]
+pub struct KafkaTransactionConductor {
+    pub properties: KafkaConfig,
+    pub inner: Arc<ThreadedProducer<DefaultProducerContext>>,
+    in_transaction: bool,
+}
+
+impl KafkaTransactionConductor {
     async fn new(config: KafkaConfig) -> Result<Self> {
-        let producer = ClientConfig::new()
+        let inner = ClientConfig::new()
             .set("bootstrap.servers", config.brokers.as_str())
             .set("message.timeout.ms", "5000")
-            .create()
+            .create_with_context(DefaultProducerContext)
             .expect("Producer creation error");
 
-        Ok(KafkaSink {
+        Ok(KafkaTransactionConductor {
             properties: config,
-            producer,
+            inner: Arc::new(inner),
+            in_transaction: false,
         })
     }
 
-    async fn flush(&mut self) -> Result<()> {
-        Ok(())
+    async fn init_transaction(&self) -> impl Future<Output = KafkaResult<()>> {
+        let inner = self.inner.clone();
+        let timeout = self.properties.timeout.clone();
+        task::spawn_blocking(move || inner.init_transactions(timeout))
+            .unwrap_or_else(|_| Err(KafkaError::Canceled))
     }
-}
 
-#[async_trait::async_trait]
-impl Sink for KafkaSink {
-    async fn write_batch(&mut self, _chunk: StreamChunk, _schema: &Schema) -> Result<()> {
-        Ok(())
+    async fn start_transaction(&self) -> impl Future<Output = KafkaResult<()>> {
+        let inner = Arc::clone(&self.inner);
+        task::spawn_blocking(move || inner.begin_transaction())
+            .unwrap_or_else(|_| Err(KafkaError::Canceled))
+    }
+
+    async fn commit_transaction(&self) -> impl Future<Output = KafkaResult<()>> {
+        let inner = Arc::clone(&self.inner);
+        let timeout = self.properties.timeout.clone();
+        task::spawn_blocking(move || inner.commit_transaction(timeout))
+            .unwrap_or_else(|_| Err(KafkaError::Canceled))
+    }
+
+    async fn abort_transaction(&self) -> impl Future<Output = KafkaResult<()>> {
+        let inner = Arc::clone(&self.inner);
+        let timeout = self.properties.timeout.clone();
+        task::spawn_blocking(move || inner.abort_transaction(timeout))
+            .unwrap_or_else(|_| Err(KafkaError::Canceled))
+    }
+
+    async fn flush(&self) -> impl Future<Output = KafkaResult<()>> {
+        let inner = Arc::clone(&self.inner);
+        let timeout = self.properties.timeout.clone();
+        task::spawn_blocking(move || inner.flush(timeout))
+            .map_ok(|_| KafkaResult::Ok(()))
+            .unwrap_or_else(|_| Err(KafkaError::Canceled))
+    }
+
+    fn send<'a, K, P>(
+        &self,
+        record: BaseRecord<'a, K, P>,
+    ) -> core::result::Result<(), (KafkaError, BaseRecord<'a, K, P>)>
+    where
+        K: ToBytes + ?Sized,
+        P: ToBytes + ?Sized,
+    {
+        self.inner.send(record)
     }
 }
 
 mod test {
-    
-    
-    
-    
-    
+    use super::*;
 
-    
+    // #[tokio::test]
+    // async fn test_kafka_producer() -> Result<()> {
+    //     let kafka_config = KafkaConfig {
+    //         brokers: "127.0.0.1:29092".to_string(),
+    //         topic: "test_producer".to_string(),
+    //     };
+    //     let sink = KafkaSink::new(kafka_config.clone()).await.unwrap();
+    //     let mut content = FutureRecord::to(kafka_config.topic.as_str());
 
-    #[tokio::test]
-    async fn test_kafka_producer() -> Result<()> {
-        let kafka_config = KafkaConfig {
-            brokers: "127.0.0.1:29092".to_string(),
-            topic: "test_producer".to_string(),
-        };
-        let sink = KafkaSink::new(kafka_config).await.unwrap();
+    //     for i in 0..10 {
+    //         content = content.payload(format!("{:?}", i).as_str());
+    //     }
 
-        // let content = FutureRecord::to("test_producer").payload("1");
+    //     Ok(())
+    // }
 
-        Ok(())
-    }
+    // #[test]
+    // fn test_chunk_to_json() -> Result<()> {
+    //     let mut column_i32_builder = I32ArrayBuilder::new(10);
+    //     for i in 0..10 {
+    //         column_i32_builder.append(Some(i)).unwrap();
+    //     }
+    //     let column_i32 = Column::new(Arc::new(ArrayImpl::from(
+    //         column_i32_builder.finish().unwrap(),
+    //     )));
+    //     let mut column_f32_builder = F32ArrayBuilder::new(10);
+    //     for i in 0..10 {
+    //         column_f32_builder
+    //             .append(Some(OrderedF32::from(i as f32)))
+    //             .unwrap();
+    //     }
+    //     let column_f32 = Column::new(Arc::new(ArrayImpl::from(
+    //         column_f32_builder.finish().unwrap(),
+    //     )));
 
-    #[test]
-    fn test_chunk_to_json() -> Result<()> {
-        let mut column_i32_builder = I32ArrayBuilder::new(10);
-        for i in 0..10 {
-            column_i32_builder.append(Some(i)).unwrap();
-        }
-        let column_i32 = Column::new(Arc::new(ArrayImpl::from(
-            column_i32_builder.finish().unwrap(),
-        )));
-        let mut column_f32_builder = F32ArrayBuilder::new(10);
-        for i in 0..10 {
-            column_f32_builder
-                .append(Some(OrderedF32::from(i as f32)))
-                .unwrap();
-        }
-        let column_f32 = Column::new(Arc::new(ArrayImpl::from(
-            column_f32_builder.finish().unwrap(),
-        )));
+    //     let column_struct = Column::new(Arc::new(ArrayImpl::from(StructArray::from_slices(
+    //         &[true, true, true, true, true, true, true, true, true, true],
+    //         vec![
+    //             array! { I32Array, [Some(1), Some(2), Some(3), Some(4), Some(5), Some(6),
+    // Some(7), Some(8), Some(9), Some(10)] }.into(),             array! { F32Array, [Some(1.0),
+    // Some(2.0), Some(3.0), Some(4.0), Some(5.0), Some(6.0), Some(7.0), Some(8.0), Some(9.0),
+    // Some(10.0)] }.into(),         ],
+    //         vec![DataType::Int32, DataType::Float32],
+    //     )
+    //         .unwrap())));
 
-        let column_struct = Column::new(Arc::new(ArrayImpl::from(StructArray::from_slices(
-            &[true, true, true, true, true, true, true, true, true, true],
-            vec![
-                array! { I32Array, [Some(1), Some(2), Some(3), Some(4), Some(5), Some(6), Some(7), Some(8), Some(9), Some(10)] }.into(),
-                array! { F32Array, [Some(1.0), Some(2.0), Some(3.0), Some(4.0), Some(5.0), Some(6.0), Some(7.0), Some(8.0), Some(9.0), Some(10.0)] }.into(),
-            ],
-            vec![DataType::Int32, DataType::Float32],
-        )
-            .unwrap())));
+    //     let chunk = DataChunk::new(vec![column_i32, column_f32], Vis::Compact(10));
 
-        let chunk = DataChunk::new(vec![column_i32, column_f32], Vis::Compact(10));
+    //     // let chunk = StreamChunk {};
 
-        // let chunk = StreamChunk {};
+    //     // let x =
+    // chunk.row_at(0).unwrap().0.value_at(2).unwrap().into_scalar_impl().into_struct();     //
+    // println! ("{:?}", x);
 
-        // let x = chunk.row_at(0).unwrap().0.value_at(2).unwrap().into_scalar_impl().into_struct();
-        // println!("{:?}", x);
+    //     let schema = Schema::new(vec![
+    //         Field {
+    //             data_type: DataType::Int32,
+    //             name: "v1".into(),
+    //             sub_fields: vec![],
+    //             type_name: "".into(),
+    //         },
+    //         Field {
+    //             data_type: DataType::Float32,
+    //             name: "v2".into(),
+    //             sub_fields: vec![],
+    //             type_name: "".into(),
+    //         },
+    //     ]);
 
-        let schema = Schema::new(vec![
-            Field {
-                data_type: DataType::Int32,
-                name: "v1".into(),
-                sub_fields: vec![],
-                type_name: "".into(),
-            },
-            Field {
-                data_type: DataType::Float32,
-                name: "v2".into(),
-                sub_fields: vec![],
-                type_name: "".into(),
-            },
-        ]);
+    //     println!("{:?}", chunk_to_json(chunk, &schema));
 
-        println!("{:?}", chunk_to_json(chunk, &schema));
-
-        Ok(())
-    }
+    //     Ok(())
+    // }
 }

--- a/src/connector/src/sink/kafka.rs
+++ b/src/connector/src/sink/kafka.rs
@@ -199,6 +199,8 @@ impl Sink for KafkaSink {
         }
     }
 
+    //  Note that epoch 0 is reserved for initializing, so we should not use epoch 0 for
+    // transaction.
     async fn begin_epoch(&mut self, epoch: u64) -> Result<()> {
         self.in_transaction_epoch = Some(epoch);
         if self.latest_success_epoch == 0 {

--- a/src/connector/src/sink/mod.rs
+++ b/src/connector/src/sink/mod.rs
@@ -132,14 +132,6 @@ impl Sink for SinkImpl {
             SinkImpl::Kafka(sink) => sink.abort().await,
         }
     }
-
-    async fn take_snapshot(&self) -> Result<SinkState> {
-        match self {
-            SinkImpl::MySQL(sink) => sink.take_snapshot().await,
-            SinkImpl::Redis(sink) => sink.take_snapshot().await,
-            SinkImpl::Kafka(sink) => sink.take_snapshot().await,
-        }
-    }
 }
 
 pub type Result<T> = std::result::Result<T, SinkError>;

--- a/src/connector/src/sink/mod.rs
+++ b/src/connector/src/sink/mod.rs
@@ -35,9 +35,6 @@ use crate::sink::redis::{RedisConfig, RedisSink};
 pub trait Sink {
     async fn write_batch(&mut self, chunk: StreamChunk, schema: &Schema) -> Result<()>;
 
-    // write execution status to state store
-    async fn take_snapshot(&self) -> Result<SinkState>;
-
     // the following interface is for transactions, if not supported, return Ok(())
     // start a transaction with epoch number. Note that epoch number should be increasing.
     async fn begin_epoch(&mut self, epoch: u64) -> Result<()>;

--- a/src/connector/src/sink/mod.rs
+++ b/src/connector/src/sink/mod.rs
@@ -77,12 +77,18 @@ pub enum SinkImpl {
 }
 
 impl SinkImpl {
-    fn new(cfg: SinkConfig) -> Self {
-        match cfg {
-            SinkConfig::Mysql(cfg) => SinkImpl::MySQL(Box::new(MySQLSink::new(cfg))),
-            SinkConfig::Redis(cfg) => SinkImpl::Redis(Box::new(RedisSink::new(cfg))),
-            SinkConfig::Kafka(_) => todo!(),
-        }
+    pub async fn new(cfg: SinkConfig) -> RwResult<Self> {
+        Ok(match cfg {
+            SinkConfig::Mysql(cfg) => {
+                SinkImpl::MySQL(Box::new(MySQLSink::new(cfg).map_err(RwError::from)?))
+            }
+            SinkConfig::Redis(cfg) => {
+                SinkImpl::Redis(Box::new(RedisSink::new(cfg).map_err(RwError::from)?))
+            }
+            SinkConfig::Kafka(cfg) => {
+                SinkImpl::Kafka(Box::new(KafkaSink::new(cfg).await.map_err(RwError::from)?))
+            }
+        })
     }
 }
 

--- a/src/connector/src/sink/mod.rs
+++ b/src/connector/src/sink/mod.rs
@@ -12,21 +12,23 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#![feature(box_patterns)]
+
 pub mod kafka;
 pub mod mysql;
 pub mod redis;
 
 use std::collections::HashMap;
-use std::hash::Hash;
+
 
 use async_trait::async_trait;
 use enum_as_inner::EnumAsInner;
-use risingwave_common::array::{StreamChunk, ArrayError};
+use risingwave_common::array::{StreamChunk};
 use risingwave_common::catalog::Schema;
 use risingwave_common::error::{ErrorCode, Result as RwResult, RwError};
 use thiserror::Error;
 
-use crate::sink::kafka::{KafkaConfig, KAFKA_SINK, KafkaSink};
+use crate::sink::kafka::{KafkaConfig, KafkaSink, KAFKA_SINK};
 use crate::sink::mysql::{MySQLConfig, MySQLSink};
 use crate::sink::redis::{RedisConfig, RedisSink};
 

--- a/src/connector/src/sink/mysql.rs
+++ b/src/connector/src/sink/mysql.rs
@@ -23,7 +23,7 @@ use risingwave_common::array::StreamChunk;
 use risingwave_common::catalog::Schema;
 use risingwave_common::types::{Datum, Decimal, ScalarImpl};
 
-use crate::sink::{Result, Sink, SinkError};
+use crate::sink::{Result, Sink, SinkError, SinkState};
 
 #[derive(Clone, Debug)]
 pub struct MySQLConfig {
@@ -188,6 +188,10 @@ impl Sink for MySQLSink {
     }
 
     async fn abort(&mut self) -> Result<()> {
+        todo!()
+    }
+
+    async fn take_snapshot(&self) -> Result<SinkState> {
         todo!()
     }
 }

--- a/src/connector/src/sink/mysql.rs
+++ b/src/connector/src/sink/mysql.rs
@@ -23,7 +23,7 @@ use risingwave_common::array::StreamChunk;
 use risingwave_common::catalog::Schema;
 use risingwave_common::types::{Datum, Decimal, ScalarImpl};
 
-use crate::sink::{Result, Sink, SinkError, SinkState};
+use crate::sink::{Result, Sink, SinkError};
 
 #[derive(Clone, Debug)]
 pub struct MySQLConfig {

--- a/src/connector/src/sink/mysql.rs
+++ b/src/connector/src/sink/mysql.rs
@@ -190,10 +190,6 @@ impl Sink for MySQLSink {
     async fn abort(&mut self) -> Result<()> {
         todo!()
     }
-
-    async fn take_snapshot(&self) -> Result<SinkState> {
-        todo!()
-    }
 }
 
 #[cfg(test)]

--- a/src/connector/src/sink/mysql.rs
+++ b/src/connector/src/sink/mysql.rs
@@ -15,6 +15,7 @@
 use std::fmt;
 
 use async_trait::async_trait;
+use enum_as_inner::EnumAsInner;
 use itertools::{join, Itertools};
 use mysql_async::prelude::*;
 use mysql_async::*;
@@ -25,6 +26,7 @@ use risingwave_common::types::{Datum, Decimal, ScalarImpl};
 
 use crate::sink::{Result, Sink, SinkError};
 
+#[derive(Clone, Debug)]
 pub struct MySQLConfig {
     pub endpoint: String,
     pub table: String,

--- a/src/connector/src/sink/mysql.rs
+++ b/src/connector/src/sink/mysql.rs
@@ -15,7 +15,6 @@
 use std::fmt;
 
 use async_trait::async_trait;
-
 use itertools::{join, Itertools};
 use mysql_async::prelude::*;
 use mysql_async::*;
@@ -178,6 +177,18 @@ impl Sink for MySQLSink {
         transaction.commit().await?;
         drop(conn);
         Ok(())
+    }
+
+    async fn begin_epoch(&mut self, epoch: u64) -> Result<()> {
+        todo!()
+    }
+
+    async fn commit(&mut self) -> Result<()> {
+        todo!()
+    }
+
+    async fn abort(&mut self) -> Result<()> {
+        todo!()
     }
 }
 

--- a/src/connector/src/sink/mysql.rs
+++ b/src/connector/src/sink/mysql.rs
@@ -15,7 +15,7 @@
 use std::fmt;
 
 use async_trait::async_trait;
-use enum_as_inner::EnumAsInner;
+
 use itertools::{join, Itertools};
 use mysql_async::prelude::*;
 use mysql_async::*;

--- a/src/connector/src/sink/mysql.rs
+++ b/src/connector/src/sink/mysql.rs
@@ -41,8 +41,8 @@ pub struct MySQLSink {
 }
 
 impl MySQLSink {
-    pub fn new(cfg: MySQLConfig) -> Self {
-        Self { cfg }
+    pub fn new(cfg: MySQLConfig) -> Result<Self> {
+        Ok(Self { cfg })
     }
 
     fn endpoint(&self) -> String {
@@ -179,7 +179,7 @@ impl Sink for MySQLSink {
         Ok(())
     }
 
-    async fn begin_epoch(&mut self, epoch: u64) -> Result<()> {
+    async fn begin_epoch(&mut self, _epoch: u64) -> Result<()> {
         todo!()
     }
 

--- a/src/connector/src/sink/redis.rs
+++ b/src/connector/src/sink/redis.rs
@@ -16,7 +16,7 @@ use async_trait::async_trait;
 use risingwave_common::array::StreamChunk;
 use risingwave_common::catalog::Schema;
 
-use crate::sink::{Result, Sink, SinkState};
+use crate::sink::{Result, Sink};
 
 #[derive(Clone, Debug)]
 pub struct RedisConfig;

--- a/src/connector/src/sink/redis.rs
+++ b/src/connector/src/sink/redis.rs
@@ -24,7 +24,7 @@ pub struct RedisConfig;
 pub struct RedisSink;
 
 impl RedisSink {
-    pub fn new(_cfg: RedisConfig) -> Self {
+    pub fn new(_cfg: RedisConfig) -> Result<Self> {
         todo!()
     }
 }
@@ -35,7 +35,7 @@ impl Sink for RedisSink {
         todo!();
     }
 
-    async fn begin_epoch(&mut self, epoch: u64) -> Result<()> {
+    async fn begin_epoch(&mut self, _epoch: u64) -> Result<()> {
         todo!()
     }
 

--- a/src/connector/src/sink/redis.rs
+++ b/src/connector/src/sink/redis.rs
@@ -46,8 +46,4 @@ impl Sink for RedisSink {
     async fn abort(&mut self) -> Result<()> {
         todo!()
     }
-
-    async fn take_snapshot(&self) -> Result<SinkState> {
-        todo!()
-    }
 }

--- a/src/connector/src/sink/redis.rs
+++ b/src/connector/src/sink/redis.rs
@@ -34,4 +34,16 @@ impl Sink for RedisSink {
     async fn write_batch(&mut self, _chunk: StreamChunk, _schema: &Schema) -> Result<()> {
         todo!();
     }
+
+    async fn begin_epoch(&mut self, epoch: u64) -> Result<()> {
+        todo!()
+    }
+
+    async fn commit(&mut self) -> Result<()> {
+        todo!()
+    }
+
+    async fn abort(&mut self) -> Result<()> {
+        todo!()
+    }
 }

--- a/src/connector/src/sink/redis.rs
+++ b/src/connector/src/sink/redis.rs
@@ -16,7 +16,7 @@ use async_trait::async_trait;
 use risingwave_common::array::StreamChunk;
 use risingwave_common::catalog::Schema;
 
-use crate::sink::{Result, Sink};
+use crate::sink::{Result, Sink, SinkState};
 
 #[derive(Clone, Debug)]
 pub struct RedisConfig;
@@ -44,6 +44,10 @@ impl Sink for RedisSink {
     }
 
     async fn abort(&mut self) -> Result<()> {
+        todo!()
+    }
+
+    async fn take_snapshot(&self) -> Result<SinkState> {
         todo!()
     }
 }

--- a/src/connector/src/sink/redis.rs
+++ b/src/connector/src/sink/redis.rs
@@ -18,6 +18,7 @@ use risingwave_common::catalog::Schema;
 
 use crate::sink::{Result, Sink};
 
+#[derive(Clone, Debug)]
 pub struct RedisConfig;
 
 pub struct RedisSink;

--- a/src/stream/src/executor/error.rs
+++ b/src/stream/src/executor/error.rs
@@ -44,6 +44,9 @@ enum StreamExecutorErrorInner {
     #[error("Source error: {0}")]
     SourceError(RwError),
 
+    #[error("Sink error: {0}")]
+    SinkError(RwError),
+
     #[error("Channel `{0}` closed")]
     ChannelClosed(String),
 
@@ -72,6 +75,10 @@ impl StreamExecutorError {
 
     pub fn source_error(error: impl Into<RwError>) -> Self {
         StreamExecutorErrorInner::SourceError(error.into()).into()
+    }
+
+    pub fn sink_error(error: impl Into<RwError>) -> Self {
+        StreamExecutorErrorInner::SinkError(error.into()).into()
     }
 
     pub fn channel_closed(name: impl Into<String>) -> Self {

--- a/src/stream/src/executor/mod.rs
+++ b/src/stream/src/executor/mod.rs
@@ -102,6 +102,7 @@ pub use project::ProjectExecutor;
 pub use rearranged_chain::RearrangedChainExecutor;
 use risingwave_pb::source::{ConnectorSplit, ConnectorSplits};
 use simple::{SimpleExecutor, SimpleExecutorWrapper};
+pub use sink::SinkExecutor;
 pub use source::*;
 pub use top_n_appendonly::AppendOnlyTopNExecutor;
 pub use top_n_new::TopNExecutorNew;

--- a/src/stream/src/executor/sink.rs
+++ b/src/stream/src/executor/sink.rs
@@ -40,13 +40,16 @@ impl<S: StateStore> SinkExecutor<S> {
     pub fn new(
         materialize_executor: BoxedExecutor,
         store: S,
-        properties: HashMap<String, String>,
+        mut properties: HashMap<String, String>,
         executor_id: u64,
     ) -> Self {
+        // This field can be used to distinguish a specific actor in parallelism to prevent
+        // transaction execution errors
+        properties.insert("identifier".to_string(), format!("sink-{:?}", executor_id));
         Self {
             input: materialize_executor,
             store,
-            properties: HashMap::new(),
+            properties,
             identity: format!("SinkExecutor_{:?}", executor_id),
         }
     }

--- a/src/stream/src/executor/sink.rs
+++ b/src/stream/src/executor/sink.rs
@@ -12,42 +12,72 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use std::collections::HashMap;
+
 use futures::StreamExt;
-use futures_async_stream::try_stream;
+use futures_async_stream::{for_await, try_stream};
 use risingwave_common::catalog::Schema;
-use risingwave_connector::sink::Sink;
+use risingwave_connector::sink::{Sink, SinkConfig, SinkImpl};
+use risingwave_pb::common::worker_node::State;
+use risingwave_storage::StateStore;
 
 use super::error::StreamExecutorError;
 use super::{BoxedExecutor, Executor, Message};
+use crate::task::ActorId;
 
-pub struct SinkExecutor<S: Sink> {
-    child: BoxedExecutor,
-    _external_sink: S,
+pub struct SinkExecutor<S: StateStore> {
+    input: BoxedExecutor,
+    store: S,
+    properties: HashMap<String, String>,
     identity: String,
 }
 
-impl<S: Sink> SinkExecutor<S> {
-    pub fn _new(materialize_executor: BoxedExecutor, _external_sink: S) -> Self {
+async fn build_sink(config: SinkConfig) -> Box<SinkImpl> {
+    todo!()
+}
+
+impl<S: StateStore> SinkExecutor<S> {
+    pub fn new(
+        materialize_executor: BoxedExecutor,
+        store: S,
+        properties: HashMap<String, String>,
+        executor_id: u64,
+    ) -> Self {
         Self {
-            child: materialize_executor,
-            _external_sink,
-            identity: "SinkExecutor".to_string(),
+            input: materialize_executor,
+            store,
+            properties: HashMap::new(),
+            identity: format!("SinkExecutor_{:?}", executor_id),
         }
     }
 
     #[try_stream(ok = Message, error = StreamExecutorError)]
     async fn execute_inner(self) {
-        todo!()
+        let sink_config = SinkConfig::from_hashmap(self.properties.clone());
+        let input = self.input.execute();
+        #[for_await]
+        for msg in input {
+            match msg? {
+                Message::Chunk(chunk) => {
+                    let visible_chunk = chunk.clone().compact()?;
+
+                    yield Message::Chunk(chunk);
+                }
+                Message::Barrier(barrier) => {
+                    yield Message::Barrier(barrier);
+                }
+            }
+        }
     }
 }
 
-impl<S: Sink + 'static + Send> Executor for SinkExecutor<S> {
+impl<S: StateStore> Executor for SinkExecutor<S> {
     fn execute(self: Box<Self>) -> super::BoxedMessageStream {
         self.execute_inner().boxed()
     }
 
     fn schema(&self) -> &Schema {
-        self.child.schema()
+        self.input.schema()
     }
 
     fn pk_indices(&self) -> super::PkIndicesRef {
@@ -83,6 +113,6 @@ mod test {
         // Mock `child`
         let mock = MockSource::with_messages(Schema::default(), PkIndices::new(), vec![]);
 
-        let _sink_executor = SinkExecutor::_new(Box::new(mock), mysql_sink);
+        // let _sink_executor = SinkExecutor::_new(Box::new(mock), mysql_sink);
     }
 }

--- a/src/stream/src/executor/sink.rs
+++ b/src/stream/src/executor/sink.rs
@@ -15,31 +15,30 @@
 use std::collections::HashMap;
 
 use futures::StreamExt;
-use futures_async_stream::{for_await, try_stream};
+use futures_async_stream::try_stream;
 use risingwave_common::catalog::Schema;
-use risingwave_connector::sink::{Sink, SinkConfig, SinkImpl};
-use risingwave_pb::common::worker_node::State;
+use risingwave_common::error::Result;
+use risingwave_connector::sink::{SinkConfig, SinkImpl};
 use risingwave_storage::StateStore;
 
 use super::error::StreamExecutorError;
 use super::{BoxedExecutor, Executor, Message};
-use crate::task::ActorId;
 
 pub struct SinkExecutor<S: StateStore> {
     input: BoxedExecutor,
-    store: S,
+    _store: S,
     properties: HashMap<String, String>,
     identity: String,
 }
 
-async fn build_sink(config: SinkConfig) -> Box<SinkImpl> {
-    todo!()
+async fn build_sink(config: SinkConfig) -> Result<Box<SinkImpl>> {
+    Ok(Box::new(SinkImpl::new(config).await?))
 }
 
 impl<S: StateStore> SinkExecutor<S> {
     pub fn new(
         materialize_executor: BoxedExecutor,
-        store: S,
+        _store: S,
         mut properties: HashMap<String, String>,
         executor_id: u64,
     ) -> Self {
@@ -48,7 +47,7 @@ impl<S: StateStore> SinkExecutor<S> {
         properties.insert("identifier".to_string(), format!("sink-{:?}", executor_id));
         Self {
             input: materialize_executor,
-            store,
+            _store,
             properties,
             identity: format!("SinkExecutor_{:?}", executor_id),
         }
@@ -56,13 +55,15 @@ impl<S: StateStore> SinkExecutor<S> {
 
     #[try_stream(ok = Message, error = StreamExecutorError)]
     async fn execute_inner(self) {
-        let sink_config = SinkConfig::from_hashmap(self.properties.clone());
+        let sink_config = SinkConfig::from_hashmap(self.properties.clone())
+            .map_err(StreamExecutorError::sink_error)?;
+        let _sink = build_sink(sink_config).await;
         let input = self.input.execute();
         #[for_await]
         for msg in input {
             match msg? {
                 Message::Chunk(chunk) => {
-                    let visible_chunk = chunk.clone().compact()?;
+                    let _visible_chunk = chunk.clone().compact()?;
 
                     yield Message::Chunk(chunk);
                 }
@@ -111,10 +112,10 @@ mod test {
             password: Some(String::from("<password>")),
         };
 
-        let mysql_sink = MySQLSink::new(cfg);
+        let _mysql_sink = MySQLSink::new(cfg);
 
         // Mock `child`
-        let mock = MockSource::with_messages(Schema::default(), PkIndices::new(), vec![]);
+        let _mock = MockSource::with_messages(Schema::default(), PkIndices::new(), vec![]);
 
         // let _sink_executor = SinkExecutor::_new(Box::new(mock), mysql_sink);
     }

--- a/src/stream/src/executor/sink.rs
+++ b/src/stream/src/executor/sink.rs
@@ -58,6 +58,12 @@ impl<S: StateStore> SinkExecutor<S> {
         let sink_config = SinkConfig::from_hashmap(self.properties.clone())
             .map_err(StreamExecutorError::sink_error)?;
         let _sink = build_sink(sink_config).await;
+
+        // TODO(tabVersion): the flag is required because kafka transaction requires at least one
+        // message, so we should abort the transaction if the flag is true.
+        #[allow(clippy::no_effect_underscore_binding)]
+        let _empty_epoch_flag = true;
+
         let input = self.input.execute();
         #[for_await]
         for msg in input {

--- a/src/stream/src/from_proto/mod.rs
+++ b/src/stream/src/from_proto/mod.rs
@@ -29,6 +29,7 @@ mod lookup_union;
 mod merge;
 mod mview;
 mod project;
+mod sink;
 mod source;
 mod top_n_appendonly;
 mod top_n_new;
@@ -57,6 +58,7 @@ use self::lookup_union::*;
 use self::merge::*;
 use self::mview::*;
 use self::project::*;
+use self::sink::*;
 use self::source::*;
 use self::top_n_appendonly::*;
 use self::top_n_new::*;
@@ -105,6 +107,7 @@ pub fn create_executor(
         store,
         stream,
         NodeBody::Source => SourceExecutorBuilder,
+        NodeBody::Sink => SinkExecutorBuilder,
         NodeBody::Project => ProjectExecutorBuilder,
         NodeBody::TopN => TopNExecutorNewBuilder,
         NodeBody::AppendOnlyTopN => AppendOnlyTopNExecutorBuilder,

--- a/src/stream/src/from_proto/sink.rs
+++ b/src/stream/src/from_proto/sink.rs
@@ -12,12 +12,10 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use risingwave_common::catalog::{ColumnId, Schema, TableId};
-use risingwave_pb::plan_common::Field;
-use tokio::sync::mpsc::unbounded_channel;
+use risingwave_common::catalog::{ColumnId, TableId};
 
 use super::*;
-use crate::executor::{Barrier, SinkExecutor};
+use crate::executor::SinkExecutor;
 
 pub struct SinkExecutorBuilder;
 
@@ -26,12 +24,12 @@ impl ExecutorBuilder for SinkExecutorBuilder {
         mut params: ExecutorParams,
         node: &StreamNode,
         store: impl StateStore,
-        stream: &mut LocalStreamManagerCore,
+        _stream: &mut LocalStreamManagerCore,
     ) -> Result<BoxedExecutor> {
         let node = try_match_expand!(node.get_node_body().unwrap(), NodeBody::Sink)?;
 
-        let sink_id = TableId::from(&node.table_ref_id);
-        let column_ids = node
+        let _sink_id = TableId::from(&node.table_ref_id);
+        let _column_ids = node
             .get_column_ids()
             .iter()
             .map(|i| ColumnId::from(*i))

--- a/src/stream/src/from_proto/sink.rs
+++ b/src/stream/src/from_proto/sink.rs
@@ -28,7 +28,7 @@ impl ExecutorBuilder for SinkExecutorBuilder {
     ) -> Result<BoxedExecutor> {
         let node = try_match_expand!(node.get_node_body().unwrap(), NodeBody::Sink)?;
 
-        let _sink_id = TableId::from(&node.table_ref_id);
+        let _sink_id = TableId::from(node.table_id);
         let _column_ids = node
             .get_column_ids()
             .iter()

--- a/src/stream/src/from_proto/sink.rs
+++ b/src/stream/src/from_proto/sink.rs
@@ -1,0 +1,47 @@
+// Copyright 2022 Singularity Data
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use risingwave_common::catalog::{ColumnId, Schema, TableId};
+use risingwave_pb::plan_common::Field;
+use tokio::sync::mpsc::unbounded_channel;
+
+use super::*;
+use crate::executor::{Barrier, SinkExecutor};
+
+pub struct SinkExecutorBuilder;
+
+impl ExecutorBuilder for SinkExecutorBuilder {
+    fn new_boxed_executor(
+        mut params: ExecutorParams,
+        node: &StreamNode,
+        store: impl StateStore,
+        stream: &mut LocalStreamManagerCore,
+    ) -> Result<BoxedExecutor> {
+        let node = try_match_expand!(node.get_node_body().unwrap(), NodeBody::Sink)?;
+
+        let sink_id = TableId::from(&node.table_ref_id);
+        let column_ids = node
+            .get_column_ids()
+            .iter()
+            .map(|i| ColumnId::from(*i))
+            .collect::<Vec<ColumnId>>();
+
+        Ok(Box::new(SinkExecutor::new(
+            params.input.remove(0),
+            store,
+            node.properties.clone(),
+            params.executor_id,
+        )))
+    }
+}


### PR DESCRIPTION
Signed-off-by: tabVersion <tabvision@bupt.icu>

I hereby agree to the terms of the [Singularity Data, Inc. Contributor License Agreement](https://gist.github.com/skyzh/0663682a70b0edde7ae991492f2314cb#file-s9y_cla).

## What's changed and what's your intention?

***PLEASE DO NOT LEAVE THIS EMPTY !!!***

Please explain **IN DETAIL** what the changes are in this PR and why they are needed:

working on kafka sink: parse stream chunk to json and sink to kafka

we can achieve exactly once  semantic by: 
* begin a kafka transaction when a barrier comes
* kafka sink records the last success epoch num and send record requests in any epoch that is smaller or equal to the saved one will be discarded
* abort the transaction whenever a request fails then roll the system back to prev epoch
* commit to kafka if there is no failure in this epoch (the next barrier comes)

- Summarize your change (**mandatory**)
- How does this PR work? Need a brief introduction for the changed logic (optional)
- Describe clearly one logical change and avoid lazy messages (optional)
- Describe any limitations of the current code (optional)

## Checklist

- [x] I have written necessary rustdoc comments
- [x] I have added necessary unit tests and integration tests
- [x] All checks passed in `./risedev check` (or alias, `./risedev c`)

## Documentation

If your pull request contains user-facing changes, please specify the types of the changes, and create a release note. Otherwise, please feel free to remove this section.

### Types of user-facing changes

Please keep the types that apply to your changes, and remove those that do not apply.

* Connector (sources & sinks)

### Release note

Please create a release note for your changes. In the release note, focus on the impact on users, and mention the environment or conditions where the impact may occur.

allow users to sink records only with `Op::Insert` to kafka in json format

the pr introduces the following options in `with` clause

* `kafka.brokers`: required, address of the Kafka broker. `Format: 'ip:port'`.
* `kafka.topic`: required, address the target topic, one sink can only have one topic 
* `sink.type`: required, accept either `append_only` or `debezium`

## Refer to a related PR or issue link (optional)
