### PR TITLE
feat(encoding): merge encoding and decoding into one trait RowSerde

### DIFF
--- a/src/storage/src/encoding/cell_based_row_deserializer.rs
+++ b/src/storage/src/encoding/cell_based_row_deserializer.rs
@@ -24,7 +24,7 @@ use risingwave_common::util::value_encoding::deserialize_cell;
 
 use super::cell_based_encoding_util::deserialize_column_id;
 use super::cell_based_row_serializer::CellBasedRowSerializer;
-use super::{Decoding, Exchanger};
+use super::{Decoding, RowSerde};
 use crate::encoding::ColumnDescMapping;
 use crate::table::storage_table::DEFAULT_VNODE;
 
@@ -207,7 +207,7 @@ impl Decoding for CellBasedRowDeserializer {
     }
 }
 
-impl Exchanger for CellBasedRowDeserializer {
+impl RowSerde for CellBasedRowDeserializer {
     type Deserializer = CellBasedRowDeserializer;
     type Serializer = CellBasedRowSerializer;
 }

--- a/src/storage/src/encoding/cell_based_row_deserializer.rs
+++ b/src/storage/src/encoding/cell_based_row_deserializer.rs
@@ -23,7 +23,8 @@ use risingwave_common::types::{DataType, Datum, VirtualNode, VIRTUAL_NODE_SIZE};
 use risingwave_common::util::value_encoding::deserialize_cell;
 
 use super::cell_based_encoding_util::deserialize_column_id;
-use super::Decoding;
+use super::cell_based_row_serializer::CellBasedRowSerializer;
+use super::{Decoding, Exchanger};
 use crate::encoding::ColumnDescMapping;
 use crate::table::storage_table::DEFAULT_VNODE;
 
@@ -206,6 +207,10 @@ impl Decoding for CellBasedRowDeserializer {
     }
 }
 
+impl Exchanger for CellBasedRowDeserializer {
+    type Deserializer = CellBasedRowDeserializer;
+    type Serializer = CellBasedRowSerializer;
+}
 #[cfg(test)]
 mod tests {
     use bytes::Bytes;

--- a/src/storage/src/encoding/cell_based_row_serializer.rs
+++ b/src/storage/src/encoding/cell_based_row_serializer.rs
@@ -20,7 +20,7 @@ use risingwave_common::types::VirtualNode;
 
 use super::cell_based_encoding_util::serialize_pk_and_row;
 use super::cell_based_row_deserializer::CellBasedRowDeserializer;
-use super::Exchanger;
+use super::RowSerde;
 use crate::encoding::{Encoding, KeyBytes, ValueBytes};
 
 #[derive(Clone)]
@@ -82,7 +82,7 @@ impl Encoding for CellBasedRowSerializer {
     }
 }
 
