### PR TITLE
fix(regress test): enable regress tests for both RW and PG

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4682,6 +4682,7 @@ dependencies = [
  "madsim-tokio",
  "path-absolutize",
  "similar",
+ "tempfile",
  "workspace-hack",
 ]
 

--- a/src/tests/regress/Cargo.toml
+++ b/src/tests/regress/Cargo.toml
@@ -11,6 +11,7 @@ log = "0.4"
 madsim = "=0.2.0-alpha.4"
 path-absolutize = "3.0"
 similar = "2"
+tempfile = "3"
 tokio = { version = "=0.2.0-alpha.4", package = "madsim-tokio", features = ["rt", "rt-multi-thread", "sync", "macros", "time", "signal", "process"] }
 workspace-hack = { version = "0.1", path = "../../workspace-hack" }
 

--- a/src/tests/regress/README.md
+++ b/src/tests/regress/README.md
@@ -22,14 +22,27 @@ tests: boolean
 
 * Install `psql` and ensure that it's in your path.
 * Start risingwave cluster.
-* Run 
+* Run tests against RisingWave.
 ```shell
 RUST_BACKTRACE=1 target/debug/risingwave_regress_test -h 127.0.0.1 \
   -p 4566 \
   -u root \
   --input `pwd`/src/tests/regress/data \
   --output `pwd`/src/tests/regress/output \
-  --schedule `pwd`/src/tests/regress/data/schedule
+  --schedule `pwd`/src/tests/regress/data/schedule \
+  --mode risingwave
+```
+
+* Run tests against PostgreSQL. Make sure PostgreSQL is running.
+```shell
+RUST_BACKTRACE=1 target/debug/risingwave_regress_test -h 127.0.0.1 \
+  -p 5432 \
+  -u `user name` \
+  --database `database name` \
+  --input `pwd`/src/tests/regress/data \
+  --output `pwd`/src/tests/regress/output \
+  --schedule `pwd`/src/tests/regress/data/schedule \
+  --mode postgres
 ```
 Please remove the `output` directory before running the test again.
 

--- a/src/tests/regress/data/expected/boolean.out
+++ b/src/tests/regress/data/expected/boolean.out
@@ -4,7 +4,6 @@
 --
 -- sanity check - if this fails go insane!
 --
-SET RW_IMPLICIT_FLUSH TO true;
 SELECT 1 AS one;
  one 
 -----

--- a/src/tests/regress/data/sql/boolean.sql
+++ b/src/tests/regress/data/sql/boolean.sql
@@ -5,7 +5,6 @@
 --
 -- sanity check - if this fails go insane!
 --
-SET RW_IMPLICIT_FLUSH TO true;
 SELECT 1 AS one;
 
 


### PR DESCRIPTION
I hereby agree to the terms of the [Singularity Data, Inc. Contributor License Agreement](https://gist.github.com/skyzh/0663682a70b0edde7ae991492f2314cb#file-s9y_cla).

## What's changed and what's your intention?
RW requires session variable assignment `SET RW_IMPLICIT_FLUSH TO true;` while PG cannot recognize it.

So we require users to input the database they are testing against,
and add this session variable assignment for each test case when running against RW only.


Will enable regress tests in CI for both RW and PG in future pr.

## Checklist

- [x] I have written necessary rustdoc comments
~- [] I have added necessary unit tests and integration tests~
- [x] All checks passed in `./risedev check` (or alias, `./risedev c`)

## Refer to a related PR or issue link (optional)
