### PR TITLE
feat(batch): prune scan partition according to scan_range

### DIFF
--- a/src/frontend/src/optimizer/plan_node/batch_seq_scan.rs
+++ b/src/frontend/src/optimizer/plan_node/batch_seq_scan.rs
@@ -81,6 +81,10 @@ impl BatchSeqScan {
     pub fn logical(&self) -> &LogicalScan {
         &self.logical
     }
+
+    pub fn scan_range(&self) -> &ScanRange {
+        &self.scan_range
+    }
 }
 
 impl_plan_tree_node_for_leaf! { BatchSeqScan }

--- a/src/frontend/src/scheduler/plan_fragmenter.rs
+++ b/src/frontend/src/scheduler/plan_fragmenter.rs
@@ -16,7 +16,7 @@ use std::collections::{HashMap, HashSet};
 use std::fmt::{Debug, Formatter};
 use std::sync::Arc;
 
-use risingwave_common::buffer::BitmapBuilder;
+use risingwave_common::buffer::{Bitmap, BitmapBuilder};
 use risingwave_common::types::ParallelUnitId;
 use risingwave_pb::batch_plan::plan_node::NodeBody;
 use risingwave_pb::batch_plan::ExchangeInfo;
@@ -24,7 +24,7 @@ use risingwave_pb::common::Buffer;
 use risingwave_pb::plan_common::Field as FieldProst;
 use uuid::Uuid;
 
-use crate::optimizer::plan_node::{PlanNodeId, PlanNodeType};
+use crate::optimizer::plan_node::{BatchSeqScan, PlanNodeId, PlanNodeType};
 use crate::optimizer::property::Distribution;
 use crate::optimizer::PlanRef;
 use crate::scheduler::worker_node_manager::WorkerNodeManagerRef;
