### PR TITLE
feat: make sink e2e work

### DIFF
--- a/src/connector/src/sink/kafka.rs
+++ b/src/connector/src/sink/kafka.rs
@@ -198,7 +198,6 @@ impl Sink for KafkaSink {
             return Ok(())
         }
         if self.config.sink_type.as_str() == "append_only" {
-            println!("append only");
             self.append_only(chunk, schema).await
         } else if self.config.sink_type.as_str() == "debezium" {
             todo!()
@@ -212,7 +211,6 @@ impl Sink for KafkaSink {
     async fn begin_epoch(&mut self, epoch: u64) -> Result<()> {
         self.in_transaction_epoch = Some(epoch);
         if self.latest_success_epoch == KafkaSinkState::Init {
-            println!("init");
             self.do_with_retry(|conductor| conductor.init_transaction())
                 .await
                 .map_err(SinkError::Kafka)?;
@@ -454,7 +452,6 @@ mod test {
         for i in 0..10 {
             let mut fail_flag = false;
             sink.begin_epoch(i).await?;
-            println!("begin epoch success");
             for i in 0..100 {
                 match sink
                     .send(
@@ -476,8 +473,6 @@ mod test {
                 sink.commit().await?;
                 println!("commit success");
             }
-
-            // tokio::time::sleep(Duration::from_secs(1)).await;
         }
 
         Ok(())

--- a/src/stream/src/executor/sink.rs
+++ b/src/stream/src/executor/sink.rs
@@ -61,7 +61,7 @@ impl<S: StateStore> SinkExecutor<S> {
     async fn execute_inner(self) {
         let sink_config = SinkConfig::from_hashmap(self.properties.clone())
             .map_err(StreamExecutorError::sink_error)?;
-        println!("SinkConfig: {:?}", sink_config);
+
         let mut sink = build_sink(sink_config)
             .await
             .map_err(StreamExecutorError::sink_error)?;
@@ -76,23 +76,16 @@ impl<S: StateStore> SinkExecutor<S> {
 
         let input = self.input.execute();
 
-        println!("ready to start sink");
-
         #[for_await]
         for msg in input {
-            println!("msg: {:?}", msg);
             match msg? {
                 Message::Chunk(chunk) => {
-                    println!("chunk {:?}", chunk);
                     if !in_transaction {
-                        println!("start transaction");
                         sink.begin_epoch(epoch)
                             .await
                             .map_err(StreamExecutorError::sink_error)?;
                         in_transaction = true;
                     }
-
-                    println!("begin epoch");
 
                     let visible_chunk = chunk.clone().compact()?;
                     if let Err(e) = sink

--- a/src/stream/src/executor/sink.rs
+++ b/src/stream/src/executor/sink.rs
@@ -19,7 +19,7 @@ use futures::StreamExt;
 use futures_async_stream::try_stream;
 use risingwave_common::catalog::Schema;
 use risingwave_common::error::Result;
-use risingwave_connector::sink::{SinkConfig, SinkImpl};
+use risingwave_connector::sink::{Sink, SinkConfig, SinkImpl};
 use risingwave_storage::StateStore;
 
 use super::error::StreamExecutorError;
@@ -61,23 +61,67 @@ impl<S: StateStore> SinkExecutor<S> {
     async fn execute_inner(self) {
         let sink_config = SinkConfig::from_hashmap(self.properties.clone())
             .map_err(StreamExecutorError::sink_error)?;
-        let _sink = build_sink(sink_config).await;
+        println!("SinkConfig: {:?}", sink_config);
+        let mut sink = build_sink(sink_config)
+            .await
+            .map_err(StreamExecutorError::sink_error)?;
 
-        // TODO(tabVersion): the flag is required because kafka transaction requires at least one
+        // the flag is required because kafka transaction requires at least one
         // message, so we should abort the transaction if the flag is true.
-        #[allow(clippy::no_effect_underscore_binding)]
-        let _empty_epoch_flag = true;
+        let mut empty_epoch_flag = true;
+        let mut in_transaction = false;
+        let mut epoch = 0;
+
+        let schema = self.schema().clone();
 
         let input = self.input.execute();
+
+        println!("ready to start sink");
+
         #[for_await]
         for msg in input {
             match msg? {
                 Message::Chunk(chunk) => {
-                    let _visible_chunk = chunk.clone().compact()?;
+                    println!("{:?}", chunk);
+                    if !in_transaction {
+                        println!("start transaction");
+                        sink.begin_epoch(epoch)
+                            .await
+                            .map_err(StreamExecutorError::sink_error)?;
+                        in_transaction = true;
+                    }
+
+                    println!("begin epoch");
+
+                    let visible_chunk = chunk.clone().compact()?;
+                    if let Err(e) = sink
+                        .write_batch(visible_chunk, &schema)
+                        .await
+                        .map_err(StreamExecutorError::sink_error)
+                    {
+                        sink.abort()
+                            .await
+                            .map_err(StreamExecutorError::sink_error)?;
+                        return Err(e);
+                    }
+                    empty_epoch_flag = false;
 
                     yield Message::Chunk(chunk);
                 }
                 Message::Barrier(barrier) => {
+                    if empty_epoch_flag {
+                        sink.abort()
+                            .await
+                            .map_err(StreamExecutorError::sink_error)?;
+                        tracing::debug!("transaction abort due to empty epoch, epoch: {:?}", epoch);
+                    } else {
+                        sink.commit()
+                            .await
+                            .map_err(StreamExecutorError::sink_error)?;
+                    }
+                    in_transaction = false;
+                    empty_epoch_flag = true;
+                    epoch = barrier.epoch.curr;
                     yield Message::Barrier(barrier);
                 }
             }


### PR DESCRIPTION
I hereby agree to the terms of the [Singularity Data, Inc. Contributor License Agreement](https://gist.github.com/skyzh/0663682a70b0edde7ae991492f2314cb#file-s9y_cla).

## What's changed and what's your intention?

***PLEASE DO NOT LEAVE THIS EMPTY !!!***

Please explain **IN DETAIL** what the changes are in this PR and why they are needed:

as title, the pr include sink executor internals, without failover part

you can now run 

```sql
create materialized source s (v1 int ) with ('connector' = 'datagen') row format json ;
create materialized view v as select * from s where v1 > 0;
 create sink si from v with ('kafka.brokers' = '127.0.0.1:29092', 'kafka.topic' = 'test_topic', 'sink.type' = 'append_only', 'sink_type' = 'kafka');
```

to try a kafka sink! 

- Summarize your change (**mandatory**)
- How does this PR work? Need a brief introduction for the changed logic (optional)
- Describe clearly one logical change and avoid lazy messages (optional)
- Describe any limitations of the current code (optional)

## Checklist

- [x] I have written necessary rustdoc comments
- [x] I have added necessary unit tests and integration tests
- [x] All checks passed in `./risedev check` (or alias, `./risedev c`)

## Refer to a related PR or issue link (optional)

a temp branch for #3674 , now the sink is functional 😀 