### PR TITLE
refactor(storage): make compactor logic more readable

### DIFF
--- a/src/bench/ss_bench/operations/mod.rs
+++ b/src/bench/ss_bench/operations/mod.rs
@@ -52,7 +52,7 @@ impl Operations {
     pub(crate) async fn run(
         store: impl StateStore,
         meta_service: Arc<MockHummockMetaClient>,
-        context: Option<(Arc<CompactorContext>, Arc<LocalVersionManager>)>,
+        context: Option<(CompactorContext, Arc<LocalVersionManager>)>,
         opts: &Opts,
     ) {
         let mut stat_display = DisplayStats::default();

--- a/src/bench/ss_bench/operations/write_batch.rs
+++ b/src/bench/ss_bench/operations/write_batch.rs
@@ -83,7 +83,7 @@ impl Operations {
         &mut self,
         store: &impl StateStore,
         opts: &Opts,
-        context: Option<(Arc<CompactorContext>, Arc<LocalVersionManager>)>,
+        context: Option<(CompactorContext, Arc<LocalVersionManager>)>,
     ) {
         let (prefixes, keys) = Workload::new_random_keys(opts, opts.writes as u64, &mut self.rng);
         let values = Workload::new_values(opts, opts.writes as u64, &mut self.rng);

--- a/src/storage/src/hummock/compactor_tests.rs
+++ b/src/storage/src/hummock/compactor_tests.rs
@@ -121,6 +121,8 @@ mod tests {
             is_share_buffer_compact: false,
             sstable_id_generator: get_remote_sstable_id_generator(hummock_meta_client.clone()),
             compaction_executor: None,
+            uncommitted_data: None,
+            local_stats: StoreLocalStatistic::default(),
         }
     }
 
@@ -176,7 +178,7 @@ mod tests {
         );
 
         // 3. compact
-        Compactor::compact(Arc::new(compact_ctx), compact_task.clone()).await;
+        Compactor::compact(compact_ctx, compact_task.clone()).await;
 
         // 4. get the latest version and check
         let version = hummock_manager_ref.get_current_version().await;
@@ -274,7 +276,7 @@ mod tests {
         );
 
         // 3. compact
-        Compactor::compact(Arc::new(compact_ctx), compact_task.clone()).await;
+        Compactor::compact(compact_ctx, compact_task.clone()).await;
 
         // 4. get the latest version and check
         let version = hummock_manager_ref.get_current_version().await;
@@ -345,6 +347,8 @@ mod tests {
             is_share_buffer_compact: false,
             sstable_id_generator: get_remote_sstable_id_generator(hummock_meta_client.clone()),
             compaction_executor: None,
+            uncommitted_data: None,
+            local_stats: StoreLocalStatistic::default(),
         };
 
         // 1. add sstables
@@ -409,7 +413,7 @@ mod tests {
         );
 
         // 3. compact
-        Compactor::compact(Arc::new(compact_ctx), compact_task.clone()).await;
+        Compactor::compact(compact_ctx, compact_task.clone()).await;
 
         // 4. get the latest version and check
         let version = hummock_manager_ref.get_current_version().await;
@@ -445,6 +449,8 @@ mod tests {
             is_share_buffer_compact: false,
             sstable_id_generator: get_remote_sstable_id_generator(hummock_meta_client.clone()),
             compaction_executor: None,
+            uncommitted_data: None,
+            local_stats: StoreLocalStatistic::default(),
         };
 
         // 1. add sstables
@@ -525,7 +531,7 @@ mod tests {
         );
 
         // 3. compact
-        Compactor::compact(Arc::new(compact_ctx), compact_task.clone()).await;
+        Compactor::compact(compact_ctx, compact_task.clone()).await;
 
         // 4. get the latest version and check
         let version: HummockVersion = hummock_manager_ref.get_current_version().await;
@@ -601,6 +607,8 @@ mod tests {
             is_share_buffer_compact: false,
             sstable_id_generator: get_remote_sstable_id_generator(hummock_meta_client.clone()),
             compaction_executor: None,
+            uncommitted_data: None,
+            local_stats: StoreLocalStatistic::default(),
         };
 
         // 1. add sstables
@@ -683,7 +691,7 @@ mod tests {
         );
 
         // 3. compact
-        Compactor::compact(Arc::new(compact_ctx), compact_task.clone()).await;
+        Compactor::compact(compact_ctx, compact_task.clone()).await;
 
         // 4. get the latest version and check
         let version: HummockVersion = hummock_manager_ref.get_current_version().await;

--- a/src/storage/src/monitor/local_metrics.rs
+++ b/src/storage/src/monitor/local_metrics.rs
@@ -14,7 +14,7 @@
 
 use crate::monitor::StateStoreMetrics;
 
-#[derive(Default)]
+#[derive(Default, Clone)]
 pub struct StoreLocalStatistic {
     pub cache_data_block_miss: u64,
     pub cache_data_block_total: u64,


### PR DESCRIPTION
I hereby agree to the terms of the [Singularity Data, Inc. Contributor License Agreement](https://gist.github.com/skyzh/0663682a70b0edde7ae991492f2314cb#file-s9y_cla).

## What's changed and what's your intention?

as title

Please explain **IN DETAIL** what the changes are in this PR and why they are needed:
- compactor_context should independent for every compact job with status
- unify the compact_impl logic of shared_buffer_compact and normal_compact

## Checklist

- [x] I have written necessary rustdoc comments
- [x] I have added necessary unit tests and integration tests
- [x] All checks passed in `./risedev check` (or alias, `./risedev c`)
