### PR TITLE
feat(expr): support regexp_match

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4264,6 +4264,7 @@ dependencies = [
  "num-traits",
  "paste",
  "prost",
+ "regex",
  "risingwave_common",
  "risingwave_pb",
  "rust_decimal",

--- a/e2e_test/batch/basic/func.slt.part
+++ b/e2e_test/batch/basic/func.slt.part
@@ -234,3 +234,33 @@ query I
 select count(current_database());
 ----
 1
+
+query T
+select regexp_match('abc', 'bc');
+----
+[bc]
+
+query T
+select regexp_match('abc', 'd');
+----
+NULL
+
+query T
+select regexp_match('foobarbequebaz', '(bar)(beque)');
+----
+[bar,beque]
+
+query T
+select regexp_match('foobarbequebaz', 'bar(beque)');
+----
+[beque]
+
+query T
+select regexp_match('foobarbequebaz', 'bar.*que');
+----
+[barbeque]
+
+query T
+select regexp_match('abc01234xyz', '(?:(.*?)(\d+)(.*)){1,1}');
+----
+[abc,01234,xyz]

--- a/proto/expr.proto
+++ b/proto/expr.proto
@@ -75,6 +75,7 @@ message ExprNode {
     OCTET_LENGTH = 229;
     BIT_LENGTH = 230;
     OVERLAY = 231;
+    REGEXP_MATCH = 232;
 
     // Boolean comparison
     IS_TRUE = 301;

--- a/src/expr/Cargo.toml
+++ b/src/expr/Cargo.toml
@@ -24,6 +24,7 @@ memcomparable = { path = "../utils/memcomparable" }
 num-traits = "0.2"
 paste = "1"
 prost = "0.10"
+regex = "1"
 risingwave_common = { path = "../common" }
 risingwave_pb = { path = "../prost" }
 rust_decimal = "1"

--- a/src/expr/src/error.rs
+++ b/src/expr/src/error.rs
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 pub use anyhow::anyhow;
+use regex;
 use risingwave_common::array::ArrayError;
 use risingwave_common::error::{ErrorCode, RwError};
 use risingwave_common::types::DataType;
@@ -49,5 +50,14 @@ pub enum ExprError {
 impl From<ExprError> for RwError {
     fn from(s: ExprError) -> Self {
         ErrorCode::ExprError(Box::new(s)).into()
+    }
+}
+
+impl From<regex::Error> for ExprError {
+    fn from(re: regex::Error) -> Self {
+        Self::InvalidParam {
+            name: "pattern",
+            reason: re.to_string(),
+        }
     }
 }

--- a/src/expr/src/expr/expr_regexp.rs
+++ b/src/expr/src/expr/expr_regexp.rs
@@ -1,0 +1,139 @@
+use std::sync::Arc;
+
+use itertools::Itertools;
+use regex::Regex;
+use risingwave_common::array::{
+    Array, ArrayBuilder, ArrayMeta, ArrayRef, DataChunk, ListArrayBuilder, ListRef, ListValue, Row,
+    Utf8Array,
+};
+use risingwave_common::types::{DataType, Datum, Scalar, ScalarImpl};
+use risingwave_pb::expr::expr_node::{RexNode, Type};
+use risingwave_pb::expr::ExprNode;
+
+use super::{build_from_prost as expr_build_from_prost, Expression};
+use crate::{bail, ensure, ExprError, Result};
+
+#[derive(Debug)]
+pub struct RegexpContext(Regex);
+
+impl RegexpContext {
+    pub fn new(pattern: &str) -> Result<Self> {
+        Ok(Self(Regex::new(pattern)?))
+    }
+}
+
+#[derive(Debug)]
+pub struct RegexpMatchExpr {
+    pub child: Box<dyn Expression>,
+    pub ctx: RegexpContext,
+}
+
+impl<'a> TryFrom<&'a ExprNode> for RegexpMatchExpr {
+    type Error = ExprError;
+
+    fn try_from(prost: &'a ExprNode) -> Result<Self> {
+        ensure!(prost.get_expr_type().unwrap() == Type::RegexpMatch);
+        let RexNode::FuncCall(func_call_node) = prost.get_rex_node().unwrap() else {
+            bail!("Expected RexNode::FuncCall");
+        };
+        let mut children = func_call_node.children.iter();
+        let Some(text_node) = children.next() else {
+            bail!("Expected argument text");
+        };
+        let text_expr = expr_build_from_prost(text_node)?;
+        let Some(pattern_node) = children.next() else {
+            bail!("Expected argument pattern");
+        };
+        let RexNode::Constant(pattern_value) = pattern_node.get_rex_node().unwrap() else {
+            return Err(ExprError::UnsupportedFunction("non-constant pattern in regexp_match".to_string()))
+        };
+        let pattern_scalar = ScalarImpl::bytes_to_scalar(
+            pattern_value.get_body(),
+            pattern_node.get_return_type().unwrap(),
+        )?;
+        let ScalarImpl::Utf8(pattern) = pattern_scalar else {
+            bail!("Expected pattern to be an String");
+        };
+
+        let ctx = RegexpContext::new(&pattern)?;
+        Ok(Self {
+            child: text_expr,
+            ctx,
+        })
+    }
+}
+
+impl RegexpMatchExpr {
+    /// Match one row and return the result.
+    // TODO: The optimization can be allocated.
+    fn match_one(&self, text: Option<&str>) -> Option<ListValue> {
+        // If there are multiple captures, then the first one is the whole match, and should be
+        // ignored in PostgreSQL's behavior.
+        let mut skip_flag = self.ctx.0.captures_len() > 1;
+
+        if let Some(text) = text {
+            if let Some(capture) = self.ctx.0.captures(text) {
+                let list = capture
+                    .iter()
+                    .skip_while(|_| {
+                        if skip_flag {
+                            skip_flag = false;
+                            true
+                        } else {
+                            false
+                        }
+                    })
+                    .filter_map(|m| m)
+                    .map(|mat| Some(mat.as_str().to_string().to_scalar_value()))
+                    .collect_vec();
+                let list = ListValue::new(list);
+                Some(list)
+            } else {
+                None
+            }
+        } else {
+            None
+        }
+    }
+}
+
+impl Expression for RegexpMatchExpr {
+    fn return_type(&self) -> DataType {
+        DataType::List {
+            datatype: Box::new(DataType::Varchar),
+        }
+    }
+
+    fn eval(&self, input: &DataChunk) -> Result<ArrayRef> {
+        let text_arr = self.child.eval_checked(input)?;
+        let text_arr: &Utf8Array = text_arr.as_ref().into();
+        let mut output = ListArrayBuilder::with_meta(
+            input.capacity(),
+            ArrayMeta::List {
+                datatype: Box::new(DataType::Varchar),
+            },
+        );
+
+        for (text, vis) in text_arr.iter().zip_eq(input.vis().iter()) {
+            if !vis {
+                output.append_null()?;
+            } else if let Some(list) = self.match_one(text) {
+                let list_ref = ListRef::ValueRef { val: &list };
+                output.append(Some(list_ref))?;
+            } else {
+                output.append_null()?;
+            }
+        }
+
+        Ok(Arc::new((output.finish()?).into()))
+    }
+
+    fn eval_row(&self, input: &Row) -> Result<Datum> {
+        let text = self.child.eval_row(input)?;
+        Ok(if let Some(ScalarImpl::Utf8(text)) = text {
+            self.match_one(Some(&text)).map(Into::into)
+        } else {
+            None
+        })
+    }
+}

--- a/src/expr/src/expr/expr_regexp.rs
+++ b/src/expr/src/expr/expr_regexp.rs
@@ -1,3 +1,17 @@
+// Copyright 2022 Singularity Data
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 use std::sync::Arc;
 
 use itertools::Itertools;

--- a/src/expr/src/expr/expr_regexp.rs
+++ b/src/expr/src/expr/expr_regexp.rs
@@ -97,7 +97,7 @@ impl RegexpMatchExpr {
                             false
                         }
                     })
-                    .filter_map(|m| m)
+                    .flatten()
                     .map(|mat| Some(mat.as_str().to_string().to_scalar_value()))
                     .collect_vec();
                 let list = ListValue::new(list);

--- a/src/expr/src/expr/mod.rs
+++ b/src/expr/src/expr/mod.rs
@@ -28,6 +28,7 @@ mod expr_is_null;
 mod expr_literal;
 mod expr_nested_construct;
 mod expr_quaternary_bytes;
+mod expr_regexp;
 mod expr_ternary_bytes;
 pub mod expr_unary;
 mod template;
@@ -48,6 +49,7 @@ use crate::expr::expr_coalesce::CoalesceExpression;
 use crate::expr::expr_concat_ws::ConcatWsExpression;
 use crate::expr::expr_field::FieldExpression;
 use crate::expr::expr_nested_construct::NestedConstructExpression;
+use crate::expr::expr_regexp::RegexpMatchExpr;
 use crate::ExprError;
 
 pub type ExpressionRef = Arc<dyn Expression>;
@@ -119,6 +121,7 @@ pub fn build_from_prost(prost: &ExprNode) -> Result<BoxedExpression> {
         Field => FieldExpression::try_from(prost).map(Expression::boxed),
         Array => NestedConstructExpression::try_from(prost).map(Expression::boxed),
         Row => NestedConstructExpression::try_from(prost).map(Expression::boxed),
+        RegexpMatch => RegexpMatchExpr::try_from(prost).map(Expression::boxed),
         _ => Err(ExprError::UnsupportedFunction(format!(
             "{:?}",
             prost.get_expr_type()

--- a/src/frontend/src/binder/expr/function.rs
+++ b/src/frontend/src/binder/expr/function.rs
@@ -139,6 +139,7 @@ impl Binder {
                 "ascii" => ExprType::Ascii,
                 "octet_length" => ExprType::OctetLength,
                 "bit_length" => ExprType::BitLength,
+                "regexp_match" => ExprType::RegexpMatch,
                 // special
                 "pg_typeof" if inputs.len() == 1 => {
                     let input = &inputs[0];

--- a/src/frontend/src/expr/function_call.rs
+++ b/src/frontend/src/expr/function_call.rs
@@ -155,6 +155,9 @@ impl FunctionCall {
                     .try_collect()?;
                 Ok(DataType::Varchar)
             }
+            ExprType::RegexpMatch => Ok(DataType::List {
+                datatype: Box::new(DataType::Varchar),
+            }),
 
             _ => {
                 // TODO(xiangjin): move variadic functions above as part of `infer_type`, as its
@@ -238,6 +241,7 @@ impl FunctionCall {
         self.inputs.as_ref()
     }
 }
+
 impl Expr for FunctionCall {
     fn return_type(&self) -> DataType {
         self.return_type.clone()


### PR DESCRIPTION
Signed-off-by: TennyZhuang <zty0826@gmail.com>

I hereby agree to the terms of the [Singularity Data, Inc. Contributor License Agreement](https://gist.github.com/skyzh/0663682a70b0edde7ae991492f2314cb#file-s9y_cla).

## What's changed and what's your intention?

Add support for the regexp_match function.

## Checklist

- [x] I have written necessary rustdoc comments
- [x] I have added necessary unit tests and integration tests
- [x] All checks passed in `./risedev check` (or alias, `./risedev c`)

## Documentation

If your pull request contains user-facing changes, please specify the types of the changes, and create a release note. Otherwise, please feel free to remove this section.

### Types of user-facing changes

Please keep the types that apply to your changes, and remove those that do not apply.

* SQL commands, functions, and operators

### Release note

Add the [regexp_match](https://www.postgresql.org/docs/current/functions-matching.html#FUNCTIONS-POSIX-REGEXP) function. Please note that the optional argument flag is not supported now.

## Refer to a related PR or issue link (optional)

#3605 