### PR TITLE
fix(sqlsmith): completely cover all exprs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4624,6 +4624,7 @@ dependencies = [
  "chrono",
  "clap 3.2.8",
  "env_logger",
+ "itertools",
  "lazy_static",
  "log",
  "madsim",

--- a/e2e_test/batch/types/interval.slt.part
+++ b/e2e_test/batch/types/interval.slt.part
@@ -52,3 +52,13 @@ query T
 SELECT interval '1' day - interval '12' hour = interval '12' hour;
 ----
 t
+
+query T
+SELECT 1.5 * INTERVAL '3 mins';
+----
+00:04:30
+
+query T
+SELECT INTERVAL '3 mins' * 1.5;
+----
+00:04:30

--- a/e2e_test/batch/types/time.slt.part
+++ b/e2e_test/batch/types/time.slt.part
@@ -7,3 +7,13 @@ query TTTTT
 select timestamp '2001-03-16 23:38:45' - timestamp '2001-02-16 20:38:40';
 ----
 28 days 03:00:05
+
+query T
+select TIME '19:46:41' <= TIME '11:33:43';
+----
+f
+
+query T
+select TIME '19:46:41' >= TIME '11:33:43';
+----
+t

--- a/src/expr/src/expr/template.rs
+++ b/src/expr/src/expr/template.rs
@@ -385,6 +385,7 @@ macro_rules! for_all_cmp_variants {
             { float64, decimal, float64, $general_f },
             { timestamp, timestamp, timestamp, $general_f },
             { interval, interval, interval, $general_f },
+            { time, time, time, $general_f },
             { date, date, date, $general_f },
             { boolean, boolean, boolean, $general_f },
             { timestamp, date, timestamp, $general_f },

--- a/src/frontend/src/expr/type_inference/func.rs
+++ b/src/frontend/src/expr/type_inference/func.rs
@@ -470,7 +470,8 @@ fn build_type_derive_map() -> FuncSigMap {
     build_binary_cmp_funcs(&mut map, cmp_exprs, &num_types);
     build_binary_cmp_funcs(&mut map, cmp_exprs, &[T::Struct, T::List]);
     build_binary_cmp_funcs(&mut map, cmp_exprs, &[T::Date, T::Timestamp, T::Timestampz]);
-    build_binary_cmp_funcs(&mut map, cmp_exprs, &[T::Time, T::Interval]);
+    // TODO: add support for time-interval comparison
+    // build_binary_cmp_funcs(&mut map, cmp_exprs, &[T::Time, T::Interval]);
     for e in cmp_exprs {
         for t in [T::Boolean, T::Varchar] {
             map.insert(*e, vec![t, t], T::Boolean);

--- a/src/frontend/src/expr/type_inference/func.rs
+++ b/src/frontend/src/expr/type_inference/func.rs
@@ -468,10 +468,13 @@ fn build_type_derive_map() -> FuncSigMap {
         E::IsDistinctFrom,
     ];
     build_binary_cmp_funcs(&mut map, cmp_exprs, &num_types);
-    build_binary_cmp_funcs(&mut map, cmp_exprs, &[T::Struct, T::List]);
+    build_binary_cmp_funcs(&mut map, cmp_exprs, &[T::Struct]);
+    build_binary_cmp_funcs(&mut map, cmp_exprs, &[T::List]);
     build_binary_cmp_funcs(&mut map, cmp_exprs, &[T::Date, T::Timestamp, T::Timestampz]);
     // TODO: add support for time-interval comparison
     // build_binary_cmp_funcs(&mut map, cmp_exprs, &[T::Time, T::Interval]);
+    build_binary_cmp_funcs(&mut map, cmp_exprs, &[T::Time]);
+    build_binary_cmp_funcs(&mut map, cmp_exprs, &[T::Interval]);
     for e in cmp_exprs {
         for t in [T::Boolean, T::Varchar] {
             map.insert(*e, vec![t, t], T::Boolean);

--- a/src/frontend/src/handler/query.rs
+++ b/src/frontend/src/handler/query.rs
@@ -92,14 +92,14 @@ async fn distribute_execute(
 
         let plan = root.gen_batch_query_plan()?;
 
-        info!(
+        tracing::trace!(
             "Generated distributed plan: {:?}",
             plan.explain_to_string()?
         );
 
         let plan_fragmenter = BatchPlanFragmenter::new(session.env().worker_node_manager_ref());
         let query = plan_fragmenter.split(plan)?;
-        info!("Generated query after plan fragmenter: {:?}", &query);
+        tracing::trace!("Generated query after plan fragmenter: {:?}", &query);
         (query, pg_descs)
     };
 
@@ -137,7 +137,7 @@ fn local_execute(
 
         let plan_fragmenter = BatchPlanFragmenter::new(session.env().worker_node_manager_ref());
         let query = plan_fragmenter.split(plan)?;
-        info!("Generated query after plan fragmenter: {:?}", &query);
+        tracing::trace!("Generated query after plan fragmenter: {:?}", &query);
         (query, pg_descs)
     };
 

--- a/src/frontend/src/scheduler/distributed/query.rs
+++ b/src/frontend/src/scheduler/distributed/query.rs
@@ -179,9 +179,10 @@ impl QueryExecution {
                     .await
                     .map_err(|e| anyhow!("Starting query execution failed: {:?}", e))??;
 
-                info!(
+                tracing::trace!(
                     "Received root stage query result fetcher: {:?}, query id: {:?}",
-                    root_stage, self.query.query_id
+                    root_stage,
+                    self.query.query_id
                 );
 
                 *state = QueryState::Running {
@@ -211,17 +212,19 @@ impl QueryRunner {
         let leaf_stages = self.query.leaf_stages();
         for stage_id in &leaf_stages {
             // TODO: We should not return error here, we should abort query.
-            info!(
+            tracing::trace!(
                 "Starting query stage: {:?}-{:?}",
-                self.query.query_id, stage_id
+                self.query.query_id,
+                stage_id
             );
             self.stage_executions[stage_id].start().await.map_err(|e| {
                 error!("Failed to start stage: {}, reason: {:?}", stage_id, e);
                 e
             })?;
-            info!(
+            tracing::trace!(
                 "Query stage {:?}-{:?} started.",
-                self.query.query_id, stage_id
+                self.query.query_id,
+                stage_id
             );
         }
         let mut stages_with_table_scan = self.query.stages_with_table_scan();
@@ -230,9 +233,10 @@ impl QueryRunner {
         while let Some(msg) = self.msg_receiver.recv().await {
             match msg {
                 Stage(Scheduled(stage_id)) => {
-                    info!(
+                    tracing::trace!(
                         "Query stage {:?}-{:?} scheduled.",
-                        self.query.query_id, stage_id
+                        self.query.query_id,
+                        stage_id
                     );
                     self.scheduled_stages_count += 1;
                     stages_with_table_scan.remove(&stage_id);
@@ -240,7 +244,7 @@ impl QueryRunner {
                         // We can be sure here that all the Hummock iterators have been created,
                         // thus they all successfully pinned a HummockVersion.
                         // So we can now unpin their epoch.
-                        info!("Query {:?} has scheduled all of its stages that have table scan (iterator creation).", self.query.query_id);
+                        tracing::trace!("Query {:?} has scheduled all of its stages that have table scan (iterator creation).", self.query.query_id);
                         self.hummock_snapshot_manager
                             .unpin_snapshot(self.epoch, self.query.query_id())
                             .await?;

--- a/src/frontend/src/scheduler/distributed/stage.rs
+++ b/src/frontend/src/scheduler/distributed/stage.rs
@@ -31,7 +31,7 @@ use tokio::spawn;
 use tokio::sync::mpsc::{channel, Receiver, Sender};
 use tokio::sync::RwLock;
 use tokio::task::JoinHandle;
-use tracing::{error, info};
+use tracing::error;
 use uuid::Uuid;
 use StageEvent::Failed;
 
@@ -188,9 +188,10 @@ impl StageExecution {
             _ => {
                 // This is possible since we notify stage schedule event to query runner, which may
                 // receive multi events and start stage multi times.
-                info!(
+                tracing::trace!(
                     "Staged {:?}-{:?} already started, skipping.",
-                    &self.stage.query_id, &self.stage.id
+                    &self.stage.query_id,
+                    &self.stage.id
                 );
                 Ok(())
             }

--- a/src/tests/sqlsmith/Cargo.toml
+++ b/src/tests/sqlsmith/Cargo.toml
@@ -8,6 +8,7 @@ anyhow = { version = "1", features = ["backtrace"] }
 chrono = "0.4"
 clap = { version = "3", features = ["derive"] }
 env_logger = { version = "0.9" }
+itertools = "0.10"
 lazy_static = "1"
 log = "0.4"
 madsim = "=0.2.0-alpha.3"

--- a/src/tests/sqlsmith/README.md
+++ b/src/tests/sqlsmith/README.md
@@ -11,5 +11,14 @@ In the second mode, it will test the entire query handling end-to-end. We provid
 
 ```sh
 cd risingwave
-./target/debug/sqlsmith --testdata ./src/tests/sqlsmith/tests/testdata
+./target/debug/sqlsmith test --testdata ./src/tests/sqlsmith/tests/testdata
 ```
+
+Additionally, in some cases where you may want to debug whether we have defined some function/operator incorrectly,
+you can try:
+
+```sh
+./target/debug/sqlsmith print-function-table > ft.txt
+```
+
+Check out ft.txt that will contain all the function signatures.

--- a/src/tests/sqlsmith/src/expr.rs
+++ b/src/tests/sqlsmith/src/expr.rs
@@ -14,6 +14,7 @@
 
 use std::collections::HashMap;
 
+use itertools::Itertools;
 use rand::seq::SliceRandom;
 use rand::Rng;
 use risingwave_frontend::expr::{func_sigs, DataTypeName, ExprType, FuncSign};
@@ -221,4 +222,20 @@ fn make_bin_op(func: ExprType, exprs: &[Expr]) -> Option<Expr> {
 
 pub(crate) fn sql_null() -> Expr {
     Expr::Value(Value::Null)
+}
+
+pub fn print_function_table() -> String {
+    func_sigs()
+        .map(|sign| {
+            format!(
+                "{:?}({}) -> {:?}",
+                sign.func,
+                sign.inputs_type
+                    .iter()
+                    .map(|arg| format!("{:?}", arg))
+                    .join(", "),
+                sign.ret_type,
+            )
+        })
+        .join("\n")
 }

--- a/src/tests/sqlsmith/src/lib.rs
+++ b/src/tests/sqlsmith/src/lib.rs
@@ -24,6 +24,7 @@ use risingwave_sqlparser::ast::{
 };
 
 mod expr;
+pub use expr::print_function_table;
 mod relation;
 mod scalar;
 
@@ -101,6 +102,7 @@ impl<'a, R: Rng> SqlGenerator<'a, R> {
 
     fn gen_order_by(&mut self) -> Vec<OrderByExpr> {
         if self.bound_relations.is_empty() {
+            println!("no order by");
             return vec![];
         }
         let mut order_by = vec![];
@@ -130,7 +132,6 @@ impl<'a, R: Rng> SqlGenerator<'a, R> {
     fn gen_select_stmt(&mut self) -> (Select, Vec<Column>) {
         // Generate random tables/relations first so that select items can refer to them.
         let from = self.gen_from();
-        let rel_num = from.len();
         let (select_list, schema) = self.gen_select_list();
         let select = Select {
             distinct: false,
@@ -141,11 +142,6 @@ impl<'a, R: Rng> SqlGenerator<'a, R> {
             group_by: self.gen_group_by(),
             having: self.gen_having(),
         };
-        // The relations used in the inner query can not be used in the outer query.
-        (0..rel_num).for_each(|_| {
-            let rel = self.bound_relations.pop();
-            assert!(rel.is_some());
-        });
         (select, schema)
     }
 

--- a/src/tests/sqlsmith/src/lib.rs
+++ b/src/tests/sqlsmith/src/lib.rs
@@ -102,7 +102,6 @@ impl<'a, R: Rng> SqlGenerator<'a, R> {
 
     fn gen_order_by(&mut self) -> Vec<OrderByExpr> {
         if self.bound_relations.is_empty() {
-            println!("no order by");
             return vec![];
         }
         let mut order_by = vec![];


### PR DESCRIPTION
I hereby agree to the terms of the [Singularity Data, Inc. Contributor License Agreement](https://gist.github.com/skyzh/0663682a70b0edde7ae991492f2314cb#file-s9y_cla).

## What's changed and what's your intention?

Now we can run sqlsmith e2e against RisingWave without failures. Sqlsmith still lacks many features and the testing is not always stable. So I will include it in our CI process when I think it's stable enough.

## Checklist

- [x] I have written necessary rustdoc comments
- [x] I have added necessary unit tests and integration tests
- [x] All checks passed in `./risedev check` (or alias, `./risedev c`)

### Release note

Please create a release note for your changes. In the release note, focus on the impact on users, and mention the environment or conditions where the impact may occur.

## Refer to a related PR or issue link (optional)

https://github.com/singularity-data/risingwave/issues/2571
Fixed https://github.com/singularity-data/risingwave/issues/3341