### PR TITLE
fix(sqlsmith): Ignore NumericOutOfRangeError

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4825,6 +4825,7 @@ dependencies = [
  "madsim-tokio",
  "paste",
  "rand 0.8.5",
+ "risingwave_expr",
  "risingwave_frontend",
  "risingwave_sqlparser",
  "tokio-postgres",

--- a/src/tests/sqlsmith/Cargo.toml
+++ b/src/tests/sqlsmith/Cargo.toml
@@ -14,6 +14,7 @@ log = "0.4"
 madsim = "=0.2.0-alpha.3"
 paste = "1"
 rand = "0.8"
+risingwave_expr = { path = "../../expr" }
 risingwave_frontend = { path = "../../frontend" }
 risingwave_sqlparser = { path = "../../sqlparser" }
 tokio = { version = "=0.2.0-alpha.3", package = "madsim-tokio" }

--- a/src/tests/sqlsmith/src/bin/main.rs
+++ b/src/tests/sqlsmith/src/bin/main.rs
@@ -21,9 +21,8 @@ use clap::Parser as ClapParser;
 use risingwave_sqlparser::ast::Statement;
 use risingwave_sqlparser::parser::Parser;
 use risingwave_sqlsmith::{print_function_table, sql_gen, Table};
+use tokio_postgres::error::{DbError, Error as PgError, SqlState};
 use tokio_postgres::NoTls;
-use tokio_postgres::error::{Error as PgError, DbError, SqlState};
-use risingwave_expr::ExprError;
 
 #[derive(ClapParser, Debug, Clone)]
 #[clap(about, version, author)]
@@ -118,7 +117,7 @@ fn is_numeric_out_of_range_err(db_error: &DbError) -> bool {
 /// Validate client responses
 fn validate_response<_Row>(response: Result<_Row, PgError>) {
     match response {
-        Ok(_) => {},
+        Ok(_) => {}
         Err(e) => {
             // Permit runtime errors conservatively.
             if let Some(e) = e.as_db_error() && is_numeric_out_of_range_err(e) {
@@ -163,9 +162,7 @@ async fn main() {
     for _ in 0..opt.count {
         let sql = sql_gen(&mut rng, tables.clone());
         log::info!("Executing: {}", sql);
-        let response = client
-            .query(sql.as_str(), &[])
-            .await;
+        let response = client.query(sql.as_str(), &[]).await;
         validate_response(response);
     }
 

--- a/src/tests/sqlsmith/src/bin/main.rs
+++ b/src/tests/sqlsmith/src/bin/main.rs
@@ -161,8 +161,7 @@ async fn main() {
 
     let mut rng = rand::thread_rng();
     for _ in 0..opt.count {
-        // let sql = sql_gen(&mut rng, tables.clone());
-        let sql = String::from("SELECT (1<<1000);"); // test numeric error handling
+        let sql = sql_gen(&mut rng, tables.clone());
         log::info!("Executing: {}", sql);
         let response = client
             .query(sql.as_str(), &[])

--- a/src/tests/sqlsmith/src/bin/main.rs
+++ b/src/tests/sqlsmith/src/bin/main.rs
@@ -132,7 +132,8 @@ async fn main() {
 
     let mut rng = rand::thread_rng();
     for _ in 0..opt.count {
-        let sql = sql_gen(&mut rng, tables.clone());
+        // let sql = sql_gen(&mut rng, tables.clone());
+        let sql = String::from("SELECT (1<<1000);"); // test numeric error handling
         log::info!("Executing: {}", sql);
         let _ = client
             .query(sql.as_str(), &[])


### PR DESCRIPTION
I hereby agree to the terms of the [Singularity Data, Inc. Contributor License Agreement](https://gist.github.com/skyzh/0663682a70b0edde7ae991492f2314cb#file-s9y_cla).

## What's changed and what's your intention?

- Summarize your change (**mandatory**)
  Permit overflow errors. Workaround by just checking error code and expected error message.

- Describe any limitations of the current code (optional)
   - This is a workaround, not a permanent solution.
   - Currently for overflows RisingWave just return an internal error code, and NumericOutOfRangeError as part of the error message. Need to design a better way to handle it.
   - We can also remove operators which potentially overflow from SqlSmith, but I think this would significantly reduce our coverage (most of arithmetic operators won't be included in SqlSmith tests).

## Checklist

- [x] I have written necessary rustdoc comments
- [x] I have added necessary unit tests and integration tests
- [x] All checks passed in `./risedev check` (or alias, `./risedev c`)

## Documentation

If your pull request contains user-facing changes, please specify the types of the changes, and create a release note. Otherwise, please feel free to remove this section.

### Types of user-facing changes

Please keep the types that apply to your changes, and remove those that do not apply.

* Installation and deployment 
* Connector (sources & sinks)
* SQL commands, functions, and operators
* RisingWave cluster configuration changes
* Other (please specify in the release note below)

### Release note

Please create a release note for your changes. In the release note, focus on the impact on users, and mention the environment or conditions where the impact may occur.

## Refer to a related PR or issue link (optional)
Workaround for #3900, #3939