### PR TITLE
chore: refine split enumerator for pulsar connector

### DIFF
--- a/src/connector/src/source/pulsar/admin/client.rs
+++ b/src/connector/src/source/pulsar/admin/client.rs
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use anyhow::{anyhow, Result};
+use anyhow::{anyhow, bail, Result};
 use http::{Response, StatusCode};
 use hyper::body::Buf;
 use hyper::{Body, Client, Uri};
@@ -42,10 +42,10 @@ impl PulsarAdminClient {
         let res = self.http_get(topic, "partitions").await?;
 
         if res.status() == StatusCode::NOT_FOUND {
-            return Err(anyhow!(
+            bail!(
                 "could not find metadata for pulsar topic {}",
                 topic.to_string()
-            ));
+            );
         }
 
         let body = hyper::body::aggregate(res).await?;

--- a/src/connector/src/source/pulsar/admin/client.rs
+++ b/src/connector/src/source/pulsar/admin/client.rs
@@ -12,9 +12,10 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use anyhow::Result;
+use anyhow::{anyhow, Result};
+use http::{Response, StatusCode};
 use hyper::body::Buf;
-use hyper::{Client, Uri};
+use hyper::{Body, Client, Uri};
 use serde_derive::{Deserialize, Serialize};
 
 use crate::source::pulsar::topic::Topic;
@@ -38,13 +39,17 @@ impl PulsarAdminClient {
     }
 
     pub async fn get_topic_metadata(&self, topic: &Topic) -> Result<PartitionedTopicMetadata> {
-        self.get(topic, "partitions").await
+        let res = self.http_get(topic, "partitions").await?;
+
+        if res.status() == StatusCode::NOT_FOUND {
+            return Err(anyhow!("could not found metadata for pulsar topic {}", topic.to_string()));
+        }
+
+        let body = hyper::body::aggregate(res).await?;
+        serde_json::from_reader(body.reader()).map_err(|e| anyhow!(e))
     }
 
-    pub async fn get<T>(&self, topic: &Topic, api: &str) -> Result<T>
-    where
-        T: for<'a> serde::Deserialize<'a>,
-    {
+    pub async fn http_get(&self, topic: &Topic, api: &str) -> Result<Response<Body>> {
         let client = Client::new();
 
         let url = format!(
@@ -56,7 +61,14 @@ impl PulsarAdminClient {
         );
 
         let url: Uri = url.parse()?;
-        let res = client.get(url).await?;
+        client.get(url).await.map_err(|e| anyhow!(e))
+    }
+
+    pub async fn get<T>(&self, topic: &Topic, api: &str) -> Result<T>
+        where
+            T: for<'a> serde::Deserialize<'a>,
+    {
+        let res = self.http_get(topic, api).await?;
         let body = hyper::body::aggregate(res).await?;
         let result: T = serde_json::from_reader(body.reader())?;
         Ok(result)
@@ -120,7 +132,7 @@ mod test {
             "/admin/v2/persistent/public/default/t2/partitions",
             "{\"partitions\":3}",
         )
-        .await;
+            .await;
 
         let client = PulsarAdminClient::new(server.uri());
 

--- a/src/connector/src/source/pulsar/admin/client.rs
+++ b/src/connector/src/source/pulsar/admin/client.rs
@@ -42,7 +42,10 @@ impl PulsarAdminClient {
         let res = self.http_get(topic, "partitions").await?;
 
         if res.status() == StatusCode::NOT_FOUND {
-            return Err(anyhow!("could not found metadata for pulsar topic {}", topic.to_string()));
+            return Err(anyhow!(
+                "could not find metadata for pulsar topic {}",
+                topic.to_string()
+            ));
         }
 
         let body = hyper::body::aggregate(res).await?;
@@ -65,8 +68,8 @@ impl PulsarAdminClient {
     }
 
     pub async fn get<T>(&self, topic: &Topic, api: &str) -> Result<T>
-        where
-            T: for<'a> serde::Deserialize<'a>,
+    where
+        T: for<'a> serde::Deserialize<'a>,
     {
         let res = self.http_get(topic, api).await?;
         let body = hyper::body::aggregate(res).await?;
@@ -132,7 +135,7 @@ mod test {
             "/admin/v2/persistent/public/default/t2/partitions",
             "{\"partitions\":3}",
         )
-            .await;
+        .await;
 
         let client = PulsarAdminClient::new(server.uri());
 

--- a/src/connector/src/source/pulsar/enumerator/client.rs
+++ b/src/connector/src/source/pulsar/enumerator/client.rs
@@ -56,7 +56,9 @@ impl SplitEnumerator for PulsarSplitEnumerator {
             Some("latest") => PulsarEnumeratorOffset::Latest,
             None => PulsarEnumeratorOffset::Earliest,
             _ => {
-                bail!("properties `startup_mode` only support earliest and latest or leave it empty");
+                bail!(
+                    "properties `startup_mode` only support earliest and latest or leave it empty"
+                );
             }
         };
 
@@ -80,7 +82,11 @@ impl SplitEnumerator for PulsarSplitEnumerator {
         let topic_metadata = self.admin_client.get_topic_metadata(&self.topic).await?;
         // note: may check topic exists by get stats
         if topic_metadata.partitions < 0 {
-            bail!("illegal metadata {:?} for pulsar topic {}",topic_metadata.partitions,self.topic.to_string());
+            bail!(
+                "illegal metadata {:?} for pulsar topic {}",
+                topic_metadata.partitions,
+                self.topic.to_string()
+            );
         }
 
         let splits = if topic_metadata.partitions > 0 {
@@ -166,7 +172,7 @@ mod test {
             "/admin/v2/persistent/public/default/t/partitions",
             "{\"partitions\":3}",
         )
-            .await;
+        .await;
 
         let prop = PulsarProperties {
             topic: "t".to_string(),
@@ -192,7 +198,7 @@ mod test {
             "/admin/v2/persistent/public/default/t/partitions",
             "{\"partitions\":0}",
         )
-            .await;
+        .await;
 
         let prop = PulsarProperties {
             topic: "t".to_string(),

--- a/src/connector/src/source/pulsar/mod.rs
+++ b/src/connector/src/source/pulsar/mod.rs
@@ -24,7 +24,7 @@ pub use split::*;
 
 pub const PULSAR_CONNECTOR: &str = "pulsar";
 
-#[derive(Clone, Debug, Deserialize, Default)]
+#[derive(Clone, Debug, Deserialize)]
 pub struct PulsarProperties {
     #[serde(rename = "pulsar.topic")]
     pub topic: String,

--- a/src/connector/src/source/pulsar/mod.rs
+++ b/src/connector/src/source/pulsar/mod.rs
@@ -24,7 +24,7 @@ pub use split::*;
 
 pub const PULSAR_CONNECTOR: &str = "pulsar";
 
-#[derive(Clone, Debug, Deserialize)]
+#[derive(Clone, Debug, Deserialize, Default)]
 pub struct PulsarProperties {
     #[serde(rename = "pulsar.topic")]
     pub topic: String,


### PR DESCRIPTION
I hereby agree to the terms of the [Singularity Data, Inc. Contributor License Agreement](https://gist.github.com/skyzh/0663682a70b0edde7ae991492f2314cb#file-s9y_cla).

## What's changed and what's your intention?

***PLEASE DO NOT LEAVE THIS EMPTY !!!***

This PR fixes an issue with Pulsar split enumerator regarding non-partitioned-topic

The previous method to determine if a topic is partitioned was based on the `-partition-` suffix, which was wrong, now the `partitions` field in the metadata is used to determine.

## Checklist

- [x] I have written necessary rustdoc comments
- [x] I have added necessary unit tests and integration tests
- [x] All checks passed in `./risedev check` (or alias, `./risedev c`)

## Documentation

If your pull request contains user-facing changes, please specify the types of the changes, and create a release note. Otherwise, please feel free to remove this section.

### Types of user-facing changes

Please keep the types that apply to your changes, and remove those that do not apply.

* Installation and deployment 
* Connector (sources & sinks)
* SQL commands, functions, and operators
* RisingWave cluster configuration changes
* Other (please specify in the release note below)

### Release note

Please create a release note for your changes. In the release note, focus on the impact on users, and mention the environment or conditions where the impact may occur.

## Refer to a related PR or issue link (optional)
