### PR TITLE
fix(lru): correctly handle future cancellation

### DIFF
--- a/src/storage/hummock_test/src/state_store_tests.rs
+++ b/src/storage/hummock_test/src/state_store_tests.rs
@@ -15,7 +15,6 @@
 use std::sync::Arc;
 
 use bytes::Bytes;
-use futures::executor::block_on;
 use risingwave_hummock_sdk::compaction_group::StaticCompactionGroupId;
 use risingwave_hummock_sdk::HummockEpoch;
 use risingwave_meta::hummock::test_utils::setup_compute_env;
@@ -659,69 +658,80 @@ async fn test_write_anytime() {
     let epoch1 = initial_epoch + 1;
 
     let assert_old_value = |epoch| {
-        // check point get
-        assert_eq!(
-            "111".as_bytes(),
-            block_on(hummock_storage.get(
-                "aa".as_bytes(),
-                ReadOptions {
-                    epoch,
-                    table_id: Default::default(),
-                    ttl: None,
-                }
-            ))
-            .unwrap()
-            .unwrap()
-        );
-        assert_eq!(
-            "222".as_bytes(),
-            block_on(hummock_storage.get(
-                "bb".as_bytes(),
-                ReadOptions {
-                    epoch,
-                    table_id: Default::default(),
-                    ttl: None,
-                }
-            ))
-            .unwrap()
-            .unwrap()
-        );
-        assert_eq!(
-            "333".as_bytes(),
-            block_on(hummock_storage.get(
-                "cc".as_bytes(),
-                ReadOptions {
-                    epoch,
-                    table_id: Default::default(),
-                    ttl: None,
-                }
-            ))
-            .unwrap()
-            .unwrap()
-        );
-        // check iter
-        let mut iter = block_on(hummock_storage.iter(
-            "aa".as_bytes()..="cc".as_bytes(),
-            ReadOptions {
-                epoch,
-                table_id: Default::default(),
-                ttl: None,
-            },
-        ))
-        .unwrap();
-        assert_eq!(
-            (Bytes::from("aa"), Bytes::from("111")),
-            block_on(iter.next()).unwrap().unwrap()
-        );
-        assert_eq!(
-            (Bytes::from("bb"), Bytes::from("222")),
-            block_on(iter.next()).unwrap().unwrap()
-        );
-        assert_eq!(
-            (Bytes::from("cc"), Bytes::from("333")),
-            block_on(iter.next()).unwrap().unwrap()
-        );
-        assert!(block_on(iter.next()).unwrap().is_none());
+        let hummock_storage = hummock_storage.clone();
+        async move {
+            // check point get
+            assert_eq!(
+                "111".as_bytes(),
+                hummock_storage
+                    .get(
+                        "aa".as_bytes(),
+                        ReadOptions {
+                            epoch,
+                            table_id: Default::default(),
+                            ttl: None,
+                        }
+                    )
+                    .await
+                    .unwrap()
+                    .unwrap()
+            );
+            assert_eq!(
+                "222".as_bytes(),
+                hummock_storage
+                    .get(
+                        "bb".as_bytes(),
+                        ReadOptions {
+                            epoch,
+                            table_id: Default::default(),
+                            ttl: None,
+                        }
+                    )
+                    .await
+                    .unwrap()
+                    .unwrap()
+            );
+            assert_eq!(
+                "333".as_bytes(),
+                hummock_storage
+                    .get(
+                        "cc".as_bytes(),
+                        ReadOptions {
+                            epoch,
+                            table_id: Default::default(),
+                            ttl: None,
+                        }
+                    )
+                    .await
+                    .unwrap()
+                    .unwrap()
+            );
+            // check iter
+            let mut iter = hummock_storage
+                .iter(
+                    "aa".as_bytes()..="cc".as_bytes(),
+                    ReadOptions {
+                        epoch,
+                        table_id: Default::default(),
+                        ttl: None,
+                    },
+                )
+                .await
+                .unwrap();
+            assert_eq!(
+                (Bytes::from("aa"), Bytes::from("111")),
+                iter.next().await.unwrap().unwrap()
+            );
+            assert_eq!(
+                (Bytes::from("bb"), Bytes::from("222")),
+                iter.next().await.unwrap().unwrap()
+            );
+            assert_eq!(
+                (Bytes::from("cc"), Bytes::from("333")),
+                iter.next().await.unwrap().unwrap()
+            );
+            assert!(iter.next().await.unwrap().is_none());
+        }
     };
 
     let batch1 = vec![
@@ -740,64 +750,75 @@ async fn test_write_anytime() {
         )
         .await
         .unwrap();
-    assert_old_value(epoch1);
+    assert_old_value(epoch1).await;
 
     let assert_new_value = |epoch| {
-        // check point get
-        assert_eq!(
-            "111_new".as_bytes(),
-            block_on(hummock_storage.get(
-                "aa".as_bytes(),
-                ReadOptions {
-                    epoch,
-                    table_id: Default::default(),
-                    ttl: None,
-                }
-            ))
-            .unwrap()
-            .unwrap()
-        );
-        assert!(block_on(hummock_storage.get(
-            "bb".as_bytes(),
-            ReadOptions {
-                epoch,
-                table_id: Default::default(),
-                ttl: None,
-            }
-        ))
-        .unwrap()
-        .is_none());
-        assert_eq!(
-            "333".as_bytes(),
-            block_on(hummock_storage.get(
-                "cc".as_bytes(),
-                ReadOptions {
-                    epoch,
-                    table_id: Default::default(),
-                    ttl: None,
-                }
-            ))
-            .unwrap()
-            .unwrap()
-        );
-        let mut iter = block_on(hummock_storage.iter(
-            "aa".as_bytes()..="cc".as_bytes(),
-            ReadOptions {
-                epoch,
-                table_id: Default::default(),
-                ttl: None,
-            },
-        ))
-        .unwrap();
-        assert_eq!(
-            (Bytes::from("aa"), Bytes::from("111_new")),
-            block_on(iter.next()).unwrap().unwrap()
-        );
-        assert_eq!(
-            (Bytes::from("cc"), Bytes::from("333")),
-            block_on(iter.next()).unwrap().unwrap()
-        );
-        assert!(block_on(iter.next()).unwrap().is_none());
+        let hummock_storage = hummock_storage.clone();
+        async move {
+            // check point get
+            assert_eq!(
+                "111_new".as_bytes(),
+                hummock_storage
+                    .get(
+                        "aa".as_bytes(),
+                        ReadOptions {
+                            epoch,
+                            table_id: Default::default(),
+                            ttl: None,
+                        }
+                    )
+                    .await
+                    .unwrap()
+                    .unwrap()
+            );
+            assert!(hummock_storage
+                .get(
+                    "bb".as_bytes(),
+                    ReadOptions {
+                        epoch,
+                        table_id: Default::default(),
+                        ttl: None,
+                    }
+                )
+                .await
+                .unwrap()
+                .is_none());
+            assert_eq!(
+                "333".as_bytes(),
+                hummock_storage
+                    .get(
+                        "cc".as_bytes(),
+                        ReadOptions {
+                            epoch,
+                            table_id: Default::default(),
+                            ttl: None,
+                        }
+                    )
+                    .await
+                    .unwrap()
+                    .unwrap()
+            );
+            let mut iter = hummock_storage
+                .iter(
+                    "aa".as_bytes()..="cc".as_bytes(),
+                    ReadOptions {
+                        epoch,
+                        table_id: Default::default(),
+                        ttl: None,
+                    },
+                )
+                .await
+                .unwrap();
+            assert_eq!(
+                (Bytes::from("aa"), Bytes::from("111_new")),
+                iter.next().await.unwrap().unwrap()
+            );
+            assert_eq!(
+                (Bytes::from("cc"), Bytes::from("333")),
+                iter.next().await.unwrap().unwrap()
+            );
+            assert!(iter.next().await.unwrap().is_none());
+        }
     };
 
     // Update aa, delete bb, cc unchanged
@@ -817,7 +838,7 @@ async fn test_write_anytime() {
         .await
         .unwrap();
 
-    assert_new_value(epoch1);
+    assert_new_value(epoch1).await;
 
     let epoch2 = epoch1 + 1;
 
@@ -833,17 +854,17 @@ async fn test_write_anytime() {
         .await
         .unwrap();
     // Assert epoch 1 unchanged
-    assert_new_value(epoch1);
+    assert_new_value(epoch1).await;
     // Assert epoch 2 correctness
-    assert_old_value(epoch2);
+    assert_old_value(epoch2).await;
 
     hummock_storage.sync(Some(epoch1)).await.unwrap();
-    assert_new_value(epoch1);
-    assert_old_value(epoch2);
+    assert_new_value(epoch1).await;
+    assert_old_value(epoch2).await;
 
     hummock_storage.sync(Some(epoch2)).await.unwrap();
-    assert_new_value(epoch1);
-    assert_old_value(epoch2);
+    assert_new_value(epoch1).await;
+    assert_old_value(epoch2).await;
 
     assert!(!hummock_storage.get_uncommitted_ssts(epoch1).is_empty());
     assert!(!hummock_storage.get_uncommitted_ssts(epoch2).is_empty());

--- a/src/storage/src/hummock/iterator/forward_merge.rs
+++ b/src/storage/src/hummock/iterator/forward_merge.rs
@@ -39,11 +39,11 @@ mod test {
     #[tokio::test]
     async fn test_merge_basic() {
         let mut unordered_iter = MergeIterator::new(
-            gen_merge_iterator_interleave_test_sstable_iters(TEST_KEYS_COUNT, 3),
+            gen_merge_iterator_interleave_test_sstable_iters(TEST_KEYS_COUNT, 3).await,
             Arc::new(StateStoreMetrics::unused()),
         );
         let mut ordered_iter = OrderedAwareMergeIterator::new(
-            gen_merge_iterator_interleave_test_sstable_iters(TEST_KEYS_COUNT, 3),
+            gen_merge_iterator_interleave_test_sstable_iters(TEST_KEYS_COUNT, 3).await,
             Arc::new(StateStoreMetrics::unused()),
         );
 
@@ -75,11 +75,11 @@ mod test {
     #[tokio::test]
     async fn test_merge_seek() {
         let mut unordered_iter = MergeIterator::new(
-            gen_merge_iterator_interleave_test_sstable_iters(TEST_KEYS_COUNT, 3),
+            gen_merge_iterator_interleave_test_sstable_iters(TEST_KEYS_COUNT, 3).await,
             Arc::new(StateStoreMetrics::unused()),
         );
         let mut ordered_iter = OrderedAwareMergeIterator::new(
-            gen_merge_iterator_interleave_test_sstable_iters(TEST_KEYS_COUNT, 3),
+            gen_merge_iterator_interleave_test_sstable_iters(TEST_KEYS_COUNT, 3).await,
             Arc::new(StateStoreMetrics::unused()),
         );
 

--- a/src/storage/src/hummock/sstable/forward_sstable_iterator.rs
+++ b/src/storage/src/hummock/sstable/forward_sstable_iterator.rs
@@ -181,7 +181,6 @@ impl SSTableIteratorType for SSTableIterator {
 
 #[cfg(test)]
 mod tests {
-    use futures::executor::block_on;
     use itertools::Itertools;
     use rand::prelude::*;
     use risingwave_hummock_sdk::key::key_with_epoch;
@@ -327,7 +326,7 @@ mod tests {
 
         let mut stats = StoreLocalStatistic::default();
         let mut sstable_iter = SSTableIterator::create(
-            block_on(sstable_store.sstable(0, &mut stats)).unwrap(),
+            sstable_store.sstable(0, &mut stats).await.unwrap(),
             sstable_store,
             Arc::new(ReadOptions { prefetch: true }),
         );

--- a/src/storage/src/storage_failpoints/test_iterator.rs
+++ b/src/storage/src/storage_failpoints/test_iterator.rs
@@ -175,7 +175,7 @@ async fn test_failpoints_merge_invalid_key() {
     let mut mi = MergeIterator::new(
         {
             let mut iters = vec![];
-            for table in tables.iter() {
+            for table in &tables {
                 iters.push(Box::new(SSTableIterator::new(
                     sstable_store
                         .sstable(table.id, &mut StoreLocalStatistic::default())
@@ -231,7 +231,7 @@ async fn test_failpoints_backward_merge_invalid_key() {
     let mut mi = BackwardMergeIterator::new(
         {
             let mut iters = vec![];
-            for table in tables.iter() {
+            for table in &tables {
                 iters.push(Box::new(BackwardSSTableIterator::new(
                     sstable_store
                         .sstable(table.id, &mut StoreLocalStatistic::default())

--- a/src/storage/src/storage_failpoints/test_iterator.rs
+++ b/src/storage/src/storage_failpoints/test_iterator.rs
@@ -173,19 +173,21 @@ async fn test_failpoints_merge_invalid_key() {
     .await;
     let tables = vec![table0, table1];
     let mut mi = MergeIterator::new(
-        tables
-            .iter()
-            .map(|table| -> Box<dyn HummockIterator<Direction = Forward>> {
-                Box::new(
-                    SSTableIterator::new(
-                        sstable_store.sstable(table.id, &mut StoreLocalStatistic::default()),
-                    )
-                    .unwrap(),
+        {
+            let mut iters = vec![];
+            for table in tables.iter() {
+                iters.push(Box::new(SSTableIterator::new(
+                    sstable_store
+                        .sstable(table.id, &mut StoreLocalStatistic::default())
+                        .await
+                        .unwrap(),
                     sstable_store.clone(),
                     Arc::new(ReadOptions::default()),
-                )
-                .await
-            }),
+                ))
+                    as Box<dyn HummockIterator<Direction = Forward>>);
+            }
+            iters
+        },
         Arc::new(StateStoreMetrics::unused()),
     );
     mi.rewind().await.unwrap();
@@ -227,17 +229,20 @@ async fn test_failpoints_backward_merge_invalid_key() {
     .await;
     let tables = vec![table0, table1];
     let mut mi = BackwardMergeIterator::new(
-        tables
-            .iter()
-            .map(|table| -> Box<dyn HummockIterator<Direction = Backward>> {
-                Box::new(BackwardSSTableIterator::new(
+        {
+            let mut iters = vec![];
+            for table in tables.iter() {
+                iters.push(Box::new(BackwardSSTableIterator::new(
                     sstable_store
                         .sstable(table.id, &mut StoreLocalStatistic::default())
                         .await
                         .unwrap(),
                     sstable_store.clone(),
                 ))
-            }),
+                    as Box<dyn HummockIterator<Direction = Backward>>);
+            }
+            iters
+        },
         Arc::new(StateStoreMetrics::unused()),
     );
     mi.rewind().await.unwrap();
@@ -279,18 +284,16 @@ async fn test_failpoints_user_read_err() {
     .await;
     let mut stats = StoreLocalStatistic::default();
     let iters: Vec<BoxedForwardHummockIterator> = vec![
-        Box::new(
-            SSTableIterator::new(sstable_store.sstable(table0.id, &mut stats)).unwrap(),
+        Box::new(SSTableIterator::new(
+            sstable_store.sstable(table0.id, &mut stats).await.unwrap(),
             sstable_store.clone(),
             Arc::new(ReadOptions::default()),
-        )
-        .await,
-        Box::new(
-            SSTableIterator::new(sstable_store.sstable(table1.id, &mut stats)).unwrap(),
+        )),
+        Box::new(SSTableIterator::new(
+            sstable_store.sstable(table1.id, &mut stats).await.unwrap(),
             sstable_store.clone(),
             Arc::new(ReadOptions::default()),
-        )
-        .await,
+        )),
     ];
 
     let mi = MergeIterator::new(iters, Arc::new(StateStoreMetrics::unused()));
@@ -343,16 +346,14 @@ async fn test_failpoints_backward_user_read_err() {
     .await;
     let mut stats = StoreLocalStatistic::default();
     let iters: Vec<BoxedBackwardHummockIterator> = vec![
-        Box::new(
-            BackwardSSTableIterator::new(sstable_store.sstable(table0.id, &mut stats)).unwrap(),
+        Box::new(BackwardSSTableIterator::new(
+            sstable_store.sstable(table0.id, &mut stats).await.unwrap(),
             sstable_store.clone(),
-        )
-        .await,
-        Box::new(
-            BackwardSSTableIterator::new(sstable_store.sstable(table1.id, &mut stats)).unwrap(),
+        )),
+        Box::new(BackwardSSTableIterator::new(
+            sstable_store.sstable(table1.id, &mut stats).await.unwrap(),
             sstable_store.clone(),
-        )
-        .await,
+        )),
     ];
 
     let mi = BackwardMergeIterator::new(iters, Arc::new(StateStoreMetrics::unused()));

--- a/src/storage/src/storage_failpoints/test_sstable.rs
+++ b/src/storage/src/storage_failpoints/test_sstable.rs
@@ -14,7 +14,6 @@
 
 use std::sync::Arc;
 
-use futures::executor::block_on;
 use risingwave_hummock_sdk::key::key_with_epoch;
 
 use crate::assert_bytes_eq;
@@ -51,7 +50,7 @@ async fn test_failpoints_table_read() {
 
     let mut stats = StoreLocalStatistic::default();
     let mut sstable_iter = SSTableIterator::create(
-        block_on(sstable_store.sstable(0, &mut stats)).unwrap(),
+        sstable_store.sstable(0, &mut stats).await.unwrap(),
         sstable_store,
         Arc::new(ReadOptions::default()),
     );
@@ -122,7 +121,7 @@ async fn test_failpoints_vacuum_and_metadata() {
     let mut stats = StoreLocalStatistic::default();
 
     let mut sstable_iter = SSTableIterator::create(
-        block_on(sstable_store.sstable(table_id, &mut stats)).unwrap(),
+        sstable_store.sstable(table_id, &mut stats).await.unwrap(),
         sstable_store,
         Arc::new(ReadOptions::default()),
     );


### PR DESCRIPTION
Signed-off-by: Alex Chi <iskyzh@gmail.com>

I hereby agree to the terms of the [Singularity Data, Inc. Contributor License Agreement](https://gist.github.com/skyzh/0663682a70b0edde7ae991492f2314cb#file-s9y_cla).

## What's changed and what's your intention?

As title. `lookup_dedup` will now spawn a task in the background, so that it won't deadlock.

Example: We have two futures running.

```
let future_1 = async move {
  lru.lookup("a", fetch_from_storage).await
}

let future_2 = async move {
  lru.lookup("a", fetch_from_storage).await
}
```

If we run them in the following way:

```
future_1.poll_next(); // so that we will cache miss, and LRU will call `fetch_from_storage` to get data.
future_2.poll_next(); // as request to "a" is in-flight, LRU will wait until future_1 completes the request.
drop(future_1);
loop {
  assert_eq!(future_2.poll_next(), Poll::pending); // future 2 will never return
}
```

Therefore, we spawn a tokio task in the background for every in-flight request, so that it won't be cancelled by users.

This PR also fixes some unit tests, so that they won't stuck in single-thread tokio runtime.

## Checklist

- [x] I have written necessary rustdoc comments
- [x] I have added necessary unit tests and integration tests
- [x] All checks passed in `./risedev check` (or alias, `./risedev c`)

## Documentation

If your pull request contains user-facing changes, please specify the types of the changes, and create a release note. Otherwise, please feel free to remove this section.

### Types of user-facing changes

Please keep the types that apply to your changes, and remove those that do not apply.

* Installation and deployment 
* Connector (sources & sinks)
* SQL commands, functions, and operators
* RisingWave cluster configuration changes
* Other (please specify in the release note below)

### Release note

Please create a release note for your changes. In the release note, focus on the impact on users, and mention the environment or conditions where the impact may occur.

## Refer to a related PR or issue link (optional)

close https://github.com/singularity-data/risingwave/issues/3909
close https://github.com/singularity-data/risingwave/pull/3907