### PR TITLE
fix(test): pass user name for regress tests

### DIFF
--- a/src/tests/regress/README.md
+++ b/src/tests/regress/README.md
@@ -25,11 +25,13 @@ tests: boolean
 * Run 
 ```shell
 RUST_BACKTRACE=1 target/debug/risingwave_regress_test -h 127.0.0.1 \
-  -p 4567 \
+  -p 4566 \
+  -u root \
   --input `pwd`/src/tests/regress/data \
   --output `pwd`/src/tests/regress/output \
   --schedule `pwd`/src/tests/regress/data/schedule
 ```
+Please remove the `output` directory before running the test again.
 
 # Reference
 

--- a/src/tests/regress/src/opts.rs
+++ b/src/tests/regress/src/opts.rs
@@ -52,6 +52,10 @@ impl Opts {
         SocketAddrV4::new(self.pg_server_host, self.pg_server_port)
     }
 
+    pub(crate) fn pg_user_name(&self) -> &str {
+        &self.pg_user_name
+    }
+
     pub(crate) fn log4rs_config_path(&self) -> &Path {
         self.log4rs_config.as_path()
     }


### PR DESCRIPTION
I hereby agree to the terms of the [Singularity Data, Inc. Contributor License Agreement](https://gist.github.com/skyzh/0663682a70b0edde7ae991492f2314cb#file-s9y_cla).

## What's changed and what's your intention?

***PLEASE DO NOT LEAVE THIS EMPTY !!!***
Pass user name for regress tests.
Mute the output of failed tests via stdin.

Will do in future PRs:
1. We only want to show the test cases that have different outputs as expected instead of the entire tests, similar to `sqllogictest`.
2. We will need to deal with the error message in special ways, check out #3853.

## Checklist

~- [ ] I have written necessary rustdoc comments~
~- [ ] I have added necessary unit tests and integration tests~
- [x] All checks passed in `./risedev check` (or alias, `./risedev c`)


## Refer to a related PR or issue link (optional)
#3853 