-impl Exchanger for CellBasedRowSerializer {
+impl RowSerde for CellBasedRowSerializer {
     type Deserializer = CellBasedRowDeserializer;
     type Serializer = CellBasedRowSerializer;
 

--- a/src/storage/src/encoding/cell_based_row_serializer.rs
+++ b/src/storage/src/encoding/cell_based_row_serializer.rs
@@ -19,6 +19,8 @@ use risingwave_common::error::Result;
 use risingwave_common::types::VirtualNode;
 
 use super::cell_based_encoding_util::serialize_pk_and_row;
+use super::cell_based_row_deserializer::CellBasedRowDeserializer;
+use super::Exchanger;
 use crate::encoding::{Encoding, KeyBytes, ValueBytes};
 
 #[derive(Clone)]
@@ -77,5 +79,25 @@ impl Encoding for CellBasedRowSerializer {
 
     fn column_ids(&self) -> &[ColumnId] {
         &self.column_ids
+    }
+}
+
+impl Exchanger for CellBasedRowSerializer {
+    type Deserializer = CellBasedRowDeserializer;
+    type Serializer = CellBasedRowSerializer;
+
+    fn create_serializer(
+        pk_indices: &[usize],
+        column_descs: &[ColumnDesc],
+        column_ids: &[ColumnId],
+    ) -> Self::Serializer {
+        Encoding::create_row_serializer(pk_indices, column_descs, column_ids)
+    }
+
+    fn create_deserializer(
+        column_mapping: std::sync::Arc<super::ColumnDescMapping>,
+        data_types: Vec<risingwave_common::types::DataType>,
+    ) -> Self::Deserializer {
+        super::Decoding::create_row_deserializer(column_mapping, data_types)
     }
 }

--- a/src/storage/src/encoding/dedup_pk_cell_based_row_serializer.rs
+++ b/src/storage/src/encoding/dedup_pk_cell_based_row_serializer.rs
@@ -22,7 +22,7 @@ use risingwave_common::types::VirtualNode;
 
 use super::cell_based_row_deserializer::CellBasedRowDeserializer;
 use super::cell_based_row_serializer::CellBasedRowSerializer;
-use super::{Encoding, Exchanger, KeyBytes, ValueBytes};
+use super::{Encoding, KeyBytes, RowSerde, ValueBytes};
 #[derive(Clone)]
 /// [`DedupPkCellBasedRowSerializer`] is identical to [`CellBasedRowSerializer`].
 /// Difference is that before serializing a row, pk datums are filtered out.
@@ -122,7 +122,7 @@ impl Encoding for DedupPkCellBasedRowSerializer {
     }
 }
 
-impl Exchanger for DedupPkCellBasedRowSerializer {
+impl RowSerde for DedupPkCellBasedRowSerializer {
     type Deserializer = CellBasedRowDeserializer;
     type Serializer = DedupPkCellBasedRowSerializer;
 

--- a/src/storage/src/encoding/dedup_pk_cell_based_row_serializer.rs
+++ b/src/storage/src/encoding/dedup_pk_cell_based_row_serializer.rs
@@ -20,9 +20,10 @@ use risingwave_common::catalog::{ColumnDesc, ColumnId};
 use risingwave_common::error::Result;
 use risingwave_common::types::VirtualNode;
 
+use super::cell_based_row_deserializer::CellBasedRowDeserializer;
 use super::cell_based_row_serializer::CellBasedRowSerializer;
-use super::{Encoding, KeyBytes, ValueBytes};
-
+use super::{Encoding, Exchanger, KeyBytes, ValueBytes};
+#[derive(Clone)]
 /// [`DedupPkCellBasedRowSerializer`] is identical to [`CellBasedRowSerializer`].
 /// Difference is that before serializing a row, pk datums are filtered out.
 pub struct DedupPkCellBasedRowSerializer {
@@ -121,6 +122,25 @@ impl Encoding for DedupPkCellBasedRowSerializer {
     }
 }
 
+impl Exchanger for DedupPkCellBasedRowSerializer {
+    type Deserializer = CellBasedRowDeserializer;
+    type Serializer = DedupPkCellBasedRowSerializer;
+
+    fn create_serializer(
+        pk_indices: &[usize],
+        column_descs: &[ColumnDesc],
+        column_ids: &[ColumnId],
+    ) -> Self::Serializer {
+        Encoding::create_row_serializer(pk_indices, column_descs, column_ids)
+    }
+
+    fn create_deserializer(
+        column_mapping: std::sync::Arc<super::ColumnDescMapping>,
+        data_types: Vec<risingwave_common::types::DataType>,
+    ) -> Self::Deserializer {
+        super::Decoding::create_row_deserializer(column_mapping, data_types)
+    }
+}
 #[cfg(test)]
 mod tests {
     use itertools::Itertools;

--- a/src/storage/src/encoding/mod.rs
+++ b/src/storage/src/encoding/mod.rs
@@ -32,7 +32,7 @@ pub type KeyBytes = Vec<u8>;
 pub type ValueBytes = Vec<u8>;
 
 /// `Encoding` defines an interface for encoding a key row into kv storage.
-pub trait Encoding {
+pub trait Encoding: Clone {
     /// Constructs a new serializer.
     fn create_row_serializer(
         pk_indices: &[usize],
@@ -88,8 +88,8 @@ pub trait Decoding {
     fn take(&mut self) -> Option<(VirtualNode, Vec<u8>, Row)>;
 }
 
-/// `RowExchange` provides the ability to convert between Row and KV entry.
-pub trait Exchange {
+/// `Exchanger` provides the ability to convert between Row and KV entry.
+pub trait Exchanger: Send + Sync + Clone {
     type Serializer: Encoding;
     type Deserializer: Decoding;
 

--- a/src/storage/src/encoding/mod.rs
+++ b/src/storage/src/encoding/mod.rs
@@ -88,11 +88,12 @@ pub trait Decoding {
     fn take(&mut self) -> Option<(VirtualNode, Vec<u8>, Row)>;
 }
 
-/// `Exchanger` provides the ability to convert between Row and KV entry.
-pub trait Exchanger: Send + Sync + Clone {
+/// `RowSerde` provides the ability to convert between Row and KV entry.
+pub trait RowSerde: Send + Sync + Clone {
     type Serializer: Encoding;
     type Deserializer: Decoding;
 
+    /// `create_serializer` will create a row serializer to convert row into KV pairs.
     fn create_serializer(
         pk_indices: &[usize],
         column_descs: &[ColumnDesc],
@@ -100,6 +101,8 @@ pub trait Exchanger: Send + Sync + Clone {
     ) -> Self::Serializer {
         Encoding::create_row_serializer(pk_indices, column_descs, column_ids)
     }
+
+    /// `create_deserializer` will create a row deserializer to convert KV pairs into row.
     fn create_deserializer(
         column_mapping: Arc<ColumnDescMapping>,
         data_types: Vec<DataType>,

--- a/src/storage/src/encoding/mod.rs
+++ b/src/storage/src/encoding/mod.rs
@@ -87,3 +87,23 @@ pub trait Decoding {
     /// Take the remaining data out of the deserializer.
     fn take(&mut self) -> Option<(VirtualNode, Vec<u8>, Row)>;
 }
+
+/// `RowExchange` provides the ability to convert between Row and KV entry.
+pub trait Exchange {
+    type Serializer: Encoding;
+    type Deserializer: Decoding;
+
+    fn create_serializer(
+        pk_indices: &[usize],
+        column_descs: &[ColumnDesc],
+        column_ids: &[ColumnId],
+    ) -> Self::Serializer {
+        Encoding::create_row_serializer(pk_indices, column_descs, column_ids)
+    }
+    fn create_deserializer(
+        column_mapping: Arc<ColumnDescMapping>,
+        data_types: Vec<DataType>,
+    ) -> Self::Deserializer {
+        Decoding::create_row_deserializer(column_mapping, data_types)
+    }
+}

--- a/src/storage/src/table/mod.rs
+++ b/src/storage/src/table/mod.rs
@@ -34,7 +34,7 @@ use crate::table::storage_table::DEFAULT_VNODE;
 /// Represents the distribution for a specific table instance.
 #[derive(Debug)]
 pub struct Distribution {
-    /// Indices of distribution keys for computing vnode, based on the all columns of the table.
+    /// Indices of distribution key for computing vnode, based on the all columns of the table.
     pub dist_key_indices: Vec<usize>,
 
     /// Virtual nodes that the table is partitioned into.

--- a/src/storage/src/table/state_table.rs
+++ b/src/storage/src/table/state_table.rs
@@ -34,7 +34,7 @@ use super::Distribution;
 use crate::encoding::cell_based_encoding_util::serialize_pk;
 use crate::encoding::cell_based_row_serializer::CellBasedRowSerializer;
 use crate::encoding::dedup_pk_cell_based_row_serializer::DedupPkCellBasedRowSerializer;
-use crate::encoding::Exchanger;
+use crate::encoding::RowSerde;
 use crate::error::{StorageError, StorageResult};
 use crate::StateStore;
 
@@ -48,7 +48,7 @@ pub type StateTable<S> = StateTableBase<S, CellBasedRowSerializer>;
 /// `StateTableBase` is the interface accessing relational data in KV(`StateStore`) with
 /// encoding, using `RowSerializer` for row to cell serializing.
 #[derive(Clone)]
-pub struct StateTableBase<S: StateStore, E: Exchanger> {
+pub struct StateTableBase<S: StateStore, E: RowSerde> {
     /// buffer row operations.
     mem_table: MemTable,
 
@@ -56,7 +56,7 @@ pub struct StateTableBase<S: StateStore, E: Exchanger> {
     storage_table: StorageTableBase<S, E, READ_WRITE>,
 }
 
-impl<S: StateStore, E: Exchanger> StateTableBase<S, E> {
+impl<S: StateStore, E: RowSerde> StateTableBase<S, E> {
     /// Create a state table without distribution, used for singleton executors and unit tests.
     pub fn new_without_distribution(
         store: S,

--- a/src/storage/src/table/state_table.rs
+++ b/src/storage/src/table/state_table.rs
@@ -48,15 +48,15 @@ pub type StateTable<S> = StateTableBase<S, CellBasedRowSerializer>;
 /// `StateTableBase` is the interface accessing relational data in KV(`StateStore`) with
 /// encoding, using `RowSerializer` for row to cell serializing.
 #[derive(Clone)]
-pub struct StateTableBase<S: StateStore, E: RowSerde> {
+pub struct StateTableBase<S: StateStore, RS: RowSerde> {
     /// buffer row operations.
     mem_table: MemTable,
 
     /// write into state store.
-    storage_table: StorageTableBase<S, E, READ_WRITE>,
+    storage_table: StorageTableBase<S, RS, READ_WRITE>,
 }
 
-impl<S: StateStore, E: RowSerde> StateTableBase<S, E> {
+impl<S: StateStore, RS: RowSerde> StateTableBase<S, RS> {
     /// Create a state table without distribution, used for singleton executors and unit tests.
     pub fn new_without_distribution(
         store: S,
@@ -104,7 +104,7 @@ impl<S: StateStore, E: RowSerde> StateTableBase<S, E> {
     }
 
     /// Get the underlying [` StorageTableBase`]. Should only be used for tests.
-    pub fn storage_table(&self) -> &StorageTableBase<S, E, READ_WRITE> {
+    pub fn storage_table(&self) -> &StorageTableBase<S, RS, READ_WRITE> {
         &self.storage_table
     }
 

--- a/src/storage/src/table/state_table.rs
+++ b/src/storage/src/table/state_table.rs
@@ -31,7 +31,7 @@ use risingwave_pb::catalog::Table;
 use super::mem_table::{MemTable, RowOp};
 use super::storage_table::{StorageTableBase, READ_WRITE};
 use super::Distribution;
-use crate::encoding::cell_based_encoding_util::serialize_pk;
+use crate::encoding::{cell_based_encoding_util::serialize_pk, Exchange};
 use crate::encoding::cell_based_row_serializer::CellBasedRowSerializer;
 use crate::encoding::dedup_pk_cell_based_row_serializer::DedupPkCellBasedRowSerializer;
 use crate::encoding::Encoding;
@@ -48,7 +48,7 @@ pub type StateTable<S> = StateTableBase<S, CellBasedRowSerializer>;
 /// `StateTableBase` is the interface accessing relational data in KV(`StateStore`) with
 /// encoding, using `RowSerializer` for row to cell serializing.
 #[derive(Clone)]
-pub struct StateTableBase<S: StateStore, E: Encoding> {
+pub struct StateTableBase<S: StateStore, E: Exchange> {
     /// buffer row operations.
     mem_table: MemTable,
 
@@ -56,7 +56,7 @@ pub struct StateTableBase<S: StateStore, E: Encoding> {
     storage_table: StorageTableBase<S, E, READ_WRITE>,
 }
 
-impl<S: StateStore, E: Encoding> StateTableBase<S, E> {
+impl<S: StateStore, E: Exchange> StateTableBase<S, E> {
     /// Create a state table without distribution, used for singleton executors and unit tests.
     pub fn new_without_distribution(
         store: S,

--- a/src/storage/src/table/state_table.rs
+++ b/src/storage/src/table/state_table.rs
@@ -31,10 +31,10 @@ use risingwave_pb::catalog::Table;
 use super::mem_table::{MemTable, RowOp};
 use super::storage_table::{StorageTableBase, READ_WRITE};
 use super::Distribution;
-use crate::encoding::{cell_based_encoding_util::serialize_pk, Exchange};
+use crate::encoding::cell_based_encoding_util::serialize_pk;
 use crate::encoding::cell_based_row_serializer::CellBasedRowSerializer;
 use crate::encoding::dedup_pk_cell_based_row_serializer::DedupPkCellBasedRowSerializer;
-use crate::encoding::Encoding;
+use crate::encoding::Exchanger;
 use crate::error::{StorageError, StorageResult};
 use crate::StateStore;
 
@@ -48,7 +48,7 @@ pub type StateTable<S> = StateTableBase<S, CellBasedRowSerializer>;
 /// `StateTableBase` is the interface accessing relational data in KV(`StateStore`) with
 /// encoding, using `RowSerializer` for row to cell serializing.
 #[derive(Clone)]
-pub struct StateTableBase<S: StateStore, E: Exchange> {
+pub struct StateTableBase<S: StateStore, E: Exchanger> {
     /// buffer row operations.
     mem_table: MemTable,
 
@@ -56,7 +56,7 @@ pub struct StateTableBase<S: StateStore, E: Exchange> {
     storage_table: StorageTableBase<S, E, READ_WRITE>,
 }
 
-impl<S: StateStore, E: Exchange> StateTableBase<S, E> {
+impl<S: StateStore, E: Exchanger> StateTableBase<S, E> {
     /// Create a state table without distribution, used for singleton executors and unit tests.
     pub fn new_without_distribution(
         store: S,

--- a/src/storage/src/table/storage_table.rs
+++ b/src/storage/src/table/storage_table.rs
@@ -752,15 +752,15 @@ impl<S: StateStore, E: Exchanger, const T: AccessType> StorageTableBase<S, E, T>
 }
 
 /// [`StorageTableIterInner`] iterates on the storage table.
-struct StorageTableIterInner<S: StateStore, D: Decoding> {
+struct StorageTableIterInner<S: StateStore, E: Exchanger> {
     /// An iterator that returns raw bytes from storage.
     iter: StripPrefixIterator<S::Iter>,
 
     /// Cell-based row deserializer
-    cell_based_row_deserializer: D, // CellBasedRowDeserializer<Arc<ColumnDescMapping>>,
+    cell_based_row_deserializer: E::Deserializer, /* CellBasedRowDeserializer<Arc<ColumnDescMapping>>, */
 }
 
-impl<S: StateStore, D: Decoding> StorageTableIterInner<S, D> {
+impl<S: StateStore, E: Exchanger> StorageTableIterInner<S, E> {
     /// If `wait_epoch` is true, it will wait for the given epoch to be committed before iteration.
     async fn new<R, B>(
         keyspace: &Keyspace<S>,
@@ -778,7 +778,7 @@ impl<S: StateStore, D: Decoding> StorageTableIterInner<S, D> {
             keyspace.state_store().wait_epoch(epoch).await?;
         }
 
-        let cell_based_row_deserializer = D::create_row_deserializer(table_descs, data_types);
+        let cell_based_row_deserializer = E::create_deserializer(table_descs, data_types);
 
         let iter = keyspace.iter_with_range(raw_key_range, epoch).await?;
         let iter = Self {

--- a/src/storage/src/table/storage_table/iter_utils.rs
+++ b/src/storage/src/table/storage_table/iter_utils.rs
@@ -35,7 +35,7 @@ struct Node<S: PkAndRowStream> {
 impl<S: PkAndRowStream> PartialEq for Node<S> {
     fn eq(&self, other: &Self) -> bool {
         match self.peeked.0 == other.peeked.0 {
-            true => unreachable!("primary keys from different iters should be unique"),
+            true => unreachable!("primary key from different iters should be unique"),
             false => false,
         }
     }
@@ -54,8 +54,8 @@ impl<S: PkAndRowStream> Ord for Node<S> {
     }
 }
 
-/// Merge multiple streams of primary keys and rows into a single stream, sorted by primary key.
-/// We should ensure that the primary keys from different streams are unique.
+/// Merge multiple streams of primary key and rows into a single stream, sorted by primary key.
+/// We should ensure that the primary key from different streams are unique.
 #[try_stream(ok = (Vec<u8>, Row), error = StorageError)]
 pub(super) async fn merge_sort<S>(streams: Vec<S>)
 where


### PR DESCRIPTION
I hereby agree to the terms of the [Singularity Data, Inc. Contributor License Agreement](https://gist.github.com/skyzh/0663682a70b0edde7ae991492f2314cb#file-s9y_cla).

## What's changed and what's your intention?
 
We have triat `Encoding` to serialize row into KV entry, and `Decoding` to deserialize KV entries into row, however, current implementation is a little confusing because `StateTableBase` bound to `Encoding` and `StorageTableIter` bound to `Decoding`. 

This PR merges `Encoding` and `Decoding` into one new trait `RowSerde` (maybe we can call it something else like `RowExchanger`...), which is responsible for the conversion between row and KV. Thus, all struct in relational table layer only need to bound with this trait. This further decouples the Encoding and Relational layers, and remove the cell-based attributes of the relational layer.
## Checklist

- [x] I have written necessary rustdoc comments
- [x] I have added necessary unit tests and integration tests
- [x] All checks passed in `./risedev check` (or alias, `./risedev c`)

## Documentation

If your pull request contains user-facing changes, please specify the types of the changes, and create a release note. Otherwise, please feel free to remove this section.

### Types of user-facing changes

Please keep the types that apply to your changes, and remove those that do not apply.

* Installation and deployment 
* Connector (sources & sinks)
* SQL commands, functions, and operators
* RisingWave cluster configuration changes
* Other (please specify in the release note below)

### Release note

Please create a release note for your changes. In the release note, focus on the impact on users, and mention the environment or conditions where the impact may occur.

## Refer to a related PR or issue link (optional)
part of https://github.com/singularity-data/risingwave/issues/3616