### PR TITLE
fix(batch): fix order_by with struct table

### DIFF
--- a/e2e_test/streaming/struct_table.slt
+++ b/e2e_test/streaming/struct_table.slt
@@ -46,13 +46,21 @@ select * from t1 order by v1;
 3 (6,(3,4))
 4 (3,(2,2))
 
+statement ok
+create materialized view mv3 as select * from t1 order by (v2).v3;
+
+# The result of select * from mv3 is not expected
+
+
+statement ok
+drop materialized view mv3;
 
 statement ok
 drop table t1;
 
 statement ok
-drop materialized view mv1
+drop materialized view mv1;
 
 statement ok
-drop table st
+drop table st;
 

--- a/e2e_test/streaming/struct_table.slt
+++ b/e2e_test/streaming/struct_table.slt
@@ -19,8 +19,40 @@ select * from mv1;
 (1,2)
 (1,3)
 
+
+statement ok
+create table t1 (v1 int, v2 struct<v3 int, v4 struct<v5 int, v6 int>>);
+
+statement ok
+insert into t1 values(4,(3,(2, 2)));
+
+statement ok
+insert into t1 values(1,(2,(1, 0)));
+
+statement ok
+insert into t1 values(2,(5,(4, 1)));
+
+statement ok
+insert into t1 values(3,(6,(3, 4)));
+
+statement ok
+flush;
+
+query II
+select * from t1 order by v1;
+----
+1 (2,(1,0))
+2 (5,(4,1))
+3 (6,(3,4))
+4 (3,(2,2))
+
+
+statement ok
+drop table t1;
+
 statement ok
 drop materialized view mv1
 
 statement ok
 drop table st
+

--- a/src/batch/src/executor/order_by.rs
+++ b/src/batch/src/executor/order_by.rs
@@ -252,7 +252,8 @@ impl OrderByExecutor {
                             Interval,
                             NaiveDate,
                             NaiveTime,
-                            NaiveDateTime
+                            NaiveDateTime,
+                            Struct
                         ]
                     );
                 }


### PR DESCRIPTION
I hereby agree to the terms of the [Singularity Data, Inc. Contributor License Agreement](https://gist.github.com/skyzh/0663682a70b0edde7ae991492f2314cb#file-s9y_cla).

## What's changed and what's your intention?
Fix panic on batch query when doing order_by with struct table

## Checklist

~~- [ ] I have written necessary rustdoc comments~~
- [x] I have added necessary unit tests and integration tests
- [x] All checks passed in `./risedev check` (or alias, `./risedev c`)


## Refer to a related PR or issue link (optional)
close #3780 