### PR TITLE
feat(sqlsmith): Provide workaround for deterministic e2e test

### DIFF
--- a/src/tests/sqlsmith/src/bin/main.rs
+++ b/src/tests/sqlsmith/src/bin/main.rs
@@ -203,7 +203,12 @@ async fn main() {
         }
     });
 
-    let mut rng = rand::thread_rng();
+    let mut rng;
+    if let Ok(x) = env::var("RW_RANDOM_SEED_SQLSMITH") && x == "true" {
+        rng = rand::rngs::SmallRng::from_entropy();
+    } else {
+        rng = rand::rngs::SmallRng::seed_from_u64(0);
+    }
 
     let (tables, mviews) = create_tables(&mut rng, &opt, &client).await;
 


### PR DESCRIPTION
I hereby agree to the terms of the [Singularity Data, Inc. Contributor License Agreement](https://gist.github.com/skyzh/0663682a70b0edde7ae991492f2314cb#file-s9y_cla).

## What's changed and what's your intention?

***PLEASE DO NOT LEAVE THIS EMPTY !!!***

Please explain **IN DETAIL** what the changes are in this PR and why they are needed:

- Summarize your change (**mandatory**)
  Workaround to allow deterministic e2e testing. 
- Limitations
  There might still be other sources of randomness: https://github.com/singularity-data/risingwave/issues/4002#issuecomment-1188642563. A complete solution is to use madsim. For now this will do.

- TODO
  - [ ] Look for usages of hashmaps and refactor accordingly: https://github.com/singularity-data/risingwave/issues/4002#issuecomment-1188654074
  - [ ] Ensure it runs deterministically locally.

## Checklist

- [ ] I have written necessary rustdoc comments
- [ ] I have added necessary unit tests and integration tests
- [ ] All checks passed in `./risedev check` (or alias, `./risedev c`)


## Documentation

If your pull request contains user-facing changes, please specify the types of the changes, and create a release note. Otherwise, please feel free to remove this section.

### Types of user-facing changes

Please keep the types that apply to your changes, and remove those that do not apply.

* Installation and deployment 
* Connector (sources & sinks)
* SQL commands, functions, and operators
* RisingWave cluster configuration changes
* Other (please specify in the release note below)

### Release note

Please create a release note for your changes. In the release note, focus on the impact on users, and mention the environment or conditions where the impact may occur.

## Refer to a related PR or issue link (optional)

Workaround for #4002.