### PR TITLE
fix(binder): no implicit row_id for QualifiedWildcard

### DIFF
--- a/e2e_test/batch/basic/query.slt.part
+++ b/e2e_test/batch/basic/query.slt.part
@@ -16,6 +16,16 @@ select v1, v2, v3 from t3;
 1 2 NULL
 
 query III
+select * from t3;
+----
+1 2 NULL
+
+query III
+select t3.* from t3;
+----
+1 2 NULL
+
+query III
 select count(*) from t3;
 ----
 1

--- a/src/frontend/test_runner/tests/testdata/order_by.yaml
+++ b/src/frontend/test_runner/tests/testdata/order_by.yaml
@@ -15,9 +15,9 @@
     create table t (v1 bigint, v2 double precision);
     select t.* from t order by v1;
   batch_plan: |
-    BatchExchange { order: [$1 ASC], dist: Single }
-      BatchSort { order: [$1 ASC] }
-        BatchScan { table: t, columns: [_row_id, v1, v2] }
+    BatchExchange { order: [$0 ASC], dist: Single }
+      BatchSort { order: [$0 ASC] }
+        BatchScan { table: t, columns: [v1, v2] }
 - sql: |
     create table t (v1 bigint, v2 double precision);
     select v1, v1+1 from t order by v1;


### PR DESCRIPTION
I hereby agree to the terms of the [Singularity Data, Inc. Contributor License Agreement](https://gist.github.com/skyzh/0663682a70b0edde7ae991492f2314cb#file-s9y_cla).

## What's changed and what's your intention?

***PLEASE DO NOT LEAVE THIS EMPTY !!!***

Please explain **IN DETAIL** what the changes are in this PR and why they are needed:
See issue #3867.

For `QualifiedWildcard`, the binder should not include hidden columns. 

The assumption made in this PR: 
these hidden columns are always placed at the beginning of the columns of a table in the binder context.

## Checklist

- [ ] I have written necessary rustdoc comments
- [ ] I have added necessary unit tests and integration tests
- [ ] All checks passed in `./risedev check` (or alias, `./risedev c`)

## Documentation

If your pull request contains user-facing changes, please specify the types of the changes, and create a release note. Otherwise, please feel free to remove this section.

`select table.* from table` will not return implicit `row_id` column anymore

### Types of user-facing changes

Please keep the types that apply to your changes, and remove those that do not apply.

* SQL commands, functions, and operators

## Refer to a related PR or issue link (optional)
closes #3867 