### PR TITLE
ci(regress test): enable regress test for RisingWave

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -52,3 +52,5 @@ risedev-components.user.env
 riselab-components.user.env
 risedev-compose.yml
 ft.txt
+# generated output from regress tests
+src/tests/regress/output/*

--- a/ci/plugins/upload-failure-logs/hooks/post-command
+++ b/ci/plugins/upload-failure-logs/hooks/post-command
@@ -7,4 +7,11 @@ if [ $BUILDKITE_COMMAND_EXIT_STATUS -ne 0 ]; then
   zip -q -r risedev-logs.zip risedev-logs/
   buildkite-agent artifact upload "risedev-logs/*"
   buildkite-agent artifact upload risedev-logs.zip
+  REGRESS_TEST_DIR="$PWD/src/tests/regress/output/results/"
+  if [ -d "$REGRESS_TEST_DIR" ]; then
+    mkdir regress-test-logs && cp src/tests/regress/output/results/* regress-test-logs/
+    zip -q -r regress-test.zip regress-test-logs/
+    buildkite-agent artifact upload "regress-test-logs/*"
+    buildkite-agent artifact upload regress-test-logs.zip
+  fi
 fi

--- a/ci/workflows/main.yml
+++ b/ci/workflows/main.yml
@@ -111,6 +111,19 @@ steps:
     timeout_in_minutes: 5
     retry: *auto-retry
 
+  - label: "regress test"
+    command: "ci/scripts/regress-test.sh"
+    depends_on: "build"
+    plugins:
+      - gencer/cache#v2.4.10: *cargo-cache
+      - docker-compose#v3.9.0:
+          run: rw-build-env
+          config: ci/docker-compose.yml
+          mount-buildkite-agent: true
+      - ./ci/plugins/upload-failure-logs
+    timeout_in_minutes: 5
+    retry: *auto-retry
+
   - label: "unit test"
     command: "ci/scripts/unit-test.sh"
     plugins:

--- a/ci/workflows/pull-request.yml
+++ b/ci/workflows/pull-request.yml
@@ -95,6 +95,19 @@ steps:
     timeout_in_minutes: 5
     retry: *auto-retry
 
+  - label: "regress test"
+    command: "ci/scripts/regress-test.sh"
+    depends_on: "build"
+    plugins:
+      - gencer/cache#v2.4.10: *cargo-cache
+      - docker-compose#v3.9.0:
+          run: rw-build-env
+          config: ci/docker-compose.yml
+          mount-buildkite-agent: true
+      - ./ci/plugins/upload-failure-logs
+    timeout_in_minutes: 5
+    retry: *auto-retry
+
   - label: "unit test"
     command: "ci/scripts/unit-test.sh"
     plugins:

--- a/src/tests/regress/src/file.rs
+++ b/src/tests/regress/src/file.rs
@@ -80,6 +80,15 @@ impl FileManager {
             .join(format!("{}.out", test_name)))
     }
 
+    /// Try to find the error output file of `test_name`.
+    pub(crate) fn error_of(&self, test_name: &str) -> anyhow::Result<PathBuf> {
+        Ok(self
+            .opts
+            .absolutized_output_dir()?
+            .join("results")
+            .join(format!("{}.err", test_name)))
+    }
+
     /// Try to find the diff file of `test_name`.
     pub(crate) fn diff_of(&self, test_name: &str) -> anyhow::Result<PathBuf> {
         Ok(self


### PR DESCRIPTION
I hereby agree to the terms of the [Singularity Data, Inc. Contributor License Agreement](https://gist.github.com/skyzh/0663682a70b0edde7ae991492f2314cb#file-s9y_cla).

## What's changed and what's your intention?

- Summarize your change (**mandatory**)
   Enable regress test for RisingWave in CI.
- How does this PR work? Need a brief introduction for the changed logic (optional)
   Add `regress-test.sh` script and invoke it in both main.yml and pull-request.yml
   Use `Stdio::piped()` instead of an input file for the command `psql`.
- Describe any limitations of the current code (optional)
   In the future, we want to let PostgreSQL also run the regress test to validate our test cases are correct.
   Also, we want to collect the failure logs into a `.zip`.


## Checklist

~- [ ] I have written necessary rustdoc comments~
- [x] I have added necessary unit tests and integration tests
- [x] All checks passed in `./risedev check` (or alias, `./risedev c`)

## Refer to a related PR or issue link (optional)
