### PR TITLE
feat(hummock manager): let client get version delta rather than versi…

### DIFF
--- a/proto/hummock.proto
+++ b/proto/hummock.proto
@@ -85,7 +85,9 @@ message PinVersionRequest {
 
 message PinVersionResponse {
   common.Status status = 1;
-  HummockVersion pinned_version = 2;
+  bool is_delta_response = 2;
+  repeated HummockVersionDelta version_deltas = 3;
+  HummockVersion pinned_version = 4;
 }
 
 message UnpinVersionRequest {

--- a/src/bench/ss_bench/operations/write_batch.rs
+++ b/src/bench/ss_bench/operations/write_batch.rs
@@ -107,7 +107,7 @@ impl Operations {
                     // LocalVersionManager::start_workers is modified into push-based.
                     let last_pinned_id = local_version_manager.get_pinned_version().id();
                     let version = self.meta_client.pin_version(last_pinned_id).await.unwrap();
-                    local_version_manager.try_update_pinned_version(version);
+                    local_version_manager.try_update_pinned_version(Some(last_pinned_id), version);
                 }
             }
         }

--- a/src/ctl/src/cmd_impl/hummock/list_version.rs
+++ b/src/ctl/src/cmd_impl/hummock/list_version.rs
@@ -19,7 +19,7 @@ use crate::common::MetaServiceOpts;
 pub async fn list_version() -> anyhow::Result<()> {
     let meta_opts = MetaServiceOpts::from_env()?;
     let meta_client = meta_opts.create_meta_client().await?;
-    let version = meta_client.pin_version(u64::MAX).await?;
+    let version = meta_client.pin_version(u64::MAX).await?.2;
     println!("{:#?}", version);
     meta_client.unpin_version(&[version.id]).await?;
     Ok(())

--- a/src/ctl/src/cmd_impl/hummock/sst_dump.rs
+++ b/src/ctl/src/cmd_impl/hummock/sst_dump.rs
@@ -28,7 +28,7 @@ pub async fn sst_dump() -> anyhow::Result<()> {
     let sstable_store = &*hummock.sstable_store();
 
     // Retrieves the latest HummockVersion from the meta client so we can access the SSTableInfo
-    let version = meta_client.pin_version(u64::MAX).await?;
+    let version = meta_client.pin_version(u64::MAX).await?.2;
 
     let sstable_id_infos = meta_client.list_sstable_id_infos(version.id).await?;
     let mut sstable_id_infos_iter = sstable_id_infos.iter();

--- a/src/meta/src/hummock/hummock_manager_tests.rs
+++ b/src/meta/src/hummock/hummock_manager_tests.rs
@@ -61,7 +61,8 @@ async fn test_hummock_pin_unpin() {
         let hummock_version = hummock_manager
             .pin_version(context_id, u64::MAX)
             .await
-            .unwrap();
+            .unwrap()
+            .2;
         let levels = hummock_version
             .get_compaction_group_levels(StaticCompactionGroupId::StateDefault.into());
         assert_eq!(version_id, hummock_version.id);
@@ -297,7 +298,8 @@ async fn test_hummock_table() {
     let pinned_version = hummock_manager
         .pin_version(context_id, u64::MAX)
         .await
-        .unwrap();
+        .unwrap()
+        .2;
     assert_eq!(
         Ordering::Equal,
         pinned_version
@@ -339,7 +341,8 @@ async fn test_hummock_transaction() {
         let pinned_version = hummock_manager
             .pin_version(context_id, u64::MAX)
             .await
-            .unwrap();
+            .unwrap()
+            .2;
         assert_eq!(pinned_version.max_committed_epoch, INVALID_EPOCH);
         assert!(get_sorted_committed_sstable_ids(&pinned_version).is_empty());
 
@@ -359,7 +362,8 @@ async fn test_hummock_transaction() {
         let pinned_version = hummock_manager
             .pin_version(context_id, u64::MAX)
             .await
-            .unwrap();
+            .unwrap()
+            .2;
         assert_eq!(pinned_version.max_committed_epoch, epoch1);
         assert_eq!(
             get_sorted_sstable_ids(&committed_tables),
@@ -390,7 +394,8 @@ async fn test_hummock_transaction() {
         let pinned_version = hummock_manager
             .pin_version(context_id, u64::MAX)
             .await
-            .unwrap();
+            .unwrap()
+            .2;
         assert_eq!(pinned_version.max_committed_epoch, epoch1);
         assert_eq!(
             get_sorted_sstable_ids(&committed_tables),
@@ -413,7 +418,8 @@ async fn test_hummock_transaction() {
         let pinned_version = hummock_manager
             .pin_version(context_id, u64::MAX)
             .await
-            .unwrap();
+            .unwrap()
+            .2;
         assert_eq!(pinned_version.max_committed_epoch, epoch2);
         assert_eq!(
             get_sorted_sstable_ids(&committed_tables),
@@ -580,7 +586,8 @@ async fn test_hummock_manager_basic() {
         let version = hummock_manager
             .pin_version(context_id_1, u64::MAX)
             .await
-            .unwrap();
+            .unwrap()
+            .2;
         assert_eq!(version.id, FIRST_VERSION_ID + 1);
         assert_eq!(
             hummock_manager
@@ -595,7 +602,8 @@ async fn test_hummock_manager_basic() {
         let version = hummock_manager
             .pin_version(context_id_2, u64::MAX)
             .await
-            .unwrap();
+            .unwrap()
+            .2;
         assert_eq!(version.id, FIRST_VERSION_ID + 1);
         assert_eq!(
             hummock_manager
@@ -640,7 +648,8 @@ async fn test_retryable_pin_version() {
     let version = hummock_manager
         .pin_version(context_id, INVALID_VERSION_ID)
         .await
-        .unwrap();
+        .unwrap()
+        .2;
     assert_eq!(version.id, FIRST_VERSION_ID);
 
     let mut epoch: u64 = 1;
@@ -672,7 +681,8 @@ async fn test_retryable_pin_version() {
     let version_retry = hummock_manager
         .pin_version(context_id, INVALID_VERSION_ID)
         .await
-        .unwrap();
+        .unwrap()
+        .2;
     assert_eq!(version_retry.id, version.id);
 
     // Use correct last_pin to pin newer version.
@@ -680,7 +690,8 @@ async fn test_retryable_pin_version() {
     let version_2 = hummock_manager
         .pin_version(context_id, version.id)
         .await
-        .unwrap();
+        .unwrap()
+        .2;
     assert_eq!(version_2.id, version.id + 2);
 
     // [ v0:pinned, v1, v2:pinned ] -> [ v0:pinned, v1, v2:pinned, v3, v4 ]
@@ -711,7 +722,8 @@ async fn test_retryable_pin_version() {
     let version_2_retry = hummock_manager
         .pin_version(context_id, version.id)
         .await
-        .unwrap();
+        .unwrap()
+        .2;
     assert_eq!(version_2_retry.id, version_2.id);
 
     // Use None as last_pin to pin greatest version
@@ -719,7 +731,8 @@ async fn test_retryable_pin_version() {
     let version_3 = hummock_manager
         .pin_version(context_id, u64::MAX)
         .await
-        .unwrap();
+        .unwrap()
+        .2;
     assert_eq!(version_3.id, version.id + 4);
 }
 

--- a/src/meta/src/hummock/mock_hummock_meta_client.rs
+++ b/src/meta/src/hummock/mock_hummock_meta_client.rs
@@ -21,8 +21,8 @@ use risingwave_hummock_sdk::{
     HummockContextId, HummockEpoch, HummockSSTableId, HummockVersionId, LocalSstableInfo,
 };
 use risingwave_pb::hummock::{
-    CompactTask, CompactionGroup, HummockSnapshot, HummockVersion, SstableIdInfo,
-    SubscribeCompactTasksResponse, VacuumTask,
+    CompactTask, CompactionGroup, HummockSnapshot, HummockVersion, HummockVersionDelta,
+    SstableIdInfo, SubscribeCompactTasksResponse, VacuumTask,
 };
 use risingwave_rpc_client::error::{Result, RpcError};
 use risingwave_rpc_client::HummockMetaClient;
@@ -61,7 +61,10 @@ fn mock_err(error: super::error::Error) -> RpcError {
 
 #[async_trait]
 impl HummockMetaClient for MockHummockMetaClient {
-    async fn pin_version(&self, last_pinned: HummockVersionId) -> Result<HummockVersion> {
+    async fn pin_version(
+        &self,
+        last_pinned: HummockVersionId,
+    ) -> Result<(bool, Vec<HummockVersionDelta>, HummockVersion)> {
         self.hummock_manager
             .pin_version(self.context_id, last_pinned)
             .await

--- a/src/meta/src/hummock/vacuum.rs
+++ b/src/meta/src/hummock/vacuum.rs
@@ -270,7 +270,8 @@ mod tests {
         let pinned_version = hummock_manager
             .pin_version(context_id, u64::MAX)
             .await
-            .unwrap();
+            .unwrap()
+            .2;
 
         // Vacuum no version because the smallest v0 is pinned.
         assert_eq!(

--- a/src/meta/src/rpc/service/hummock_service.rs
+++ b/src/meta/src/rpc/service/hummock_service.rs
@@ -77,10 +77,14 @@ where
             .pin_version(req.context_id, req.last_pinned)
             .await;
         match result {
-            Ok(pinned_version) => Ok(Response::new(PinVersionResponse {
-                status: None,
-                pinned_version: Some(pinned_version),
-            })),
+            Ok((is_delta_response, version_deltas, pinned_version)) => {
+                Ok(Response::new(PinVersionResponse {
+                    status: None,
+                    is_delta_response,
+                    version_deltas,
+                    pinned_version: Some(pinned_version),
+                }))
+            }
             Err(e) => Err(tonic_err(e)),
         }
     }

--- a/src/rpc_client/src/hummock_meta_client.rs
+++ b/src/rpc_client/src/hummock_meta_client.rs
@@ -15,8 +15,8 @@
 use async_trait::async_trait;
 use risingwave_hummock_sdk::{HummockEpoch, HummockSSTableId, HummockVersionId, LocalSstableInfo};
 use risingwave_pb::hummock::{
-    CompactTask, CompactionGroup, HummockVersion, SstableIdInfo, SubscribeCompactTasksResponse,
-    VacuumTask,
+    CompactTask, CompactionGroup, HummockVersion, HummockVersionDelta, SstableIdInfo,
+    SubscribeCompactTasksResponse, VacuumTask,
 };
 use tonic::Streaming;
 
@@ -24,7 +24,10 @@ use crate::error::Result;
 
 #[async_trait]
 pub trait HummockMetaClient: Send + Sync + 'static {
-    async fn pin_version(&self, last_pinned: HummockVersionId) -> Result<HummockVersion>;
+    async fn pin_version(
+        &self,
+        last_pinned: HummockVersionId,
+    ) -> Result<(bool, Vec<HummockVersionDelta>, HummockVersion)>;
     async fn unpin_version(&self, pinned_version_ids: &[HummockVersionId]) -> Result<()>;
     async fn pin_snapshot(&self) -> Result<HummockEpoch>;
     async fn unpin_snapshot(&self) -> Result<()>;

--- a/src/rpc_client/src/meta_client.rs
+++ b/src/rpc_client/src/meta_client.rs
@@ -345,13 +345,20 @@ impl MetaClient {
 
 #[async_trait]
 impl HummockMetaClient for MetaClient {
-    async fn pin_version(&self, last_pinned: HummockVersionId) -> Result<HummockVersion> {
+    async fn pin_version(
+        &self,
+        last_pinned: HummockVersionId,
+    ) -> Result<(bool, Vec<HummockVersionDelta>, HummockVersion)> {
         let req = PinVersionRequest {
             context_id: self.worker_id(),
             last_pinned,
         };
         let resp = self.inner.pin_version(req).await?;
-        Ok(resp.pinned_version.unwrap())
+        Ok((
+            resp.is_delta_response,
+            resp.version_deltas,
+            resp.pinned_version.unwrap(),
+        ))
     }
 
     async fn unpin_version(&self, pinned_version_ids: &[HummockVersionId]) -> Result<()> {

--- a/src/storage/hummock_sdk/src/compaction_group/hummock_version_ext.rs
+++ b/src/storage/hummock_sdk/src/compaction_group/hummock_version_ext.rs
@@ -14,7 +14,7 @@
 
 use std::collections::HashSet;
 
-use risingwave_pb::hummock::{HummockVersion, Level, SstableInfo};
+use risingwave_pb::hummock::{HummockVersion, HummockVersionDelta, Level, SstableInfo};
 
 use crate::prost_key_range::KeyRangeExt;
 use crate::CompactionGroupId;
@@ -38,6 +38,7 @@ pub trait HummockVersionExt {
         insert_sst_level: u32,
         insert_table_infos: Vec<SstableInfo>,
     );
+    fn apply_version_delta(&mut self, version_delta: &HummockVersionDelta);
 }
 
 impl HummockVersionExt for HummockVersion {
@@ -90,6 +91,37 @@ impl HummockVersionExt for HummockVersion {
                 &l0_remove_position,
             );
         }
+    }
+
+    fn apply_version_delta(&mut self, version_delta: &HummockVersionDelta) {
+        for (compaction_group_id, level_deltas) in &version_delta.level_deltas {
+            let mut delete_sst_levels = Vec::with_capacity(level_deltas.level_deltas.len());
+            let mut delete_sst_ids_set = HashSet::new();
+            let mut insert_sst_level = u32::MAX;
+            let mut insert_table_infos = vec![];
+            for level_delta in &level_deltas.level_deltas {
+                if !level_delta.removed_table_ids.is_empty() {
+                    delete_sst_levels.push(level_delta.level_idx);
+                    delete_sst_ids_set.extend(level_delta.removed_table_ids.iter().clone());
+                }
+                if !level_delta.inserted_table_infos.is_empty() {
+                    insert_sst_level = level_delta.level_idx;
+                    insert_table_infos.extend(level_delta.inserted_table_infos.iter().cloned());
+                }
+            }
+            let operand = &mut self
+                .get_compaction_group_levels_mut(*compaction_group_id as CompactionGroupId);
+            HummockVersion::apply_compact_ssts(
+                operand,
+                &delete_sst_levels,
+                &delete_sst_ids_set,
+                insert_sst_level,
+                insert_table_infos,
+            );
+        }
+        self.id = version_delta.id;
+        self.max_committed_epoch = version_delta.max_committed_epoch;
+        self.safe_epoch = version_delta.safe_epoch;
     }
 }
 

--- a/src/storage/src/hummock/compactor_tests.rs
+++ b/src/storage/src/hummock/compactor_tests.rs
@@ -190,7 +190,7 @@ mod tests {
             .id;
         storage
             .local_version_manager()
-            .try_update_pinned_version(version);
+            .try_update_pinned_version(None, (false, vec![], version));
         let table = storage
             .sstable_store()
             .sstable(output_table_id, &mut StoreLocalStatistic::default())
@@ -303,7 +303,7 @@ mod tests {
         // 5. storage get back the correct kv after compaction
         storage
             .local_version_manager()
-            .try_update_pinned_version(version);
+            .try_update_pinned_version(None, (false, vec![], version));
         let get_val = storage
             .get(
                 &key,
@@ -560,7 +560,7 @@ mod tests {
         // to update version for hummock_storage
         storage
             .local_version_manager()
-            .try_update_pinned_version(version);
+            .try_update_pinned_version(None, (false, vec![], version));
 
         // 6. scan kv to check key table_id
         let scan_result = storage
@@ -719,7 +719,7 @@ mod tests {
         // to update version for hummock_storage
         storage
             .local_version_manager()
-            .try_update_pinned_version(version);
+            .try_update_pinned_version(None, (false, vec![], version));
 
         // 6. scan kv to check key table_id
         let scan_result = storage

--- a/src/storage/src/hummock/hummock_meta_client.rs
+++ b/src/storage/src/hummock/hummock_meta_client.rs
@@ -17,8 +17,8 @@ use std::sync::Arc;
 use async_trait::async_trait;
 use risingwave_hummock_sdk::LocalSstableInfo;
 use risingwave_pb::hummock::{
-    CompactTask, CompactionGroup, HummockVersion, SstableIdInfo, SubscribeCompactTasksResponse,
-    VacuumTask,
+    CompactTask, CompactionGroup, HummockVersion, HummockVersionDelta, SstableIdInfo,
+    SubscribeCompactTasksResponse, VacuumTask,
 };
 use risingwave_rpc_client::error::Result;
 use risingwave_rpc_client::{HummockMetaClient, MetaClient};
@@ -41,7 +41,10 @@ impl MonitoredHummockMetaClient {
 
 #[async_trait]
 impl HummockMetaClient for MonitoredHummockMetaClient {
-    async fn pin_version(&self, last_pinned: HummockVersionId) -> Result<HummockVersion> {
+    async fn pin_version(
+        &self,
+        last_pinned: HummockVersionId,
+    ) -> Result<(bool, Vec<HummockVersionDelta>, HummockVersion)> {
         self.stats.pin_version_counts.inc();
         let timer = self.stats.pin_version_latency.start_timer();
         let res = self.meta_client.pin_version(last_pinned).await;

--- a/src/storage/src/hummock/local_version.rs
+++ b/src/storage/src/hummock/local_version.rs
@@ -163,7 +163,6 @@ impl PinnedVersion {
         self.version.safe_epoch
     }
 
-    #[cfg(test)]
     pub fn version(&self) -> HummockVersion {
         self.version.clone()
     }


### PR DESCRIPTION
…on in `pin_version`

I hereby agree to the terms of the [Singularity Data, Inc. Contributor License Agreement](https://gist.github.com/skyzh/0663682a70b0edde7ae991492f2314cb#file-s9y_cla).

## What's changed and what's your intention?

let client get version delta rather than version in `pin_version`

## Checklist

## Documentation

If your pull request contains user-facing changes, please specify the types of the changes, and create a release note. Otherwise, please feel free to remove this section.

### Types of user-facing changes

Please keep the types that apply to your changes, and remove those that do not apply.

* Installation and deployment 
* Connector (sources & sinks)
* SQL commands, functions, and operators
* RisingWave cluster configuration changes
* Other (please specify in the release note below)

### Release note

Please create a release note for your changes. In the release note, focus on the impact on users, and mention the environment or conditions where the impact may occur.

## Refer to a related PR or issue link (optional)
