### PR TITLE
refactor(batch-task-service): remove unused RPC `remove_task()`

### DIFF
--- a/proto/task_service.proto
+++ b/proto/task_service.proto
@@ -50,14 +50,6 @@ message AbortTaskResponse {
   common.Status status = 1;
 }
 
-message RemoveTaskRequest {
-  batch_plan.TaskId task_id = 1;
-}
-
-message RemoveTaskResponse {
-  common.Status status = 1;
-}
-
 message GetTaskInfoRequest {
   batch_plan.TaskId task_id = 1;
 }
@@ -89,7 +81,6 @@ service TaskService {
   rpc CreateTask(CreateTaskRequest) returns (CreateTaskResponse);
   rpc GetTaskInfo(GetTaskInfoRequest) returns (GetTaskInfoResponse);
   rpc AbortTask(AbortTaskRequest) returns (AbortTaskResponse);
-  rpc RemoveTask(RemoveTaskRequest) returns (RemoveTaskResponse);
   rpc Execute(ExecuteRequest) returns (stream GetDataResponse);
 }
 

--- a/src/batch/src/rpc/service/task_service.rs
+++ b/src/batch/src/rpc/service/task_service.rs
@@ -19,8 +19,7 @@ use risingwave_pb::batch_plan::TaskOutputId;
 use risingwave_pb::task_service::task_service_server::TaskService;
 use risingwave_pb::task_service::{
     AbortTaskRequest, AbortTaskResponse, CreateTaskRequest, CreateTaskResponse, ExecuteRequest,
-    GetDataResponse, GetTaskInfoRequest, GetTaskInfoResponse, RemoveTaskRequest,
-    RemoveTaskResponse,
+    GetDataResponse, GetTaskInfoRequest, GetTaskInfoResponse,
 };
 use tokio_stream::wrappers::ReceiverStream;
 use tonic::{Request, Response, Status};
@@ -96,24 +95,6 @@ impl TaskService for BatchServiceImpl {
             Ok(_) => Ok(Response::new(AbortTaskResponse { status: None })),
             Err(e) => {
                 error!("failed to abort task {}", e);
-                Err(e.into())
-            }
-        }
-    }
-
-    #[cfg_attr(coverage, no_coverage)]
-    async fn remove_task(
-        &self,
-        req: Request<RemoveTaskRequest>,
-    ) -> Result<Response<RemoveTaskResponse>, Status> {
-        let req = req.into_inner();
-        let res = self
-            .mgr
-            .remove_task(req.get_task_id().expect("no task id found"));
-        match res {
-            Ok(_) => Ok(Response::new(RemoveTaskResponse { status: None })),
-            Err(e) => {
-                error!("failed to remove task {}", e);
                 Err(e.into())
             }
         }


### PR DESCRIPTION
I hereby agree to the terms of the [Singularity Data, Inc. Contributor License Agreement](https://gist.github.com/skyzh/0663682a70b0edde7ae991492f2314cb#file-s9y_cla).

## What's changed and what's your intention?

***PLEASE DO NOT LEAVE THIS EMPTY !!!***

Please explain **IN DETAIL** what the changes are in this PR and why they are needed:

- Summarize your change (**mandatory**)
- How does this PR work? Need a brief introduction for the changed logic (optional)
- Describe clearly one logical change and avoid lazy messages (optional)
- Describe any limitations of the current code (optional)

## Checklist

- [ ] I have written necessary rustdoc comments
- [ ] I have added necessary unit tests and integration tests
- [ ] All checks passed in `./risedev check` (or alias, `./risedev c`)

## Documentation

If your pull request contains user-facing changes, please specify the types of the changes, and create a release note. Otherwise, please feel free to remove this section.

### Types of user-facing changes

Please keep the types that apply to your changes, and remove those that do not apply.

* Installation and deployment 
* Connector (sources & sinks)
* SQL commands, functions, and operators
* RisingWave cluster configuration changes
* Other (please specify in the release note below)

### Release note

Please create a release note for your changes. In the release note, focus on the impact on users, and mention the environment or conditions where the impact may occur.

## Refer to a related PR or issue link (optional)
