### PR TITLE
refactor(batch,agg): merge `Aggregator::update*` and refactor `SortAggExecutor`

### DIFF
--- a/src/batch/src/executor/hash_agg.rs
+++ b/src/batch/src/executor/hash_agg.rs
@@ -207,7 +207,7 @@ impl<K: HashKey + Send + Sync> HashAggExecutor<K> {
                 // TODO: currently not a vectorized implementation
                 states
                     .iter_mut()
-                    .for_each(|state| state.update_with_row(&chunk, row_id).unwrap());
+                    .for_each(|state| state.update_single(&chunk, row_id).unwrap());
             }
         }
 

--- a/src/batch/src/executor/sort_agg.rs
+++ b/src/batch/src/executor/sort_agg.rs
@@ -231,7 +231,7 @@ impl SortAggExecutor {
     ) -> Result<()> {
         agg_states
             .iter_mut()
-            .try_for_each(|state| state.update_multi(&child_chunk, start_row_idx, end_row_idx))
+            .try_for_each(|state| state.update_multi(child_chunk, start_row_idx, end_row_idx))
     }
 
     fn output_sorted_groupers(

--- a/src/common/src/array/iterator.rs
+++ b/src/common/src/array/iterator.rs
@@ -76,6 +76,16 @@ impl<'a> Iterator for ArrayImplIterator<'a> {
         }
     }
 
