### PR TITLE
fix(type): fix decimal from_str and add e2e test

### DIFF
--- a/e2e_test/streaming/basic.slt
+++ b/e2e_test/streaming/basic.slt
@@ -26,10 +26,10 @@ statement ok
 insert into t5 values ('NaN'::decimal);
 
 statement ok
-insert into t5 values ('Infinity'::decimal);
+insert into t5 values ('+inf');
 
 statement ok
-insert into t5 values ('-Infinity'::decimal);
+insert into t5 values ('-inf');
 
 statement ok
 create materialized view mv1 as select * from t1;
@@ -84,8 +84,8 @@ query IR rowsort
 select * from mv4
 ----
 1 NaN
-1 Infinity
-1 -Infinity
+1 +Inf
+1 -Inf
 
 statement ok
 drop materialized view mv1

--- a/e2e_test/streaming/basic.slt
+++ b/e2e_test/streaming/basic.slt
@@ -11,6 +11,9 @@ statement ok
 create table t4 (v1 real not null, v2 int not null, v3 real not null);
 
 statement ok
+create table t5 (d decimal);
+
+statement ok
 insert into t1 values (1,4,2), (2,3,3);
 
 statement ok
@@ -20,6 +23,15 @@ statement ok
 insert into t4 values (1,1,4), (5,1,4), (1,9,1), (9,8,1), (0,2,3);
 
 statement ok
+insert into t5 values ('NaN'::decimal);
+
+statement ok
+insert into t5 values ('Infinity'::decimal);
+
+statement ok
+insert into t5 values ('-Infinity'::decimal);
+
+statement ok
 create materialized view mv1 as select * from t1;
 
 statement ok
@@ -27,6 +39,9 @@ create materialized view mv2 as select round(avg(v1), 1) as avg_v1, sum(v2) as s
 
 statement ok
 create materialized view mv3 as select v3, sum(v1) as sum_v1, min(v1) as min_v1, max(v1) as max_v1 from t4 group by v3;
+
+statement ok
+create materialized view mv4 as select count(*) as count, d from t5 group by d;
 
 query III rowsort
 select v1, v2, v3 from mv1;
@@ -65,6 +80,13 @@ select sum_v1, min_v1, max_v1, v3 from mv3 order by sum_v1;
 6  1 5 4
 10 1 9 1
 
+query IR rowsort
+select * from mv4
+----
+1 NaN
+1 Infinity
+1 -Infinity
+
 statement ok
 drop materialized view mv1
 
@@ -73,6 +95,9 @@ drop materialized view mv2
 
 statement ok
 drop materialized view mv3
+
+statement ok
+drop materialized view mv4
 
 statement ok
 drop table t1
@@ -85,3 +110,6 @@ drop table t3
 
 statement ok
 drop table t4
+
+statement ok
+drop table t5

--- a/src/common/src/types/decimal.rs
+++ b/src/common/src/types/decimal.rs
@@ -602,8 +602,39 @@ mod tests {
     #[test]
     fn basic_test() {
         assert_eq!(Decimal::from_str("nan").unwrap(), Decimal::NaN,);
+        assert_eq!(Decimal::from_str("NaN").unwrap(), Decimal::NaN,);
+        assert_eq!(Decimal::from_str("NAN").unwrap(), Decimal::NaN,);
+
         assert_eq!(Decimal::from_str("inf").unwrap(), Decimal::PositiveINF,);
+        assert_eq!(Decimal::from_str("INF").unwrap(), Decimal::PositiveINF,);
+        assert_eq!(Decimal::from_str("+inf").unwrap(), Decimal::PositiveINF,);
+        assert_eq!(Decimal::from_str("+INF").unwrap(), Decimal::PositiveINF,);
+        assert_eq!(Decimal::from_str("+Inf").unwrap(), Decimal::PositiveINF,);
+
         assert_eq!(Decimal::from_str("-inf").unwrap(), Decimal::NegativeINF,);
+        assert_eq!(Decimal::from_str("-INF").unwrap(), Decimal::NegativeINF,);
+        assert_eq!(Decimal::from_str("-Inf").unwrap(), Decimal::NegativeINF,);
+
+        assert!(Decimal::from_str("nAn").is_err());
+        assert!(Decimal::from_str("nAN").is_err());
+        assert!(Decimal::from_str("Nan").is_err());
+        assert!(Decimal::from_str("NAn").is_err());
+
+        assert!(Decimal::from_str("iNF").is_err());
+        assert!(Decimal::from_str("inF").is_err());
+        assert!(Decimal::from_str("InF").is_err());
+        assert!(Decimal::from_str("INf").is_err());
+
+        assert!(Decimal::from_str("+iNF").is_err());
+        assert!(Decimal::from_str("+inF").is_err());
+        assert!(Decimal::from_str("+InF").is_err());
+        assert!(Decimal::from_str("+INf").is_err());
+
+        assert!(Decimal::from_str("-iNF").is_err());
+        assert!(Decimal::from_str("-inF").is_err());
+        assert!(Decimal::from_str("-InF").is_err());
+        assert!(Decimal::from_str("-INf").is_err());
+
         assert_eq!(
             Decimal::from_f32(10.0).unwrap() / Decimal::PositiveINF,
             Decimal::from_f32(0.0).unwrap(),

--- a/src/common/src/types/decimal.rs
+++ b/src/common/src/types/decimal.rs
@@ -541,8 +541,8 @@ impl FromStr for Decimal {
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         match s {
             "nan" | "NaN" | "NAN" => Ok(Decimal::NaN),
-            "inf" | "INF" | "+inf" | "+INF" => Ok(Decimal::PositiveINF),
-            "-inf" | "-INF" => Ok(Decimal::NegativeINF),
+            "inf" | "INF" | "+inf" | "+INF" | "+Inf" => Ok(Decimal::PositiveINF),
+            "-inf" | "-INF" | "-Inf" => Ok(Decimal::NegativeINF),
             s => RustDecimal::from_str(s).map(Decimal::Normalized),
         }
     }


### PR DESCRIPTION
I hereby agree to the terms of the [Singularity Data, Inc. Contributor License Agreement](https://gist.github.com/skyzh/0663682a70b0edde7ae991492f2314cb#file-s9y_cla).

## What's changed and what's your intention?

as title

Please explain **IN DETAIL** what the changes are in this PR and why they are needed:

- fix decimal from_str pattern match
- add e2e test for decimal

## Checklist

- ~[ ] I have written necessary rustdoc comments~
- [x] I have added necessary unit tests and integration tests
- [x] All checks passed in `./risedev check` (or alias, `./risedev c`)

## Refer to a related PR or issue link (optional)
- https://github.com/singularity-data/risingwave/issues/3817