### PR TITLE
fix(parser): case insensitive except double quotes

### DIFF
--- a/e2e_test/ddl/schema.slt
+++ b/e2e_test/ddl/schema.slt
@@ -44,3 +44,22 @@ drop table ddl_table;
 # Drop it again with if exists.
 statement ok
 drop schema if exists ddl_schema;
+
+# We test the case sensitivity of schema name.
+statement ok
+create schema Myschema;
+
+statement ok
+drop schema myschema;
+
+statement ok
+create schema "Myschema";
+
+statement error
+drop schema myschema;
+
+statement error
+drop schema Myschema;
+
+statement ok
+drop schema "Myschema";

--- a/e2e_test/ddl/table.slt
+++ b/e2e_test/ddl/table.slt
@@ -65,3 +65,44 @@ create table st (v1 int, v2 struct<v1 int, v2 struct<v1 int, v2 int>>);
 
 statement ok
 drop table st
+
+# We test the case sensitivity of table name and column name.
+statement ok
+create table t1 (v1 int);
+
+statement ok
+drop table T1;
+
+statement ok
+create table T1 (v1 int);
+
+statement ok
+drop table t1;
+
+statement ok
+create table "T1" (v1 int);
+
+# Since we have not really bound the columns in the insert statement
+# this test case cannot be enabled.
+# statement error
+# insert into "T1" ("V1") values (1);
+
+statement error
+drop table t1;
+
+statement error
+drop table T1;
+
+statement ok
+drop table "T1";
+
+statement ok
+create table "T2" ("V1" int);
+
+# Since we have not really bound the columns in the insert statement
+# this test case cannot be enabled.
+# statement error
+# insert into "T2" (V1) values (1);
+
+statement ok
+insert into "T2" ("V1") values (1);

