### PR TITLE
[IGNORE ME] frontend(batch-scheduler): draft-pr for cancel running tasks.

### DIFF
--- a/src/frontend/src/scheduler/distributed/query.rs
+++ b/src/frontend/src/scheduler/distributed/query.rs
@@ -285,7 +285,10 @@ impl QueryRunner {
                             );
                         }
                     }
-                    // TODO: We should can cancel all scheduled stages here.
+                    for (_stage_id, stage_execution) in self.stage_executions.iter() {
+                        // TODO: spawn task and await them.
+                        stage_execution.stop().await
+                    }
                 }
                 rest => {
                     return Err(SchedulerError::NotImplemented(

--- a/src/rpc_client/src/compute_client.rs
+++ b/src/rpc_client/src/compute_client.rs
@@ -19,8 +19,8 @@ use risingwave_pb::batch_plan::{PlanFragment, TaskId, TaskOutputId};
 use risingwave_pb::task_service::exchange_service_client::ExchangeServiceClient;
 use risingwave_pb::task_service::task_service_client::TaskServiceClient;
 use risingwave_pb::task_service::{
-    CreateTaskRequest, CreateTaskResponse, ExecuteRequest, GetDataRequest, GetDataResponse,
-    GetStreamRequest, GetStreamResponse,
+    AbortTaskRequest, AbortTaskResponse, CreateTaskRequest, CreateTaskResponse, ExecuteRequest,
+    GetDataRequest, GetDataResponse, GetStreamRequest, GetStreamResponse,
 };
 use tonic::transport::{Channel, Endpoint};
 use tonic::Streaming;
@@ -110,5 +110,14 @@ impl ComputeClient {
 
     pub async fn execute(&self, req: ExecuteRequest) -> Result<Streaming<GetDataResponse>> {
         Ok(self.task_client.to_owned().execute(req).await?.into_inner())
+    }
+
+    pub async fn abort(&self, req: AbortTaskRequest) -> Result<AbortTaskResponse> {
+        Ok(self
+            .task_client
+            .to_owned()
+            .abort_task(req)
+            .await?
+            .into_inner())
     }
 }


### PR DESCRIPTION
I hereby agree to the terms of the [Singularity Data, Inc. Contributor License Agreement](https://gist.github.com/skyzh/0663682a70b0edde7ae991492f2314cb#file-s9y_cla).

## What's changed and what's your intention?

Follows current message passing scheme, The flow of cancel task is as follows.

1. `StageRunner 1` write Failed Message to channel 
2. `QueryRunner` get the message, call `.stop` on each `StageExecution` (2, 3, 4).
3. e.g. `StageExecution 2` write Stop Message to channel, notify `StageRunner 2`.
4. `StageRunner 2` will change `StageState` and call `abort_task` RPC to CN. 
5. `QueryRunner` wait on all StageExecution and StageRunner finish 3, 4. returned and mark this query as canceled.

## Checklist

- [ ] I have written necessary rustdoc comments
- [ ] I have added necessary unit tests and integration tests
- [ ] All checks passed in `./risedev check` (or alias, `./risedev c`)

## Documentation

If your pull request contains user-facing changes, please specify the types of the changes, and create a release note. Otherwise, please feel free to remove this section.

### Types of user-facing changes

Please keep the types that apply to your changes, and remove those that do not apply.

* Installation and deployment 
* Connector (sources & sinks)
* SQL commands, functions, and operators
* RisingWave cluster configuration changes
* Other (please specify in the release note below)

### Release note

Please create a release note for your changes. In the release note, focus on the impact on users, and mention the environment or conditions where the impact may occur.

## Refer to a related PR or issue link (optional)
