### PR TITLE
fix(connector): support parsing non-string nexmark properties

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4229,6 +4229,7 @@ dependencies = [
  "serde",
  "serde_derive",
  "serde_json",
+ "serde_with",
  "smallvec",
  "static_assertions",
  "tempfile",

--- a/src/connector/Cargo.toml
+++ b/src/connector/Cargo.toml
@@ -47,6 +47,7 @@ risingwave_storage = { path = "../storage" }
 serde = { version = "1", features = ["derive"] }
 serde_derive = "1"
 serde_json = "1"
+serde_with = "1"
 smallvec = "1"
 static_assertions = "1"
 tempfile = "3"

--- a/src/connector/src/base.rs
+++ b/src/connector/src/base.rs
@@ -109,12 +109,12 @@ pub enum ConnectorProperties {
 
 impl_connector_properties! {
     [ ] ,
-    { Kafka, KafkaProperties, KAFKA_CONNECTOR },
-    { Pulsar, PulsarProperties, PULSAR_CONNECTOR },
-    { Kinesis, KinesisProperties, KINESIS_CONNECTOR },
-    { Nexmark, NexmarkProperties, NEXMARK_CONNECTOR },
-    { Datagen, DatagenProperties, DATAGEN_CONNECTOR },
-    { S3, S3Properties, S3_CONNECTOR }
+    { Kafka, KAFKA_CONNECTOR },
+    { Pulsar, PULSAR_CONNECTOR },
+    { Kinesis, KINESIS_CONNECTOR },
+    { Nexmark, NEXMARK_CONNECTOR },
+    { Datagen, DATAGEN_CONNECTOR },
+    { S3, S3_CONNECTOR }
 }
 
 impl_split_enumerator! {

--- a/src/connector/src/datagen/mod.rs
+++ b/src/connector/src/datagen/mod.rs
@@ -24,6 +24,7 @@ pub use source::*;
 pub use split::*;
 
 pub const DATAGEN_CONNECTOR: &str = "datagen";
+
 #[derive(Clone, Debug, Deserialize)]
 pub struct DatagenProperties {
     /// split_num means data source partition

--- a/src/connector/src/macros.rs
+++ b/src/connector/src/macros.rs
@@ -122,14 +122,19 @@ macro_rules! impl_split_reader {
 
 #[macro_export]
 macro_rules! impl_connector_properties {
-    ([], $({ $variant_name:ident, $connector_name:ident } ),*) => {
+    ([], $({ $variant_name:ident, $struct_name:ident, $connector_name:ident } ),*) => {
         impl ConnectorProperties {
             pub fn extract(mut props: HashMap<String, String>) -> Result<Self> {
                 const UPSTREAM_SOURCE_KEY: &str = "connector";
                 let connector = props.remove(UPSTREAM_SOURCE_KEY).ok_or_else(|| anyhow!("Must specify 'connector' in WITH clause"))?;
-                let json_value = serde_json::to_value(props).map_err(|e| anyhow!(e))?;
                 match connector.to_lowercase().as_str() {
-                    $( $connector_name => { serde_json::from_value(json_value).map_err(|e| anyhow!(e.to_string())).map(Self::$variant_name) } ,)*
+                    $(
+                    $connector_name => {
+                        $struct_name::deserialize(
+                            serde::de::value::MapDeserializer::<_, serde_json::Error>::new(props.into_iter()),
+                        ).map_err(|e| anyhow!(e.to_string())).map(Self::$variant_name)
+                    },
+                    )*
                     _ => {
                         Err(anyhow!("connector '{}' is not supported", connector,))
                     }

--- a/src/connector/src/nexmark/enumerator/mod.rs
+++ b/src/connector/src/nexmark/enumerator/mod.rs
@@ -26,11 +26,11 @@ impl NexmarkSplitEnumerator {}
 
 #[async_trait]
 impl SplitEnumerator for NexmarkSplitEnumerator {
-    type Properties = Box<NexmarkProperties>;
+    type Properties = NexmarkProperties;
     type Split = NexmarkSplit;
 
-    async fn new(properties: Box<NexmarkProperties>) -> anyhow::Result<NexmarkSplitEnumerator> {
-        let split_num = properties.split_num.unwrap_or(1);
+    async fn new(properties: NexmarkProperties) -> anyhow::Result<NexmarkSplitEnumerator> {
+        let split_num = properties.split_num;
         Ok(Self { split_num })
     }
 
@@ -53,6 +53,7 @@ mod tests {
 
     use super::*;
     use crate::SplitMetaData;
+
     #[tokio::test]
     async fn test_nexmark_split_enumerator() -> Result<()> {
         let mut enumerator = NexmarkSplitEnumerator { split_num: 4 };

--- a/src/connector/src/nexmark/mod.rs
+++ b/src/connector/src/nexmark/mod.rs
@@ -40,9 +40,11 @@ const fn none<T>() -> Option<T> {
     None
 }
 
+pub type NexmarkProperties = Box<NexmarkPropertiesInner>;
+
 #[serde_as]
 #[derive(Clone, Debug, Deserialize)]
-pub struct NexmarkProperties {
+pub struct NexmarkPropertiesInner {
     #[serde_as(as = "DisplayFromStr")]
     #[serde(rename = "nexmark.split.num", default = "identity_i32::<1>")]
     pub split_num: i32,
@@ -204,9 +206,9 @@ fn default_event_num() -> i64 {
     -1
 }
 
-impl Default for NexmarkProperties {
+impl Default for NexmarkPropertiesInner {
     fn default() -> Self {
         let v = serde_json::to_value(HashMap::<String, String>::new()).unwrap();
-        NexmarkProperties::deserialize(v).unwrap()
+        NexmarkPropertiesInner::deserialize(v).unwrap()
     }
 }

--- a/src/connector/src/nexmark/mod.rs
+++ b/src/connector/src/nexmark/mod.rs
@@ -20,118 +20,188 @@ pub mod split;
 use std::collections::HashMap;
 
 pub use enumerator::*;
+use serde::Deserialize;
+use serde_with::{serde_as, DisplayFromStr};
 pub use split::*;
 
 const NEXMARK_BASE_TIME: usize = 1_436_918_400_000;
 
-use serde::Deserialize;
-
 pub const NEXMARK_CONNECTOR: &str = "nexmark";
 
+const fn identity_i32<const V: i32>() -> i32 {
+    V
+}
+
+const fn identity_u64<const V: u64>() -> u64 {
+    V
+}
+
+const fn none<T>() -> Option<T> {
+    None
+}
+
+#[serde_as]
 #[derive(Clone, Debug, Deserialize)]
 pub struct NexmarkProperties {
-    #[serde(rename = "nexmark.split.num")]
-    pub split_num: Option<i32>,
+    #[serde_as(as = "DisplayFromStr")]
+    #[serde(rename = "nexmark.split.num", default = "identity_i32::<1>")]
+    pub split_num: i32,
 
     /// The total event count of Bid + Auction + Person
+    #[serde_as(as = "DisplayFromStr")]
     #[serde(rename = "nexmark.event.num", default = "default_event_num")]
     pub event_num: i64,
 
     #[serde(rename = "nexmark.table.type", default)]
     pub table_type: String,
 
-    #[serde(rename = "nexmark.max.chunk.size", default = "default_max_chunk_size")]
+    #[serde_as(as = "DisplayFromStr")]
+    #[serde(rename = "nexmark.max.chunk.size", default = "identity_u64::<1024>")]
     pub max_chunk_size: u64,
 
+    #[serde_as(as = "DisplayFromStr")]
     /// The event time gap will be like the time gap in the generated data, default false
     #[serde(rename = "nexmark.use.real.time", default)]
     pub use_real_time: bool,
 
+    #[serde_as(as = "DisplayFromStr")]
     /// Minimal gap between two events, default 100000, so that the default max throughput is 10000
     #[serde(
         rename = "nexmark.min.event.gap.in.ns",
-        default = "default_min_event_gap_in_ns"
+        default = "identity_u64::<100_000>"
     )]
     pub min_event_gap_in_ns: u64,
 
-    #[serde(rename = "nexmark.active.people")]
+    #[serde_as(as = "Option<DisplayFromStr>")]
+    #[serde(rename = "nexmark.active.people", default = "none")]
     pub active_people: Option<usize>,
-    #[serde(rename = "nexmark.in.flight.auctions")]
+
+    #[serde_as(as = "Option<DisplayFromStr>")]
+    #[serde(rename = "nexmark.in.flight.auctions", default = "none")]
     pub in_flight_auctions: Option<usize>,
-    #[serde(rename = "nexmark.out.of.order.group.size")]
+
+    #[serde_as(as = "Option<DisplayFromStr>")]
+    #[serde(rename = "nexmark.out.of.order.group.size", default = "none")]
     pub out_of_order_group_size: Option<usize>,
-    #[serde(rename = "nexmark.hot.seller.ratio")]
+
+    #[serde_as(as = "Option<DisplayFromStr>")]
+    #[serde(rename = "nexmark.hot.seller.ratio", default = "none")]
     pub hot_seller_ratio: Option<usize>,
-    #[serde(rename = "nexmark.hot.auction.ratio")]
+
+    #[serde_as(as = "Option<DisplayFromStr>")]
+    #[serde(rename = "nexmark.hot.auction.ratio", default = "none")]
     pub hot_auction_ratio: Option<usize>,
-    #[serde(rename = "nexmark.hot.bidder.ratio")]
+
+    #[serde_as(as = "Option<DisplayFromStr>")]
+    #[serde(rename = "nexmark.hot.bidder.ratio", default = "none")]
     pub hot_bidder_ratio: Option<usize>,
-    #[serde(rename = "nexmark.first.event.id")]
+
+    #[serde_as(as = "Option<DisplayFromStr>")]
+    #[serde(rename = "nexmark.first.event.id", default = "none")]
     pub hot_first_event_id: Option<usize>,
-    #[serde(rename = "nexmark.first.event.number")]
+
+    #[serde_as(as = "Option<DisplayFromStr>")]
+    #[serde(rename = "nexmark.first.event.number", default = "none")]
     pub first_event_number: Option<usize>,
-    #[serde(rename = "nexmark.num.categories")]
+
+    #[serde_as(as = "Option<DisplayFromStr>")]
+    #[serde(rename = "nexmark.num.categories", default = "none")]
     pub num_categories: Option<usize>,
-    #[serde(rename = "nexmark.auction.id.lead")]
+
+    #[serde_as(as = "Option<DisplayFromStr>")]
+    #[serde(rename = "nexmark.auction.id.lead", default = "none")]
     pub auction_id_lead: Option<usize>,
-    #[serde(rename = "nexmark.hot.seller.ratio.2")]
+
+    #[serde_as(as = "Option<DisplayFromStr>")]
+    #[serde(rename = "nexmark.hot.seller.ratio.2", default = "none")]
     pub hot_seller_ratio_2: Option<usize>,
-    #[serde(rename = "nexmark.hot.auction.ratio.2")]
+
+    #[serde_as(as = "Option<DisplayFromStr>")]
+    #[serde(rename = "nexmark.hot.auction.ratio.2", default = "none")]
     pub hot_auction_ratio_2: Option<usize>,
-    #[serde(rename = "nexmark.hot.bidder.ratio.2")]
+
+    #[serde_as(as = "Option<DisplayFromStr>")]
+    #[serde(rename = "nexmark.hot.bidder.ratio.2", default = "none")]
     pub hot_bidder_ratio_2: Option<usize>,
-    #[serde(rename = "nexmark.person.proportion")]
+
+    #[serde_as(as = "Option<DisplayFromStr>")]
+    #[serde(rename = "nexmark.person.proportion", default = "none")]
     pub person_proportion: Option<usize>,
-    #[serde(rename = "nexmark.auction.proportion")]
+
+    #[serde_as(as = "Option<DisplayFromStr>")]
+    #[serde(rename = "nexmark.auction.proportion", default = "none")]
     pub auction_proportion: Option<usize>,
-    #[serde(rename = "nexmark.bid.proportion")]
+
+    #[serde_as(as = "Option<DisplayFromStr>")]
+    #[serde(rename = "nexmark.bid.proportion", default = "none")]
     pub bid_proportion: Option<usize>,
-    #[serde(rename = "nexmark.first.auction.id")]
+
+    #[serde_as(as = "Option<DisplayFromStr>")]
+    #[serde(rename = "nexmark.first.auction.id", default = "none")]
     pub first_auction_id: Option<usize>,
-    #[serde(rename = "nexmark.first.person.id")]
+
+    #[serde_as(as = "Option<DisplayFromStr>")]
+    #[serde(rename = "nexmark.first.person.id", default = "none")]
     pub first_person_id: Option<usize>,
-    #[serde(rename = "nexmark.first.category.id")]
+
+    #[serde_as(as = "Option<DisplayFromStr>")]
+    #[serde(rename = "nexmark.first.category.id", default = "none")]
     pub first_category_id: Option<usize>,
-    #[serde(rename = "nexmark.person.id.lead")]
+
+    #[serde_as(as = "Option<DisplayFromStr>")]
+    #[serde(rename = "nexmark.person.id.lead", default = "none")]
     pub person_id_lead: Option<usize>,
-    #[serde(rename = "nexmark.sine.approx.steps")]
+
+    #[serde_as(as = "Option<DisplayFromStr>")]
+    #[serde(rename = "nexmark.sine.approx.steps", default = "none")]
     pub sine_approx_steps: Option<usize>,
-    #[serde(rename = "nexmark.base.time")]
+
+    #[serde_as(as = "Option<DisplayFromStr>")]
+    #[serde(rename = "nexmark.base.time", default = "none")]
     pub base_time: Option<usize>,
+
     #[serde(rename = "nexmark.us.states")]
     pub us_states: Option<String>,
+
     #[serde(rename = "nexmark.us.cities")]
     pub us_cities: Option<String>,
+
     #[serde(rename = "nexmark.first.names")]
     pub first_names: Option<String>,
+
     #[serde(rename = "nexmark.last.names")]
     pub last_names: Option<String>,
+
     #[serde(rename = "nexmark.rate.shape")]
     pub rate_shape: Option<String>,
-    #[serde(rename = "nexmark.rate.period")]
+
+    #[serde_as(as = "Option<DisplayFromStr>")]
+    #[serde(rename = "nexmark.rate.period", default = "none")]
     pub rate_period: Option<usize>,
-    #[serde(rename = "nexmark.first.event.rate")]
+
+    #[serde_as(as = "Option<DisplayFromStr>")]
+    #[serde(rename = "nexmark.first.event.rate", default = "none")]
     pub first_event_rate: Option<usize>,
-    #[serde(rename = "nexmark.events.per.sec")]
+
+    #[serde_as(as = "Option<DisplayFromStr>")]
+    #[serde(rename = "nexmark.events.per.sec", default = "none")]
     pub events_per_sec: Option<usize>,
-    #[serde(rename = "nexmark.next.event.rate")]
+
+    #[serde_as(as = "Option<DisplayFromStr>")]
+    #[serde(rename = "nexmark.next.event.rate", default = "none")]
     pub next_event_rate: Option<usize>,
-    #[serde(rename = "nexmark.us.per.unit")]
+
+    #[serde_as(as = "Option<DisplayFromStr>")]
+    #[serde(rename = "nexmark.us.per.unit", default = "none")]
     pub us_per_unit: Option<usize>,
-    #[serde(rename = "nexmark.threads")]
+
+    #[serde_as(as = "Option<DisplayFromStr>")]
+    #[serde(rename = "nexmark.threads", default = "none")]
     pub threads: Option<usize>,
 }
 
 fn default_event_num() -> i64 {
     -1
-}
-
-fn default_min_event_gap_in_ns() -> u64 {
-    100000
-}
-
-fn default_max_chunk_size() -> u64 {
-    1024
 }
 
 impl Default for NexmarkProperties {

--- a/src/connector/src/nexmark/source/generator.rs
+++ b/src/connector/src/nexmark/source/generator.rs
@@ -25,7 +25,7 @@ use crate::SourceMessage;
 pub struct NexmarkEventGenerator {
     pub events_so_far: u64,
     pub event_num: i64,
-    pub config: Box<NexmarkConfig>,
+    pub config: NexmarkConfig,
     pub wall_clock_base_time: usize,
     pub split_index: i32,
     pub split_num: i32,

--- a/src/connector/src/nexmark/source/reader.rs
+++ b/src/connector/src/nexmark/source/reader.rs
@@ -121,18 +121,18 @@ mod tests {
     use anyhow::Result;
 
     use super::*;
-    use crate::nexmark::NexmarkSplitEnumerator;
+    use crate::nexmark::{NexmarkPropertiesInner, NexmarkSplitEnumerator};
     use crate::{SplitEnumerator, SplitImpl};
 
     #[tokio::test]
     async fn test_nexmark_split_reader() -> Result<()> {
-        let props = NexmarkProperties {
+        let props = Box::new(NexmarkPropertiesInner {
             split_num: 2,
             min_event_gap_in_ns: 0,
             table_type: "Bid".to_string(),
             max_chunk_size: 5,
             ..Default::default()
-        };
+        });
 
         let mut enumerator = NexmarkSplitEnumerator::new(props.clone()).await?;
         let list_splits_resp = enumerator


### PR DESCRIPTION
Signed-off-by: TennyZhuang <zty0826@gmail.com>

I hereby agree to the terms of the [Singularity Data, Inc. Contributor License Agreement](https://gist.github.com/skyzh/0663682a70b0edde7ae991492f2314cb#file-s9y_cla).

## What's changed and what's your intention?

1. ~I removed the special `Box` for `NexmarkProperty`, although it's large, it's really a non-critical path so I think we can just keep it simple.~
2. Introduced `serde_with` crate then parse the integer correctly.

Now we can create source with integer properties, e.g.:

```sql
create source auction (a_id INTEGER, item_name VARCHAR(24), description VARCHAR(104), initial_bid INTEGER, reserve INTEGER, a_date_time TIMESTAMP, expires TIMESTAMP, seller INTEGER, category INTEGER) with ( 'connector' = 'nexmark', 'nexmark.table.type' = 'Auction', 'nexmark.split.num' = '1' ) row format json;
```

## Checklist

- [x] I have written necessary rustdoc comments
- [x] I have added necessary unit tests and integration tests
- [x] All checks passed in `./risedev check` (or alias, `./risedev c`)

## Documentation

## Refer to a related PR or issue link (optional)