--- a/src/frontend/src/binder/bind_context.rs
+++ b/src/frontend/src/binder/bind_context.rs
@@ -67,7 +67,7 @@ pub struct BindContext {
 impl BindContext {
     pub fn get_column_binding_index(
         &self,
-        table_name: Option<&String>,
+        table_name: &Option<String>,
         column_name: &String,
     ) -> Result<usize> {
         match table_name {

--- a/src/frontend/src/binder/expr/column.rs
+++ b/src/frontend/src/binder/expr/column.rs
@@ -22,9 +22,13 @@ impl Binder {
     pub fn bind_column(&mut self, idents: &[Ident]) -> Result<ExprImpl> {
         // TODO: check quote style of `ident`.
         let (_schema_name, table_name, column_name) = match idents {
-            [column] => (None, None, &column.value),
-            [table, column] => (None, Some(&table.value), &column.value),
-            [schema, table, column] => (Some(&schema.value), Some(&table.value), &column.value),
+            [column] => (None, None, column.real_value()),
+            [table, column] => (None, Some(table.real_value()), column.real_value()),
+            [schema, table, column] => (
+                Some(schema.real_value()),
+                Some(table.real_value()),
+                column.real_value(),
+            ),
             _ => {
                 return Err(
                     ErrorCode::InternalError(format!("Too many idents: {:?}", idents)).into(),
@@ -34,7 +38,7 @@ impl Binder {
 
         if let Ok(index) = self
             .context
-            .get_column_binding_index(table_name, column_name)
+            .get_column_binding_index(&table_name, &column_name)
         {
             let column = &self.context.columns[index];
             return Ok(InputRef::new(column.index, column.field.data_type.clone()).into());
@@ -45,7 +49,7 @@ impl Binder {
         for (i, context) in self.upper_contexts.iter().rev().enumerate() {
             // `depth` starts from 1.
             let depth = i + 1;
-            match context.get_column_binding_index(table_name, column_name) {
+            match context.get_column_binding_index(&table_name, &column_name) {
                 Ok(index) => {
                     let column = &context.columns[index];
                     return Ok(CorrelatedInputRef::new(

--- a/src/frontend/src/binder/expr/mod.rs
+++ b/src/frontend/src/binder/expr/mod.rs
@@ -379,7 +379,7 @@ pub fn bind_struct_field(column_def: &StructField) -> Result<ColumnDesc> {
                     data_type: bind_data_type(&f.data_type)?,
                     // Literals don't have `column_id`.
                     column_id: ColumnId::new(0),
-                    name: f.name.value.clone(),
+                    name: f.name.real_value(),
                     field_descs: vec![],
                     type_name: "".to_string(),
                 })
@@ -391,7 +391,7 @@ pub fn bind_struct_field(column_def: &StructField) -> Result<ColumnDesc> {
     Ok(ColumnDesc {
         data_type: bind_data_type(&column_def.data_type)?,
         column_id: ColumnId::new(0),
-        name: column_def.name.value.clone(),
+        name: column_def.name.real_value(),
         field_descs,
         type_name: "".to_string(),
     })

--- a/src/frontend/src/binder/query.rs
+++ b/src/frontend/src/binder/query.rs
@@ -130,7 +130,7 @@ impl Binder {
             Some(false) => Direction::Desc,
         };
         let index = match order_by_expr.expr {
-            Expr::Identifier(name) if let Some(index) = name_to_index.get(&name.value) => match *index != usize::MAX {
+            Expr::Identifier(name) if let Some(index) = name_to_index.get(&name.real_value()) => match *index != usize::MAX {
                 true => *index,
                 false => return Err(ErrorCode::BindError(format!("ORDER BY \"{}\" is ambiguous", name.value)).into()),
             }
@@ -158,7 +158,7 @@ impl Binder {
         } else {
             for cte_table in with.cte_tables {
                 let Cte { alias, query, .. } = cte_table;
-                let table_name = alias.name.value.clone();
+                let table_name = alias.name.real_value();
                 let bound_query = self.bind_query(query)?;
                 self.cte_to_relation
                     .insert(table_name, (bound_query, alias));

--- a/src/frontend/src/binder/relation/mod.rs
+++ b/src/frontend/src/binder/relation/mod.rs
@@ -64,11 +64,11 @@ impl Binder {
         let second_name = identifiers
             .pop()
             .ok_or_else(|| ErrorCode::InternalError(err_str.into()))?
-            .value;
+            .real_value();
 
         let first_name = identifiers
             .pop()
-            .map(|ident| ident.value)
+            .map(|ident| ident.real_value())
             .unwrap_or_else(|| default_name.into());
 
         Ok((first_name, second_name))
@@ -85,7 +85,7 @@ impl Binder {
         let name = identifiers
             .pop()
             .ok_or_else(|| ErrorCode::InternalError(format!("empty {}", ident_desc)))?
-            .value;
+            .real_value();
 
         Ok(name)
     }
@@ -122,7 +122,7 @@ impl Binder {
     ) -> Result<()> {
         let (table_name, column_aliases) = match alias {
             None => (table_name, vec![]),
-            Some(TableAlias { name, columns }) => (name.value, columns),
+            Some(TableAlias { name, columns }) => (name.real_value(), columns),
         };
 
         let begin = self.context.columns.len();

--- a/src/frontend/src/binder/select.rs
+++ b/src/frontend/src/binder/select.rs
@@ -127,15 +127,15 @@ impl Binder {
                 SelectItem::UnnamedExpr(expr) => {
                     let (select_expr, alias) = match &expr.clone() {
                         Expr::Identifier(ident) => {
-                            (self.bind_expr(expr)?, Some(ident.value.clone()))
+                            (self.bind_expr(expr)?, Some(ident.real_value()))
                         }
                         Expr::CompoundIdentifier(idents) => (
                             self.bind_expr(expr)?,
-                            idents.last().map(|ident| ident.value.clone()),
+                            idents.last().map(|ident| ident.real_value()),
                         ),
                         Expr::FieldIdentifier(field_expr, idents) => (
                             self.bind_single_field_column(*field_expr.clone(), idents)?,
-                            idents.last().map(|ident| ident.value.clone()),
+                            idents.last().map(|ident| ident.real_value()),
                         ),
                         _ => (self.bind_expr(expr)?, None),
                     };
@@ -143,11 +143,11 @@ impl Binder {
                     aliases.push(alias);
                 }
                 SelectItem::ExprWithAlias { expr, alias } => {
-                    check_valid_column_name(&alias.value)?;
+                    check_valid_column_name(&alias.real_value())?;
 
                     let expr = self.bind_expr(expr)?;
                     select_list.push(expr);
-                    aliases.push(Some(alias.value));
+                    aliases.push(Some(alias.real_value()));
                 }
                 SelectItem::QualifiedWildcard(obj_name) => {
                     let table_name = &obj_name.0.last().unwrap().value;

--- a/src/frontend/src/handler/create_table.rs
+++ b/src/frontend/src/handler/create_table.rs
@@ -45,7 +45,7 @@ pub fn bind_sql_columns(columns: Vec<ColumnDef>) -> Result<Vec<ColumnCatalog>> {
         column_descs.push(row_id_column_desc());
         // Then user columns.
         for (i, column) in columns.into_iter().enumerate() {
-            check_valid_column_name(&column.name.value)?;
+            check_valid_column_name(&column.name.real_value())?;
             let field_descs = if let AstDataType::Struct(fields) = &column.data_type {
                 fields
                     .iter()
@@ -57,7 +57,7 @@ pub fn bind_sql_columns(columns: Vec<ColumnDef>) -> Result<Vec<ColumnCatalog>> {
             column_descs.push(ColumnDesc {
                 data_type: bind_data_type(&column.data_type)?,
                 column_id: ColumnId::new((i + 1) as i32),
-                name: column.name.value,
+                name: column.name.real_value(),
                 field_descs,
                 type_name: "".to_string(),
             });

--- a/src/frontend/src/handler/handle_privilege.rs
+++ b/src/frontend/src/handler/handle_privilege.rs
@@ -204,6 +204,7 @@ pub async fn handle_grant_privilege(
             return Err(ErrorCode::BindError("Grantee does not exist".to_string()).into());
         }
         if let Some(granted_by) = &granted_by {
+            // We remark that the user name is always case-sensitive.
             let user = reader.get_user_by_name(&granted_by.value);
             if user.is_none() {
                 return Err(ErrorCode::BindError("Grantor does not exist".to_string()).into());

--- a/src/frontend/src/handler/show.rs
+++ b/src/frontend/src/handler/show.rs
@@ -49,10 +49,10 @@ pub fn get_columns_from_table(
         .collect())
 }
 
-fn schema_or_default(schema: &Option<Ident>) -> &str {
+fn schema_or_default(schema: &Option<Ident>) -> String {
     schema
         .as_ref()
-        .map_or_else(|| DEFAULT_SCHEMA_NAME, |s| &s.value)
+        .map_or_else(|| DEFAULT_SCHEMA_NAME.to_string(), |s| s.real_value())
 }
 
 pub fn handle_show_object(context: OptimizerContext, command: ShowObject) -> Result<PgResponse> {
@@ -62,7 +62,7 @@ pub fn handle_show_object(context: OptimizerContext, command: ShowObject) -> Res
     let names = match command {
         // If not include schema name, use default schema name
         ShowObject::Table { schema } => catalog_reader
-            .get_schema_by_name(session.database(), schema_or_default(&schema))?
+            .get_schema_by_name(session.database(), &schema_or_default(&schema))?
             .iter_table()
             .map(|t| t.name.clone())
             .collect(),
@@ -70,17 +70,17 @@ pub fn handle_show_object(context: OptimizerContext, command: ShowObject) -> Res
         ShowObject::Schema => catalog_reader.get_all_schema_names(session.database())?,
         // If not include schema name, use default schema name
         ShowObject::MaterializedView { schema } => catalog_reader
-            .get_schema_by_name(session.database(), schema_or_default(&schema))?
+            .get_schema_by_name(session.database(), &schema_or_default(&schema))?
             .iter_mv()
             .map(|t| t.name.clone())
             .collect(),
         ShowObject::Source { schema } => catalog_reader
-            .get_schema_by_name(session.database(), schema_or_default(&schema))?
+            .get_schema_by_name(session.database(), &schema_or_default(&schema))?
             .iter_source()
             .map(|t| t.name.clone())
             .collect(),
         ShowObject::MaterializedSource { schema } => catalog_reader
-            .get_schema_by_name(session.database(), schema_or_default(&schema))?
+            .get_schema_by_name(session.database(), &schema_or_default(&schema))?
             .iter_materialized_source()
             .map(|t| t.name.clone())
             .collect(),

--- a/src/frontend/src/handler/variable.rs
+++ b/src/frontend/src/handler/variable.rs
@@ -28,7 +28,10 @@ pub(super) fn handle_set(
     let string_val = to_string(&value[0]);
     // Currently store the config variable simply as String -> ConfigEntry(String).
     // In future we can add converter/parser to make the API more robust.
-    context.session_ctx.set_config(&name.value, &string_val)?;
+    // We remark that the name of session parameter is always case-insensitive.
+    context
+        .session_ctx
+        .set_config(&name.value.to_lowercase(), &string_val)?;
 
     Ok(PgResponse::empty_result(StatementType::SET_OPTION))
 }
@@ -40,7 +43,8 @@ pub(super) fn handle_show(context: OptimizerContext, variable: Vec<Ident>) -> Re
             ErrorCode::InvalidInputSyntax("only one variable or ALL required".to_string()).into(),
         );
     }
-    let name = &variable[0].value;
+    // TODO: Verify that the name used in `show` command is indeed always case-insensitive.
+    let name = &variable[0].value.to_lowercase();
     if name.eq_ignore_ascii_case("ALL") {
         return handle_show_all(&context);
     }

--- a/src/frontend/test_runner/tests/testdata/nexmark.yaml
+++ b/src/frontend/test_runner/tests/testdata/nexmark.yaml
@@ -46,10 +46,10 @@
     SELECT auction, bidder, price, dateTime FROM bid;
   batch_plan: |
     BatchExchange { order: [], dist: Single }
-      BatchScan { table: bid, columns: [auction, bidder, price, dateTime] }
+      BatchScan { table: bid, columns: [auction, bidder, price, datetime] }
   stream_plan: |
-    StreamMaterialize { columns: [auction, bidder, price, dateTime, bid._row_id(hidden)], pk_columns: [bid._row_id] }
-      StreamTableScan { table: bid, columns: [auction, bidder, price, dateTime, _row_id], pk_indices: [4] }
+    StreamMaterialize { columns: [auction, bidder, price, datetime, bid._row_id(hidden)], pk_columns: [bid._row_id] }
+      StreamTableScan { table: bid, columns: [auction, bidder, price, datetime, _row_id], pk_indices: [4] }
 - id: nexmark_q1
   before:
     - create_tables
@@ -63,11 +63,11 @@
   batch_plan: |
     BatchExchange { order: [], dist: Single }
       BatchProject { exprs: [$0, $1, (0.908:Decimal * $2), $3] }
-        BatchScan { table: bid, columns: [auction, bidder, price, dateTime] }
+        BatchScan { table: bid, columns: [auction, bidder, price, datetime] }
   stream_plan: |
-    StreamMaterialize { columns: [auction, bidder, price, dateTime, bid._row_id(hidden)], pk_columns: [bid._row_id] }
+    StreamMaterialize { columns: [auction, bidder, price, datetime, bid._row_id(hidden)], pk_columns: [bid._row_id] }
       StreamProject { exprs: [$0, $1, (0.908:Decimal * $2), $3, $4] }
-        StreamTableScan { table: bid, columns: [auction, bidder, price, dateTime, _row_id], pk_indices: [4] }
+        StreamTableScan { table: bid, columns: [auction, bidder, price, datetime, _row_id], pk_indices: [4] }
 - id: nexmark_q2
   before:
     - create_tables
@@ -138,9 +138,9 @@
                   BatchFilter { predicate: ($6 >= $1) AND ($6 <= $2) }
                     BatchHashJoin { type: Inner, predicate: $0 = $4, output_indices: all }
                       BatchExchange { order: [], dist: HashShard([0]) }
-                        BatchScan { table: auction, columns: [id, dateTime, expires, category] }
+                        BatchScan { table: auction, columns: [id, datetime, expires, category] }
                       BatchExchange { order: [], dist: HashShard([0]) }
-                        BatchScan { table: bid, columns: [auction, price, dateTime] }
+                        BatchScan { table: bid, columns: [auction, price, datetime] }
   stream_plan: |
     StreamMaterialize { columns: [category, avg], pk_columns: [category] }
       StreamProject { exprs: [$0, ($2 / $3)] }
@@ -152,9 +152,9 @@
                   StreamFilter { predicate: ($7 >= $1) AND ($7 <= $2) }
                     StreamHashJoin { type: Inner, predicate: $0 = $5, output_indices: all }
                       StreamExchange { dist: HashShard([0]) }
-                        StreamTableScan { table: auction, columns: [id, dateTime, expires, category, _row_id], pk_indices: [4] }
+                        StreamTableScan { table: auction, columns: [id, datetime, expires, category, _row_id], pk_indices: [4] }
                       StreamExchange { dist: HashShard([0]) }
-                        StreamTableScan { table: bid, columns: [auction, price, dateTime, _row_id], pk_indices: [3] }
+                        StreamTableScan { table: bid, columns: [auction, price, datetime, _row_id], pk_indices: [3] }
 - id: nexmark_q5
   before:
     - create_tables
@@ -170,7 +170,7 @@
                   BatchExchange { order: [], dist: HashShard([0, 1]) }
                     BatchProject { exprs: [$1, $0] }
                       BatchHopWindow { time_col: $1, slide: 00:00:02, size: 00:00:10, output_indices: [0, 2] }
-                        BatchScan { table: bid, columns: [auction, dateTime] }
+                        BatchScan { table: bid, columns: [auction, datetime] }
             BatchProject { exprs: [$1, $0] }
               BatchHashAgg { group_key: [$0], aggs: [max($1)] }
                 BatchExchange { order: [], dist: HashShard([0]) }
@@ -178,7 +178,7 @@
                     BatchHashAgg { group_key: [$0, $1], aggs: [count] }
                       BatchHopWindow { time_col: $1, slide: 00:00:02, size: 00:00:10, output_indices: [0, 2] }
                         BatchExchange { order: [], dist: HashShard([0]) }
-                          BatchScan { table: bid, columns: [auction, dateTime] }
+                          BatchScan { table: bid, columns: [auction, datetime] }
   stream_plan: |
     StreamMaterialize { columns: [auction, num, window_start(hidden), window_start#1(hidden)], pk_columns: [window_start, auction, window_start#1] }
       StreamProject { exprs: [$0, $1, $2, $4] }
@@ -190,7 +190,7 @@
                   StreamExchange { dist: HashShard([0, 1]) }
                     StreamProject { exprs: [$1, $0, $2] }
                       StreamHopWindow { time_col: $1, slide: 00:00:02, size: 00:00:10, output_indices: [0, 3, 2] }
-                        StreamTableScan { table: bid, columns: [auction, dateTime, _row_id], pk_indices: [2] }
+                        StreamTableScan { table: bid, columns: [auction, datetime, _row_id], pk_indices: [2] }
             StreamProject { exprs: [$2, $0] }
               StreamHashAgg { group_key: [$0], aggs: [count, max($1)] }
                 StreamExchange { dist: HashShard([0]) }
@@ -198,7 +198,7 @@
                     StreamHashAgg { group_key: [$0, $1], aggs: [count, count] }
                       StreamExchange { dist: HashShard([0, 1]) }
                         StreamHopWindow { time_col: $1, slide: 00:00:02, size: 00:00:10, output_indices: [0, 3, 2] }
-                          StreamTableScan { table: bid, columns: [auction, dateTime, _row_id], pk_indices: [2] }
+                          StreamTableScan { table: bid, columns: [auction, datetime, _row_id], pk_indices: [2] }
 - id: nexmark_q6
   before:
     - create_tables
@@ -244,27 +244,27 @@
         BatchFilter { predicate: ($3 >= ($5 - '00:00:10':Interval)) AND ($3 <= $5) }
           BatchHashJoin { type: Inner, predicate: $2 = $4, output_indices: all }
             BatchExchange { order: [], dist: HashShard([2]) }
-              BatchScan { table: bid, columns: [auction, bidder, price, dateTime] }
+              BatchScan { table: bid, columns: [auction, bidder, price, datetime] }
             BatchExchange { order: [], dist: HashShard([0]) }
               BatchProject { exprs: [$1, $0] }
                 BatchHashAgg { group_key: [$0], aggs: [max($1)] }
                   BatchExchange { order: [], dist: HashShard([0]) }
                     BatchProject { exprs: [(TumbleStart($1, '00:00:10':Interval) + '00:00:10':Interval), $0] }
-                      BatchScan { table: bid, columns: [price, dateTime] }
+                      BatchScan { table: bid, columns: [price, datetime] }
   stream_plan: |
-    StreamMaterialize { columns: [auction, price, bidder, dateTime, bid._row_id(hidden), (TumbleStart(bid.dateTime, '00:00:10':Interval) + '00:00:10':Interval)(hidden)], pk_columns: [bid._row_id, (TumbleStart(bid.dateTime, '00:00:10':Interval) + '00:00:10':Interval)] }
+    StreamMaterialize { columns: [auction, price, bidder, datetime, bid._row_id(hidden), (TumbleStart(bid.datetime, '00:00:10':Interval) + '00:00:10':Interval)(hidden)], pk_columns: [bid._row_id, (TumbleStart(bid.datetime, '00:00:10':Interval) + '00:00:10':Interval)] }
       StreamExchange { dist: HashShard([4, 5]) }
         StreamProject { exprs: [$0, $2, $1, $3, $4, $6] }
           StreamFilter { predicate: ($3 >= ($6 - '00:00:10':Interval)) AND ($3 <= $6) }
             StreamHashJoin { type: Inner, predicate: $2 = $5, output_indices: all }
               StreamExchange { dist: HashShard([2]) }
-                StreamTableScan { table: bid, columns: [auction, bidder, price, dateTime, _row_id], pk_indices: [4] }
+                StreamTableScan { table: bid, columns: [auction, bidder, price, datetime, _row_id], pk_indices: [4] }
               StreamExchange { dist: HashShard([0]) }
                 StreamProject { exprs: [$2, $0] }
                   StreamHashAgg { group_key: [$0], aggs: [count, max($1)] }
                     StreamExchange { dist: HashShard([0]) }
                       StreamProject { exprs: [(TumbleStart($1, '00:00:10':Interval) + '00:00:10':Interval), $0, $2] }
-                        StreamTableScan { table: bid, columns: [price, dateTime, _row_id], pk_indices: [2] }
+                        StreamTableScan { table: bid, columns: [price, datetime, _row_id], pk_indices: [2] }
 - id: nexmark_q8
   before:
     - create_tables
@@ -309,23 +309,23 @@
           BatchHashAgg { group_key: [$0, $1, $2, $3], aggs: [] }
             BatchExchange { order: [], dist: HashShard([0, 1, 2, 3]) }
               BatchProject { exprs: [$0, $1, TumbleStart($2, '00:00:10':Interval), (TumbleStart($2, '00:00:10':Interval) + '00:00:10':Interval)] }
-                BatchScan { table: person, columns: [id, name, dateTime] }
+                BatchScan { table: person, columns: [id, name, datetime] }
         BatchHashAgg { group_key: [$0, $1, $2], aggs: [] }
           BatchExchange { order: [], dist: HashShard([0, 1, 2]) }
             BatchProject { exprs: [$1, TumbleStart($0, '00:00:10':Interval), (TumbleStart($0, '00:00:10':Interval) + '00:00:10':Interval)] }
-              BatchScan { table: auction, columns: [dateTime, seller] }
+              BatchScan { table: auction, columns: [datetime, seller] }
   stream_plan: |
-    StreamMaterialize { columns: [id, name, starttime, (TumbleStart(person.dateTime, '00:00:10':Interval) + '00:00:10':Interval)(hidden), auction.seller(hidden), TumbleStart(auction.dateTime, '00:00:10':Interval)(hidden), (TumbleStart(auction.dateTime, '00:00:10':Interval) + '00:00:10':Interval)(hidden)], pk_columns: [id, name, starttime, (TumbleStart(person.dateTime, '00:00:10':Interval) + '00:00:10':Interval), auction.seller, TumbleStart(auction.dateTime, '00:00:10':Interval), (TumbleStart(auction.dateTime, '00:00:10':Interval) + '00:00:10':Interval)] }
+    StreamMaterialize { columns: [id, name, starttime, (TumbleStart(person.datetime, '00:00:10':Interval) + '00:00:10':Interval)(hidden), auction.seller(hidden), TumbleStart(auction.datetime, '00:00:10':Interval)(hidden), (TumbleStart(auction.datetime, '00:00:10':Interval) + '00:00:10':Interval)(hidden)], pk_columns: [id, name, starttime, (TumbleStart(person.datetime, '00:00:10':Interval) + '00:00:10':Interval), auction.seller, TumbleStart(auction.datetime, '00:00:10':Interval), (TumbleStart(auction.datetime, '00:00:10':Interval) + '00:00:10':Interval)] }
       StreamHashJoin { type: Inner, predicate: $0 = $5 AND $2 = $6 AND $3 = $7, output_indices: [0, 1, 2, 3, 5, 6, 7] }
         StreamExchange { dist: HashShard([0, 2, 3]) }
           StreamHashAgg { group_key: [$0, $1, $2, $3], aggs: [count] }
             StreamExchange { dist: HashShard([0, 1, 2, 3]) }
               StreamProject { exprs: [$0, $1, TumbleStart($2, '00:00:10':Interval), (TumbleStart($2, '00:00:10':Interval) + '00:00:10':Interval), $3] }
-                StreamTableScan { table: person, columns: [id, name, dateTime, _row_id], pk_indices: [3] }
+                StreamTableScan { table: person, columns: [id, name, datetime, _row_id], pk_indices: [3] }
         StreamHashAgg { group_key: [$0, $1, $2], aggs: [count] }
           StreamExchange { dist: HashShard([0, 1, 2]) }
             StreamProject { exprs: [$1, TumbleStart($0, '00:00:10':Interval), (TumbleStart($0, '00:00:10':Interval) + '00:00:10':Interval), $2] }
-              StreamTableScan { table: auction, columns: [dateTime, seller, _row_id], pk_indices: [2] }
+              StreamTableScan { table: auction, columns: [datetime, seller, _row_id], pk_indices: [2] }
 - id: nexmark_q9
   before:
     - create_tables
@@ -340,7 +340,7 @@
       WHERE A.id = B.auction AND B.dateTime BETWEEN A.dateTime AND A.expires
     )
     WHERE rownum <= 1;
-  binder_error: 'Feature is not yet implemented: unsupported function: "row_number", Tracking issue: https://github.com/singularity-data/risingwave/issues/112'
+  binder_error: 'Item not found: relation "A"'
 - id: nexmark_q10
   before:
     - create_tables
@@ -349,11 +349,11 @@
   batch_plan: |
     BatchExchange { order: [], dist: Single }
       BatchProject { exprs: [$0, $1, $2, $3, ToChar($3, 'YYYY-MM-DD':Varchar), ToChar($3, 'HH:MI':Varchar)] }
-        BatchScan { table: bid, columns: [auction, bidder, price, dateTime] }
+        BatchScan { table: bid, columns: [auction, bidder, price, datetime] }
   stream_plan: |
-    StreamMaterialize { columns: [auction, bidder, price, dateTime, date, time, bid._row_id(hidden)], pk_columns: [bid._row_id] }
+    StreamMaterialize { columns: [auction, bidder, price, datetime, date, time, bid._row_id(hidden)], pk_columns: [bid._row_id] }
       StreamProject { exprs: [$0, $1, $2, $3, ToChar($3, 'YYYY-MM-DD':Varchar), ToChar($3, 'HH:MI':Varchar), $4] }
-        StreamTableScan { table: bid, columns: [auction, bidder, price, dateTime, _row_id], pk_indices: [4] }
+        StreamTableScan { table: bid, columns: [auction, bidder, price, datetime, _row_id], pk_indices: [4] }
 - id: nexmark_q11
   before:
     - create_tables
@@ -422,12 +422,12 @@
     BatchExchange { order: [], dist: Single }
       BatchProject { exprs: [$0, $1, (0.908:Decimal * $2), Case(((Extract('HOUR':Varchar, $3) >= 8:Int32) AND (Extract('HOUR':Varchar, $3) <= 18:Int32)), 'dayTime':Varchar, ((Extract('HOUR':Varchar, $3) <= 6:Int32) OR (Extract('HOUR':Varchar, $3) >= 20:Int32)), 'nightTime':Varchar, 'otherTime':Varchar), $3, $4] }
         BatchFilter { predicate: ((0.908:Decimal * $2) > 1000000:Int32) AND ((0.908:Decimal * $2) < 50000000:Int32) }
-          BatchScan { table: bid, columns: [auction, bidder, price, dateTime, extra] }
+          BatchScan { table: bid, columns: [auction, bidder, price, datetime, extra] }
   stream_plan: |
-    StreamMaterialize { columns: [auction, bidder, price, bidTimeType, dateTime, extra, bid._row_id(hidden)], pk_columns: [bid._row_id] }
+    StreamMaterialize { columns: [auction, bidder, price, bidtimetype, datetime, extra, bid._row_id(hidden)], pk_columns: [bid._row_id] }
       StreamProject { exprs: [$0, $1, (0.908:Decimal * $2), Case(((Extract('HOUR':Varchar, $3) >= 8:Int32) AND (Extract('HOUR':Varchar, $3) <= 18:Int32)), 'dayTime':Varchar, ((Extract('HOUR':Varchar, $3) <= 6:Int32) OR (Extract('HOUR':Varchar, $3) >= 20:Int32)), 'nightTime':Varchar, 'otherTime':Varchar), $3, $4, $5] }
         StreamFilter { predicate: ((0.908:Decimal * $2) > 1000000:Int32) AND ((0.908:Decimal * $2) < 50000000:Int32) }
-          StreamTableScan { table: bid, columns: [auction, bidder, price, dateTime, extra, _row_id], pk_indices: [5] }
+          StreamTableScan { table: bid, columns: [auction, bidder, price, datetime, extra, _row_id], pk_indices: [5] }
 - id: nexmark_q15
   before:
     - create_tables
@@ -456,7 +456,7 @@
             BatchExchange { order: [], dist: HashShard([0, 2, 3, 4]) }
               BatchExpand { column_subsets: [[0, 1], [0, 2], [0, 1, 2], [0, 1, 2], [0, 1, 2], [0, 3], [0, 1, 3], [0, 1, 3], [0, 1, 3]] }
                 BatchProject { exprs: [ToChar($3, 'yyyy-MM-dd':Varchar), $2, $1, $0] }
-                  BatchScan { table: bid, columns: [auction, bidder, price, dateTime] }
+                  BatchScan { table: bid, columns: [auction, bidder, price, datetime] }
   stream_plan: |
     StreamMaterialize { columns: [day, count(hidden), total_bids, rank1_bids, rank2_bids, rank3_bids, total_bidders, rank1_bidders, rank2_bidders, rank3_bidders, total_auctions, rank1_auctions, rank2_auctions, rank3_auctions], pk_columns: [day] }
       StreamHashAgg { group_key: [$0], aggs: [count, sum($11) filter(($9 = 0:Int64)), sum($12) filter(($9 = 0:Int64)), sum($13) filter(($9 = 0:Int64)), sum($14) filter(($9 = 0:Int64)), count($1) filter(($9 = 1:Int64)), count($2) filter((($15 > 0:Int64) AND ($9 = 2:Int64))), count($3) filter((($16 > 0:Int64) AND ($9 = 3:Int64))), count($4) filter((($17 > 0:Int64) AND ($9 = 4:Int64))), count($5) filter(($9 = 5:Int64)), count($6) filter((($18 > 0:Int64) AND ($9 = 6:Int64))), count($7) filter((($19 > 0:Int64) AND ($9 = 7:Int64))), count($8) filter((($20 > 0:Int64) AND ($9 = 8:Int64)))] }
@@ -465,7 +465,7 @@
             StreamExchange { dist: HashShard([0, 2, 3, 5]) }
               StreamExpand { column_subsets: [[0, 1], [0, 2], [0, 1, 2], [0, 1, 2], [0, 1, 2], [0, 3], [0, 1, 3], [0, 1, 3], [0, 1, 3]] }
                 StreamProject { exprs: [ToChar($3, 'yyyy-MM-dd':Varchar), $2, $1, $0, $4] }
-                  StreamTableScan { table: bid, columns: [auction, bidder, price, dateTime, _row_id], pk_indices: [4] }
+                  StreamTableScan { table: bid, columns: [auction, bidder, price, datetime, _row_id], pk_indices: [4] }
 - id: nexmark_q16
   before:
     - create_tables
@@ -496,7 +496,7 @@
             BatchExchange { order: [], dist: HashShard([0, 1, 4, 5, 6]) }
               BatchExpand { column_subsets: [[0, 1, 2, 3], [0, 1, 4], [0, 1, 3, 4], [0, 1, 3, 4], [0, 1, 3, 4], [0, 1, 5], [0, 1, 3, 5], [0, 1, 3, 5], [0, 1, 3, 5]] }
                 BatchProject { exprs: [$3, ToChar($4, 'yyyy-MM-dd':Varchar), ToChar($4, 'HH:mm':Varchar), $2, $1, $0] }
-                  BatchScan { table: bid, columns: [auction, bidder, price, channel, dateTime] }
+                  BatchScan { table: bid, columns: [auction, bidder, price, channel, datetime] }
   stream_plan: |
     StreamMaterialize { columns: [channel, day, count(hidden), minute, total_bids, rank1_bids, rank2_bids, rank3_bids, total_bidders, rank1_bidders, rank2_bidders, rank3_bidders, total_auctions, rank1_auctions, rank2_auctions, rank3_auctions], pk_columns: [channel, day] }
       StreamHashAgg { group_key: [$0, $1], aggs: [count, max($12) filter(($10 = 0:Int64)), sum($13) filter(($10 = 0:Int64)), sum($14) filter(($10 = 0:Int64)), sum($15) filter(($10 = 0:Int64)), sum($16) filter(($10 = 0:Int64)), count($2) filter(($10 = 1:Int64)), count($3) filter((($17 > 0:Int64) AND ($10 = 2:Int64))), count($4) filter((($18 > 0:Int64) AND ($10 = 3:Int64))), count($5) filter((($19 > 0:Int64) AND ($10 = 4:Int64))), count($6) filter(($10 = 5:Int64)), count($7) filter((($20 > 0:Int64) AND ($10 = 6:Int64))), count($8) filter((($21 > 0:Int64) AND ($10 = 7:Int64))), count($9) filter((($22 > 0:Int64) AND ($10 = 8:Int64)))] }
@@ -505,7 +505,7 @@
             StreamExchange { dist: HashShard([0, 1, 4, 5, 7]) }
               StreamExpand { column_subsets: [[0, 1, 2, 3], [0, 1, 4], [0, 1, 3, 4], [0, 1, 3, 4], [0, 1, 3, 4], [0, 1, 5], [0, 1, 3, 5], [0, 1, 3, 5], [0, 1, 3, 5]] }
                 StreamProject { exprs: [$3, ToChar($4, 'yyyy-MM-dd':Varchar), ToChar($4, 'HH:mm':Varchar), $2, $1, $0, $5] }
-                  StreamTableScan { table: bid, columns: [auction, bidder, price, channel, dateTime, _row_id], pk_indices: [5] }
+                  StreamTableScan { table: bid, columns: [auction, bidder, price, channel, datetime, _row_id], pk_indices: [5] }
 - id: nexmark_q17
   before:
     - create_tables
@@ -529,14 +529,14 @@
         BatchHashAgg { group_key: [$0, $1], aggs: [count, count filter(($2 < 10000:Int32)), count filter((($2 >= 10000:Int32) AND ($2 < 1000000:Int32))), count filter(($2 >= 1000000:Int32)), min($2), max($2), sum($2), count($2), sum($2)] }
           BatchExchange { order: [], dist: HashShard([0, 1]) }
             BatchProject { exprs: [$0, ToChar($2, 'yyyy-MM-dd':Varchar), $1] }
-              BatchScan { table: bid, columns: [auction, price, dateTime] }
+              BatchScan { table: bid, columns: [auction, price, datetime] }
   stream_plan: |
     StreamMaterialize { columns: [auction, day, total_bids, rank1_bids, rank2_bids, rank3_bids, min_price, max_price, avg_price, sum_price], pk_columns: [auction, day] }
       StreamProject { exprs: [$0, $1, $3, $4, $5, $6, $7, $8, ($9 / $10), $11] }
         StreamHashAgg { group_key: [$0, $1], aggs: [count, count, count filter(($2 < 10000:Int32)), count filter((($2 >= 10000:Int32) AND ($2 < 1000000:Int32))), count filter(($2 >= 1000000:Int32)), min($2), max($2), sum($2), count($2), sum($2)] }
           StreamExchange { dist: HashShard([0, 1]) }
             StreamProject { exprs: [$0, ToChar($2, 'yyyy-MM-dd':Varchar), $1, $3] }
-              StreamTableScan { table: bid, columns: [auction, price, dateTime, _row_id], pk_indices: [3] }
+              StreamTableScan { table: bid, columns: [auction, price, datetime, _row_id], pk_indices: [3] }
 - id: nexmark_q18
   before:
     - create_tables
@@ -568,19 +568,19 @@
     BatchExchange { order: [], dist: Single }
       BatchHashJoin { type: Inner, predicate: $0 = $6, output_indices: [0, 1, 2, 3, 4, 5, 7, 8, 9, 10, 11, 12, 13, 14] }
         BatchExchange { order: [], dist: HashShard([0]) }
-          BatchScan { table: bid, columns: [auction, bidder, price, channel, url, dateTime] }
+          BatchScan { table: bid, columns: [auction, bidder, price, channel, url, datetime] }
         BatchExchange { order: [], dist: HashShard([0]) }
           BatchFilter { predicate: ($8 = 10:Int32) }
-            BatchScan { table: auction, columns: [id, itemName, description, initialBid, reserve, dateTime, expires, seller, category] }
+            BatchScan { table: auction, columns: [id, itemname, description, initialbid, reserve, datetime, expires, seller, category] }
   stream_plan: |
-    StreamMaterialize { columns: [auction, bidder, price, channel, url, dateTimeB, itemName, description, initialBid, reserve, dateTimeA, expires, seller, category, bid._row_id(hidden), auction._row_id(hidden)], pk_columns: [bid._row_id, auction._row_id] }
+    StreamMaterialize { columns: [auction, bidder, price, channel, url, datetimeb, itemname, description, initialbid, reserve, datetimea, expires, seller, category, bid._row_id(hidden), auction._row_id(hidden)], pk_columns: [bid._row_id, auction._row_id] }
       StreamExchange { dist: HashShard([14, 15]) }
         StreamHashJoin { type: Inner, predicate: $0 = $7, output_indices: [0, 1, 2, 3, 4, 5, 8, 9, 10, 11, 12, 13, 14, 15, 6, 16] }
           StreamExchange { dist: HashShard([0]) }
-            StreamTableScan { table: bid, columns: [auction, bidder, price, channel, url, dateTime, _row_id], pk_indices: [6] }
+            StreamTableScan { table: bid, columns: [auction, bidder, price, channel, url, datetime, _row_id], pk_indices: [6] }
           StreamExchange { dist: HashShard([0]) }
             StreamFilter { predicate: ($8 = 10:Int32) }
-              StreamTableScan { table: auction, columns: [id, itemName, description, initialBid, reserve, dateTime, expires, seller, category, _row_id], pk_indices: [9] }
+              StreamTableScan { table: auction, columns: [id, itemname, description, initialbid, reserve, datetime, expires, seller, category, _row_id], pk_indices: [9] }
 - id: nexmark_q21
   before:
     - create_tables

--- a/src/sqlparser/src/ast/mod.rs
+++ b/src/sqlparser/src/ast/mod.rs
@@ -118,6 +118,16 @@ impl Ident {
             quote_style: Some(quote),
         }
     }
+
+    /// Value after considering quote style
+    /// In certain places, double quotes can force case-sensitive, but not always
+    /// e.g. session variables.
+    pub fn real_value(&self) -> String {
+        match self.quote_style {
+            Some('"') => self.value.clone(),
+            _ => self.value.to_lowercase(),
+        }
+    }
 }
 
 impl From<&str> for Ident {


### PR DESCRIPTION
I hereby agree to the terms of the [Singularity Data, Inc. Contributor License Agreement](https://gist.github.com/skyzh/0663682a70b0edde7ae991492f2314cb#file-s9y_cla).

## What's changed and what's your intention?
Fix #3888, this PR makes the decision of case sensitivity during parsing.

There are three cases:
1. always case-insensitive even with double quotes, such as session variables
2. case-sensitive by double quotes
3. case-insensitive with no quotes

## Checklist

- [x] I have written necessary rustdoc comments
- [x] I have added necessary unit tests and integration tests
- [x] All checks passed in `./risedev check` (or alias, `./risedev c`)

## Documentation

If your pull request contains user-facing changes, please specify the types of the changes, and create a release note. Otherwise, please feel free to remove this section.

Names are case-insensitive by default, e.g. column name, table name, etc, unless the name is double-quoted. In this case, they are case-sensitive.

### Types of user-facing changes

Please keep the types that apply to your changes, and remove those that do not apply.

* SQL commands, functions, and operators

### Release note

Please create a release note for your changes. In the release note, focus on the impact on users, and mention the environment or conditions where the impact may occur.

Names are case-insensitive by default, e.g. column name, table name, etc, unless the name is double-quoted. In this case, they are case-sensitive.

## Refer to a related PR or issue link (optional)
closes #3888 