### PR TITLE
fix(sqlsmith): workaround fifo channel errors

### DIFF
--- a/src/tests/sqlsmith/src/bin/main.rs
+++ b/src/tests/sqlsmith/src/bin/main.rs
@@ -132,11 +132,23 @@ async fn drop_tables(mviews: &[Table], opt: &TestOptions, client: &tokio_postgre
 /// See: <https://github.com/singularity-data/risingwave/blob/b4eb1107bc16f8d583563f776f748632ddcaa0cb/src/expr/src/vector_op/bitwise_op.rs#L24>
 /// FIXME: This approach is brittle and should change in the future,
 /// when we have a better way of handling overflows.
-/// Tracked here: <https://github.com/singularity-data/risingwave/issues/3900>
+/// Tracked by: <https://github.com/singularity-data/risingwave/issues/3900>
 fn is_numeric_out_of_range_err(db_error: &DbError) -> bool {
+    db_error.message().contains("Expr error: NumericOutOfRange")
+}
+
+/// Workaround to permit runtime errors not being propagated through channels.
+/// FIXME: This also means some internal system errors won't be caught.
+/// Tracked by: <https://github.com/singularity-data/risingwave/issues/3908#issuecomment-1186782810>
+fn is_broken_chan_err(db_error: &DbError) -> bool {
+    db_error
+        .message()
+        .contains("internal error: broken fifo_channel")
+}
+
+fn is_permissible_error(db_error: &DbError) -> bool {
     let is_internal_error = *db_error.code() == SqlState::INTERNAL_ERROR;
-    let is_numeric_error = db_error.message().contains("Expr error: NumericOutOfRange");
-    is_internal_error && is_numeric_error
+    is_internal_error && (is_numeric_out_of_range_err(db_error) || is_broken_chan_err(db_error))
 }
 
 /// Validate client responses
@@ -145,7 +157,9 @@ fn validate_response<_Row>(response: Result<_Row, PgError>) {
         Ok(_) => {}
         Err(e) => {
             // Permit runtime errors conservatively.
-            if let Some(e) = e.as_db_error() && is_numeric_out_of_range_err(e) {
+            if let Some(e) = e.as_db_error()
+                && is_permissible_error(e)
+            {
                 return;
             }
             panic!("{}", e);


### PR DESCRIPTION
I hereby agree to the terms of the [Singularity Data, Inc. Contributor License Agreement](https://gist.github.com/skyzh/0663682a70b0edde7ae991492f2314cb#file-s9y_cla).

## What's changed and what's your intention?

As per title.

***PLEASE DO NOT LEAVE THIS EMPTY !!!***

Please explain **IN DETAIL** what the changes are in this PR and why they are needed:

- Summarize your change (**mandatory**)
- How does this PR work? Need a brief introduction for the changed logic (optional)
- Describe clearly one logical change and avoid lazy messages (optional)
- Describe any limitations of the current code (optional)

## Checklist

- [ ] I have written necessary rustdoc comments
- [ ] I have added necessary unit tests and integration tests
- [ ] All checks passed in `./risedev check` (or alias, `./risedev c`)

## Documentation

If your pull request contains user-facing changes, please specify the types of the changes, and create a release note. Otherwise, please feel free to remove this section.

### Types of user-facing changes

Please keep the types that apply to your changes, and remove those that do not apply.

* Installation and deployment 
* Connector (sources & sinks)
* SQL commands, functions, and operators
* RisingWave cluster configuration changes
* Other (please specify in the release note below)

### Release note

Please create a release note for your changes. In the release note, focus on the impact on users, and mention the environment or conditions where the impact may occur.

## Refer to a related PR or issue link (optional)

Workaround for #3908 