### PR TITLE
refactor: remove stale AggKind::RowCount

### DIFF
--- a/src/expr/src/expr/agg.rs
+++ b/src/expr/src/expr/agg.rs
@@ -24,7 +24,6 @@ pub enum AggKind {
     Max,
     Sum,
     Count,
-    RowCount,
     Avg,
     StringAgg,
     SingleValue,
@@ -38,7 +37,6 @@ impl std::fmt::Display for AggKind {
             AggKind::Max => write!(f, "max"),
             AggKind::Sum => write!(f, "sum"),
             AggKind::Count => write!(f, "count"),
-            AggKind::RowCount => write!(f, "row_count"),
             AggKind::Avg => write!(f, "avg"),
             AggKind::StringAgg => write!(f, "string_agg"),
             AggKind::SingleValue => write!(f, "single_value"),
@@ -75,9 +73,6 @@ impl AggKind {
             Self::Count => Type::Count,
             Self::StringAgg => Type::StringAgg,
             Self::SingleValue => Type::SingleValue,
-            Self::RowCount => {
-                panic!("cannot convert RowCount to prost, TODO: remove RowCount from AggKind")
-            }
             Self::ApproxCountDistinct => Type::ApproxCountDistinct,
         }
     }

--- a/src/frontend/src/expr/agg_call.rs
+++ b/src/frontend/src/expr/agg_call.rs
@@ -52,13 +52,6 @@ impl AggCall {
     /// Infer the return type for the given agg call.
     /// Returns error if not supported or the arguments are invalid.
     pub fn infer_return_type(agg_kind: &AggKind, inputs: &[DataType]) -> Result<DataType> {
-        let unsupported = || {
-            let args = inputs.iter().map(|t| format!("{:?}", t)).join(", ");
-            Err(RwError::from(ErrorCode::NotImplemented(
-                format!("Unsupported aggregation: {}({})", agg_kind, args),
-                112.into(),
-            )))
-        };
         let invalid = || {
             let args = inputs.iter().map(|t| format!("{:?}", t)).join(", ");
             Err(RwError::from(ErrorCode::InvalidInputSyntax(format!(
@@ -107,9 +100,6 @@ impl AggCall {
             // SingleValue
             (AggKind::SingleValue, [input]) => input.clone(),
             (AggKind::SingleValue, _) => return invalid(),
-
-            // Others
-            _ => return unsupported(),
         };
 
         Ok(return_type)

--- a/src/frontend/src/optimizer/plan_node/logical_agg.rs
+++ b/src/frontend/src/optimizer/plan_node/logical_agg.rs
@@ -103,9 +103,7 @@ impl PlanAggCall {
             | AggKind::StringAgg
             | AggKind::SingleValue => self.agg_kind.clone(),
 
-            AggKind::Count | AggKind::RowCount | AggKind::Sum | AggKind::ApproxCountDistinct => {
-                AggKind::Sum
-            }
+            AggKind::Count | AggKind::Sum | AggKind::ApproxCountDistinct => AggKind::Sum,
         };
         PlanAggCall {
             agg_kind: total_agg_kind,
@@ -184,7 +182,6 @@ impl LogicalAgg {
                 }
                 AggKind::Sum
                 | AggKind::Count
-                | AggKind::RowCount
                 | AggKind::Avg
                 | AggKind::SingleValue
                 | AggKind::ApproxCountDistinct => {

--- a/src/stream/src/executor/aggregation/agg_call.rs
+++ b/src/stream/src/executor/aggregation/agg_call.rs
@@ -20,7 +20,7 @@ use risingwave_expr::expr::AggKind;
 /// An aggregation function may accept 0, 1 or 2 arguments.
 #[derive(Clone, Debug)]
 pub enum AggArgs {
-    /// `None` is used for aggregation function accepts 0 arguments, such as [`AggKind::RowCount`].
+    /// `None` is used for aggregation function accepts 0 arguments, such as `count(*)`.
     None,
     /// `Unary` is used for aggregation function accepts 1 argument, such as [`AggKind::Sum`].
     Unary(DataType, usize),

--- a/src/stream/src/executor/aggregation/mod.rs
+++ b/src/stream/src/executor/aggregation/mod.rs
@@ -269,12 +269,6 @@ pub fn create_streaming_agg_state(
         }
         [] => {
             match (agg_type, return_type, datum) {
-                // `AggKind::Count` for partial/local Count(*) == RowCount while `AggKind::Sum` for
-                // final/global Count(*)
-                (AggKind::RowCount, DataType::Int64, Some(datum)) => {
-                    Box::new(StreamingRowCountAgg::with_row_cnt(datum))
-                }
-                (AggKind::RowCount, DataType::Int64, None) => Box::new(StreamingRowCountAgg::new()),
                 // According to the function header comments and the link, Count(*) == RowCount
                 // `StreamingCountAgg` does not count `NULL`, so we use `StreamingRowCountAgg` here.
                 (AggKind::Count, DataType::Int64, Some(datum)) => {

--- a/src/stream/src/executor/global_simple_agg.rs
+++ b/src/stream/src/executor/global_simple_agg.rs
@@ -321,7 +321,7 @@ mod tests {
         let append_only = false;
         let agg_calls = vec![
             AggCall {
-                kind: AggKind::RowCount,
+                kind: AggKind::Count,
                 args: AggArgs::None,
                 return_type: DataType::Int64,
                 append_only,

--- a/src/stream/src/executor/hash_agg.rs
+++ b/src/stream/src/executor/hash_agg.rs
@@ -573,7 +573,7 @@ mod tests {
         let append_only = false;
         let agg_calls = vec![
             AggCall {
-                kind: AggKind::RowCount,
+                kind: AggKind::Count,
                 args: AggArgs::None,
                 return_type: DataType::Int64,
                 append_only,
@@ -660,7 +660,7 @@ mod tests {
         let append_only = false;
         let agg_calls = vec![
             AggCall {
-                kind: AggKind::RowCount,
+                kind: AggKind::Count,
                 args: AggArgs::None,
                 return_type: DataType::Int64,
                 append_only,
@@ -755,7 +755,7 @@ mod tests {
         let keys = vec![0];
         let agg_calls = vec![
             AggCall {
-                kind: AggKind::RowCount,
+                kind: AggKind::Count,
                 args: AggArgs::None,
                 return_type: DataType::Int64,
                 append_only: false,
@@ -844,7 +844,7 @@ mod tests {
         let append_only = true;
         let agg_calls = vec![
             AggCall {
-                kind: AggKind::RowCount,
+                kind: AggKind::Count,
                 args: AggArgs::None,
                 return_type: DataType::Int64,
                 append_only,

--- a/src/stream/src/executor/integration_tests.rs
+++ b/src/stream/src/executor/integration_tests.rs
@@ -60,7 +60,7 @@ async fn test_merger_sum_aggr() {
             input.boxed(),
             vec![
                 AggCall {
-                    kind: AggKind::RowCount,
+                    kind: AggKind::Count,
                     args: AggArgs::None,
                     return_type: DataType::Int64,
                     append_only,

--- a/src/stream/src/executor/local_simple_agg.rs
+++ b/src/stream/src/executor/local_simple_agg.rs
@@ -183,7 +183,7 @@ mod tests {
         tx.push_barrier(3, false);
 
         let agg_calls = vec![AggCall {
-            kind: AggKind::RowCount,
+            kind: AggKind::Count,
             args: AggArgs::None,
             return_type: DataType::Int64,
             append_only: false,
@@ -237,7 +237,7 @@ mod tests {
         // This is local simple aggregation, so we add another row count state
         let agg_calls = vec![
             AggCall {
-                kind: AggKind::RowCount,
+                kind: AggKind::Count,
                 args: AggArgs::None,
                 return_type: DataType::Int64,
                 append_only: false,

--- a/src/stream/src/executor/managed_state/aggregation/mod.rs
+++ b/src/stream/src/executor/managed_state/aggregation/mod.rs
@@ -164,12 +164,6 @@ impl<S: StateStore> ManagedStateImpl<S> {
                     ManagedValueState::new(agg_call, row_count, pk, state_table).await?,
                 ))
             }
-            AggKind::RowCount => {
-                assert!(is_row_count);
-                Ok(Self::Value(
-                    ManagedValueState::new(agg_call, row_count, pk, state_table).await?,
-                ))
-            }
             AggKind::SingleValue => Ok(Self::Value(
                 ManagedValueState::new(agg_call, row_count, pk, state_table).await?,
             )),


### PR DESCRIPTION
I hereby agree to the terms of the [Singularity Data, Inc. Contributor License Agreement](https://gist.github.com/skyzh/0663682a70b0edde7ae991492f2314cb#file-s9y_cla).

## What's changed and what's your intention?

`AggKind::RowCount` was used to present `count(*)` but later we converged to just use `AggKind::Count` with 0 arguments. The current rust frontend never generates a `AggKind` in the binder/planner, and the match arms in `stream` crate are dead and identical to `Count`.

## Checklist

- [x] I have written necessary rustdoc comments
- [x] I have added necessary unit tests and integration tests
- [x] All checks passed in `./risedev check` (or alias, `./risedev c`)

## Refer to a related PR or issue link (optional)
