### PR TITLE
feat(sqlsmith): Implement Having without agg

### DIFF
--- a/src/tests/sqlsmith/src/lib.rs
+++ b/src/tests/sqlsmith/src/lib.rs
@@ -160,6 +160,7 @@ impl<'a, R: Rng> SqlGenerator<'a, R> {
         let from = self.gen_from();
         let selection = self.gen_where();
         let group_by = self.gen_group_by();
+        let having = self.gen_having(!group_by.is_empty());
         let (select_list, schema) = self.gen_select_list();
         let select = Select {
             distinct: false,
@@ -168,7 +169,7 @@ impl<'a, R: Rng> SqlGenerator<'a, R> {
             lateral_views: vec![],
             selection,
             group_by,
-            having: self.gen_having(),
+            having,
         };
         (select, schema)
     }
@@ -246,8 +247,8 @@ impl<'a, R: Rng> SqlGenerator<'a, R> {
         }
     }
 
-    fn gen_having(&mut self) -> Option<Expr> {
-        if self.flip_coin() {
+    fn gen_having(&mut self, have_group_by: bool) -> Option<Expr> {
+        if have_group_by & self.flip_coin() {
             Some(self.gen_expr(DataTypeName::Boolean))
         } else {
             None

--- a/src/tests/sqlsmith/src/lib.rs
+++ b/src/tests/sqlsmith/src/lib.rs
@@ -158,6 +158,7 @@ impl<'a, R: Rng> SqlGenerator<'a, R> {
     fn gen_select_stmt(&mut self) -> (Select, Vec<Column>) {
         // Generate random tables/relations first so that select items can refer to them.
         let from = self.gen_from();
+        let selection = self.gen_where();
         let group_by = self.gen_group_by();
         let (select_list, schema) = self.gen_select_list();
         let select = Select {
@@ -165,7 +166,7 @@ impl<'a, R: Rng> SqlGenerator<'a, R> {
             projection: select_list,
             from,
             lateral_views: vec![],
-            selection: self.gen_where(),
+            selection,
             group_by,
             having: self.gen_having(),
         };
@@ -245,8 +246,12 @@ impl<'a, R: Rng> SqlGenerator<'a, R> {
         }
     }
 
-    fn gen_having(&self) -> Option<Expr> {
-        None
+    fn gen_having(&mut self) -> Option<Expr> {
+        if self.flip_coin() {
+            Some(self.gen_expr(DataTypeName::Boolean))
+        } else {
+            None
+        }
     }
 
     /// 50/50 chance to be true/false.


### PR DESCRIPTION
I hereby agree to the terms of the [Singularity Data, Inc. Contributor License Agreement](https://gist.github.com/skyzh/0663682a70b0edde7ae991492f2314cb#file-s9y_cla).

## What's changed and what's your intention?

This temporarily PR refer to https://github.com/singularity-data/risingwave/issues/3367.
Implement Having but not yet complete because agg haven,t implement finish. (After finish agg will close this issue)

Some change is the order of Group by, this suggest that it should be after where because the restricted bounded column affects Having and Select only.

Please explain **IN DETAIL** what the changes are in this PR and why they are needed:

- Summarize your change (**mandatory**)
- How does this PR work? Need a brief introduction for the changed logic (optional)
- Describe clearly one logical change and avoid lazy messages (optional)
- Describe any limitations of the current code (optional)

## Checklist

- [x] I have written necessary rustdoc comments
- [x] I have added necessary unit tests and integration tests
- [x] All checks passed in `./risedev check` (or alias, `./risedev c`)

## Documentation

If your pull request contains user-facing changes, please specify the types of the changes, and create a release note. Otherwise, please feel free to remove this section.

### Types of user-facing changes

Please keep the types that apply to your changes, and remove those that do not apply.

* Installation and deployment 
* Connector (sources & sinks)
* SQL commands, functions, and operators
* RisingWave cluster configuration changes
* Other (please specify in the release note below)

### Release note

Please create a release note for your changes. In the release note, focus on the impact on users, and mention the environment or conditions where the impact may occur.

## Refer to a related PR or issue link (optional)
