### PR TITLE
feat(row-based encoding): introduce row-based encoding by using value encoding 

### DIFF
--- a/src/storage/src/encoding/mod.rs
+++ b/src/storage/src/encoding/mod.rs
@@ -25,6 +25,8 @@ pub mod cell_based_row_deserializer;
 pub mod cell_based_row_serializer;
 pub mod dedup_pk_cell_based_row_deserializer;
 pub mod dedup_pk_cell_based_row_serializer;
+pub mod row_based_deserializer;
+pub mod row_based_serializer;
 
 pub type KeyBytes = Vec<u8>;
 pub type ValueBytes = Vec<u8>;

--- a/src/storage/src/encoding/row_based_deserializer.rs
+++ b/src/storage/src/encoding/row_based_deserializer.rs
@@ -1,0 +1,115 @@
+// Copyright 2022 Singularity Data
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use bytes::Buf;
+use risingwave_common::array::Row;
+use risingwave_common::error::Result;
+use risingwave_common::types::DataType;
+use risingwave_common::util::value_encoding::deserialize_datum;
+
+#[derive(Clone)]
+pub struct RowBasedDeserializer {
+    data_types: Vec<DataType>,
+}
+
+impl RowBasedDeserializer {
+    pub fn new(data_types: Vec<DataType>) -> Self {
+        Self { data_types }
+    }
+
+    /// Deserialize bytes into a row.
+    pub fn deserialize(&self, mut row: impl Buf) -> Result<Row> {
+        // value encoding
+        let mut values = Vec::with_capacity(self.data_types.len());
+        for ty in &self.data_types {
+            values.push(deserialize_datum(&mut row, ty)?);
+        }
+        Ok(Row(values))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use risingwave_common::array::Row;
+    use risingwave_common::types::{DataType, IntervalUnit, ScalarImpl};
+
+    use crate::encoding::row_based_deserializer::RowBasedDeserializer;
+    use crate::encoding::row_based_serializer::RowBasedSerializer;
+
+    #[test]
+    fn test_row_based_serialize_and_deserialize_not_null() {
+        let row = Row(vec![
+            Some(ScalarImpl::Utf8("string".into())),
+            Some(ScalarImpl::Bool(true)),
+            Some(ScalarImpl::Int16(1)),
+            Some(ScalarImpl::Int32(2)),
+            Some(ScalarImpl::Int64(3)),
+            Some(ScalarImpl::Float32(4.0.into())),
+            Some(ScalarImpl::Float64(5.0.into())),
+            Some(ScalarImpl::Decimal("-233.3".parse().unwrap())),
+            Some(ScalarImpl::Interval(IntervalUnit::new(7, 8, 9))),
+        ]);
+        let mut se = RowBasedSerializer::new();
+        let bytes = se.serialize(&row).unwrap();
+        // each cell will add a null_tag (u8)
+        assert_eq!(bytes.len(), 11 + 2 + 3 + 5 + 9 + 5 + 9 + 17 + 17);
+
+        let de = RowBasedDeserializer::new(vec![
+            DataType::Varchar,
+            DataType::Boolean,
+            DataType::Int16,
+            DataType::Int32,
+            DataType::Int64,
+            DataType::Float32,
+            DataType::Float64,
+            DataType::Decimal,
+            DataType::Interval,
+        ]);
+        let row1 = de.deserialize(&*bytes).unwrap();
+        assert_eq!(row, row1);
+    }
+
+    #[test]
+    fn test_row_based_serialize_and_deserialize_with_null() {
+        let row = Row(vec![
+            Some(ScalarImpl::Utf8("string".into())),
+            Some(ScalarImpl::Bool(true)),
+            Some(ScalarImpl::Int16(1)),
+            Some(ScalarImpl::Int32(2)),
+            Some(ScalarImpl::Int64(3)),
+            Some(ScalarImpl::Float32(4.0.into())),
+            Some(ScalarImpl::Float64(5.0.into())),
+            Some(ScalarImpl::Decimal("-233.3".parse().unwrap())),
+            Some(ScalarImpl::Interval(IntervalUnit::new(7, 8, 9))),
+        ]);
+        let mut se = RowBasedSerializer::new();
+        let bytes = se.serialize(&row).unwrap();
+        // each cell will add a is_none flag (u8)
+        assert_eq!(bytes.len(), 11 + 2 + 3 + 5 + 9 + 5 + 9 + 17 + 17);
+
+        let de = RowBasedDeserializer::new(vec![
+            DataType::Varchar,
+            DataType::Boolean,
+            DataType::Int16,
+            DataType::Int32,
+            DataType::Int64,
+            DataType::Float32,
+            DataType::Float64,
+            DataType::Decimal,
+            DataType::Interval,
+        ]);
+        let row1 = de.deserialize(&*bytes).unwrap();
+        assert_eq!(row, row1);
+    }
+}

--- a/src/storage/src/encoding/row_based_serializer.rs
+++ b/src/storage/src/encoding/row_based_serializer.rs
@@ -1,0 +1,43 @@
+// Copyright 2022 Singularity Data
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use risingwave_common::array::Row;
+use risingwave_common::error::Result;
+use risingwave_common::util::value_encoding::serialize_datum;
+type ValueBytes = Vec<u8>;
+
+#[derive(Clone)]
+pub struct RowBasedSerializer {}
+
+impl RowBasedSerializer {
+    pub fn new() -> Self {
+        Self {}
+    }
+
+    /// Serialize key and value. The `row` must be in the same order with the column ids in this
+    /// serializer.
+    pub fn serialize(&mut self, row: &Row) -> Result<ValueBytes> {
+        let mut res = vec![];
+        for cell in row.0.clone() {
+            res.extend(serialize_datum(&cell)?);
+        }
+        Ok(res)
+    }
+}
+
+impl Default for RowBasedSerializer {
+    fn default() -> Self {
+        Self::new()
+    }
+}


### PR DESCRIPTION
I hereby agree to the terms of the [Singularity Data, Inc. Contributor License Agreement](https://gist.github.com/skyzh/0663682a70b0edde7ae991492f2314cb#file-s9y_cla).

## What's changed and what's your intention?
This PR introduces the row-based encoding, which serializes/deserializes row into/from KV entry with value encoding.

Note that current implementation is just a preliminary version to make refactoring `StorageTable` simpler and more clear, and a more efficient row-format will be designed later.

Subsequent PRs will do this:
- make `StateTable`/`StorageTable` aware of encoding ways.
- come up with new row format.
## Checklist

- [ ] I have written necessary rustdoc comments
- [ ] I have added necessary unit tests and integration tests
- [ ] All checks passed in `./risedev check` (or alias, `./risedev c`)

## Documentation

If your pull request contains user-facing changes, please specify the types of the changes, and create a release note. Otherwise, please feel free to remove this section.

### Types of user-facing changes

Please keep the types that apply to your changes, and remove those that do not apply.

* Installation and deployment 
* Connector (sources & sinks)
* SQL commands, functions, and operators
* RisingWave cluster configuration changes
* Other (please specify in the release note below)

### Release note

Please create a release note for your changes. In the release note, focus on the impact on users, and mention the environment or conditions where the impact may occur.

## Refer to a related PR or issue link (optional)
Tracking https://github.com/singularity-data/risingwave/issues/3615