### PR TITLE
feat(hummock manager): let client get version delta rather than versi…

### DIFF
--- a/proto/hummock.proto
+++ b/proto/hummock.proto
@@ -85,7 +85,9 @@ message PinVersionRequest {
 
 message PinVersionResponse {
   common.Status status = 1;
-  HummockVersion pinned_version = 2;
+  bool is_delta_response = 2;
+  repeated HummockVersionDelta version_deltas = 3;
+  HummockVersion pinned_version = 4;
 }
 
 message UnpinVersionBeforeRequest {

--- a/src/bench/ss_bench/operations/write_batch.rs
+++ b/src/bench/ss_bench/operations/write_batch.rs
@@ -107,7 +107,7 @@ impl Operations {
                     // LocalVersionManager::start_workers is modified into push-based.
                     let last_pinned_id = local_version_manager.get_pinned_version().id();
                     let version = self.meta_client.pin_version(last_pinned_id).await.unwrap();
-                    local_version_manager.try_update_pinned_version(version);
+                    local_version_manager.try_update_pinned_version(Some(last_pinned_id), version);
                 }
             }
         }

--- a/src/ctl/src/cmd_impl/hummock/list_version.rs
+++ b/src/ctl/src/cmd_impl/hummock/list_version.rs
@@ -19,7 +19,7 @@ use crate::common::MetaServiceOpts;
 pub async fn list_version() -> anyhow::Result<()> {
     let meta_opts = MetaServiceOpts::from_env()?;
     let meta_client = meta_opts.create_meta_client().await?;
-    let version = meta_client.pin_version(u64::MAX).await?;
+    let version = meta_client.pin_version(u64::MAX).await?.2;
     println!("{:#?}", version);
     meta_client.unpin_version().await?;
     Ok(())

--- a/src/ctl/src/cmd_impl/hummock/sst_dump.rs
+++ b/src/ctl/src/cmd_impl/hummock/sst_dump.rs
@@ -28,7 +28,7 @@ pub async fn sst_dump() -> anyhow::Result<()> {
     let sstable_store = &*hummock.sstable_store();
 
     // Retrieves the latest HummockVersion from the meta client so we can access the SSTableInfo
-    let version = meta_client.pin_version(u64::MAX).await?;
+    let version = meta_client.pin_version(u64::MAX).await?.2;
 
     let sstable_id_infos = meta_client.list_sstable_id_infos(version.id).await?;
     let mut sstable_id_infos_iter = sstable_id_infos.iter();

--- a/src/ctl/src/cmd_impl/hummock/sst_dump.rs
+++ b/src/ctl/src/cmd_impl/hummock/sst_dump.rs
@@ -28,7 +28,7 @@ pub async fn sst_dump() -> anyhow::Result<()> {
     let sstable_store = &*hummock.sstable_store();
 
     // Retrieves the latest HummockVersion from the meta client so we can access the SSTableInfo
-    let version = meta_client.pin_version(u64::MAX).await?.2;
+    let version = meta_client.pin_version(u64::MAX).await?.2.unwrap();
 
     let sstable_id_infos = meta_client.list_sstable_id_infos(version.id).await?;
     let mut sstable_id_infos_iter = sstable_id_infos.iter();

--- a/src/meta/src/hummock/hummock_manager.rs
+++ b/src/meta/src/hummock/hummock_manager.rs
@@ -415,7 +415,7 @@ where
         &self,
         context_id: HummockContextId,
         last_pinned: HummockVersionId,
-    ) -> Result<(bool, Vec<HummockVersionDelta>, HummockVersion)> {
+    ) -> Result<(bool, Vec<HummockVersionDelta>, Option<HummockVersion>)> {
         let mut versioning_guard = write_lock!(self, versioning).await;
         let _timer = start_measure_real_process_timer!(self);
         let versioning = versioning_guard.deref_mut();
@@ -457,7 +457,11 @@ where
         let ret = Ok((
             is_delta,
             ret_deltas,
-            hummock_versions.get(&version_id).unwrap().clone(),
+            if is_delta {
+                None
+            } else {
+                Some(hummock_versions.get(&version_id).unwrap().clone())
+            },
         ));
 
         #[cfg(test)]

--- a/src/meta/src/hummock/hummock_manager.rs
+++ b/src/meta/src/hummock/hummock_manager.rs
@@ -15,6 +15,7 @@
 use std::borrow::BorrowMut;
 use std::collections::{BTreeMap, HashSet, VecDeque};
 use std::future::Future;
+use std::ops::Bound::{Excluded, Included};
 use std::ops::DerefMut;
 use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::Arc;
@@ -329,37 +330,9 @@ where
             .hummock_versions
             .insert(redo_state.id, redo_state.clone());
 
-        for (id, version_delta) in &hummock_version_deltas {
+        for version_delta in hummock_version_deltas.values() {
             if version_delta.prev_id == redo_state.id {
-                for (compaction_group_id, level_deltas) in &version_delta.level_deltas {
-                    let mut delete_sst_levels = Vec::with_capacity(level_deltas.level_deltas.len());
-                    let mut delete_sst_ids_set = HashSet::new();
-                    let mut insert_sst_level = u32::MAX;
-                    let mut insert_table_infos = vec![];
-                    for level_delta in &level_deltas.level_deltas {
-                        if !level_delta.removed_table_ids.is_empty() {
-                            delete_sst_levels.push(level_delta.level_idx);
-                            delete_sst_ids_set.extend(level_delta.removed_table_ids.iter().clone());
-                        }
-                        if !level_delta.inserted_table_infos.is_empty() {
-                            insert_sst_level = level_delta.level_idx;
-                            insert_table_infos
-                                .extend(level_delta.inserted_table_infos.iter().cloned());
-                        }
-                    }
-                    let operand = &mut redo_state
-                        .get_compaction_group_levels_mut(*compaction_group_id as CompactionGroupId);
-                    HummockVersion::apply_compact_ssts(
-                        operand,
-                        &delete_sst_levels,
-                        &delete_sst_ids_set,
-                        insert_sst_level,
-                        insert_table_infos,
-                    );
-                }
-                redo_state.id = *id;
-                redo_state.max_committed_epoch = version_delta.max_committed_epoch;
-                redo_state.safe_epoch = version_delta.safe_epoch;
+                redo_state.apply_version_delta(version_delta);
 
                 versioning_guard
                     .hummock_versions
@@ -441,8 +414,8 @@ where
     pub async fn pin_version(
         &self,
         context_id: HummockContextId,
-        _last_pinned: HummockVersionId,
-    ) -> Result<HummockVersion> {
+        last_pinned: HummockVersionId,
+    ) -> Result<(bool, Vec<HummockVersionDelta>, HummockVersion)> {
         let mut versioning_guard = write_lock!(self, versioning).await;
         let _timer = start_measure_real_process_timer!(self);
         let versioning = versioning_guard.deref_mut();
@@ -459,12 +432,33 @@ where
 
         let version_id = current_version_id.id();
 
+        let (is_delta, ret_deltas) = {
+            if last_pinned <= version_id
+                && versioning.hummock_version_deltas.contains_key(&last_pinned)
+            {
+                (
+                    true,
+                    versioning
+                        .hummock_version_deltas
+                        .range((Excluded(last_pinned), Included(version_id)))
+                        .map(|(_, delta)| delta.clone())
+                        .collect_vec(),
+                )
+            } else {
+                (false, vec![])
+            }
+        };
+
         if context_pinned_version.min_pinned_id == 0 {
             context_pinned_version.min_pinned_id = version_id;
             commit_multi_var!(self, Some(context_id), context_pinned_version)?;
         }
 
-        let ret = Ok(hummock_versions.get(&version_id).unwrap().clone());
+        let ret = Ok((
+            is_delta,
+            ret_deltas,
+            hummock_versions.get(&version_id).unwrap().clone(),
+        ));
 
         #[cfg(test)]
         {

--- a/src/meta/src/hummock/hummock_manager_tests.rs
+++ b/src/meta/src/hummock/hummock_manager_tests.rs
@@ -59,7 +59,8 @@ async fn test_hummock_pin_unpin() {
         let hummock_version = hummock_manager
             .pin_version(context_id, u64::MAX)
             .await
-            .unwrap();
+            .unwrap()
+            .2;
         let levels = hummock_version
             .get_compaction_group_levels(StaticCompactionGroupId::StateDefault.into());
         assert_eq!(version_id, hummock_version.id);
@@ -286,7 +287,8 @@ async fn test_hummock_table() {
     let pinned_version = hummock_manager
         .pin_version(context_id, u64::MAX)
         .await
-        .unwrap();
+        .unwrap()
+        .2;
     assert_eq!(
         Ordering::Equal,
         pinned_version
@@ -328,7 +330,8 @@ async fn test_hummock_transaction() {
         let pinned_version = hummock_manager
             .pin_version(context_id, u64::MAX)
             .await
-            .unwrap();
+            .unwrap()
+            .2;
         assert_eq!(pinned_version.max_committed_epoch, INVALID_EPOCH);
         assert!(get_sorted_committed_sstable_ids(&pinned_version).is_empty());
 
@@ -345,7 +348,8 @@ async fn test_hummock_transaction() {
         let pinned_version = hummock_manager
             .pin_version(context_id, u64::MAX)
             .await
-            .unwrap();
+            .unwrap()
+            .2;
         assert_eq!(pinned_version.max_committed_epoch, epoch1);
         assert_eq!(
             get_sorted_sstable_ids(&committed_tables),
@@ -373,7 +377,8 @@ async fn test_hummock_transaction() {
         let pinned_version = hummock_manager
             .pin_version(context_id, u64::MAX)
             .await
-            .unwrap();
+            .unwrap()
+            .2;
         assert_eq!(pinned_version.max_committed_epoch, epoch1);
         assert_eq!(
             get_sorted_sstable_ids(&committed_tables),
@@ -393,7 +398,8 @@ async fn test_hummock_transaction() {
         let pinned_version = hummock_manager
             .pin_version(context_id, u64::MAX)
             .await
-            .unwrap();
+            .unwrap()
+            .2;
         assert_eq!(pinned_version.max_committed_epoch, epoch2);
         assert_eq!(
             get_sorted_sstable_ids(&committed_tables),
@@ -551,7 +557,8 @@ async fn test_hummock_manager_basic() {
         let version = hummock_manager
             .pin_version(context_id_1, u64::MAX)
             .await
-            .unwrap();
+            .unwrap()
+            .2;
         assert_eq!(version.id, FIRST_VERSION_ID + 1);
         assert_eq!(
             hummock_manager
@@ -566,7 +573,8 @@ async fn test_hummock_manager_basic() {
         let version = hummock_manager
             .pin_version(context_id_2, u64::MAX)
             .await
-            .unwrap();
+            .unwrap()
+            .2;
         assert_eq!(version.id, FIRST_VERSION_ID + 1);
         assert_eq!(
             hummock_manager

--- a/src/meta/src/hummock/hummock_manager_tests.rs
+++ b/src/meta/src/hummock/hummock_manager_tests.rs
@@ -60,7 +60,8 @@ async fn test_hummock_pin_unpin() {
             .pin_version(context_id, u64::MAX)
             .await
             .unwrap()
-            .2;
+            .2
+            .unwrap();
         let levels = hummock_version
             .get_compaction_group_levels(StaticCompactionGroupId::StateDefault.into());
         assert_eq!(version_id, hummock_version.id);
@@ -288,7 +289,8 @@ async fn test_hummock_table() {
         .pin_version(context_id, u64::MAX)
         .await
         .unwrap()
-        .2;
+        .2
+        .unwrap();
     assert_eq!(
         Ordering::Equal,
         pinned_version
@@ -331,7 +333,8 @@ async fn test_hummock_transaction() {
             .pin_version(context_id, u64::MAX)
             .await
             .unwrap()
-            .2;
+            .2
+            .unwrap();
         assert_eq!(pinned_version.max_committed_epoch, INVALID_EPOCH);
         assert!(get_sorted_committed_sstable_ids(&pinned_version).is_empty());
 
@@ -349,7 +352,8 @@ async fn test_hummock_transaction() {
             .pin_version(context_id, u64::MAX)
             .await
             .unwrap()
-            .2;
+            .2
+            .unwrap();
         assert_eq!(pinned_version.max_committed_epoch, epoch1);
         assert_eq!(
             get_sorted_sstable_ids(&committed_tables),
@@ -378,7 +382,8 @@ async fn test_hummock_transaction() {
             .pin_version(context_id, u64::MAX)
             .await
             .unwrap()
-            .2;
+            .2
+            .unwrap();
         assert_eq!(pinned_version.max_committed_epoch, epoch1);
         assert_eq!(
             get_sorted_sstable_ids(&committed_tables),
@@ -399,7 +404,8 @@ async fn test_hummock_transaction() {
             .pin_version(context_id, u64::MAX)
             .await
             .unwrap()
-            .2;
+            .2
+            .unwrap();
         assert_eq!(pinned_version.max_committed_epoch, epoch2);
         assert_eq!(
             get_sorted_sstable_ids(&committed_tables),
@@ -558,7 +564,8 @@ async fn test_hummock_manager_basic() {
             .pin_version(context_id_1, u64::MAX)
             .await
             .unwrap()
-            .2;
+            .2
+            .unwrap();
         assert_eq!(version.id, FIRST_VERSION_ID + 1);
         assert_eq!(
             hummock_manager
@@ -574,7 +581,8 @@ async fn test_hummock_manager_basic() {
             .pin_version(context_id_2, u64::MAX)
             .await
             .unwrap()
-            .2;
+            .2
+            .unwrap();
         assert_eq!(version.id, FIRST_VERSION_ID + 1);
         assert_eq!(
             hummock_manager

--- a/src/meta/src/hummock/mock_hummock_meta_client.rs
+++ b/src/meta/src/hummock/mock_hummock_meta_client.rs
@@ -21,8 +21,8 @@ use risingwave_hummock_sdk::{
     HummockContextId, HummockEpoch, HummockSSTableId, HummockVersionId, LocalSstableInfo,
 };
 use risingwave_pb::hummock::{
-    CompactTask, CompactionGroup, HummockSnapshot, HummockVersion, SstableIdInfo,
-    SubscribeCompactTasksResponse, VacuumTask,
+    CompactTask, CompactionGroup, HummockSnapshot, HummockVersion, HummockVersionDelta,
+    SstableIdInfo, SubscribeCompactTasksResponse, VacuumTask,
 };
 use risingwave_rpc_client::error::{Result, RpcError};
 use risingwave_rpc_client::HummockMetaClient;
@@ -61,7 +61,10 @@ fn mock_err(error: super::error::Error) -> RpcError {
 
 #[async_trait]
 impl HummockMetaClient for MockHummockMetaClient {
-    async fn pin_version(&self, last_pinned: HummockVersionId) -> Result<HummockVersion> {
+    async fn pin_version(
+        &self,
+        last_pinned: HummockVersionId,
+    ) -> Result<(bool, Vec<HummockVersionDelta>, HummockVersion)> {
         self.hummock_manager
             .pin_version(self.context_id, last_pinned)
             .await

--- a/src/meta/src/hummock/mock_hummock_meta_client.rs
+++ b/src/meta/src/hummock/mock_hummock_meta_client.rs
@@ -64,7 +64,7 @@ impl HummockMetaClient for MockHummockMetaClient {
     async fn pin_version(
         &self,
         last_pinned: HummockVersionId,
-    ) -> Result<(bool, Vec<HummockVersionDelta>, HummockVersion)> {
+    ) -> Result<(bool, Vec<HummockVersionDelta>, Option<HummockVersion>)> {
         self.hummock_manager
             .pin_version(self.context_id, last_pinned)
             .await

--- a/src/meta/src/rpc/service/hummock_service.rs
+++ b/src/meta/src/rpc/service/hummock_service.rs
@@ -77,10 +77,14 @@ where
             .pin_version(req.context_id, req.last_pinned)
             .await;
         match result {
-            Ok(pinned_version) => Ok(Response::new(PinVersionResponse {
-                status: None,
-                pinned_version: Some(pinned_version),
-            })),
+            Ok((is_delta_response, version_deltas, pinned_version)) => {
+                Ok(Response::new(PinVersionResponse {
+                    status: None,
+                    is_delta_response,
+                    version_deltas,
+                    pinned_version: Some(pinned_version),
+                }))
+            }
             Err(e) => Err(tonic_err(e)),
         }
     }

--- a/src/meta/src/rpc/service/hummock_service.rs
+++ b/src/meta/src/rpc/service/hummock_service.rs
@@ -82,7 +82,7 @@ where
                     status: None,
                     is_delta_response,
                     version_deltas,
-                    pinned_version: Some(pinned_version),
+                    pinned_version,
                 }))
             }
             Err(e) => Err(tonic_err(e)),

--- a/src/rpc_client/src/hummock_meta_client.rs
+++ b/src/rpc_client/src/hummock_meta_client.rs
@@ -27,7 +27,7 @@ pub trait HummockMetaClient: Send + Sync + 'static {
     async fn pin_version(
         &self,
         last_pinned: HummockVersionId,
-    ) -> Result<(bool, Vec<HummockVersionDelta>, HummockVersion)>;
+    ) -> Result<(bool, Vec<HummockVersionDelta>, Option<HummockVersion>)>;
     async fn unpin_version(&self) -> Result<()>;
     async fn unpin_version_before(&self, unpin_version_before: HummockVersionId) -> Result<()>;
     async fn pin_snapshot(&self) -> Result<HummockEpoch>;

--- a/src/rpc_client/src/hummock_meta_client.rs
+++ b/src/rpc_client/src/hummock_meta_client.rs
@@ -15,8 +15,8 @@
 use async_trait::async_trait;
 use risingwave_hummock_sdk::{HummockEpoch, HummockSSTableId, HummockVersionId, LocalSstableInfo};
 use risingwave_pb::hummock::{
-    CompactTask, CompactionGroup, HummockVersion, SstableIdInfo, SubscribeCompactTasksResponse,
-    VacuumTask,
+    CompactTask, CompactionGroup, HummockVersion, HummockVersionDelta, SstableIdInfo,
+    SubscribeCompactTasksResponse, VacuumTask,
 };
 use tonic::Streaming;
 
@@ -24,7 +24,10 @@ use crate::error::Result;
 
 #[async_trait]
 pub trait HummockMetaClient: Send + Sync + 'static {
-    async fn pin_version(&self, last_pinned: HummockVersionId) -> Result<HummockVersion>;
+    async fn pin_version(
+        &self,
+        last_pinned: HummockVersionId,
+    ) -> Result<(bool, Vec<HummockVersionDelta>, HummockVersion)>;
     async fn unpin_version(&self) -> Result<()>;
     async fn unpin_version_before(&self, unpin_version_before: HummockVersionId) -> Result<()>;
     async fn pin_snapshot(&self) -> Result<HummockEpoch>;

--- a/src/rpc_client/src/meta_client.rs
+++ b/src/rpc_client/src/meta_client.rs
@@ -348,7 +348,7 @@ impl HummockMetaClient for MetaClient {
     async fn pin_version(
         &self,
         last_pinned: HummockVersionId,
-    ) -> Result<(bool, Vec<HummockVersionDelta>, HummockVersion)> {
+    ) -> Result<(bool, Vec<HummockVersionDelta>, Option<HummockVersion>)> {
         let req = PinVersionRequest {
             context_id: self.worker_id(),
             last_pinned,
@@ -357,7 +357,7 @@ impl HummockMetaClient for MetaClient {
         Ok((
             resp.is_delta_response,
             resp.version_deltas,
-            resp.pinned_version.unwrap(),
+            resp.pinned_version,
         ))
     }
 

--- a/src/rpc_client/src/meta_client.rs
+++ b/src/rpc_client/src/meta_client.rs
@@ -345,13 +345,20 @@ impl MetaClient {
 
 #[async_trait]
 impl HummockMetaClient for MetaClient {
-    async fn pin_version(&self, last_pinned: HummockVersionId) -> Result<HummockVersion> {
+    async fn pin_version(
+        &self,
+        last_pinned: HummockVersionId,
+    ) -> Result<(bool, Vec<HummockVersionDelta>, HummockVersion)> {
         let req = PinVersionRequest {
             context_id: self.worker_id(),
             last_pinned,
         };
         let resp = self.inner.pin_version(req).await?;
-        Ok(resp.pinned_version.unwrap())
+        Ok((
+            resp.is_delta_response,
+            resp.version_deltas,
+            resp.pinned_version.unwrap(),
+        ))
     }
 
     async fn unpin_version(&self) -> Result<()> {

--- a/src/storage/hummock_sdk/src/compaction_group/hummock_version_ext.rs
+++ b/src/storage/hummock_sdk/src/compaction_group/hummock_version_ext.rs
@@ -14,7 +14,7 @@
 
 use std::collections::HashSet;
 
-use risingwave_pb::hummock::{HummockVersion, Level, SstableInfo};
+use risingwave_pb::hummock::{HummockVersion, HummockVersionDelta, Level, SstableInfo};
 
 use crate::prost_key_range::KeyRangeExt;
 use crate::CompactionGroupId;
@@ -38,6 +38,7 @@ pub trait HummockVersionExt {
         insert_sst_level: u32,
         insert_table_infos: Vec<SstableInfo>,
     );
+    fn apply_version_delta(&mut self, version_delta: &HummockVersionDelta);
 }
 
 impl HummockVersionExt for HummockVersion {
@@ -90,6 +91,37 @@ impl HummockVersionExt for HummockVersion {
                 &l0_remove_position,
             );
         }
+    }
+
+    fn apply_version_delta(&mut self, version_delta: &HummockVersionDelta) {
+        for (compaction_group_id, level_deltas) in &version_delta.level_deltas {
+            let mut delete_sst_levels = Vec::with_capacity(level_deltas.level_deltas.len());
+            let mut delete_sst_ids_set = HashSet::new();
+            let mut insert_sst_level = u32::MAX;
+            let mut insert_table_infos = vec![];
+            for level_delta in &level_deltas.level_deltas {
+                if !level_delta.removed_table_ids.is_empty() {
+                    delete_sst_levels.push(level_delta.level_idx);
+                    delete_sst_ids_set.extend(level_delta.removed_table_ids.iter().clone());
+                }
+                if !level_delta.inserted_table_infos.is_empty() {
+                    insert_sst_level = level_delta.level_idx;
+                    insert_table_infos.extend(level_delta.inserted_table_infos.iter().cloned());
+                }
+            }
+            let operand = &mut self
+                .get_compaction_group_levels_mut(*compaction_group_id as CompactionGroupId);
+            HummockVersion::apply_compact_ssts(
+                operand,
+                &delete_sst_levels,
+                &delete_sst_ids_set,
+                insert_sst_level,
+                insert_table_infos,
+            );
+        }
+        self.id = version_delta.id;
+        self.max_committed_epoch = version_delta.max_committed_epoch;
+        self.safe_epoch = version_delta.safe_epoch;
     }
 }
 

--- a/src/storage/hummock_test/src/compactor_tests.rs
+++ b/src/storage/hummock_test/src/compactor_tests.rs
@@ -191,7 +191,7 @@ mod tests {
             .id;
         storage
             .local_version_manager()
-            .try_update_pinned_version(version);
+            .try_update_pinned_version(None, (false, vec![], version));
         let table = storage
             .sstable_store()
             .sstable(output_table_id, &mut StoreLocalStatistic::default())
@@ -304,7 +304,7 @@ mod tests {
         // 5. storage get back the correct kv after compaction
         storage
             .local_version_manager()
-            .try_update_pinned_version(version);
+            .try_update_pinned_version(None, (false, vec![], version));
         let get_val = storage
             .get(
                 &key,
@@ -561,7 +561,7 @@ mod tests {
         // to update version for hummock_storage
         storage
             .local_version_manager()
-            .try_update_pinned_version(version);
+            .try_update_pinned_version(None, (false, vec![], version));
 
         // 6. scan kv to check key table_id
         let scan_result = storage
@@ -720,7 +720,7 @@ mod tests {
         // to update version for hummock_storage
         storage
             .local_version_manager()
-            .try_update_pinned_version(version);
+            .try_update_pinned_version(None, (false, vec![], version));
 
         // 6. scan kv to check key table_id
         let scan_result = storage

--- a/src/storage/hummock_test/src/compactor_tests.rs
+++ b/src/storage/hummock_test/src/compactor_tests.rs
@@ -191,7 +191,7 @@ mod tests {
             .id;
         storage
             .local_version_manager()
-            .try_update_pinned_version(None, (false, vec![], version));
+            .try_update_pinned_version(None, (false, vec![], Some(version)));
         let table = storage
             .sstable_store()
             .sstable(output_table_id, &mut StoreLocalStatistic::default())
@@ -304,7 +304,7 @@ mod tests {
         // 5. storage get back the correct kv after compaction
         storage
             .local_version_manager()
-            .try_update_pinned_version(None, (false, vec![], version));
+            .try_update_pinned_version(None, (false, vec![], Some(version)));
         let get_val = storage
             .get(
                 &key,
@@ -561,7 +561,7 @@ mod tests {
         // to update version for hummock_storage
         storage
             .local_version_manager()
-            .try_update_pinned_version(None, (false, vec![], version));
+            .try_update_pinned_version(None, (false, vec![], Some(version)));
 
         // 6. scan kv to check key table_id
         let scan_result = storage
@@ -720,7 +720,7 @@ mod tests {
         // to update version for hummock_storage
         storage
             .local_version_manager()
-            .try_update_pinned_version(None, (false, vec![], version));
+            .try_update_pinned_version(None, (false, vec![], Some(version)));
 
         // 6. scan kv to check key table_id
         let scan_result = storage

--- a/src/storage/hummock_test/src/local_version_manager_tests.rs
+++ b/src/storage/hummock_test/src/local_version_manager_tests.rs
@@ -95,7 +95,7 @@ async fn test_update_pinned_version() {
         max_committed_epoch: epochs[0],
         ..Default::default()
     };
-    local_version_manager.try_update_pinned_version(version);
+    local_version_manager.try_update_pinned_version(None, (false, vec![], version));
     let local_version = local_version_manager.get_local_version();
     assert!(local_version.get_shared_buffer(epochs[0]).is_none());
     assert_eq!(
@@ -115,7 +115,7 @@ async fn test_update_pinned_version() {
         max_committed_epoch: epochs[1],
         ..Default::default()
     };
-    local_version_manager.try_update_pinned_version(version);
+    local_version_manager.try_update_pinned_version(None, (false, vec![], version));
     let local_version = local_version_manager.get_local_version();
     assert!(local_version.get_shared_buffer(epochs[0]).is_none());
     assert!(local_version.get_shared_buffer(epochs[1]).is_none());
@@ -282,7 +282,7 @@ async fn test_update_uncommitted_ssts() {
         max_committed_epoch: epochs[0],
         ..Default::default()
     };
-    assert!(local_version_manager.try_update_pinned_version(version.clone()));
+    assert!(local_version_manager.try_update_pinned_version(None, (false, vec![], version.clone())));
     let local_version = local_version_manager.get_local_version();
     // Check shared buffer
     assert!(local_version.get_shared_buffer(epochs[0]).is_none());
@@ -315,7 +315,7 @@ async fn test_update_uncommitted_ssts() {
         max_committed_epoch: epochs[1],
         ..Default::default()
     };
-    local_version_manager.try_update_pinned_version(version.clone());
+    local_version_manager.try_update_pinned_version(None, (false, vec![], version.clone()));
     let local_version = local_version_manager.get_local_version();
     assert!(local_version.get_shared_buffer(epochs[0]).is_none());
     assert!(local_version.get_shared_buffer(epochs[1]).is_none());

--- a/src/storage/hummock_test/src/local_version_manager_tests.rs
+++ b/src/storage/hummock_test/src/local_version_manager_tests.rs
@@ -95,7 +95,7 @@ async fn test_update_pinned_version() {
         max_committed_epoch: epochs[0],
         ..Default::default()
     };
-    local_version_manager.try_update_pinned_version(None, (false, vec![], version));
+    local_version_manager.try_update_pinned_version(None, (false, vec![], Some(version)));
     let local_version = local_version_manager.get_local_version();
     assert!(local_version.get_shared_buffer(epochs[0]).is_none());
     assert_eq!(
@@ -115,7 +115,7 @@ async fn test_update_pinned_version() {
         max_committed_epoch: epochs[1],
         ..Default::default()
     };
-    local_version_manager.try_update_pinned_version(None, (false, vec![], version));
+    local_version_manager.try_update_pinned_version(None, (false, vec![], Some(version)));
     let local_version = local_version_manager.get_local_version();
     assert!(local_version.get_shared_buffer(epochs[0]).is_none());
     assert!(local_version.get_shared_buffer(epochs[1]).is_none());
@@ -282,7 +282,8 @@ async fn test_update_uncommitted_ssts() {
         max_committed_epoch: epochs[0],
         ..Default::default()
     };
-    assert!(local_version_manager.try_update_pinned_version(None, (false, vec![], version.clone())));
+    assert!(local_version_manager
+        .try_update_pinned_version(None, (false, vec![], Some(version.clone()))));
     let local_version = local_version_manager.get_local_version();
     // Check shared buffer
     assert!(local_version.get_shared_buffer(epochs[0]).is_none());
@@ -315,7 +316,7 @@ async fn test_update_uncommitted_ssts() {
         max_committed_epoch: epochs[1],
         ..Default::default()
     };
-    local_version_manager.try_update_pinned_version(None, (false, vec![], version.clone()));
+    local_version_manager.try_update_pinned_version(None, (false, vec![], Some(version.clone())));
     let local_version = local_version_manager.get_local_version();
     assert!(local_version.get_shared_buffer(epochs[0]).is_none());
     assert!(local_version.get_shared_buffer(epochs[1]).is_none());

--- a/src/storage/src/hummock/hummock_meta_client.rs
+++ b/src/storage/src/hummock/hummock_meta_client.rs
@@ -17,8 +17,8 @@ use std::sync::Arc;
 use async_trait::async_trait;
 use risingwave_hummock_sdk::LocalSstableInfo;
 use risingwave_pb::hummock::{
-    CompactTask, CompactionGroup, HummockVersion, SstableIdInfo, SubscribeCompactTasksResponse,
-    VacuumTask,
+    CompactTask, CompactionGroup, HummockVersion, HummockVersionDelta, SstableIdInfo,
+    SubscribeCompactTasksResponse, VacuumTask,
 };
 use risingwave_rpc_client::error::Result;
 use risingwave_rpc_client::{HummockMetaClient, MetaClient};
@@ -41,7 +41,10 @@ impl MonitoredHummockMetaClient {
 
 #[async_trait]
 impl HummockMetaClient for MonitoredHummockMetaClient {
-    async fn pin_version(&self, last_pinned: HummockVersionId) -> Result<HummockVersion> {
+    async fn pin_version(
+        &self,
+        last_pinned: HummockVersionId,
+    ) -> Result<(bool, Vec<HummockVersionDelta>, HummockVersion)> {
         self.stats.pin_version_counts.inc();
         let timer = self.stats.pin_version_latency.start_timer();
         let res = self.meta_client.pin_version(last_pinned).await;

--- a/src/storage/src/hummock/hummock_meta_client.rs
+++ b/src/storage/src/hummock/hummock_meta_client.rs
@@ -44,7 +44,7 @@ impl HummockMetaClient for MonitoredHummockMetaClient {
     async fn pin_version(
         &self,
         last_pinned: HummockVersionId,
-    ) -> Result<(bool, Vec<HummockVersionDelta>, HummockVersion)> {
+    ) -> Result<(bool, Vec<HummockVersionDelta>, Option<HummockVersion>)> {
         self.stats.pin_version_counts.inc();
         let timer = self.stats.pin_version_latency.start_timer();
         let res = self.meta_client.pin_version(last_pinned).await;

--- a/src/storage/src/hummock/local_version.rs
+++ b/src/storage/src/hummock/local_version.rs
@@ -169,7 +169,6 @@ impl PinnedVersion {
         self.version.safe_epoch
     }
 
-    #[cfg(any(test, feature = "test"))]
     pub fn version(&self) -> HummockVersion {
         self.version.clone()
     }

--- a/src/storage/src/hummock/local_version.rs
+++ b/src/storage/src/hummock/local_version.rs
@@ -169,6 +169,7 @@ impl PinnedVersion {
         self.version.safe_epoch
     }
 
+    /// ret value can't be used as `HummockVersion`. it must be modified with delta
     pub fn version(&self) -> HummockVersion {
         self.version.clone()
     }

--- a/src/storage/src/hummock/local_version_manager.rs
+++ b/src/storage/src/hummock/local_version_manager.rs
@@ -162,7 +162,8 @@ impl LocalVersionManager {
         .await
         .expect("should be `Some` since `break_condition` is always false")
         .expect("should be able to pinned the first version")
-        .2;
+        .2
+        .unwrap();
 
         let (buffer_event_sender, buffer_event_receiver) = mpsc::unbounded_channel();
 
@@ -218,7 +219,7 @@ impl LocalVersionManager {
     pub fn try_update_pinned_version(
         &self,
         last_pinned: Option<u64>,
-        pin_resp: (bool, Vec<HummockVersionDelta>, HummockVersion),
+        pin_resp: (bool, Vec<HummockVersionDelta>, Option<HummockVersion>),
     ) -> bool {
         let old_version = self.local_version.upgradable_read();
         if let Some(last_pinned_id) = last_pinned {
@@ -233,7 +234,7 @@ impl LocalVersionManager {
             }
             version_to_apply
         } else {
-            pin_resp.2
+            pin_resp.2.unwrap()
         };
         let new_version_id = newly_pinned_version.id;
         for levels in newly_pinned_version.levels.values() {
@@ -533,7 +534,7 @@ impl LocalVersionManager {
         last_pinned: HummockVersionId,
         max_retry: usize,
         break_condition: impl Fn() -> bool,
-    ) -> Option<HummockResult<(bool, Vec<HummockVersionDelta>, HummockVersion)>> {
+    ) -> Option<HummockResult<(bool, Vec<HummockVersionDelta>, Option<HummockVersion>)>> {
         let max_retry_interval = Duration::from_secs(10);
         let mut retry_backoff = tokio_retry::strategy::ExponentialBackoff::from_millis(10)
             .max_delay(max_retry_interval)

--- a/src/storage/src/hummock/local_version_manager.rs
+++ b/src/storage/src/hummock/local_version_manager.rs
@@ -23,9 +23,10 @@ use futures::future::{join_all, try_join_all};
 use itertools::Itertools;
 use parking_lot::{RwLock, RwLockUpgradableReadGuard, RwLockWriteGuard};
 use risingwave_common::config::StorageConfig;
+use risingwave_hummock_sdk::compaction_group::hummock_version_ext::HummockVersionExt;
 use risingwave_hummock_sdk::key::FullKey;
 use risingwave_hummock_sdk::{CompactionGroupId, LocalSstableInfo};
-use risingwave_pb::hummock::HummockVersion;
+use risingwave_pb::hummock::{HummockVersion, HummockVersionDelta};
 use risingwave_rpc_client::HummockMetaClient;
 use tokio::sync::mpsc::error::TryRecvError;
 use tokio::sync::mpsc::UnboundedReceiver;
@@ -160,7 +161,8 @@ impl LocalVersionManager {
         )
         .await
         .expect("should be `Some` since `break_condition` is always false")
-        .expect("should be able to pinned the first version");
+        .expect("should be able to pinned the first version")
+        .2;
 
         let (buffer_event_sender, buffer_event_receiver) = mpsc::unbounded_channel();
 
@@ -213,7 +215,26 @@ impl LocalVersionManager {
     /// Updates cached version if the new version is of greater id.
     /// You shouldn't unpin even the method returns false, as it is possible `hummock_version` is
     /// being referenced by some readers.
-    pub fn try_update_pinned_version(&self, newly_pinned_version: HummockVersion) -> bool {
+    pub fn try_update_pinned_version(
+        &self,
+        last_pinned: Option<u64>,
+        pin_resp: (bool, Vec<HummockVersionDelta>, HummockVersion),
+    ) -> bool {
+        let old_version = self.local_version.upgradable_read();
+        if let Some(last_pinned_id) = last_pinned {
+            if old_version.pinned_version().id() != last_pinned_id {
+                return false;
+            }
+        }
+        let newly_pinned_version = if pin_resp.0 {
+            let mut version_to_apply = old_version.pinned_version().version();
+            for version_delta in pin_resp.1 {
+                version_to_apply.apply_version_delta(&version_delta);
+            }
+            version_to_apply
+        } else {
+            pin_resp.2
+        };
         let new_version_id = newly_pinned_version.id;
         for levels in newly_pinned_version.levels.values() {
             if validate_table_key_range(&levels.levels).is_err() {
@@ -221,8 +242,6 @@ impl LocalVersionManager {
                 return false;
             }
         }
-
-        let old_version = self.local_version.upgradable_read();
         if old_version.pinned_version().id() >= new_version_id {
             return false;
         }
@@ -514,7 +533,7 @@ impl LocalVersionManager {
         last_pinned: HummockVersionId,
         max_retry: usize,
         break_condition: impl Fn() -> bool,
-    ) -> Option<HummockResult<HummockVersion>> {
+    ) -> Option<HummockResult<(bool, Vec<HummockVersionDelta>, HummockVersion)>> {
         let max_retry_interval = Duration::from_secs(10);
         let mut retry_backoff = tokio_retry::strategy::ExponentialBackoff::from_millis(10)
             .max_delay(max_retry_interval)
@@ -585,7 +604,8 @@ impl LocalVersionManager {
             .await
             {
                 Some(Ok(pinned_version)) => {
-                    local_version_manager.try_update_pinned_version(pinned_version);
+                    local_version_manager
+                        .try_update_pinned_version(Some(last_pinned), pinned_version);
                 }
                 Some(Err(_)) => {
                     unreachable!(
@@ -835,7 +855,7 @@ impl LocalVersionManager {
     pub async fn refresh_version(&self, hummock_meta_client: &dyn HummockMetaClient) -> bool {
         let last_pinned = self.get_pinned_version().id();
         let version = hummock_meta_client.pin_version(last_pinned).await.unwrap();
-        self.try_update_pinned_version(version)
+        self.try_update_pinned_version(Some(last_pinned), version)
     }
 
     pub fn local_version(&self) -> &RwLock<LocalVersion> {


### PR DESCRIPTION
…on in `pin_version`

I hereby agree to the terms of the [Singularity Data, Inc. Contributor License Agreement](https://gist.github.com/skyzh/0663682a70b0edde7ae991492f2314cb#file-s9y_cla).

## What's changed and what's your intention?

let client get version delta rather than version in pin_version
see #3597 

## Checklist

## Documentation

If your pull request contains user-facing changes, please specify the types of the changes, and create a release note. Otherwise, please feel free to remove this section.

### Types of user-facing changes

Please keep the types that apply to your changes, and remove those that do not apply.

* Installation and deployment 
* Connector (sources & sinks)
* SQL commands, functions, and operators
* RisingWave cluster configuration changes
* Other (please specify in the release note below)

### Release note

Please create a release note for your changes. In the release note, focus on the impact on users, and mention the environment or conditions where the impact may occur.

## Refer to a related PR or issue link (optional)
