### PR TITLE
fix(batch): add first-match optimization for left semi join

### DIFF
--- a/src/batch/src/executor/join/nested_loop_join.rs
+++ b/src/batch/src/executor/join/nested_loop_join.rs
@@ -320,7 +320,9 @@ impl NestedLoopJoinExecutor {
         for right_chunk in right.execute() {
             let right_chunk = right_chunk?;
             for (left_row_idx, left_row) in left.iter().flat_map(|chunk| chunk.rows()).enumerate() {
-                // TODO: use first-match optimization
+                if matched.is_set(left_row_idx) {
+                    continue;
+                }
                 let chunk = Self::concatenate_and_eval(
                     join_expr.as_ref(),
                     &left_data_types,


### PR DESCRIPTION
I hereby agree to the terms of the [Singularity Data, Inc. Contributor License Agreement](https://gist.github.com/skyzh/0663682a70b0edde7ae991492f2314cb#file-s9y_cla).

## What's changed and what's your intention?

In https://github.com/singularity-data/risingwave/pull/3724, when doing left semi join, we iterate all left rows for each right chunk no matter if the left row has been matched in previous outer loops. This is a compromise due to the lack of interface to check if a specific bit is set when building a bitmap.

Now that `is_set` is added in https://github.com/singularity-data/risingwave/pull/3768, we can implement first-match optimization for left semi join, i.e., skipping the left rows matched in previous loops.

This change can greatly reduce the execution time for left semi join in some workloads. Take the randomly generated benchmark dataset for example:

| Type | Before | After|
| --- | --- | --- |
| LeftSemi(32) | 277.09 ms | **4.8026 ms** |
| LeftSemi(128) | 217.63 ms | **14.055 ms** |
| LeftSemi(512) | 212.73 ms | **52.910 ms** |

## Checklist

- [x] I have written necessary rustdoc comments
- [x] I have added necessary unit tests and integration tests
- [x] All checks passed in `./risedev check` (or alias, `./risedev c`)

## Refer to a related PR or issue link (optional)
https://github.com/singularity-data/risingwave/pull/3724
https://github.com/singularity-data/risingwave/pull/3768