### PR TITLE
feat(batch): Implement full outer join for nested loop join

### DIFF
--- a/src/batch/benches/nested_loop_join.rs
+++ b/src/batch/benches/nested_loop_join.rs
@@ -161,6 +161,7 @@ fn bench_nested_loop_join(c: &mut Criterion) {
         JoinType::RightOuter,
         JoinType::RightSemi,
         JoinType::RightAnti,
+        JoinType::FullOuter,
     ] {
         for chunk_size in &[32, 128, 512, 1024] {
             c.bench_with_input(


### PR DESCRIPTION
I hereby agree to the terms of the [Singularity Data, Inc. Contributor License Agreement](https://gist.github.com/skyzh/0663682a70b0edde7ae991492f2314cb#file-s9y_cla).

## What's changed and what's your intention?

Implement full outer join (by copy & paste from left/right outer join).

The code logic of left/right/full outer join may be further simplified in later PRs.

## Checklist

- [x] I have written necessary rustdoc comments
- [x] I have added necessary unit tests and integration tests
- [x] All checks passed in `./risedev check` (or alias, `./risedev c`)


## Refer to a related PR or issue link (optional)
https://github.com/singularity-data/risingwave/issues/3767