+    fn nth(&mut self, n: usize) -> Option<Self::Item> {
+        if self.pos + n >= self.data.len() {
+            None
+        } else {
+            let item = self.data.value_at(self.pos + n);
+            self.pos += n + 1;
+            Some(item)
+        }
+    }
+
     fn size_hint(&self) -> (usize, Option<usize>) {
         let size = self.data.len() - self.pos;
         (size, Some(size))

--- a/src/common/src/array/iterator.rs
+++ b/src/common/src/array/iterator.rs
@@ -107,24 +107,26 @@ mod tests {
                     #[test]
                     fn [<test_trusted_len_for_ $suffix_name _array>]() {
                         use crate::array::$builder;
-                        let mut builder = $builder::new(3);
-                        for _ in 0..3 {
+                        let mut builder = $builder::new(5);
+                        for _ in 0..5 {
                             builder.append_null().unwrap();
                         }
                         let array = builder.finish().unwrap();
                         let mut iter = array.iter();
 
-                        assert_eq!(iter.size_hint(), (3, Some(3))); iter.next();
-                        assert_eq!(iter.size_hint(), (2, Some(2))); iter.next();
-                        assert_eq!(iter.size_hint(), (1, Some(1))); iter.next();
+                        assert_eq!(iter.size_hint(), (5, Some(5))); iter.next();
+                        assert_eq!(iter.size_hint(), (4, Some(4))); iter.next();
+                        assert_eq!(iter.size_hint(), (3, Some(3))); iter.nth(0);
+                        assert_eq!(iter.size_hint(), (2, Some(2))); iter.nth(1);
                         assert_eq!(iter.size_hint(), (0, Some(0)));
 
                         let array_impl = ArrayImpl::from(array);
                         let mut iter = array_impl.iter();
 
-                        assert_eq!(iter.size_hint(), (3, Some(3))); iter.next();
-                        assert_eq!(iter.size_hint(), (2, Some(2))); iter.next();
-                        assert_eq!(iter.size_hint(), (1, Some(1))); iter.next();
+                        assert_eq!(iter.size_hint(), (5, Some(5))); iter.next();
+                        assert_eq!(iter.size_hint(), (4, Some(4))); iter.next();
+                        assert_eq!(iter.size_hint(), (3, Some(3))); iter.nth(0);
+                        assert_eq!(iter.size_hint(), (2, Some(2))); iter.nth(1);
                         assert_eq!(iter.size_hint(), (0, Some(0)));
                     }
                 }

--- a/src/expr/src/vector_op/agg/aggregator.rs
+++ b/src/expr/src/vector_op/agg/aggregator.rs
@@ -23,49 +23,27 @@ use crate::vector_op::agg::count_star::CountStar;
 use crate::vector_op::agg::functions::*;
 use crate::vector_op::agg::general_agg::*;
 use crate::vector_op::agg::general_distinct_agg::*;
-use crate::vector_op::agg::general_sorted_grouper::EqGroups;
 
 /// An `Aggregator` supports `update` data and `output` result.
 pub trait Aggregator: Send + 'static {
     fn return_type(&self) -> DataType;
 
-    /// `update` the aggregator with a row with type checked at runtime.
-    fn update_with_row(&mut self, input: &DataChunk, row_id: usize) -> Result<()>;
-    /// `update` the aggregator with `Array` with input with type checked at runtime.
-    ///
-    /// This may be deprecated as it consumes whole array without sort or hash group info.
-    fn update(&mut self, input: &DataChunk) -> Result<()>;
+    /// `update_single` update the aggregator with a single row with type checked at runtime.
+    fn update_single(&mut self, input: &DataChunk, row_id: usize) -> Result<()>;
 
-    /// `output` the aggregator to `ArrayBuilder` with input with type checked at runtime.
-    fn output(&self, builder: &mut ArrayBuilderImpl) -> Result<()>;
-
-    /// `update_and_output_with_sorted_groups` supersede `update` when grouping with the sort
-    /// aggregate algorithm.
-    ///
-    /// Rather than updating with the whole `input` array all at once, it updates with each
-    /// subslice of the `input` array according to the `EqGroups`. Finished groups are outputted
-    /// to `builder` immediately along the way. After this call, the internal state is about
-    /// the last group which may continue in the next chunk. It can be obtained with `output` when
-    /// there are no more upstream data.
-    fn update_and_output_with_sorted_groups(
-        &mut self,
-        input: &DataChunk,
-        builder: &mut ArrayBuilderImpl,
-        groups: &EqGroups,
-    ) -> Result<()>;
-
-    fn update_chunk(
+    /// `update_multi` update the aggregator with multiple rows with type checked at runtime.
+    fn update_multi(
         &mut self,
         input: &DataChunk,
         start_row_id: usize,
         end_row_id: usize,
-    ) -> Result<()> {
-        todo!()
-    }
+    ) -> Result<()>;
 
-    fn output_and_reset(&mut self, builder: &mut ArrayBuilderImpl) -> Result<()> {
-        todo!()
-    }
+    /// `output` the aggregator to `ArrayBuilder` with input with type checked at runtime.
+    fn output(&self, builder: &mut ArrayBuilderImpl) -> Result<()>;
+
+    /// `output_and_reset` output the aggregator to `ArrayBuilder` and reset the internal state.
+    fn output_and_reset(&mut self, builder: &mut ArrayBuilderImpl) -> Result<()>;
 }
 
 pub type BoxedAggState = Box<dyn Aggregator>;
@@ -133,7 +111,7 @@ impl AggStateFactory {
                 self.distinct,
             )
         } else {
-            Ok(Box::new(CountStar::new(self.return_type.clone(), 0)))
+            Ok(Box::new(CountStar::new(self.return_type.clone())))
         }
     }
 

--- a/src/expr/src/vector_op/agg/aggregator.rs
+++ b/src/expr/src/vector_op/agg/aggregator.rs
@@ -53,6 +53,19 @@ pub trait Aggregator: Send + 'static {
         builder: &mut ArrayBuilderImpl,
         groups: &EqGroups,
     ) -> Result<()>;
+
+    fn update_chunk(
+        &mut self,
+        input: &DataChunk,
+        start_row_id: usize,
+        end_row_id: usize,
+    ) -> Result<()> {
+        todo!()
+    }
+
+    fn output_and_reset(&mut self, builder: &mut ArrayBuilderImpl) -> Result<()> {
+        todo!()
+    }
 }
 
 pub type BoxedAggState = Box<dyn Aggregator>;

--- a/src/expr/src/vector_op/agg/approx_count_distinct.rs
+++ b/src/expr/src/vector_op/agg/approx_count_distinct.rs
@@ -20,7 +20,6 @@ use risingwave_common::error::{ErrorCode, Result};
 use risingwave_common::types::*;
 
 use crate::vector_op::agg::aggregator::Aggregator;
