### PR TITLE
feat(sqlsmith): generate `with`

### DIFF
--- a/src/tests/sqlsmith/src/lib.rs
+++ b/src/tests/sqlsmith/src/lib.rs
@@ -329,7 +329,7 @@ impl<'a, R: Rng> SqlGenerator<'a, R> {
     }
 
     fn gen_from(&mut self, with_tables: Vec<Table>) -> Vec<TableWithJoins> {
-        // Cross join with `with` fails.
+        // Cross join with `with` fails. Hence we generate it in isolation.
         // Tracked in: <https://github.com/singularity-data/risingwave/issues/4025>
         if !with_tables.is_empty() {
             let with_table = with_tables
@@ -396,7 +396,7 @@ impl<'a, R: Rng> SqlGenerator<'a, R> {
 
     /// Provide recursion bounds.
     pub(crate) fn can_recurse(&mut self) -> bool {
-        self.rng.gen_bool(0.2)
+        self.rng.gen_bool(0.3)
     }
 }
 

--- a/src/tests/sqlsmith/src/lib.rs
+++ b/src/tests/sqlsmith/src/lib.rs
@@ -329,9 +329,8 @@ impl<'a, R: Rng> SqlGenerator<'a, R> {
     }
 
     fn gen_from(&mut self, with_tables: Vec<Table>) -> Vec<TableWithJoins> {
-        // Logical Join fails, not exactly sure how.
-        // Only happens when generating with clause along with another table.
-        // Tracked in: <TODO>
+        // Cross join with `with` fails.
+        // Tracked in: <https://github.com/singularity-data/risingwave/issues/4025>
         if !with_tables.is_empty() {
             let with_table = with_tables
                 .choose(&mut self.rng)

--- a/src/tests/sqlsmith/src/lib.rs
+++ b/src/tests/sqlsmith/src/lib.rs
@@ -203,7 +203,7 @@ impl<'a, R: Rng> SqlGenerator<'a, R> {
             false => {
                 let (with, tables) = self.gen_with_inner();
                 (Some(with), tables)
-            },
+            }
         }
     }
 
@@ -221,10 +221,13 @@ impl<'a, R: Rng> SqlGenerator<'a, R> {
             name: alias.name.value,
             columns: query_schema,
         }];
-        (With {
-            recursive: false,
-            cte_tables: vec![cte],
-        }, with_tables)
+        (
+            With {
+                recursive: false,
+                cte_tables: vec![cte],
+            },
+            with_tables,
+        )
     }
 
     fn gen_set_expr(&mut self, with_tables: Vec<Table>) -> (SetExpr, Vec<Column>) {
@@ -329,7 +332,9 @@ impl<'a, R: Rng> SqlGenerator<'a, R> {
         let mut from = if with_tables.is_empty() {
             vec![self.gen_from_relation()]
         } else {
-            let with_table = with_tables.choose(&mut self.rng).expect("with tables should not be empty");
+            let with_table = with_tables
+                .choose(&mut self.rng)
+                .expect("with tables should not be empty");
             vec![create_table_with_joins_from_table(with_table)]
         };
         if self.is_mview {

--- a/src/tests/sqlsmith/src/lib.rs
+++ b/src/tests/sqlsmith/src/lib.rs
@@ -141,6 +141,7 @@ impl<'a, R: Rng> SqlGenerator<'a, R> {
         (mview, table)
     }
 
+    /// Returns query expression and query schema
     fn gen_query(&mut self) -> (Query, Vec<Column>) {
         let with = self.gen_with();
         let (query, schema) = self.gen_set_expr();
@@ -166,7 +167,7 @@ impl<'a, R: Rng> SqlGenerator<'a, R> {
 
     fn gen_with_inner(&mut self) -> With {
         let alias = self.gen_alias_with_prefix("with");
-        let query = todo!();
+        let (query, query_schema) = self.gen_query();
         let from = todo!();
         let cte = Cte {
             alias,

--- a/src/tests/sqlsmith/src/lib.rs
+++ b/src/tests/sqlsmith/src/lib.rs
@@ -168,12 +168,19 @@ impl<'a, R: Rng> SqlGenerator<'a, R> {
     fn gen_with_inner(&mut self) -> With {
         let alias = self.gen_alias_with_prefix("with");
         let (query, query_schema) = self.gen_query();
-        let from = todo!();
+        let from = None;
         let cte = Cte {
-            alias,
+            alias: alias.clone(),
             query,
             from,
         };
+
+        let table = Table {
+            name: alias.name.value,
+            columns: query_schema,
+        };
+        self.add_relation_to_context(table);
+
         With {
             recursive: false,
             cte_tables: vec![cte],

--- a/src/tests/sqlsmith/src/lib.rs
+++ b/src/tests/sqlsmith/src/lib.rs
@@ -186,6 +186,15 @@ impl<'a, R: Rng> SqlGenerator<'a, R> {
         )
     }
 
+    /// Generates a query with local context.
+    /// Used by `WITH`, (and perhaps subquery should use this too)
+    fn gen_local_query(&mut self) -> (Query, Vec<Column>) {
+        let old_ctxt = self.new_local_ctxt();
+        let t = self.gen_query();
+        self.restore_ctxt(old_ctxt);
+        t
+    }
+
     fn gen_with(&mut self) -> Option<With> {
         match self.flip_coin() {
             true => None,
@@ -195,7 +204,7 @@ impl<'a, R: Rng> SqlGenerator<'a, R> {
 
     fn gen_with_inner(&mut self) -> With {
         let alias = self.gen_alias_with_prefix("with");
-        let (query, query_schema) = self.gen_query();
+        let (query, query_schema) = self.gen_local_query();
         let from = None;
         let cte = Cte {
             alias: alias.clone(),

--- a/src/tests/sqlsmith/src/lib.rs
+++ b/src/tests/sqlsmith/src/lib.rs
@@ -171,7 +171,6 @@ impl<'a, R: Rng> SqlGenerator<'a, R> {
     }
 
     /// Generates a simple query which will not recurse.
-    /// e.g. through `gen_with` or other generated parts of the query.
     fn gen_simple_query(&mut self) -> (Query, Vec<Column>) {
         let with_tables = vec![];
         let (query, schema) = self.gen_set_expr(with_tables);
@@ -193,7 +192,7 @@ impl<'a, R: Rng> SqlGenerator<'a, R> {
     fn gen_local_query(&mut self) -> (Query, Vec<Column>) {
         let old_ctxt = self.new_local_ctxt();
         let t = self.gen_query();
-        self.restore_ctxt(old_ctxt);
+        self.restore_context(old_ctxt);
         t
     }
 

--- a/src/tests/sqlsmith/src/lib.rs
+++ b/src/tests/sqlsmith/src/lib.rs
@@ -165,7 +165,7 @@ impl<'a, R: Rng> SqlGenerator<'a, R> {
     }
 
     fn gen_with_inner(&mut self) -> With {
-        let alias = todo!();
+        let alias = self.gen_alias_with_prefix("with");
         let query = todo!();
         let from = todo!();
         let cte = Cte {

--- a/src/tests/sqlsmith/src/lib.rs
+++ b/src/tests/sqlsmith/src/lib.rs
@@ -30,6 +30,7 @@ mod relation;
 mod scalar;
 mod time_window;
 mod utils;
+use crate::utils::create_table_with_joins_from_table;
 
 #[derive(Clone, Debug)]
 pub struct Table {
@@ -325,17 +326,22 @@ impl<'a, R: Rng> SqlGenerator<'a, R> {
     }
 
     fn gen_from(&mut self, with_tables: Vec<Table>) -> Vec<TableWithJoins> {
+        let mut from = if with_tables.is_empty() {
+            vec![self.gen_from_relation()]
+        } else {
+            let with_table = with_tables.choose(&mut self.rng).expect("with tables should not be empty");
+            vec![create_table_with_joins_from_table(with_table)]
+        };
         if self.is_mview {
-            // TODO: These constraints are workarounds required for mview.
+            // TODO: These constraints are workarounds required by mview.
             // Tracked by: <https://github.com/singularity-data/risingwave/issues/4024>.
             assert!(with_tables.len() <= 1);
             assert!(!self.tables.is_empty());
-            return vec![self.gen_from_relation(&with_tables)];
+            return from;
         }
-        let mut from = vec![];
-        for _ in 0..self.tables.len() {
+        for _ in 1..self.tables.len() {
             if self.flip_coin() {
-                from.push(self.gen_from_relation(&with_tables));
+                from.push(self.gen_from_relation());
             }
         }
         from

--- a/src/tests/sqlsmith/src/lib.rs
+++ b/src/tests/sqlsmith/src/lib.rs
@@ -29,6 +29,7 @@ pub use expr::print_function_table;
 mod relation;
 mod scalar;
 mod time_window;
+mod utils;
 
 #[derive(Clone, Debug)]
 pub struct Table {

--- a/src/tests/sqlsmith/src/lib.rs
+++ b/src/tests/sqlsmith/src/lib.rs
@@ -20,7 +20,7 @@ use rand::Rng;
 use risingwave_frontend::binder::bind_data_type;
 use risingwave_frontend::expr::DataTypeName;
 use risingwave_sqlparser::ast::{
-    BinaryOperator, ColumnDef, Expr, Ident, Join, JoinConstraint, JoinOperator, ObjectName,
+    BinaryOperator, ColumnDef, Cte, Expr, Ident, Join, JoinConstraint, JoinOperator, ObjectName,
     OrderByExpr, Query, Select, SelectItem, SetExpr, Statement, TableWithJoins, Value, With,
 };
 
@@ -157,7 +157,25 @@ impl<'a, R: Rng> SqlGenerator<'a, R> {
     }
 
     fn gen_with(&mut self) -> Option<With> {
-        None
+        match self.flip_coin() {
+            true => None,
+            false => Some(self.gen_with_inner()),
+        }
+    }
+
+    fn gen_with_inner(&mut self) -> With {
+        let alias = todo!();
+        let query = todo!();
+        let from = todo!();
+        let cte = Cte {
+            alias,
+            query,
+            from,
+        };
+        With {
+            recursive: false,
+            cte_tables: vec![cte],
+        }
     }
 
     fn gen_set_expr(&mut self) -> (SetExpr, Vec<Column>) {

--- a/src/tests/sqlsmith/src/relation.rs
+++ b/src/tests/sqlsmith/src/relation.rs
@@ -32,7 +32,7 @@ fn create_join_on_clause(left: String, right: String) -> Expr {
 
 impl<'a, R: Rng> SqlGenerator<'a, R> {
     /// A relation specified in the FROM clause.
-    pub(crate) fn gen_from_relation(&mut self) -> TableWithJoins {
+    pub(crate) fn gen_from_relation(&mut self, with_tables: &[Table]) -> TableWithJoins {
         match self.rng.gen_range(0..=9) {
             0..=8 => self.gen_simple_table(),
             9..=9 => self.gen_time_window_func(),

--- a/src/tests/sqlsmith/src/relation.rs
+++ b/src/tests/sqlsmith/src/relation.rs
@@ -32,7 +32,7 @@ fn create_join_on_clause(left: String, right: String) -> Expr {
 
 impl<'a, R: Rng> SqlGenerator<'a, R> {
     /// A relation specified in the FROM clause.
-    pub(crate) fn gen_from_relation(&mut self, with_tables: &[Table]) -> TableWithJoins {
+    pub(crate) fn gen_from_relation(&mut self) -> TableWithJoins {
         match self.rng.gen_range(0..=9) {
             0..=8 => self.gen_simple_table(),
             9..=9 => self.gen_time_window_func(),

--- a/src/tests/sqlsmith/src/time_window.rs
+++ b/src/tests/sqlsmith/src/time_window.rs
@@ -103,11 +103,6 @@ fn create_tvf(name: &str, alias: TableAlias, args: Vec<FunctionArg>) -> TableWit
     }
 }
 
-/// Create `FunctionArg` from an `Expr`.
-fn create_function_arg_from_expr(expr: Expr) -> FunctionArg {
-    FunctionArg::Unnamed(FunctionArgExpr::Expr(expr))
-}
-
 fn is_timestamp_col(c: &Column) -> bool {
     c.data_type == DataTypeName::Timestamp || c.data_type == DataTypeName::Timestampz
 }

--- a/src/tests/sqlsmith/src/time_window.rs
+++ b/src/tests/sqlsmith/src/time_window.rs
@@ -20,7 +20,7 @@ use risingwave_sqlparser::ast::{
     DataType, FunctionArg, ObjectName, TableAlias, TableFactor, TableWithJoins,
 };
 
-use crate::utils::{create_alias, create_args};
+use crate::utils::{create_args, create_table_alias};
 use crate::{Column, Expr, SqlGenerator, Table};
 
 impl<'a, R: Rng> SqlGenerator<'a, R> {
@@ -40,7 +40,7 @@ impl<'a, R: Rng> SqlGenerator<'a, R> {
             .choose(&mut self.rng)
             .expect("seeded tables all do not have timestamp");
         let table_name = self.create_table_name_with_prefix("tumble");
-        let alias = create_alias(&table_name);
+        let alias = create_table_alias(&table_name);
 
         let name = Expr::Identifier(source_table_name.as_str().into());
         // TODO: Currently only literal size expr supported.
@@ -65,7 +65,7 @@ impl<'a, R: Rng> SqlGenerator<'a, R> {
             .choose(&mut self.rng)
             .expect("seeded tables all do not have timestamp");
         let table_name = self.create_table_name_with_prefix("hop");
-        let alias = create_alias(&table_name);
+        let alias = create_table_alias(&table_name);
 
         let time_col = time_cols.choose(&mut self.rng).unwrap();
 

--- a/src/tests/sqlsmith/src/time_window.rs
+++ b/src/tests/sqlsmith/src/time_window.rs
@@ -21,6 +21,7 @@ use risingwave_sqlparser::ast::{
 };
 
 use crate::{Column, Expr, SqlGenerator, Table};
+use crate::utils::{create_alias, create_args};
 
 impl<'a, R: Rng> SqlGenerator<'a, R> {
     /// Generates time window functions.
@@ -86,24 +87,6 @@ impl<'a, R: Rng> SqlGenerator<'a, R> {
         self.add_relation_to_context(table);
 
         relation
-    }
-
-    fn create_table_name_with_prefix(&self, prefix: &str) -> String {
-        format!("{}_{}", prefix, &self.bound_relations.len())
-    }
-}
-
-fn create_args(arg_exprs: Vec<Expr>) -> Vec<FunctionArg> {
-    arg_exprs
-        .into_iter()
-        .map(create_function_arg_from_expr)
-        .collect()
-}
-
-fn create_alias(table_name: &str) -> TableAlias {
-    TableAlias {
-        name: table_name.into(),
-        columns: vec![],
     }
 }
 

--- a/src/tests/sqlsmith/src/time_window.rs
+++ b/src/tests/sqlsmith/src/time_window.rs
@@ -17,11 +17,11 @@ use rand::prelude::SliceRandom;
 use rand::Rng;
 use risingwave_frontend::expr::DataTypeName;
 use risingwave_sqlparser::ast::{
-    DataType, FunctionArg, FunctionArgExpr, ObjectName, TableAlias, TableFactor, TableWithJoins,
+    DataType, FunctionArg, ObjectName, TableAlias, TableFactor, TableWithJoins,
 };
 
-use crate::{Column, Expr, SqlGenerator, Table};
 use crate::utils::{create_alias, create_args};
+use crate::{Column, Expr, SqlGenerator, Table};
 
 impl<'a, R: Rng> SqlGenerator<'a, R> {
     /// Generates time window functions.

--- a/src/tests/sqlsmith/src/utils.rs
+++ b/src/tests/sqlsmith/src/utils.rs
@@ -1,0 +1,53 @@
+// Copyright 2022 Singularity Data
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use itertools::Itertools;
+use rand::prelude::SliceRandom;
+use rand::Rng;
+use risingwave_frontend::expr::DataTypeName;
+use risingwave_sqlparser::ast::{
+    DataType, FunctionArg, FunctionArgExpr, ObjectName, TableAlias, TableFactor, TableWithJoins,
+};
+
+use crate::{Column, Expr, SqlGenerator, Table};
+
+impl<'a, R: Rng> SqlGenerator<'a, R> {
+    pub(crate) fn create_table_name_with_prefix(&self, prefix: &str) -> String {
+        format!("{}_{}", prefix, &self.bound_relations.len())
+    }
+
+    pub(crate) fn gen_alias_with_prefix(&self, prefix: &str) -> TableAlias {
+        let name = &self.create_table_name_with_prefix(prefix);
+        create_alias(name)
+    }
+}
+
+pub (crate) fn create_alias(table_name: &str) -> TableAlias {
+    TableAlias {
+        name: table_name.into(),
+        columns: vec![],
+    }
+}
+
+pub (crate) fn create_args(arg_exprs: Vec<Expr>) -> Vec<FunctionArg> {
+    arg_exprs
+        .into_iter()
+        .map(create_function_arg_from_expr)
+        .collect()
+}
+
+/// Create `FunctionArg` from an `Expr`.
+fn create_function_arg_from_expr(expr: Expr) -> FunctionArg {
+    FunctionArg::Unnamed(FunctionArgExpr::Expr(expr))
+}

--- a/src/tests/sqlsmith/src/utils.rs
+++ b/src/tests/sqlsmith/src/utils.rs
@@ -13,10 +13,10 @@
 // limitations under the License.
 
 use rand::Rng;
-use risingwave_sqlparser::ast::{FunctionArg, FunctionArgExpr, TableAlias};
+use risingwave_sqlparser::ast::{FunctionArg, FunctionArgExpr, TableAlias, TableFactor, TableWithJoins};
 
 use std::mem;
-use crate::{Column, Expr, Table, SqlGenerator};
+use crate::{Column, Expr, ObjectName, Ident, Table, SqlGenerator};
 
 type Context = (Vec<Column>, Vec<Table>);
 
@@ -42,6 +42,21 @@ impl<'a, R: Rng> SqlGenerator<'a, R> {
     pub(crate) fn gen_alias_with_prefix(&self, prefix: &str) -> TableAlias {
         let name = &self.create_table_name_with_prefix(prefix);
         create_alias(name)
+    }
+}
+
+pub(crate) fn create_table_factor_from_table(table: &Table) -> TableFactor {
+    TableFactor::Table {
+        name: ObjectName(vec![Ident::new(&table.name)]),
+        alias: None,
+        args: vec![],
+    }
+}
+
+pub(crate) fn create_table_with_joins_from_table(table: &Table) -> TableWithJoins {
+    TableWithJoins {
+        relation: create_table_factor_from_table(table),
+        joins: vec![],
     }
 }
 

--- a/src/tests/sqlsmith/src/utils.rs
+++ b/src/tests/sqlsmith/src/utils.rs
@@ -12,15 +12,10 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use itertools::Itertools;
-use rand::prelude::SliceRandom;
 use rand::Rng;
-use risingwave_frontend::expr::DataTypeName;
-use risingwave_sqlparser::ast::{
-    DataType, FunctionArg, FunctionArgExpr, ObjectName, TableAlias, TableFactor, TableWithJoins,
-};
+use risingwave_sqlparser::ast::{FunctionArg, FunctionArgExpr, TableAlias};
 
-use crate::{Column, Expr, SqlGenerator, Table};
+use crate::{Expr, SqlGenerator};
 
 impl<'a, R: Rng> SqlGenerator<'a, R> {
     pub(crate) fn create_table_name_with_prefix(&self, prefix: &str) -> String {
@@ -33,14 +28,14 @@ impl<'a, R: Rng> SqlGenerator<'a, R> {
     }
 }
 
-pub (crate) fn create_alias(table_name: &str) -> TableAlias {
+pub(crate) fn create_alias(table_name: &str) -> TableAlias {
     TableAlias {
         name: table_name.into(),
         columns: vec![],
     }
 }
 
-pub (crate) fn create_args(arg_exprs: Vec<Expr>) -> Vec<FunctionArg> {
+pub(crate) fn create_args(arg_exprs: Vec<Expr>) -> Vec<FunctionArg> {
     arg_exprs
         .into_iter()
         .map(create_function_arg_from_expr)

--- a/src/tests/sqlsmith/src/utils.rs
+++ b/src/tests/sqlsmith/src/utils.rs
@@ -45,7 +45,7 @@ impl<'a, R: Rng> SqlGenerator<'a, R> {
 
     pub(crate) fn gen_alias_with_prefix(&self, prefix: &str) -> TableAlias {
         let name = &self.create_table_name_with_prefix(prefix);
-        create_alias(name)
+        create_table_alias(name)
     }
 }
 

--- a/src/tests/sqlsmith/src/utils.rs
+++ b/src/tests/sqlsmith/src/utils.rs
@@ -12,11 +12,14 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use rand::Rng;
-use risingwave_sqlparser::ast::{FunctionArg, FunctionArgExpr, TableAlias, TableFactor, TableWithJoins};
-
 use std::mem;
-use crate::{Column, Expr, ObjectName, Ident, Table, SqlGenerator};
+
+use rand::Rng;
+use risingwave_sqlparser::ast::{
+    FunctionArg, FunctionArgExpr, TableAlias, TableFactor, TableWithJoins,
+};
+
+use crate::{Column, Expr, Ident, ObjectName, SqlGenerator, Table};
 
 type Context = (Vec<Column>, Vec<Table>);
 
@@ -27,6 +30,7 @@ impl<'a, R: Rng> SqlGenerator<'a, R> {
         let current_bound_columns = mem::take(&mut self.bound_columns);
         (current_bound_columns, current_bound_relations)
     }
+
     pub(crate) fn restore_ctxt(&mut self, (old_cols, old_rels): Context) {
         self.bound_relations = old_rels;
         self.bound_columns = old_cols;

--- a/src/tests/sqlsmith/src/utils.rs
+++ b/src/tests/sqlsmith/src/utils.rs
@@ -64,7 +64,7 @@ pub(crate) fn create_table_with_joins_from_table(table: &Table) -> TableWithJoin
     }
 }
 
-pub(crate) fn create_alias(table_name: &str) -> TableAlias {
+pub(crate) fn create_table_alias(table_name: &str) -> TableAlias {
     TableAlias {
         name: table_name.into(),
         columns: vec![],

--- a/src/tests/sqlsmith/src/utils.rs
+++ b/src/tests/sqlsmith/src/utils.rs
@@ -31,7 +31,7 @@ impl<'a, R: Rng> SqlGenerator<'a, R> {
         (current_bound_columns, current_bound_relations)
     }
 
-    pub(crate) fn restore_ctxt(&mut self, (old_cols, old_rels): Context) {
+    pub(crate) fn restore_context(&mut self, (old_cols, old_rels): Context) {
         self.bound_relations = old_rels;
         self.bound_columns = old_cols;
     }

--- a/src/tests/sqlsmith/src/utils.rs
+++ b/src/tests/sqlsmith/src/utils.rs
@@ -15,8 +15,25 @@
 use rand::Rng;
 use risingwave_sqlparser::ast::{FunctionArg, FunctionArgExpr, TableAlias};
 
-use crate::{Expr, SqlGenerator};
+use std::mem;
+use crate::{Column, Expr, Table, SqlGenerator};
 
+type Context = (Vec<Column>, Vec<Table>);
+
+/// Context utils
+impl<'a, R: Rng> SqlGenerator<'a, R> {
+    pub(crate) fn new_local_ctxt(&mut self) -> Context {
+        let current_bound_relations = mem::take(&mut self.bound_relations);
+        let current_bound_columns = mem::take(&mut self.bound_columns);
+        (current_bound_columns, current_bound_relations)
+    }
+    pub(crate) fn restore_ctxt(&mut self, (old_cols, old_rels): Context) {
+        self.bound_relations = old_rels;
+        self.bound_columns = old_cols;
+    }
+}
+
+/// Gen utils
 impl<'a, R: Rng> SqlGenerator<'a, R> {
     pub(crate) fn create_table_name_with_prefix(&self, prefix: &str) -> String {
         format!("{}_{}", prefix, &self.bound_relations.len())


### PR DESCRIPTION
I hereby agree to the terms of the [Singularity Data, Inc. Contributor License Agreement](https://gist.github.com/skyzh/0663682a70b0edde7ae991492f2314cb#file-s9y_cla).

## What's changed and what's your intention?

Ran sqlsmith e2e locally.

- Summarize your change (**mandatory**)
  Implement `gen_with`.
- How does this PR work? Need a brief introduction for the changed logic (optional)
  - Control complexity of `gen_query` by providing terminating branch. This is required because it is mutually recursive with `gen_with`.
  - Provide local context for selected query in generated with clause.
  - Pass `with_tables` to `gen_from`. Once we generate `with` clauses, we expect they are used in the `FROM` clause.
- Describe any limitations of the current code (optional)
  - Only generate simple with query, we only generate a single `CTE`. In the future can generate more complex queries if required.

## Checklist

- [x] I have written necessary rustdoc comments
- [x] I have added necessary unit tests and integration tests
- [x] All checks passed in `./risedev check` (or alias, `./risedev c`)

## Documentation

If your pull request contains user-facing changes, please specify the types of the changes, and create a release note. Otherwise, please feel free to remove this section.

### Types of user-facing changes

Please keep the types that apply to your changes, and remove those that do not apply.

* Installation and deployment 
* Connector (sources & sinks)
* SQL commands, functions, and operators
* RisingWave cluster configuration changes
* Other (please specify in the release note below)

### Release note

Please create a release note for your changes. In the release note, focus on the impact on users, and mention the environment or conditions where the impact may occur.

## Refer to a related PR or issue link (optional)

Closes #3959
Workaround for #4025 