@@ -164,7 +164,8 @@ impl Query {
 
 #[derive(Clone)]
 pub struct TableScanInfo {
-    /// Indicates data distribution and partition of the table.
+    /// Indicates the table partitions to be read by scan tasks. Unnecessary partitions are already
+    /// pruned.
     ///
     /// `None` if the table is not partitioned (system table).
     pub vnode_bitmaps: Option<HashMap<ParallelUnitId, Buffer>>,
@@ -391,9 +392,9 @@ impl BatchPlanFragmenter {
                     builder.root = Some(Arc::new(execution_plan_node));
                 }
                 // Check out the comments for `has_table_scan` in `QueryStage`.
-                if let Some(scan_node) = node.as_batch_seq_scan() {
-                    let table_desc = scan_node.logical().table_desc();
-
+                let scan_node: Option<&BatchSeqScan> = node.as_batch_seq_scan();
+                if let Some(scan_node) = scan_node {
+                    // TODO: handle multiple table scan inside a stage
                     assert!(
                         builder.table_scan_info.is_none()
                             || builder
@@ -404,11 +405,42 @@ impl BatchPlanFragmenter {
                                 .is_none(),
                         "multiple table scan inside a stage"
                     );
-                    builder.table_scan_info = Some(TableScanInfo {
-                        vnode_bitmaps: table_desc
-                            .vnode_mapping
-                            .clone()
-                            .map(vnode_mapping_to_owner_mapping),
+
+                    builder.table_scan_info = Some({
+                        let table_desc = scan_node.logical().table_desc();
+
+                        match table_desc.vnode_mapping {
+                            Some(ref vnode_mapping) => {
+                                let num_vnodes = vnode_mapping.len();
+                                let scan_range = scan_node.scan_range();
+                                // Try to derive the partition to read from the scan range.
+                                // It can be derived if the value of the distribution key is already
+                                // known.
+                                let vnode_bitmaps = match scan_range.try_compute_vnode(
+                                    &table_desc.distribution_keys,
+                                    &table_desc.order_column_indices(),
+                                ) {
+                                    None => vnode_mapping_to_owner_mapping(vnode_mapping.clone()),
+                                    Some(vnode) => {
+                                        let parallel_unit_id = vnode_mapping[vnode as usize];
+                                        let mut vnode_bitmaps = HashMap::new();
+                                        vnode_bitmaps.insert(
+                                            parallel_unit_id,
+                                            bitmap_with_single_vnode(vnode as usize, num_vnodes)
+                                                .to_protobuf(),
+                                        );
+                                        vnode_bitmaps
+                                    }
+                                };
+                                TableScanInfo {
+                                    vnode_bitmaps: Some(vnode_bitmaps),
+                                }
+                            }
+                            // not partitioned table
+                            None => TableScanInfo {
+                                vnode_bitmaps: None,
+                            },
+                        }
                     });
                 }
             }
@@ -453,6 +485,11 @@ fn vnode_mapping_to_owner_mapping(
         .collect()
 }
 
+fn bitmap_with_single_vnode(vnode: usize, num_vnodes: usize) -> Bitmap {
+    let mut bitmap = BitmapBuilder::zeroed(num_vnodes);
+    bitmap.set(vnode as usize, true);
+    bitmap.finish()
+}
 #[cfg(test)]
 mod tests {
     use std::collections::{HashMap, HashSet};

--- a/src/storage/src/table/storage_table.rs
+++ b/src/storage/src/table/storage_table.rs
@@ -275,25 +275,13 @@ impl<S: StateStore, E: Encoding, const T: AccessType> StorageTableBase<S, E, T> 
 /// Get
 impl<S: StateStore, E: Encoding, const T: AccessType> StorageTableBase<S, E, T> {
     /// Check whether the given `vnode` is set in the `vnodes` of this table.
-    ///
-    /// - For `READ_WRITE` or streaming usages, this will panic on `false` and always return `true`
-    ///   since the table should only be used to access entries with vnode specified in
-    ///   `self.vnodes`.
-    /// - For `READ_ONLY` or batch usages, this will return the result verbatim. The caller may
-    ///   filter out the scanned row according to the result.
-    fn check_vnode_is_set(&self, vnode: VirtualNode) -> bool {
+    fn check_vnode_is_set(&self, vnode: VirtualNode) {
         let is_set = self.vnodes.is_set(vnode as usize).unwrap();
-        match T {
-            READ_WRITE => {
-                assert!(
-                    is_set,
-                    "vnode {} should not be accessed by this table: {:#?}, dist key {:?}",
-                    vnode, self.table_columns, self.dist_key_indices
-                );
-            }
-            READ_ONLY => {}
-        }
-        is_set
+        assert!(
+            is_set,
+            "vnode {} should not be accessed by this table: {:#?}, dist key {:?}",
+            vnode, self.table_columns, self.dist_key_indices
+        );
     }
 
     /// Get vnode value with `indices` on the given `row`. Should not be used directly.
@@ -307,7 +295,7 @@ impl<S: StateStore, E: Encoding, const T: AccessType> StorageTableBase<S, E, T> 
 
         tracing::trace!(target: "events::storage::storage_table", "compute vnode: {:?} keys {:?} => {}", row, indices, vnode);
 
-        let _ = self.check_vnode_is_set(vnode);
+        self.check_vnode_is_set(vnode);
         vnode
     }
 
@@ -355,7 +343,10 @@ impl<S: StateStore, E: Encoding, const T: AccessType> StorageTableBase<S, E, T> 
         }
 
         let result = deserializer.take();
-        Ok(result.and_then(|(vnode, _pk, row)| self.check_vnode_is_set(vnode).then_some(row)))
+        Ok(result.map(|(vnode, _pk, row)| {
+            self.check_vnode_is_set(vnode);
+            row
+        }))
     }
 
     /// Get a single row by range scan
@@ -374,7 +365,10 @@ impl<S: StateStore, E: Encoding, const T: AccessType> StorageTableBase<S, E, T> 
         }
 
         let result = deserializer.take();
-        Ok(result.and_then(|(vnode, _pk, row)| self.check_vnode_is_set(vnode).then_some(row)))
+        Ok(result.map(|(vnode, _pk, row)| {
+            self.check_vnode_is_set(vnode);
+            row
+        }))
     }
 }
 


### PR DESCRIPTION
I hereby agree to the terms of the [Singularity Data, Inc. Contributor License Agreement](https://gist.github.com/skyzh/0663682a70b0edde7ae991492f2314cb#file-s9y_cla).

## What's changed and what's your intention?

As title. Also disallow accessing other vnodes from batch scan. 

Limitation: Currently either one or all paritions will be read, since multiple scan ranges not supported yet (https://github.com/singularity-data/risingwave/issues/3477). But after it is implemented, the pruning part only needs minor modifications.

## Checklist

- [x] I have written necessary rustdoc comments
- [x] I have added necessary unit tests and integration tests
- [x] All checks passed in `./risedev check` (or alias, `./risedev c`)

## Refer to a related PR or issue link (optional)
https://github.com/singularity-data/risingwave/issues/3450
