### PR TITLE
feat(ctl): For sst-dump, iterate over KV-pairs, print pairs in human readble format, and interprete them based on table schema

### DIFF
--- a/src/ctl/src/cmd_impl/hummock/sst_dump.rs
+++ b/src/ctl/src/cmd_impl/hummock/sst_dump.rs
@@ -180,9 +180,9 @@ fn print_kv_pairs(block_data: Bytes, table_data: &TableData) -> anyhow::Result<(
 
         let full_val = block_iter.value();
         let humm_val = HummockValue::from_slice(block_iter.value())?;
-        let (is_put, val_meta, user_val) = match humm_val {
-            HummockValue::Put(meta, uval) => (true, meta.vnode, uval),
-            HummockValue::Delete(meta) => (false, meta.vnode, &[] as &[u8]),
+        let (is_put, user_val) = match humm_val {
+            HummockValue::Put(uval) => (true, uval),
+            HummockValue::Delete() => (false, &[] as &[u8]),
         };
 
         let epoch = get_epoch(full_key);
@@ -193,7 +193,6 @@ fn print_kv_pairs(block_data: Bytes, table_data: &TableData) -> anyhow::Result<(
         println!("\t\tuser value: {:02x?}", user_val);
         println!("\t\t     epoch: {}", epoch);
         println!("\t\t      type: {}", if is_put { "Put" } else { "Delete" });
-        println!("\t\tvalue-meta: {}", val_meta);
 
         if let Some(table_id) = get_table_id(full_key) {
             let (table_name, columns) = table_data.get(&table_id).unwrap();

--- a/src/ctl/src/cmd_impl/hummock/sst_dump.rs
+++ b/src/ctl/src/cmd_impl/hummock/sst_dump.rs
@@ -15,6 +15,8 @@
 use std::collections::HashMap;
 
 use bytes::Buf;
+use risingwave_common::util::value_encoding::deserialize_cell;
+use risingwave_frontend::catalog::TableCatalog;
 use risingwave_hummock_sdk::compaction_group::hummock_version_ext::HummockVersionExt;
 use risingwave_hummock_sdk::key::{get_epoch, get_table_id, user_key};
 use risingwave_object_store::object::{BlockLocation, ObjectStore};
@@ -23,7 +25,7 @@ use risingwave_storage::hummock::value::HummockValue;
 use risingwave_storage::hummock::{Block, BlockHolder, BlockIterator, CompressionAlgorithm};
 use risingwave_storage::monitor::StoreLocalStatistic;
 
-use crate::common::HummockServiceOpts;
+use crate::common::{HummockServiceOpts, MetaServiceOpts};
 
 pub async fn sst_dump() -> anyhow::Result<()> {
     // Retrieves the SSTable store so we can access the SSTableMeta
@@ -39,6 +41,25 @@ pub async fn sst_dump() -> anyhow::Result<()> {
     let sstable_id_infos = meta_client.list_sstable_id_infos(version.id).await?;
     sstable_id_infos.iter().for_each(|id_info| {
         id_info_map.insert(id_info.id, id_info);
+    });
+
+    // Determine all database tables ...
+    let meta_opts = MetaServiceOpts::from_env()?;
+    let meta = meta_opts.create_meta_client().await?;
+    let mvs = meta.risectl_list_state_tables().await?;
+
+    // ... and add a list of their types into a hash table.
+    let mut column_table = HashMap::new();
+    mvs.iter().for_each(|tbl| {
+        let mut col_list = vec![];
+        TableCatalog::from(tbl).columns.iter().for_each(|clm| {
+            col_list.push((
+                clm.data_type().clone(),
+                String::from(clm.name()),
+                clm.is_hidden().clone(),
+            ));
+        });
+        column_table.insert(tbl.id, (tbl.name.clone(), col_list));
     });
 
     for level in version.get_combined_levels() {
@@ -111,28 +132,53 @@ pub async fn sst_dump() -> anyhow::Result<()> {
                 let mut block_iter = BlockIterator::new(holder);
                 block_iter.seek_to_first();
 
+                let mut column_idx: usize = 0;
                 while block_iter.is_valid() {
                     let full_key = block_iter.key();
                     let user_key = user_key(full_key);
 
                     let full_val = block_iter.value();
                     let humm_val = HummockValue::from_slice(block_iter.value())?;
-                    let (val_type, val_meta, user_val) = match humm_val {
-                        HummockValue::Put(meta, uval) => ("Put", meta.vnode, uval),
-                        HummockValue::Delete(meta) => ("Delete", meta.vnode, &[] as &[u8]),
+                    let (isPut, val_meta, user_val) = match humm_val {
+                        HummockValue::Put(meta, uval) => (true, meta.vnode, uval),
+                        HummockValue::Delete(meta) => (false, meta.vnode, &[] as &[u8]),
                     };
 
                     let epoch = get_epoch(full_key);
-                    let table_id = get_table_id(full_key).unwrap();
 
                     println!("\t\t  full key: {:02x?}", full_key);
                     println!("\t\tfull value: {:02x?}", full_val);
                     println!("\t\t  user key: {:02x?}", user_key);
                     println!("\t\tuser value: {:02x?}", user_val);
-                    println!("\t\tvalue-meta: {}", val_meta);
                     println!("\t\t     epoch: {}", epoch);
-                    println!("\t\t  table ID: {}", table_id);
-                    println!("\t\t      type: {}", val_type);
+                    println!("\t\t      type: {}", if isPut { "Put" } else { "Delete" });
+                    println!("\t\tvalue-meta: {}", val_meta);
+
+                    if let Some(table_id) = get_table_id(full_key) {
+                        let (table_name, columns) = &column_table.get(&table_id).unwrap();
+                        println!("\t\t     table: {} - {}", table_id, table_name);
+
+                        // Check if new row.
+                        if isPut {
+                            if user_val.len() == 0
+                                && (&user_key[user_key.len() - 4..]).get_i32() == 0x7fffffff
+                            {
+                                // New row. Reset column index.
+                                column_idx = 0;
+                            } else {
+                                let (data_type, name, is_hidden) = &columns[column_idx];
+                                let datum = deserialize_cell(user_val, data_type).unwrap().unwrap();
+                                println!(
+                                    "\t\t    column: {} {}",
+                                    name,
+                                    if is_hidden.clone() { "(hidden)" } else { "" }
+                                );
+                                println!("\t\t     datum: {:?}", datum);
+                                column_idx += 1;
+                            }
+                        }
+                    }
+
                     println!();
 
                     block_iter.next();

--- a/src/ctl/src/cmd_impl/hummock/sst_dump.rs
+++ b/src/ctl/src/cmd_impl/hummock/sst_dump.rs
@@ -40,7 +40,7 @@ pub async fn sst_dump() -> anyhow::Result<()> {
     });
 
     for level in version.get_combined_levels() {
-        for sstable_info in level.table_infos.clone() {
+        for sstable_info in &level.table_infos {
             let id = sstable_info.id;
 
             let sstable_cache = sstable_store
@@ -53,6 +53,7 @@ pub async fn sst_dump() -> anyhow::Result<()> {
 
             println!("SST id: {}", id);
             println!("-------------------------------------");
+            println!("Level: {}", level.level_type);
             println!(
                 "Creation Timestamp: {}",
                 sstable_id_info.id_create_timestamp
@@ -67,7 +68,7 @@ pub async fn sst_dump() -> anyhow::Result<()> {
             );
             println!("File Size: {}", sstable_info.file_size);
 
-            if let Some(key_range) = sstable_info.key_range {
+            if let Some(key_range) = sstable_info.key_range.as_ref() {
                 println!("Key Range:");
                 println!(
                     "\tleft:\t{:?}\n\tright:\t{:?}\n\tinf:\t{:?}",


### PR DESCRIPTION
I hereby agree to the terms of the [Singularity Data, Inc. Contributor License Agreement](https://gist.github.com/skyzh/0663682a70b0edde7ae991492f2314cb#file-s9y_cla).

## What's changed and what's your intention?

Extended the functionality of sst-dump to iterate over and print stored KV-pairs. The data of pairs is printed as well as interpretation of the data.

### Example
```sql
Create Table t1 (k int, v1 int, v2 int);
Insert Into t1 Values (1, null, 2);
```
Results in the following:
```
Block 0
-----------
Offset: 0, Size: 126, Checksum: 13688900580554635392, Compression Algorithm: None
KV-Pairs:
      full key: [74, 00, 00, 03, ea, 1a, 01, 82, 5d, 71, 94, 24, 80, 10, 00, 7f, ff, ff, ff, ff, f6, 8a, 39, af, 86, ff, ff]
    full value: [00]
      user key: [74, 00, 00, 03, ea, 1a, 01, 82, 5d, 71, 94, 24, 80, 10, 00, 7f, ff, ff, ff]
    user value: []
         epoch: 2662769404477440
          type: Put
         table: 1002 - t1

      full key: [74, 00, 00, 03, ea, 1a, 01, 82, 5d, 71, 94, 24, 80, 10, 00, 80, 00, 00, 00, ff, f6, 8a, 39, af, 86, ff, ff]
    full value: [00, 00, 10, 80, 24, 94, 71, 5d, 02]
      user key: [74, 00, 00, 03, ea, 1a, 01, 82, 5d, 71, 94, 24, 80, 10, 00, 80, 00, 00, 00]
    user value: [00, 10, 80, 24, 94, 71, 5d, 02]
         epoch: 2662769404477440
          type: Put
         table: 1002 - t1
        column: _row_id (hidden)
         datum: Int64(170417241991417856)

      full key: [74, 00, 00, 03, ea, 1a, 01, 82, 5d, 71, 94, 24, 80, 10, 00, 80, 00, 00, 01, ff, f6, 8a, 39, af, 86, ff, ff]
    full value: [00, 01, 00, 00, 00]
      user key: [74, 00, 00, 03, ea, 1a, 01, 82, 5d, 71, 94, 24, 80, 10, 00, 80, 00, 00, 01]
    user value: [01, 00, 00, 00]
         epoch: 2662769404477440
          type: Put
         table: 1002 - t1
        column: k 
         datum: Int32(1)

      full key: [74, 00, 00, 03, ea, 1a, 01, 82, 5d, 71, 94, 24, 80, 10, 00, 80, 00, 00, 03, ff, f6, 8a, 39, af, 86, ff, ff]
    full value: [00, 02, 00, 00, 00]
      user key: [74, 00, 00, 03, ea, 1a, 01, 82, 5d, 71, 94, 24, 80, 10, 00, 80, 00, 00, 03]
    user value: [02, 00, 00, 00]
         epoch: 2662769404477440
          type: Put
         table: 1002 - t1
        column: v2 
         datum: Int32(2)
```


## Checklist

- [x] I have written necessary rustdoc comments
- ~~[ ] I have added necessary unit tests and integration tests~~
- [x] All checks passed in `./risedev check` (or alias, `./risedev c`)

## Refer to a related PR or issue link (optional)
tool: support sst dump in risectl #3101 