-use crate::vector_op::agg::general_sorted_grouper::EqGroups;
 
 const INDEX_BITS: u8 = 14; // number of bits used for finding the index of each 64-bit hash
 const NUM_OF_REGISTERS: usize = 1 << INDEX_BITS; // number of indices available
@@ -122,17 +121,25 @@ impl Aggregator for ApproxCountDistinct {
         self.return_type.clone()
     }
 
-    fn update_with_row(&mut self, input: &DataChunk, row_id: usize) -> Result<()> {
+    fn update_single(&mut self, input: &DataChunk, row_id: usize) -> Result<()> {
         let array = input.column_at(self.input_col_idx).array_ref();
         let datum_ref = array.value_at(row_id);
         self.add_datum(datum_ref);
-
         Ok(())
     }
 
-    fn update(&mut self, input: &DataChunk) -> Result<()> {
+    fn update_multi(
+        &mut self,
+        input: &DataChunk,
+        start_row_id: usize,
+        end_row_id: usize,
+    ) -> Result<()> {
         let array = input.column_at(self.input_col_idx).array_ref();
-        for datum_ref in array.iter() {
+        for datum_ref in array
+            .iter()
+            .skip(start_row_id)
+            .take(end_row_id - start_row_id)
+        {
             self.add_datum(datum_ref);
         }
         Ok(())
@@ -146,45 +153,10 @@ impl Aggregator for ApproxCountDistinct {
         }
     }
 
-    fn update_and_output_with_sorted_groups(
-        &mut self,
-        input: &DataChunk,
-        builder: &mut ArrayBuilderImpl,
-        groups: &EqGroups,
-    ) -> Result<()> {
-        let builder = match builder {
-            ArrayBuilderImpl::Int64(b) => b,
-            _ => {
-                return Err(ErrorCode::InternalError(
-                    "Unexpected builder for approx_distinct_count().".into(),
-                )
-                .into())
-            }
-        };
-
-        let array = input.column_at(self.input_col_idx).array_ref();
-        let mut group_cnt = 0;
-        let mut groups_iter = groups.starting_indices().iter().peekable();
-        let chunk_offset = groups.chunk_offset();
-        for (i, datum_ref) in array.iter().skip(chunk_offset).enumerate() {
-            // reset state and output result when new group is found
-            if groups_iter.peek() == Some(&&i) {
-                groups_iter.next();
-                group_cnt += 1;
-                builder.append(Some(self.calculate_result()))?;
-                self.registers = [0; NUM_OF_REGISTERS];
-            }
-
-            self.add_datum(datum_ref);
-
-            // reset state and exit when reach limit
-            if groups.is_reach_limit(group_cnt) {
-                self.registers = [0; NUM_OF_REGISTERS];
-                break;
-            }
-        }
-
-        Ok(())
+    fn output_and_reset(&mut self, builder: &mut ArrayBuilderImpl) -> Result<()> {
+        let res = self.output(builder);
+        self.registers = [0; NUM_OF_REGISTERS];
+        res
     }
 }
 
@@ -200,7 +172,6 @@ mod tests {
 
     use crate::vector_op::agg::aggregator::Aggregator;
     use crate::vector_op::agg::approx_count_distinct::ApproxCountDistinct;
-    use crate::vector_op::agg::EqGroups;
 
     fn generate_data_chunk(size: usize, start: i32) -> DataChunk {
         let mut lhs = vec![];
@@ -218,7 +189,7 @@ mod tests {
     }
 
     #[test]
-    fn test_update_and_output() {
+    fn test_update_single() {
         let inputs_size: [usize; 3] = [20000, 10000, 5000];
         let inputs_start: [i32; 3] = [0, 20000, 30000];
 
@@ -227,8 +198,10 @@ mod tests {
 
         for i in 0..3 {
             let data_chunk = generate_data_chunk(inputs_size[i], inputs_start[i]);
-            agg.update(&data_chunk).unwrap();
-            agg.output(&mut builder).unwrap();
+            for row_id in 0..data_chunk.cardinality() {
+                agg.update_single(&data_chunk, row_id).unwrap();
+            }
+            agg.output_and_reset(&mut builder).unwrap();
         }
 
         let array = builder.finish().unwrap();
@@ -236,16 +209,21 @@ mod tests {
     }
 
     #[test]
-    fn test_update_and_output_with_sorted_groups() {
-        let mut a = ApproxCountDistinct::new(DataType::Int64, 0);
+    fn test_update_multi() {
+        let inputs_size: [usize; 3] = [20000, 10000, 5000];
+        let inputs_start: [i32; 3] = [0, 20000, 30000];
 
-        let data_chunk = generate_data_chunk(30001, 0);
-        let mut builder = ArrayBuilderImpl::Int64(I64ArrayBuilder::new(5));
-        let mut group = EqGroups::new(vec![5000, 10000, 14000, 20000, 30000]);
-        group.set_limit(5);
+        let mut agg = ApproxCountDistinct::new(DataType::Int64, 0);
+        let mut builder = ArrayBuilderImpl::Int64(I64ArrayBuilder::new(3));
 
-        let _ = a.update_and_output_with_sorted_groups(&data_chunk, &mut builder, &group);
+        for i in 0..3 {
+            let data_chunk = generate_data_chunk(inputs_size[i], inputs_start[i]);
+            agg.update_multi(&data_chunk, 0, data_chunk.cardinality())
+                .unwrap();
+            agg.output_and_reset(&mut builder).unwrap();
+        }
+
         let array = builder.finish().unwrap();
-        assert_eq!(array.len(), 5);
+        assert_eq!(array.len(), 3);
     }
 }

--- a/src/expr/src/vector_op/agg/count_star.rs
+++ b/src/expr/src/vector_op/agg/count_star.rs
@@ -17,20 +17,17 @@ use risingwave_common::error::{ErrorCode, Result};
 use risingwave_common::types::*;
 
 use crate::vector_op::agg::aggregator::Aggregator;
-use crate::vector_op::agg::general_sorted_grouper::EqGroups;
 
 pub struct CountStar {
     return_type: DataType,
     result: usize,
-    reached_limit: bool,
 }
 
 impl CountStar {
-    pub fn new(return_type: DataType, result: usize) -> Self {
+    pub fn new(return_type: DataType) -> Self {
         Self {
             return_type,
-            result,
-            reached_limit: false,
+            result: 0,
         }
     }
 }
@@ -40,21 +37,23 @@ impl Aggregator for CountStar {
         self.return_type.clone()
     }
 
-    fn update(&mut self, input: &DataChunk) -> Result<()> {
-        self.result += input.cardinality();
+    fn update_single(&mut self, input: &DataChunk, row_id: usize) -> Result<()> {
+        if let Some(visibility) = input.visibility() {
+            if visibility.is_set(row_id)? {
+                self.result += 1;
+            }
+        } else {
+            self.result += 1;
+        }
         Ok(())
     }
 
-    fn update_chunk(
+    fn update_multi(
         &mut self,
         input: &DataChunk,
         start_row_id: usize,
         end_row_id: usize,
     ) -> Result<()> {
-        println!(
-            "[rc] CountStar::update_chunk, input: {:?}, start_row_id: {}, end_row_id: {}",
-            input, start_row_id, end_row_id
-        );
         if let Some(visibility) = input.visibility() {
             for row_id in start_row_id..end_row_id {
                 if visibility.is_set(row_id)? {
@@ -78,74 +77,5 @@ impl Aggregator for CountStar {
             ArrayBuilderImpl::Int64(b) => b.append(Some(self.result as i64)).map_err(Into::into),
             _ => Err(ErrorCode::InternalError("Unexpected builder for count(*).".into()).into()),
         }
-    }
-
-    fn update_and_output_with_sorted_groups(
-        &mut self,
-        input: &DataChunk,
-        builder: &mut ArrayBuilderImpl,
-        groups: &EqGroups,
-    ) -> Result<()> {
-        todo!();
-        let builder = match builder {
-            ArrayBuilderImpl::Int64(b) => b,
-            _ => {
-                return Err(
-                    ErrorCode::InternalError("Unexpected builder for count(*).".into()).into(),
-                )
-            }
-        };
-        // The first element continues the same group in `self.result`. The following
-        // groups' sizes are simply distance between group start indices. The distance
-        // between last element and `input.cardinality()` is the ongoing group that
-        // may continue in following chunks.
-        //
-        // Since the number of groups in an output chunk is limited, if we reach the limit
-        // in the process of counting, we set the `reached_limit` flag and save the start
-        // index of previous group to `self.result`.
-        let mut groups_iter = groups.starting_indices().iter();
-        if let Some(first) = groups_iter.next() {
-            let first_count = {
-                if self.reached_limit {
-                    first - self.result
-                } else {
-                    first + self.result
-                }
-            };
-            builder.append(Some(first_count as i64))?;
-            let mut group_cnt = 1;
-            let mut prev = first;
-            for g in groups_iter {
-                builder.append(Some((g - prev) as i64))?;
-                prev = g;
-                group_cnt += 1;
-
-                // stop and save state if we reach limit
-                if groups.is_reach_limit(group_cnt) {
-                    self.reached_limit = true;
-                    self.result = *prev;
-                    break;
-                }
-            }
-            if group_cnt == groups.len() {
-                self.reached_limit = false;
-                self.result = input.cardinality() - prev;
-            }
-        } else {
-            self.result += input.cardinality();
-        }
-
-        Ok(())
-    }
-
-    fn update_with_row(&mut self, input: &DataChunk, row_id: usize) -> Result<()> {
-        if let Some(visibility) = input.visibility() {
-            if visibility.is_set(row_id)? {
-                self.result += 1;
-            }
-        } else {
-            self.result += 1;
-        }
-        Ok(())
     }
 }

--- a/src/expr/src/vector_op/agg/general_distinct_agg.rs
+++ b/src/expr/src/vector_op/agg/general_distinct_agg.rs
@@ -21,7 +21,6 @@ use risingwave_common::types::*;
 
 use crate::vector_op::agg::aggregator::Aggregator;
 use crate::vector_op::agg::functions::RTFn;
-use crate::vector_op::agg::general_sorted_grouper::EqGroups;
 
 /// Where the actual aggregation happens.
 ///
@@ -59,7 +58,7 @@ where
         }
     }
 
-    fn update_with_scalar_concrete(&mut self, input: &T, row_id: usize) -> Result<()> {
+    fn update_single_concrete(&mut self, input: &T, row_id: usize) -> Result<()> {
         let value = input
             .value_at(row_id)
             .map(|scalar_ref| scalar_ref.to_owned_scalar().to_scalar_value());
@@ -76,11 +75,21 @@ where
         Ok(())
     }
 
-    fn update_concrete(&mut self, input: &T) -> Result<()> {
-        let input = input.iter().filter(|scalar_ref| {
-            self.exists
-                .insert(scalar_ref.map(|scalar_ref| scalar_ref.to_owned_scalar().to_scalar_value()))
-        });
+    fn update_multi_concrete(
+        &mut self,
+        input: &T,
+        start_row_id: usize,
+        end_row_id: usize,
+    ) -> Result<()> {
+        let input = input
+            .iter()
+            .skip(start_row_id)
+            .take(end_row_id - start_row_id)
+            .filter(|scalar_ref| {
+                self.exists.insert(
+                    scalar_ref.map(|scalar_ref| scalar_ref.to_owned_scalar().to_scalar_value()),
+                )
+            });
         let mut cur = self.result.as_ref().map(|x| x.as_scalar_ref());
         for datum in input {
             cur = self.f.eval(cur, datum)?;
@@ -96,36 +105,10 @@ where
             .map_err(Into::into)
     }
 
-    fn update_and_output_with_sorted_groups_concrete(
-        &mut self,
-        input: &T,
-        builder: &mut R::Builder,
-        groups: &EqGroups,
-    ) -> Result<()> {
-        let mut group_cnt = 0;
-        let mut groups_iter = groups.starting_indices().iter().peekable();
-        let mut cur = self.result.as_ref().map(|x| x.as_scalar_ref());
-        let chunk_offset = groups.chunk_offset();
-        for (i, v) in input.iter().skip(chunk_offset).enumerate() {
-            if groups_iter.peek() == Some(&&i) {
-                groups_iter.next();
-                group_cnt += 1;
-                builder.append(cur)?;
-                cur = None;
-            }
-            let scalar_impl = v.map(|scalar_ref| scalar_ref.to_owned_scalar().to_scalar_value());
-            if self.exists.insert(scalar_impl) {
-                cur = self.f.eval(cur, v)?;
-            }
-
-            // reset state and exit when reach limit
-            if groups.is_reach_limit(group_cnt) {
-                cur = None;
-                break;
-            }
-        }
-        self.result = cur.map(|x| x.to_owned_scalar());
-        Ok(())
+    fn output_and_reset_concrete(&mut self, builder: &mut R::Builder) -> Result<()> {
+        let res = self.output_concrete(builder);
+        self.result = None;
+        res
     }
 }
 
@@ -139,11 +122,11 @@ macro_rules! impl_aggregator {
                 self.return_type.clone()
             }
 
-            fn update_with_row(&mut self, input: &DataChunk, row_id: usize) -> Result<()> {
+            fn update_single(&mut self, input: &DataChunk, row_id: usize) -> Result<()> {
                 if let ArrayImpl::$input_variant(i) =
                     input.column_at(self.input_col_idx).array_ref()
                 {
-                    self.update_with_scalar_concrete(i, row_id)
+                    self.update_single_concrete(i, row_id)
                 } else {
                     Err(ErrorCode::InternalError(format!(
                         "Input fail to match {}.",
@@ -153,11 +136,16 @@ macro_rules! impl_aggregator {
                 }
             }
 
-            fn update(&mut self, input: &DataChunk) -> Result<()> {
+            fn update_multi(
+                &mut self,
+                input: &DataChunk,
+                start_row_id: usize,
+                end_row_id: usize,
+            ) -> Result<()> {
                 if let ArrayImpl::$input_variant(i) =
                     input.column_at(self.input_col_idx).array_ref()
                 {
-                    self.update_concrete(i)
+                    self.update_multi_concrete(i, start_row_id, end_row_id)
                 } else {
                     Err(ErrorCode::InternalError(format!(
                         "Input fail to match {}.",
@@ -179,20 +167,12 @@ macro_rules! impl_aggregator {
                 }
             }
 
-            fn update_and_output_with_sorted_groups(
-                &mut self,
-                input: &DataChunk,
-                builder: &mut ArrayBuilderImpl,
-                groups: &EqGroups,
-            ) -> Result<()> {
-                if let (ArrayImpl::$input_variant(i), ArrayBuilderImpl::$result_variant(b)) =
-                    (input.column_at(self.input_col_idx).array_ref(), builder)
-                {
-                    self.update_and_output_with_sorted_groups_concrete(i, b, groups)
+            fn output_and_reset(&mut self, builder: &mut ArrayBuilderImpl) -> Result<()> {
+                if let ArrayBuilderImpl::$result_variant(b) = builder {
+                    self.output_and_reset_concrete(b)
                 } else {
                     Err(ErrorCode::InternalError(format!(
-                        "Input fail to match {} or builder fail to match {}.",
-                        stringify!($input_variant),
+                        "Builder fail to match {}.",
                         stringify!($result_variant)
                     ))
                     .into())
@@ -257,7 +237,7 @@ mod tests {
         let len = input.len();
         let input_chunk = DataChunk::new(vec![Column::new(input)], len);
         let mut agg_state = create_agg_state_unary(input_type, 0, agg_type, return_type, true)?;
-        agg_state.update(&input_chunk)?;
+        agg_state.update_multi(&input_chunk, 0, input_chunk.cardinality())?;
         agg_state.output(&mut builder)?;
         builder.finish().map_err(Into::into)
     }

--- a/src/expr/src/vector_op/agg/general_sorted_grouper.rs
+++ b/src/expr/src/vector_op/agg/general_sorted_grouper.rs
@@ -74,7 +74,7 @@ impl EqGroups {
 
 /// `SortedGrouper` contains the state of a group column in the sort aggregate
 /// algorithm, just like `Aggregator` contains the state of an aggregate column.
-/// TODO(rc): This can be deprecated and the logic can be moved to SortAggExecutor.
+/// TODO(rc): This can be deprecated and the logic can be moved to `SortAggExecutor`.
 pub trait SortedGrouper: Send + 'static {
     /// `detect_groups` detects the `EqGroups` from the `input` array if appended
     /// to current state. See the documentation of `EqGroups` to learn more.
@@ -227,16 +227,16 @@ mod tests {
         let input = I32Array::from_slice(&[Some(1), Some(1), Some(3)]).unwrap();
         let eq = g.detect_groups_concrete(&input)?;
         assert_eq!(eq.indices, vec![2]);
-        g.update_concrete(&input, 0, *eq.indices.get(0).unwrap())?;
+        g.update_concrete(&input, 0, *eq.indices.first().unwrap())?;
         g.output_and_reset_concrete(&mut builder)?;
-        g.update_concrete(&input, *eq.indices.get(0).unwrap(), input.len())?;
+        g.update_concrete(&input, *eq.indices.first().unwrap(), input.len())?;
 
         let input = I32Array::from_slice(&[Some(3), Some(4), Some(4)]).unwrap();
         let eq = g.detect_groups_concrete(&input)?;
         assert_eq!(eq.indices, vec![1]);
-        g.update_concrete(&input, 0, *eq.indices.get(0).unwrap())?;
+        g.update_concrete(&input, 0, *eq.indices.first().unwrap())?;
         g.output_and_reset_concrete(&mut builder)?;
-        g.update_concrete(&input, *eq.indices.get(0).unwrap(), input.len())?;
+        g.update_concrete(&input, *eq.indices.first().unwrap(), input.len())?;
         g.output_and_reset_concrete(&mut builder)?;
 
         assert_eq!(


### PR DESCRIPTION
I hereby agree to the terms of the [Singularity Data, Inc. Contributor License Agreement](https://gist.github.com/skyzh/0663682a70b0edde7ae991492f2314cb#file-s9y_cla).

## What's changed and what's your intention?

Before this PR,

- `HashAggExecutor` used `Aggregator::update_with_row` to feed the aggregator one row at a time and used `Aggregator::output` to generate the aggregation result
- `SortAggExecutor` used `Aggregator::update_and_output_with_sorted_groups` to feed the aggregator with multiple rows together with `EqGroups`, and used `Aggregator::output` to generate the aggregation result

Several problems existed:

- `Aggregator::update(input: &DataChunk)` was not used
- `Aggregator::update_and_output_with_sorted_groups` impls needed to know about `EqGroups`, and control the timing of output and reset of internal state, making the code unnecessarily complicated and inconsistent
- `Aggregator::output` did not clear the internal state of the aggregator, so it can't be called multiple times during feeding updates

Changes in this PR:

- Remove `Aggregator::update`
- Rename `Aggregator::update_with_row` to `Aggregator::update_single`
- Add `Aggregator::update_multi` to feed Aggregator a slice of input
- Remove `Aggregator::update_and_output_with_sorted_groups`, and move the control of output out of aggregators to `SortAggExecutor`
- Add `Aggregator::output_and_reset` to output the aggregated result and reset the internal state

After this PR, `Aggregator`s are intended to be used as follows:

```rust
agg.update_single(input, 0);
agg.update_multi(input, 1, input.len());
agg.output(builder); // output the current result, but don't clear internal state
agg.output(builder); // output the same result as the above
agg.output_and_reset(builder); // output the result and reset aggregator state
agg.update_multi(input2, 0, input2.len());
agg.update_multi(input3, 0, input3.len());
agg.output(builder); // output the agg result of input2 & input3
```

`Aggregator`s only need to take care about **how to aggregate values**, but never need to know the boundary of `EqGroups`.

## Checklist

- [x] I have written necessary rustdoc comments
- [x] I have added necessary unit tests and integration tests
- [x] All checks passed in `./risedev check` (or alias, `./risedev c`)

## Refer to a related PR or issue link (optional)
