### PR TITLE
fix: remove `unsafe_worker_node_parallel_degree` in risingwave.toml

### DIFF
--- a/src/config/risingwave.toml
+++ b/src/config/risingwave.toml
@@ -6,7 +6,6 @@ heartbeat_interval_ms = 1000
 [streaming]
 checkpoint_interval_ms = 250
 in_flight_barrier_nums = 40
-unsafe_worker_node_parallel_degree = 2
 
 [storage]
 shared_buffer_capacity_mb = 4096


### PR DESCRIPTION
I hereby agree to the terms of the [Singularity Data, Inc. Contributor License Agreement](https://gist.github.com/skyzh/0663682a70b0edde7ae991492f2314cb#file-s9y_cla).

## What's changed and what's your intention?

As title. 

I tried to fix it along with #3910 but CI timed out... Let's try it separately.

## Checklist

- [x] I have written necessary rustdoc comments
- [x] I have added necessary unit tests and integration tests
- [x] All checks passed in `./risedev check` (or alias, `./risedev c`)

## Documentation

If your pull request contains user-facing changes, please specify the types of the changes, and create a release note. Otherwise, please feel free to remove this section.

### Types of user-facing changes

Please keep the types that apply to your changes, and remove those that do not apply.

* Installation and deployment 
* Connector (sources & sinks)
* SQL commands, functions, and operators
* RisingWave cluster configuration changes
* Other (please specify in the release note below)

### Release note

Please create a release note for your changes. In the release note, focus on the impact on users, and mention the environment or conditions where the impact may occur.

## Refer to a related PR or issue link (optional)
