### PR TITLE
feat(storage): support deserialize_prefix_len for prefix_bloom_filter

### DIFF
--- a/src/common/src/types/mod.rs
+++ b/src/common/src/types/mod.rs
@@ -740,6 +740,11 @@ impl ScalarImpl {
         })
     }
 
+    /// Deserialize the `data_size` of `input_data_type` in `storage_encoding`. This function will
+    /// consume the offset of deserializer then return the length (without memcopy, only length
+    /// calculation). The difference between `encoding_data_size` and `ScalarImpl::data_size` is
+    /// that `ScalarImpl::data_size` calculates the `memory_length` of type instead of
+    /// `storage_encoding`
     pub fn encoding_data_size(
         data_type: &DataType,
         deserializer: &mut memcomparable::Deserializer<impl Buf>,
@@ -765,6 +770,8 @@ impl ScalarImpl {
 
                     DataType::Decimal => deserializer.read_decimal_len()?,
                     DataType::List { .. } | DataType::Struct { .. } => {
+                        // these two types is var-length and should only be determine at runtime.
+                        // TODO: need some test for this case (e.g. e2e test)
                         deserializer.read_struct_and_list_len()?
                     }
                     DataType::Varchar => deserializer.read_bytes_len()?,

--- a/src/common/src/util/ordered/serde.rs
+++ b/src/common/src/util/ordered/serde.rs
@@ -102,9 +102,7 @@ impl OrderedRowSerializer {
             let mut serializer = memcomparable::Serializer::new(vec![]);
             serializer.set_reverse(*order_type == OrderType::Descending);
             serialize_datum_into(datum, &mut serializer).unwrap();
-
-            let extra = serializer.into_inner();
-            append_to.extend(extra);
+            append_to.extend(serializer.into_inner());
         }
     }
 

--- a/src/utils/memcomparable/src/de.rs
+++ b/src/utils/memcomparable/src/de.rs
@@ -221,7 +221,7 @@ impl<B: Buf> Deserializer<B> {
         let mut len: usize = 0;
 
         let flag = self.input.get_u8();
-        if !(0x6..=0x23).contains(&flag) {
+        if !(DECIMAL_FLAG_LOW_BOUND..=DECIMAL_FLAG_UP_BOUND).contains(&flag) {
             return Err(Error::InvalidBytesEncoding(flag));
         }
         loop {


### PR DESCRIPTION
I hereby agree to the terms of the [Singularity Data, Inc. Contributor License Agreement](https://gist.github.com/skyzh/0663682a70b0edde7ae991492f2314cb#file-s9y_cla).

as title

***PLEASE DO NOT LEAVE THIS EMPTY !!!***

Please explain **IN DETAIL** what the changes are in this PR and why they are needed:

- support get encoding_data_size by DataType without mem copy
- deserialize_prefix_len_with_column_indices for prefix_bloom_filter
- some unit-test

## Checklist

- [x] I have written necessary rustdoc comments
- [x] I have added necessary unit tests and integration tests
- [x] All checks passed in `./risedev check` (or alias, `./risedev c`)

## Refer to a related PR or issue link (optional)
