### PR TITLE
fix: fix heartbeat req field and meta client impl

### DIFF
--- a/proto/meta.proto
+++ b/proto/meta.proto
@@ -12,7 +12,6 @@ option optimize_for = SPEED;
 
 message HeartbeatRequest {
   uint32 node_id = 1;
-  common.WorkerType worker_type = 2;
 }
 
 message HeartbeatResponse {

--- a/src/rpc_client/src/meta_client.rs
+++ b/src/rpc_client/src/meta_client.rs
@@ -114,10 +114,7 @@ impl MetaClient {
 
     /// Send heartbeat signal to meta service.
     pub async fn send_heartbeat(&self, node_id: u32) -> Result<()> {
-        let request = HeartbeatRequest {
-            node_id,
-            worker_type: WorkerType::ComputeNode as i32,
-        };
+        let request = HeartbeatRequest { node_id };
         self.inner.heartbeat(request).await?;
         Ok(())
     }


### PR DESCRIPTION
I hereby agree to the terms of the [Singularity Data, Inc. Contributor License Agreement](https://gist.github.com/skyzh/0663682a70b0edde7ae991492f2314cb#file-s9y_cla).

As title, the worker type field in `HeartbeatRequest` is not necessary and should not always be CN in `MetaClient` impl.

***PLEASE DO NOT LEAVE THIS EMPTY !!!***

Please explain **IN DETAIL** what the changes are in this PR and why they are needed:

- Summarize your change (**mandatory**)
- How does this PR work? Need a brief introduction for the changed logic (optional)
- Describe clearly one logical change and avoid lazy messages (optional)
- Describe any limitations of the current code (optional)

## Checklist

- [x] I have written necessary rustdoc comments
- [x] I have added necessary unit tests and integration tests
- [x] All checks passed in `./risedev check` (or alias, `./risedev c`)

## Documentation

If your pull request contains user-facing changes, please specify the types of the changes, and create a release note. Otherwise, please feel free to remove this section.

### Types of user-facing changes

Please keep the types that apply to your changes, and remove those that do not apply.

* Installation and deployment 
* Connector (sources & sinks)
* SQL commands, functions, and operators
* RisingWave cluster configuration changes
* Other (please specify in the release note below)

### Release note

Please create a release note for your changes. In the release note, focus on the impact on users, and mention the environment or conditions where the impact may occur.

## Refer to a related PR or issue link (optional)
