### PR TITLE
fix: parallelism should not be subtracted 1

### DIFF
--- a/src/config/risingwave.toml
+++ b/src/config/risingwave.toml
@@ -6,6 +6,8 @@ heartbeat_interval_ms = 1000
 [streaming]
 checkpoint_interval_ms = 250
 in_flight_barrier_nums = 40
+# FIXME
+unsafe_worker_node_parallel_degree = 3
 
 [storage]
 shared_buffer_capacity_mb = 4096

--- a/src/config/risingwave.toml
+++ b/src/config/risingwave.toml
@@ -6,7 +6,7 @@ heartbeat_interval_ms = 1000
 [streaming]
 checkpoint_interval_ms = 250
 in_flight_barrier_nums = 40
-unsafe_worker_node_parallel_degree = 2
+unsafe_worker_node_parallel_degree = 4
 
 [storage]
 shared_buffer_capacity_mb = 4096

--- a/src/config/risingwave.toml
+++ b/src/config/risingwave.toml
@@ -6,7 +6,6 @@ heartbeat_interval_ms = 1000
 [streaming]
 checkpoint_interval_ms = 250
 in_flight_barrier_nums = 40
-unsafe_worker_node_parallel_degree = 4
 
 [storage]
 shared_buffer_capacity_mb = 4096

--- a/src/frontend/src/scheduler/distributed/query.rs
+++ b/src/frontend/src/scheduler/distributed/query.rs
@@ -528,7 +528,7 @@ mod tests {
             r#type: ParallelUnitType::Single as i32,
             worker_node_id: node_id,
         }];
-        for id in start_id + 1..start_id + parallel_degree {
+        for id in start_id + 1..start_id + 1 + parallel_degree {
             parallel_units.push(ParallelUnit {
                 id,
                 r#type: ParallelUnitType::Hash as i32,

--- a/src/frontend/src/scheduler/plan_fragmenter.rs
+++ b/src/frontend/src/scheduler/plan_fragmenter.rs
@@ -733,7 +733,7 @@ mod tests {
             r#type: ParallelUnitType::Single as i32,
             worker_node_id: node_id,
         }];
-        for id in start_id + 1..start_id + parallel_degree {
+        for id in start_id + 1..start_id + 1 + parallel_degree {
             parallel_units.push(ParallelUnit {
                 id,
                 r#type: ParallelUnitType::Hash as i32,

--- a/src/meta/src/cluster/mod.rs
+++ b/src/meta/src/cluster/mod.rs
@@ -328,7 +328,7 @@ where
             worker_node_id: worker_id,
         };
         parallel_units.push(single_parallel_unit);
-        (start_id + 1..start_id + parallel_degree as ParallelUnitId).for_each(|id| {
+        (start_id + 1..start_id + 1 + parallel_degree as ParallelUnitId).for_each(|id| {
             let hash_parallel_unit = ParallelUnit {
                 id,
                 r#type: ParallelUnitType::Hash as i32,
@@ -527,7 +527,7 @@ mod tests {
         }
 
         let single_parallel_count = worker_count;
-        let hash_parallel_count = (env.opts.unsafe_worker_node_parallel_degree - 1) * worker_count;
+        let hash_parallel_count = env.opts.unsafe_worker_node_parallel_degree * worker_count;
         assert_cluster_manager(&cluster_manager, single_parallel_count, hash_parallel_count).await;
 
         let worker_to_delete_count = 4usize;
@@ -544,7 +544,7 @@ mod tests {
         assert_cluster_manager(
             &cluster_manager,
             1,
-            env.opts.unsafe_worker_node_parallel_degree - 1,
+            env.opts.unsafe_worker_node_parallel_degree,
         )
         .await;
 

--- a/src/meta/src/cluster/mod.rs
+++ b/src/meta/src/cluster/mod.rs
@@ -311,6 +311,7 @@ where
         core.get_parallel_unit_count(parallel_unit_type)
     }
 
+    /// Generate `parallel_degree` hash parallel units and 1 single parallel unit.
     async fn generate_cn_parallel_units(
         &self,
         parallel_degree: usize,
@@ -319,9 +320,9 @@ where
         let start_id = self
             .env
             .id_gen_manager()
-            .generate_interval::<{ IdCategory::ParallelUnit }>(parallel_degree as i32)
+            .generate_interval::<{ IdCategory::ParallelUnit }>((parallel_degree + 1) as i32)
             .await? as ParallelUnitId;
-        let mut parallel_units = Vec::with_capacity(parallel_degree);
+        let mut parallel_units = Vec::with_capacity(parallel_degree + 1);
         let single_parallel_unit = ParallelUnit {
             id: start_id,
             r#type: ParallelUnitType::Single as i32,

--- a/src/meta/src/manager/env.rs
+++ b/src/meta/src/manager/env.rs
@@ -94,6 +94,7 @@ impl Default for MetaOpts {
 
 impl MetaOpts {
     /// some test need `enable_recovery=true`
+    #[cfg(test)]
     pub fn test(enable_recovery: bool) -> Self {
         Self {
             enable_recovery,

--- a/src/meta/src/stream/scheduler.rs
+++ b/src/meta/src/stream/scheduler.rs
@@ -348,7 +348,7 @@ mod test {
             })
             .collect_vec();
 
-        let parallel_degree = env.opts.unsafe_worker_node_parallel_degree - 1;
+        let parallel_degree = env.opts.unsafe_worker_node_parallel_degree;
         let mut normal_fragments = (6..8u32)
             .map(|fragment_id| {
                 let actors = (actor_id..actor_id + node_count * parallel_degree as u32)


### PR DESCRIPTION
I hereby agree to the terms of the [Singularity Data, Inc. Contributor License Agreement](https://gist.github.com/skyzh/0663682a70b0edde7ae991492f2314cb#file-s9y_cla).

## What's changed and what's your intention?

As title.

For example, given `unsafe_worker_node_parallel_degree = 4`, there will be 4 hash parallel units and 1 single parallel units.

## Checklist

- [x] I have written necessary rustdoc comments
- [x] I have added necessary unit tests and integration tests
- [x] All checks passed in `./risedev check` (or alias, `./risedev c`)

## Documentation

If your pull request contains user-facing changes, please specify the types of the changes, and create a release note. Otherwise, please feel free to remove this section.

### Types of user-facing changes

Please keep the types that apply to your changes, and remove those that do not apply.

* Installation and deployment 
* Connector (sources & sinks)
* SQL commands, functions, and operators
* RisingWave cluster configuration changes
* Other (please specify in the release note below)

### Release note

Please create a release note for your changes. In the release note, focus on the impact on users, and mention the environment or conditions where the impact may occur.

## Refer to a related PR or issue link (optional)
