### PR TITLE
feat(storage): SliceTransform for prefix bloom filter

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4549,6 +4549,7 @@ dependencies = [
  "madsim",
  "madsim-tokio",
  "prost",
+ "risingwave_common",
  "risingwave_pb",
  "workspace-hack",
 ]

--- a/src/common/src/util/ordered/serde.rs
+++ b/src/common/src/util/ordered/serde.rs
@@ -158,7 +158,7 @@ impl OrderedRowDeserializer {
     pub fn deserialize_prefix_len_with_column_indices(
         &self,
         key: &[u8],
-        column_indices: Vec<usize>,
+        column_indices: impl Iterator<Item = usize>,
     ) -> memcomparable::Result<usize> {
         use crate::types::ScalarImpl;
         let mut len: usize = 0;
@@ -359,7 +359,7 @@ mod tests {
 
         {
             let row_0_idx_0_len = deserializer
-                .deserialize_prefix_len_with_column_indices(&array[0], vec![0])
+                .deserialize_prefix_len_with_column_indices(&array[0], 0..=0)
                 .unwrap();
 
             let schema = vec![DataType::Varchar];
@@ -374,7 +374,7 @@ mod tests {
 
         {
             let row_0_idx_1_len = deserializer
-                .deserialize_prefix_len_with_column_indices(&array[0], vec![0, 1])
+                .deserialize_prefix_len_with_column_indices(&array[0], 0..=1)
                 .unwrap();
 
             let order_types = vec![OrderType::Descending, OrderType::Ascending];

--- a/src/storage/hummock_sdk/Cargo.toml
+++ b/src/storage/hummock_sdk/Cargo.toml
@@ -9,6 +9,14 @@ hex = "0.4"
 log = "0.4"
 madsim = "=0.2.0-alpha.4"
 prost = "0.10"
+risingwave_common = { path = "../../common" }
 risingwave_pb = { path = "../../prost" }
-tokio = { version = "=0.2.0-alpha.4", package = "madsim-tokio", features = ["rt", "rt-multi-thread", "sync", "macros", "time", "signal"] }
+tokio = { version = "=0.2.0-alpha.4", package = "madsim-tokio", features = [
+    "rt",
+    "rt-multi-thread",
+    "sync",
+    "macros",
+    "time",
+    "signal",
+] }
 workspace-hack = { version = "0.1", path = "../../workspace-hack" }

--- a/src/storage/hummock_sdk/src/key.rs
+++ b/src/storage/hummock_sdk/src/key.rs
@@ -22,6 +22,7 @@ use super::version_cmp::VersionedComparator;
 
 pub type Epoch = u64;
 const EPOCH_LEN: usize = std::mem::size_of::<Epoch>();
+pub const TABLE_PREFIX_LEN: usize = 5;
 
 /// Converts user key to full key by appending `u64::MAX - epoch` to the user key.
 ///

--- a/src/storage/hummock_sdk/src/lib.rs
+++ b/src/storage/hummock_sdk/src/lib.rs
@@ -21,6 +21,7 @@ pub mod compaction_group;
 pub mod key;
 pub mod key_range;
 pub mod prost_key_range;
+pub mod slice_transform;
 
 pub type HummockSSTableId = u64;
 pub type HummockRefCount = u64;

--- a/src/storage/hummock_sdk/src/lib.rs
+++ b/src/storage/hummock_sdk/src/lib.rs
@@ -12,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#![feature(lint_reasons)]
+
 mod version_cmp;
 
 use risingwave_pb::hummock::SstableInfo;

--- a/src/storage/hummock_sdk/src/slice_transform.rs
+++ b/src/storage/hummock_sdk/src/slice_transform.rs
@@ -1,0 +1,58 @@
+// use risingwave_pb::plan_commoEn::ColumnDesc as ProstColumnDesc;
+use risingwave_common::catalog::{ColumnDesc, OrderedColumnDesc};
+use risingwave_common::types::DataType;
+// use risingwave_pb::plan_common::ColumnDesc as ProstColumnDesc;
+// use risingwave_pb::plan_common::ColumnCatalog;
+use risingwave_common::util::ordered::OrderedRowDeserializer;
+use risingwave_common::util::sort_util::OrderType;
+use risingwave_pb::catalog::Table;
+
+trait SliceTransform<'a> {
+    fn transfer(&self, full_key: &'a [u8]) -> &'a [u8];
+}
+
+pub struct SchemaSliceTransform {
+    // table_catalog: Table,
+    read_pattern_prefix_column: u32,
+    // data_types: Vec<DataType>,
+    // order_types: Vec<OrderType>,
+    deserializer: OrderedRowDeserializer,
+}
+
+impl<'a> SliceTransform<'a> for SchemaSliceTransform {
+    fn transfer(&self, full_key: &'a [u8]) -> &'a [u8] {
+        let prefix_len = self
+            .deserializer
+            .deserialize_prefix_len_with_column_indices(
+                &full_key,
+                (0..self.read_pattern_prefix_column as usize).collect(),
+            )
+            .unwrap();
+        &full_key[0..prefix_len]
+    }
+}
+
+impl SchemaSliceTransform {
+    fn new(table_catalog: &Table) -> Self {
+        let data_types: Vec<DataType> = table_catalog
+            .columns
+            .iter()
+            .map(|col| ColumnDesc::from(col.column_desc.as_ref().unwrap()).data_type)
+            .collect();
+
+        let order_types: Vec<OrderType> = table_catalog
+            .order_key
+            .iter()
+            .map(|col_order| {
+                OrderType::from_prost(
+                    &risingwave_pb::plan_common::OrderType::from_i32(col_order.order_type).unwrap(),
+                )
+            })
+            .collect();
+
+        Self {
+            read_pattern_prefix_column: table_catalog.read_pattern_prefix_column,
+            deserializer: OrderedRowDeserializer::new(data_types, order_types),
+        }
+    }
+}

--- a/src/storage/hummock_sdk/src/slice_transform.rs
+++ b/src/storage/hummock_sdk/src/slice_transform.rs
@@ -1,3 +1,17 @@
+// Copyright 2022 Singularity Data
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 #![allow(dead_code)]
 use std::collections::HashMap;
 use std::sync::Arc;

--- a/src/storage/hummock_sdk/src/slice_transform.rs
+++ b/src/storage/hummock_sdk/src/slice_transform.rs
@@ -1,42 +1,75 @@
-// use risingwave_pb::plan_commoEn::ColumnDesc as ProstColumnDesc;
-use risingwave_common::catalog::{ColumnDesc, OrderedColumnDesc};
-use risingwave_common::types::DataType;
-// use risingwave_pb::plan_common::ColumnDesc as ProstColumnDesc;
-// use risingwave_pb::plan_common::ColumnCatalog;
+#![allow(dead_code)]
+use std::collections::HashMap;
+use std::sync::Arc;
+
+use risingwave_common::catalog::ColumnDesc;
+use risingwave_common::types::VIRTUAL_NODE_SIZE;
 use risingwave_common::util::ordered::OrderedRowDeserializer;
 use risingwave_common::util::sort_util::OrderType;
 use risingwave_pb::catalog::Table;
 
-trait SliceTransform<'a> {
-    fn transfer(&self, full_key: &'a [u8]) -> &'a [u8];
+use crate::key::{get_table_id, TABLE_PREFIX_LEN};
+
+trait SliceTransform {
+    fn transfer<'a>(&self, full_key: &'a [u8]) -> &'a [u8];
+}
+
+#[derive(Default)]
+pub struct FullKeySliceTransform;
+
+impl SliceTransform for FullKeySliceTransform {
+    fn transfer<'a>(&self, full_key: &'a [u8]) -> &'a [u8] {
+        full_key
+    }
+}
+
+#[derive(Default)]
+pub struct DummySliceTransform;
+
+impl SliceTransform for DummySliceTransform {
+    fn transfer<'a>(&self, full_key: &'a [u8]) -> &'a [u8] {
+        &full_key[0..0]
+    }
 }
 
 pub struct SchemaSliceTransform {
     // table_catalog: Table,
     read_pattern_prefix_column: u32,
-    // data_types: Vec<DataType>,
-    // order_types: Vec<OrderType>,
     deserializer: OrderedRowDeserializer,
 }
 
-impl<'a> SliceTransform<'a> for SchemaSliceTransform {
-    fn transfer(&self, full_key: &'a [u8]) -> &'a [u8] {
-        let prefix_len = self
+impl SliceTransform for SchemaSliceTransform {
+    fn transfer<'a>(&self, full_key: &'a [u8]) -> &'a [u8] {
+        let (_table_prefix, key) = full_key.split_at(TABLE_PREFIX_LEN);
+        let (_vnode_prefix, pk) = key.split_at(VIRTUAL_NODE_SIZE);
+
+        let pk_prefix_len = self
             .deserializer
             .deserialize_prefix_len_with_column_indices(
-                &full_key,
+                pk,
                 (0..self.read_pattern_prefix_column as usize).collect(),
             )
             .unwrap();
+
+        let prefix_len = TABLE_PREFIX_LEN + VIRTUAL_NODE_SIZE + pk_prefix_len;
         &full_key[0..prefix_len]
     }
 }
 
 impl SchemaSliceTransform {
     fn new(table_catalog: &Table) -> Self {
-        let data_types: Vec<DataType> = table_catalog
-            .columns
+        assert_ne!(0, table_catalog.read_pattern_prefix_column);
+
+        // column_index in pk
+        let pk_indices: Vec<usize> = table_catalog
+            .order_key
             .iter()
+            .map(|col_order| col_order.index as usize)
+            .collect();
+
+        let data_types = pk_indices
+            .iter()
+            .map(|column_idx| &table_catalog.columns[*column_idx])
             .map(|col| ColumnDesc::from(col.column_desc.as_ref().unwrap()).data_type)
             .collect();
 
@@ -53,6 +86,318 @@ impl SchemaSliceTransform {
         Self {
             read_pattern_prefix_column: table_catalog.read_pattern_prefix_column,
             deserializer: OrderedRowDeserializer::new(data_types, order_types),
+        }
+    }
+}
+
+#[derive(Default)]
+pub struct MultiSliceTransForm {
+    id_to_slice_transform: HashMap<u32, Arc<dyn SliceTransform>>,
+
+    // cached state
+    last_slice_transform_state: Option<(u32, Arc<dyn SliceTransform>)>,
+}
+
+impl MultiSliceTransForm {
+    fn register(&mut self, table_id: u32, slice_transform: Arc<dyn SliceTransform>) {
+        self.id_to_slice_transform.insert(table_id, slice_transform);
+    }
+
+    fn update_state(&mut self, new_table_id: u32) {
+        match self.id_to_slice_transform.get(&new_table_id) {
+            Some(box_slice_transform) => {
+                self.last_slice_transform_state = Some((new_table_id, box_slice_transform.clone()))
+            }
+
+            None => {
+                unreachable!();
+            }
+        }
+    }
+
+    fn transfer<'a>(&mut self, full_key: &'a [u8]) -> &'a [u8] {
+        assert!(full_key.len() > TABLE_PREFIX_LEN + VIRTUAL_NODE_SIZE);
+        let table_id = get_table_id(full_key).unwrap();
+        match self.last_slice_transform_state.as_ref() {
+            Some(last_slice_transform_state) => {
+                if table_id != last_slice_transform_state.0 {
+                    self.update_state(table_id);
+                }
+            }
+
+            None => {
+                self.update_state(table_id);
+            }
+        }
+
+        self.last_slice_transform_state
+            .as_ref()
+            .unwrap()
+            .1
+            .transfer(full_key)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::collections::HashMap;
+    use std::mem;
+    use std::sync::Arc;
+
+    use bytes::{BufMut, BytesMut};
+    use risingwave_common::array::Row;
+    use risingwave_common::catalog::{ColumnDesc, ColumnId};
+    use risingwave_common::types::ScalarImpl::{self};
+    use risingwave_common::types::{DataType, VIRTUAL_NODE_SIZE};
+    use risingwave_common::util::ordered::{OrderedRowDeserializer, OrderedRowSerializer};
+    use risingwave_common::util::sort_util::OrderType;
+    use risingwave_pb::catalog::Table as ProstTable;
+    use risingwave_pb::plan_common::{ColumnCatalog as ProstColumnCatalog, ColumnOrder};
+
+    use super::{DummySliceTransform, SchemaSliceTransform, SliceTransform};
+    use crate::key::TABLE_PREFIX_LEN;
+    use crate::slice_transform::{FullKeySliceTransform, MultiSliceTransForm};
+
+    #[test]
+    fn test_default_slice_transform() {
+        let dummy_slice_transform = DummySliceTransform::default();
+        let full_key = "full_key".as_bytes();
+        let output_key = dummy_slice_transform.transfer(full_key);
+
+        assert_eq!("".as_bytes(), output_key);
+
+        let full_key_slice_transform = FullKeySliceTransform::default();
+        let output_key = full_key_slice_transform.transfer(full_key);
+
+        assert_eq!(full_key, output_key);
+    }
+
+    fn build_table_with_prefix_column_num(column_count: u32) -> ProstTable {
+        ProstTable {
+            is_index: false,
+            index_on_id: 0,
+            id: 0,
+            schema_id: 0,
+            database_id: 0,
+            name: "test".to_string(),
+            columns: vec![
+                ProstColumnCatalog {
+                    column_desc: Some(
+                        (&ColumnDesc {
+                            data_type: DataType::Int64,
+                            column_id: ColumnId::new(0),
+                            name: "_row_id".to_string(),
+                            field_descs: vec![],
+                            type_name: "".to_string(),
+                        })
+                            .into(),
+                    ),
+                    is_hidden: true,
+                },
+                ProstColumnCatalog {
+                    column_desc: Some(
+                        (&ColumnDesc {
+                            data_type: DataType::Int64,
+                            column_id: ColumnId::new(0),
+                            name: "col_1".to_string(),
+                            field_descs: vec![],
+                            type_name: "Int64".to_string(),
+                        })
+                            .into(),
+                    ),
+                    is_hidden: false,
+                },
+                ProstColumnCatalog {
+                    column_desc: Some(
+                        (&ColumnDesc {
+                            data_type: DataType::Float64,
+                            column_id: ColumnId::new(0),
+                            name: "col_2".to_string(),
+                            field_descs: vec![],
+                            type_name: "Float64".to_string(),
+                        })
+                            .into(),
+                    ),
+                    is_hidden: false,
+                },
+                ProstColumnCatalog {
+                    column_desc: Some(
+                        (&ColumnDesc {
+                            data_type: DataType::Varchar,
+                            column_id: ColumnId::new(0),
+                            name: "col_3".to_string(),
+                            field_descs: vec![],
+                            type_name: "Varchar".to_string(),
+                        })
+                            .into(),
+                    ),
+                    is_hidden: false,
+                },
+            ],
+            order_key: vec![
+                ColumnOrder {
+                    order_type: 1, // Ascending
+                    index: 1,
+                },
+                ColumnOrder {
+                    order_type: 1, // Ascending
+                    index: 3,
+                },
+            ],
+            pk: vec![0],
+            dependent_relations: vec![],
+            distribution_key: vec![],
+            optional_associated_source_id: None,
+            appendonly: false,
+            owner: risingwave_common::catalog::DEFAULT_SUPPER_USER.to_string(),
+            mapping: None,
+            properties: HashMap::from([(String::from("ttl"), String::from("300"))]),
+            read_pattern_prefix_column: column_count, // 1 column
+        }
+    }
+
+    #[test]
+    fn test_schema_slice_transform() {
+        let prost_table = build_table_with_prefix_column_num(1);
+        let schema_slice_transform = SchemaSliceTransform::new(&prost_table);
+
+        let order_types: Vec<OrderType> = vec![OrderType::Ascending, OrderType::Ascending];
+
+        let serializer = OrderedRowSerializer::new(order_types);
+        let row = Row(vec![
+            Some(ScalarImpl::Int64(100)),
+            Some(ScalarImpl::Utf8("abc".to_string())),
+        ]);
+        let mut row_bytes = vec![];
+        serializer.serialize(&row, &mut row_bytes);
+
+        let table_prefix = {
+            let mut buf = BytesMut::with_capacity(TABLE_PREFIX_LEN);
+            buf.put_u8(b't');
+            buf.put_u32(1);
+            buf.to_vec()
+        };
+
+        let vnode_prefix = "v".as_bytes();
+        assert_eq!(VIRTUAL_NODE_SIZE, vnode_prefix.len());
+
+        let full_key = [&table_prefix, vnode_prefix, &row_bytes].concat();
+        let output_key = schema_slice_transform.transfer(&full_key);
+        assert_eq!(
+            TABLE_PREFIX_LEN + VIRTUAL_NODE_SIZE + 1 + mem::size_of::<i64>(),
+            output_key.len()
+        );
+    }
+
+    #[test]
+    fn test_multi_slice_transform() {
+        let mut multi_slice_transform = MultiSliceTransForm::default();
+
+        {
+            // test table_id 1
+            let prost_table = build_table_with_prefix_column_num(1);
+            let schema_slice_transform = SchemaSliceTransform::new(&prost_table);
+            multi_slice_transform.register(1, Arc::new(schema_slice_transform));
+            let order_types: Vec<OrderType> = vec![OrderType::Ascending, OrderType::Ascending];
+
+            let serializer = OrderedRowSerializer::new(order_types);
+            let row = Row(vec![
+                Some(ScalarImpl::Int64(100)),
+                Some(ScalarImpl::Utf8("abc".to_string())),
+            ]);
+            let mut row_bytes = vec![];
+            serializer.serialize(&row, &mut row_bytes);
+
+            let table_prefix = {
+                let mut buf = BytesMut::with_capacity(TABLE_PREFIX_LEN);
+                buf.put_u8(b't');
+                buf.put_u32(1);
+                buf.to_vec()
+            };
+
+            let vnode_prefix = "v".as_bytes();
+            assert_eq!(VIRTUAL_NODE_SIZE, vnode_prefix.len());
+
+            let full_key = [&table_prefix, vnode_prefix, &row_bytes].concat();
+            let output_key = multi_slice_transform.transfer(&full_key);
+
+            let data_types = vec![DataType::Int64];
+            let order_types = vec![OrderType::Ascending];
+            let deserializer = OrderedRowDeserializer::new(data_types, order_types);
+
+            let pk_prefix_len = deserializer
+                .deserialize_prefix_len_with_column_indices(&row_bytes, vec![0])
+                .unwrap();
+            assert_eq!(
+                TABLE_PREFIX_LEN + VIRTUAL_NODE_SIZE + pk_prefix_len,
+                output_key.len()
+            );
+        }
+
+        {
+            // test table_id 1
+            let prost_table = build_table_with_prefix_column_num(2);
+            let schema_slice_transform = SchemaSliceTransform::new(&prost_table);
+            multi_slice_transform.register(2, Arc::new(schema_slice_transform));
+            let order_types: Vec<OrderType> = vec![OrderType::Ascending, OrderType::Ascending];
+
+            let serializer = OrderedRowSerializer::new(order_types);
+            let row = Row(vec![
+                Some(ScalarImpl::Int64(100)),
+                Some(ScalarImpl::Utf8("abc".to_string())),
+            ]);
+            let mut row_bytes = vec![];
+            serializer.serialize(&row, &mut row_bytes);
+
+            let table_prefix = {
+                let mut buf = BytesMut::with_capacity(TABLE_PREFIX_LEN);
+                buf.put_u8(b't');
+                buf.put_u32(2);
+                buf.to_vec()
+            };
+
+            let vnode_prefix = "v".as_bytes();
+            assert_eq!(VIRTUAL_NODE_SIZE, vnode_prefix.len());
+
+            let full_key = [&table_prefix, vnode_prefix, &row_bytes].concat();
+            let output_key = multi_slice_transform.transfer(&full_key);
+
+            let data_types = vec![DataType::Int64, DataType::Varchar];
+            let order_types = vec![OrderType::Ascending, OrderType::Ascending];
+            let deserializer = OrderedRowDeserializer::new(data_types, order_types);
+
+            let pk_prefix_len = deserializer
+                .deserialize_prefix_len_with_column_indices(&row_bytes, vec![0, 1])
+                .unwrap();
+
+            assert_eq!(
+                TABLE_PREFIX_LEN + VIRTUAL_NODE_SIZE + pk_prefix_len,
+                output_key.len()
+            );
+        }
+
+        {
+            let full_key_slice_transform = FullKeySliceTransform::default();
+            multi_slice_transform.register(3, Arc::new(full_key_slice_transform));
+
+            let table_prefix = {
+                let mut buf = BytesMut::with_capacity(TABLE_PREFIX_LEN);
+                buf.put_u8(b't');
+                buf.put_u32(3);
+                buf.to_vec()
+            };
+
+            let vnode_prefix = "v".as_bytes();
+            assert_eq!(VIRTUAL_NODE_SIZE, vnode_prefix.len());
+
+            let row_bytes = "full_key".as_bytes();
+
+            let full_key = [&table_prefix, vnode_prefix, row_bytes].concat();
+            let output_key = multi_slice_transform.transfer(&full_key);
+            assert_eq!(
+                TABLE_PREFIX_LEN + VIRTUAL_NODE_SIZE + row_bytes.len(),
+                output_key.len()
+            );
         }
     }
 }

--- a/src/storage/hummock_sdk/src/slice_transform.rs
+++ b/src/storage/hummock_sdk/src/slice_transform.rs
@@ -171,6 +171,7 @@ impl MultiSliceTransForm {
 }
 
 #[cfg(test)]
+#[expect(clippy::needless_borrow)]
 mod tests {
     use std::collections::HashMap;
     use std::mem;

--- a/src/storage/hummock_sdk/src/slice_transform.rs
+++ b/src/storage/hummock_sdk/src/slice_transform.rs
@@ -59,9 +59,19 @@ pub struct SchemaSliceTransform {
 
 impl SliceTransform for SchemaSliceTransform {
     fn transform<'a>(&self, full_key: &'a [u8]) -> &'a [u8] {
+        if full_key.len() < TABLE_PREFIX_LEN + VIRTUAL_NODE_SIZE {
+            panic!(
+                "full_key {:?} len {} not match the schema",
+                full_key,
+                full_key.len()
+            );
+        }
+
         let (_table_prefix, key) = full_key.split_at(TABLE_PREFIX_LEN);
         let (_vnode_prefix, pk) = key.split_at(VIRTUAL_NODE_SIZE);
 
+        // if the key with table_id deserializer fail from schema, that shoud panic here for early
+        // detection
         let pk_prefix_len = self
             .deserializer
             .deserialize_prefix_len_with_column_indices(

--- a/src/storage/hummock_sdk/src/slice_transform.rs
+++ b/src/storage/hummock_sdk/src/slice_transform.rs
@@ -55,6 +55,8 @@ pub struct SchemaSliceTransform {
     // `StorageKey`
     read_pattern_prefix_column: u32,
     deserializer: OrderedRowDeserializer,
+    // TODO:need some bench test for same prefix case like join (if we need a prefix_cache for same
+    // prefix_key)
 }
 
 impl SliceTransform for SchemaSliceTransform {

--- a/src/storage/src/keyspace.rs
+++ b/src/storage/src/keyspace.rs
@@ -17,7 +17,7 @@ use std::ops::RangeBounds;
 
 use bytes::{BufMut, Bytes, BytesMut};
 use risingwave_common::catalog::TableId;
-use risingwave_hummock_sdk::key::prefixed_range;
+use risingwave_hummock_sdk::key::{prefixed_range, TABLE_PREFIX_LEN};
 
 use crate::error::StorageResult;
 use crate::store::ReadOptions;
@@ -45,7 +45,7 @@ impl<S: StateStore> Keyspace<S> {
     /// Creates a root [`Keyspace`] for a table.
     pub fn table_root(store: S, id: &TableId) -> Self {
         let prefix = {
-            let mut buf = BytesMut::with_capacity(5);
+            let mut buf = BytesMut::with_capacity(TABLE_PREFIX_LEN);
             buf.put_u8(b't');
             buf.put_u32(id.table_id);
             buf.to_vec()


### PR DESCRIPTION
I hereby agree to the terms of the [Singularity Data, Inc. Contributor License Agreement](https://gist.github.com/skyzh/0663682a70b0edde7ae991492f2314cb#file-s9y_cla).

## What's changed and what's your intention?

support slice transform

Please explain **IN DETAIL** what the changes are in this PR and why they are needed:

- add SchemaSliceTransform
- some unit-test

## Checklist

- ~[ ] I have written necessary rustdoc comments~
- [x] I have added necessary unit tests and integration tests
- [x] All checks passed in `./risedev check` (or alias, `./risedev c`)

## Refer to a related PR or issue link (optional)
- https://github.com/singularity-data/risingwave/issues/3927