### PR TITLE
build(deps): use official pulsar-rs instead of fork

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3617,9 +3617,11 @@ dependencies = [
 
 [[package]]
 name = "pulsar"
-version = "4.1.1"
-source = "git+https://github.com/singularity-data/pulsar-rs.git?rev=8d4789eea780d520136e1cc2535a1fec9385c53d#8d4789eea780d520136e1cc2535a1fec9385c53d"
+version = "4.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "31a5a4fbe9363c113b7e25ae76dd2d6455411c815d688977be6f0b68ae5e73b8"
 dependencies = [
+ "async-trait",
  "bit-vec",
  "bytes",
  "chrono",

--- a/src/connector/Cargo.toml
+++ b/src/connector/Cargo.toml
@@ -38,7 +38,7 @@ mysql_async = "0.30"
 num-traits = "0.2"
 paste = "1"
 prost = "0.10"
-pulsar = { git = "https://github.com/singularity-data/pulsar-rs.git", rev = "8d4789eea780d520136e1cc2535a1fec9385c53d", default-features = false, features = ["tokio-runtime"] }
+pulsar = { version = "4", default-features = false, features = ["tokio-runtime"] }
 rand = "0.8"
 rdkafka = { version = "0.28", features = ["cmake-build"] }
 risingwave_common = { path = "../common" }


### PR DESCRIPTION
Signed-off-by: TennyZhuang <zty0826@gmail.com>

I hereby agree to the terms of the [Singularity Data, Inc. Contributor License Agreement](https://gist.github.com/skyzh/0663682a70b0edde7ae991492f2314cb#file-s9y_cla).

## What's changed and what's your intention?

***PLEASE DO NOT LEAVE THIS EMPTY !!!***

Our PR has been merged, and the upstream repo is actively maintained now, just remove the fork.

## Checklist

- [x] I have written necessary rustdoc comments
- [x] I have added necessary unit tests and integration tests
- [x] All checks passed in `./risedev check` (or alias, `./risedev c`)

## Refer to a related PR or issue link (optional)

https://github.com/streamnative/pulsar-rs/pull/196
