### PR TITLE
fix(nexmark): rename the field names to lower style

### DIFF
--- a/e2e_test/nexmark/create_tables.slt.part
+++ b/e2e_test/nexmark/create_tables.slt.part
@@ -1,31 +1,31 @@
 statement ok
 CREATE TABLE person (
-    id BIGINT,
-    name VARCHAR,
-    emailAddress VARCHAR,
-    creditCard VARCHAR,
-    city VARCHAR,
-    state VARCHAR,
-    dateTime TIMESTAMP
+    "id" BIGINT,
+    "name" VARCHAR,
+    "email_address" VARCHAR,
+    "credit_card" VARCHAR,
+    "city" VARCHAR,
+    "state" VARCHAR,
+    "date_time" TIMESTAMP
 );
 
 statement ok
 CREATE TABLE auction (
-    id BIGINT,
-    itemName VARCHAR,
-    description VARCHAR,
-    initialBid BIGINT,
-    reserve BIGINT,
-    dateTime TIMESTAMP,
-    expires TIMESTAMP,
-    seller BIGINT,
-    category BIGINT
+    "id" BIGINT,
+    "item_name" VARCHAR,
+    "description" VARCHAR,
+    "initial_bid" BIGINT,
+    "reserve" BIGINT,
+    "date_time" TIMESTAMP,
+    "expires" TIMESTAMP,
+    "seller" BIGINT,
+    "category" BIGINT
 );
 
 statement ok
 CREATE TABLE bid (
-    auction BIGINT,
-    bidder BIGINT,
-    price BIGINT,
-    dateTime TIMESTAMP
+    "auction" BIGINT,
+    "bidder" BIGINT,
+    "price" BIGINT,
+    "date_time" TIMESTAMP
 );

--- a/e2e_test/nexmark/insert_auction.slt.part
+++ b/e2e_test/nexmark/insert_auction.slt.part
@@ -1,11 +1,11 @@
 statement ok
 INSERT INTO auction (
     id,
-    itemName,
+    item_name,
     description,
-    initialBid,
+    initial_bid,
     reserve,
-    dateTime,
+    date_time,
     expires,
     seller,
     category

--- a/e2e_test/nexmark/insert_bid.slt.part
+++ b/e2e_test/nexmark/insert_bid.slt.part
@@ -3,7 +3,7 @@ INSERT INTO bid (
     auction,
     bidder,
     price,
-    dateTime
+    date_time
 ) VALUES
 (1000, 1001, 499920, '2015-07-15 00:00:01.001'),
 (1000, 1007, 12655, '2015-07-15 00:00:01.001'),

--- a/e2e_test/nexmark/insert_person.slt.part
+++ b/e2e_test/nexmark/insert_person.slt.part
@@ -2,11 +2,11 @@ statement ok
 INSERT INTO person (
     id,
     name,
-    emailAddress,
-    creditCard,
+    email_address,
+    credit_card,
     city,
     state,
-    dateTime
+    date_time
 ) VALUES
 (1000, 'vicky noris', 'vzbhp@wxv.com', '4355 0142 3460 9324', 'boise', 'ca', '2015-07-15 00:00:00'),
 (1001, 'peter smith', 'lf@sas.com', '1932 7149 7430 9595', 'cheyenne', 'ca', '2015-07-15 00:00:00.005'),

--- a/e2e_test/streaming/nexmark/views/q0.slt.part
+++ b/e2e_test/streaming/nexmark/views/q0.slt.part
@@ -1,4 +1,4 @@
 statement ok
 CREATE MATERIALIZED VIEW nexmark_q0
 AS
-SELECT auction, bidder, price, dateTime FROM bid;
+SELECT auction, bidder, price, date_time FROM bid;

--- a/e2e_test/streaming/nexmark/views/q1.slt.part
+++ b/e2e_test/streaming/nexmark/views/q1.slt.part
@@ -11,5 +11,5 @@ SELECT
     auction,
     bidder,
     0.908 * price as price,
-    dateTime
+    date_time
 FROM bid;

--- a/e2e_test/streaming/nexmark/views/q10.slt.part
+++ b/e2e_test/streaming/nexmark/views/q10.slt.part
@@ -1,3 +1,3 @@
 statement ok
 CREATE MATERIALIZED VIEW nexmark_q10 AS
-SELECT auction, bidder, price, dateTime, TO_CHAR(dateTime, 'YYYY-MM-DD') as date, TO_CHAR(dateTime, 'HH:MI') as time FROM bid;
+SELECT auction, bidder, price, date_time, TO_CHAR(date_time, 'YYYY-MM-DD') as date, TO_CHAR(date_time, 'HH:MI') as time FROM bid;

--- a/e2e_test/streaming/nexmark/views/q14.slt.part
+++ b/e2e_test/streaming/nexmark/views/q14.slt.part
@@ -6,16 +6,16 @@ SELECT
   0.908 * price as price,
   CASE
     WHEN
-      extract(hour from dateTime) >= 8 AND
-      extract(hour from dateTime) <= 18
+      extract(hour from date_time) >= 8 AND
+      extract(hour from date_time) <= 18
     THEN 'dayTime'
     WHEN
-      extract(hour from dateTime) <= 6 OR
-      extract(hour from dateTime) >= 20
+      extract(hour from date_time) <= 6 OR
+      extract(hour from date_time) >= 20
     THEN 'nightTime'
     ELSE 'otherTime'
   END AS bidTimeType,
-  dateTime
+  date_time
   -- extra
   -- TODO: count_char is an UDF, add it back when we support similar functionality.
   -- https://github.com/nexmark/nexmark/blob/master/nexmark-flink/src/main/java/com/github/nexmark/flink/udf/CountChar.java

--- a/e2e_test/streaming/nexmark/views/q4.slt.part
+++ b/e2e_test/streaming/nexmark/views/q4.slt.part
@@ -12,7 +12,7 @@ FROM (
         bid B
     WHERE 
         A.id = B.auction AND 
-        B.dateTime BETWEEN A.dateTime AND A.expires
+        B.date_time BETWEEN A.date_time AND A.expires
     GROUP BY 
         A.id, A.category
     ) Q

--- a/e2e_test/streaming/nexmark/views/q5.slt.part
+++ b/e2e_test/streaming/nexmark/views/q5.slt.part
@@ -9,7 +9,7 @@ FROM (
 		count(*) AS num, 
         window_start AS starttime
     FROM 
-        HOP(bid, dateTime, INTERVAL '2' SECOND, INTERVAL '10' SECOND)
+        HOP(bid, date_time, INTERVAL '2' SECOND, INTERVAL '10' SECOND)
     GROUP BY
     	window_start, 
 		bid.auction
@@ -22,7 +22,7 @@ JOIN (
 		SELECT
 			count(*) AS num,
 			window_start AS starttime_c
-		FROM HOP(bid, dateTime, INTERVAL '2' SECOND, INTERVAL '10' SECOND)
+		FROM HOP(bid, date_time, INTERVAL '2' SECOND, INTERVAL '10' SECOND)
 		GROUP BY
 			bid.auction,
 			window_start

--- a/e2e_test/streaming/nexmark/views/q7.slt.part
+++ b/e2e_test/streaming/nexmark/views/q7.slt.part
@@ -5,18 +5,18 @@ SELECT
     B.auction,
     B.price,
     B.bidder,
-    B.dateTime
+    B.date_time
 from
     bid B
     JOIN (
         SELECT
             MAX(price) AS maxprice,
-            window_end as dateTime
+            window_end as date_time
         FROM
-            TUMBLE(bid, dateTime, INTERVAL '10' SECOND)
+            TUMBLE(bid, date_time, INTERVAL '10' SECOND)
         GROUP BY
             window_end
     ) B1 ON B.price = B1.maxprice
 WHERE
-    B.dateTime BETWEEN B1.dateTime - INTERVAL '10' SECOND
-    AND B1.dateTime;
+    B.date_time BETWEEN B1.date_time - INTERVAL '10' SECOND
+    AND B1.date_time;

--- a/e2e_test/streaming/nexmark/views/q8.slt.part
+++ b/e2e_test/streaming/nexmark/views/q8.slt.part
@@ -13,7 +13,7 @@ FROM
             window_start AS starttime,
             window_end AS endtime
         FROM
-            TUMBLE(person, dateTime, INTERVAL '10' SECOND)
+            TUMBLE(person, date_time, INTERVAL '10' SECOND)
         GROUP BY
             id,
             name,
@@ -26,7 +26,7 @@ FROM
             window_start AS starttime,
             window_end AS endtime
         FROM
-            TUMBLE(auction, dateTime, INTERVAL '10' SECOND)
+            TUMBLE(auction, date_time, INTERVAL '10' SECOND)
         GROUP BY
             seller,
             window_start,

--- a/risedev.yml
+++ b/risedev.yml
@@ -6,7 +6,7 @@ risedev:
   # The default configuration will start 1 compute node, 1 meta node and 1 frontend.
   default:
     # If you want to use the local s3 storage, enable the following line
-    # - use: minio
+    - use: minio
 
     # If you want to use aws-s3, configure AK and SK in env var and enable the following lines:
     # - use: aws-s3
@@ -23,7 +23,7 @@ risedev:
     - use: frontend
 
     # If you want to enable compactor, uncomment the following line, and enable either minio or aws-s3 as well.
-    # - use: compactor
+    - use: compactor
 
     # If you want to enable metrics, uncomment those two lines.
     # - use: prometheus

--- a/risedev.yml
+++ b/risedev.yml
@@ -23,7 +23,7 @@ risedev:
     - use: frontend
 
     # If you want to enable compactor, uncomment the following line, and enable either minio or aws-s3 as well.
-    - use: compactor
+    # - use: compactor
 
     # If you want to enable metrics, uncomment those two lines.
     # - use: prometheus

--- a/risedev.yml
+++ b/risedev.yml
@@ -6,7 +6,7 @@ risedev:
   # The default configuration will start 1 compute node, 1 meta node and 1 frontend.
   default:
     # If you want to use the local s3 storage, enable the following line
-    - use: minio
+    # - use: minio
 
     # If you want to use aws-s3, configure AK and SK in env var and enable the following lines:
     # - use: aws-s3

--- a/src/connector/src/source/nexmark/source/event.rs
+++ b/src/connector/src/source/nexmark/source/event.rs
@@ -141,7 +141,6 @@ impl Event {
 /// Person represents a person submitting an item for auction and/or making a
 /// bid on an auction.
 #[derive(PartialEq, Eq, Clone, Debug, Serialize, Deserialize)]
-#[serde(rename_all = "camelCase")]
 pub struct Person {
     /// A person-unique integer ID.
     pub id: Id,
@@ -198,7 +197,6 @@ impl Person {
 
 /// Auction represents an item under auction.
 #[derive(PartialEq, Eq, Clone, Debug, Serialize, Deserialize)]
-#[serde(rename_all = "camelCase")]
 pub struct Auction {
     /// An auction-unique integer ID.
     pub id: Id,
@@ -291,7 +289,6 @@ impl Auction {
 
 /// Bid represents a bid for an item under auction.
 #[derive(PartialEq, Eq, Clone, Debug, Serialize, Deserialize)]
-#[serde(rename_all = "camelCase")]
 pub struct Bid {
     /// The ID of the auction this bid is for.
     pub auction: Id,
@@ -368,7 +365,7 @@ mod tests {
         let (event_2, _) = Event::new(0, &config, NEXMARK_BASE_TIME);
         assert_eq!(event_1, event_2);
 
-        let event_1_payload = r#"{"id":1000,"name":"vicky noris","emailAddress":"vzbhp@wxv.com","creditCard":"4355 0142 3460 9324","city":"boise","state":"ca","dateTime":"2015-07-15 00:00:00"}"#.to_string();
+        let event_1_payload = r#"{"id":1000,"name":"vicky noris","email_address":"vzbhp@wxv.com","credit_card":"4355 0142 3460 9324","city":"boise","state":"ca","date_time":"2015-07-15 00:00:00"}"#.to_string();
         assert_eq!(event_1.to_json(), event_1_payload);
         Ok(())
     }

--- a/src/frontend/test_runner/tests/testdata/nexmark.yaml
+++ b/src/frontend/test_runner/tests/testdata/nexmark.yaml
@@ -4,33 +4,33 @@
     CREATE TABLE person (
         id BIGINT,
         name VARCHAR,
-        emailAddress VARCHAR,
-        creditCard VARCHAR,
+        email_address VARCHAR,
+        credit_card VARCHAR,
         city VARCHAR,
         state VARCHAR,
-        dateTime TIMESTAMP
+        date_time TIMESTAMP
     );
 
     CREATE TABLE auction (
         id BIGINT,
-        itemName VARCHAR,
-        description VARCHAR,
-        initialBid BIGINT,
-        reserve BIGINT,
-        dateTime TIMESTAMP,
-        expires TIMESTAMP,
-        seller BIGINT,
-        category BIGINT
+        "item_name" VARCHAR,
+        "description" VARCHAR,
+        "initial_bid" BIGINT,
+        "reserve" BIGINT,
+        "date_time" TIMESTAMP,
+        "expires" TIMESTAMP,
+        "seller" BIGINT,
+        "category" BIGINT
     );
 
     CREATE TABLE bid (
-        auction BIGINT,
-        bidder BIGINT,
-        price BIGINT,
-        channel VARCHAR,
-        url VARCHAR,
-        dateTime TIMESTAMP,
-        extra VARCHAR
+        "auction" BIGINT,
+        "bidder" BIGINT,
+        "price" BIGINT,
+        "channel" VARCHAR,
+        "url" VARCHAR,
+        "date_time" TIMESTAMP,
+        "extra" VARCHAR
     );
 - id: nexmark_q0
   before:
@@ -38,18 +38,18 @@
   sql: |
     CREATE MATERIALIZED VIEW nexmark_q0
       AS
-    SELECT auction, bidder, price, dateTime FROM bid;
+    SELECT auction, bidder, price, date_time FROM bid;
 - id: nexmark_q0
   before:
     - create_tables
   sql: |
-    SELECT auction, bidder, price, dateTime FROM bid;
+    SELECT auction, bidder, price, date_time FROM bid;
   batch_plan: |
     BatchExchange { order: [], dist: Single }
-      BatchScan { table: bid, columns: [auction, bidder, price, datetime] }
+      BatchScan { table: bid, columns: [auction, bidder, price, date_time] }
   stream_plan: |
-    StreamMaterialize { columns: [auction, bidder, price, datetime, bid._row_id(hidden)], pk_columns: [bid._row_id] }
-      StreamTableScan { table: bid, columns: [auction, bidder, price, datetime, _row_id], pk_indices: [4] }
+    StreamMaterialize { columns: [auction, bidder, price, date_time, bid._row_id(hidden)], pk_columns: [bid._row_id] }
+      StreamTableScan { table: bid, columns: [auction, bidder, price, date_time, _row_id], pk_indices: [4] }
 - id: nexmark_q1
   before:
     - create_tables
@@ -58,16 +58,16 @@
       auction,
       bidder,
       0.908 * price as price,
-      dateTime
+      date_time
     FROM bid;
   batch_plan: |
     BatchExchange { order: [], dist: Single }
       BatchProject { exprs: [$0, $1, (0.908:Decimal * $2), $3] }
-        BatchScan { table: bid, columns: [auction, bidder, price, datetime] }
+        BatchScan { table: bid, columns: [auction, bidder, price, date_time] }
   stream_plan: |
-    StreamMaterialize { columns: [auction, bidder, price, datetime, bid._row_id(hidden)], pk_columns: [bid._row_id] }
+    StreamMaterialize { columns: [auction, bidder, price, date_time, bid._row_id(hidden)], pk_columns: [bid._row_id] }
       StreamProject { exprs: [$0, $1, (0.908:Decimal * $2), $3, $4] }
-        StreamTableScan { table: bid, columns: [auction, bidder, price, datetime, _row_id], pk_indices: [4] }
+        StreamTableScan { table: bid, columns: [auction, bidder, price, date_time, _row_id], pk_indices: [4] }
 - id: nexmark_q2
   before:
     - create_tables
@@ -123,7 +123,7 @@
     FROM (
         SELECT MAX(B.price) AS final, A.category
         FROM auction A, bid B
-        WHERE A.id = B.auction AND B.dateTime BETWEEN A.dateTime AND A.expires
+        WHERE A.id = B.auction AND B.date_time BETWEEN A.date_time AND A.expires
         GROUP BY A.id, A.category
     ) Q
     GROUP BY Q.category;
@@ -138,9 +138,9 @@
                   BatchFilter { predicate: ($6 >= $1) AND ($6 <= $2) }
                     BatchHashJoin { type: Inner, predicate: $0 = $4, output_indices: all }
                       BatchExchange { order: [], dist: HashShard([0]) }
-                        BatchScan { table: auction, columns: [id, datetime, expires, category] }
+                        BatchScan { table: auction, columns: [id, date_time, expires, category] }
                       BatchExchange { order: [], dist: HashShard([0]) }
-                        BatchScan { table: bid, columns: [auction, price, datetime] }
+                        BatchScan { table: bid, columns: [auction, price, date_time] }
   stream_plan: |
     StreamMaterialize { columns: [category, avg], pk_columns: [category] }
       StreamProject { exprs: [$0, ($2 / $3)] }
@@ -152,9 +152,9 @@
                   StreamFilter { predicate: ($7 >= $1) AND ($7 <= $2) }
                     StreamHashJoin { type: Inner, predicate: $0 = $5, output_indices: all }
                       StreamExchange { dist: HashShard([0]) }
-                        StreamTableScan { table: auction, columns: [id, datetime, expires, category, _row_id], pk_indices: [4] }
+                        StreamTableScan { table: auction, columns: [id, date_time, expires, category, _row_id], pk_indices: [4] }
                       StreamExchange { dist: HashShard([0]) }
-                        StreamTableScan { table: bid, columns: [auction, price, datetime, _row_id], pk_indices: [3] }
+                        StreamTableScan { table: bid, columns: [auction, price, date_time, _row_id], pk_indices: [3] }
 - id: nexmark_q5
   before:
     - create_tables
@@ -165,7 +165,7 @@
         count(*) AS num,
         window_start AS starttime
       FROM
-        HOP(bid, dateTime, INTERVAL '2' SECOND, INTERVAL '10' SECOND)
+        HOP(bid, date_time, INTERVAL '2' SECOND, INTERVAL '10' SECOND)
       GROUP BY
         window_start,
         bid.auction
@@ -178,7 +178,7 @@
         SELECT
           count(*) AS num,
           window_start AS starttime_c
-        FROM HOP(bid, dateTime, INTERVAL '2' SECOND, INTERVAL '10' SECOND)
+        FROM HOP(bid, date_time, INTERVAL '2' SECOND, INTERVAL '10' SECOND)
         GROUP BY
           bid.auction,
           window_start
@@ -198,7 +198,7 @@
                   BatchExchange { order: [], dist: HashShard([0, 1]) }
                     BatchProject { exprs: [$1, $0] }
                       BatchHopWindow { time_col: $1, slide: 00:00:02, size: 00:00:10, output_indices: [0, 2] }
-                        BatchScan { table: bid, columns: [auction, datetime] }
+                        BatchScan { table: bid, columns: [auction, date_time] }
             BatchProject { exprs: [$1, $0] }
               BatchHashAgg { group_key: [$0], aggs: [max($1)] }
                 BatchExchange { order: [], dist: HashShard([0]) }
@@ -206,7 +206,7 @@
                     BatchHashAgg { group_key: [$0, $1], aggs: [count] }
                       BatchHopWindow { time_col: $1, slide: 00:00:02, size: 00:00:10, output_indices: [0, 2] }
                         BatchExchange { order: [], dist: HashShard([0]) }
-                          BatchScan { table: bid, columns: [auction, datetime] }
+                          BatchScan { table: bid, columns: [auction, date_time] }
   stream_plan: |
     StreamMaterialize { columns: [auction, num, window_start(hidden), window_start#1(hidden)], pk_columns: [window_start, auction, window_start#1] }
       StreamProject { exprs: [$0, $1, $2, $4] }
@@ -218,7 +218,7 @@
                   StreamExchange { dist: HashShard([0, 1]) }
                     StreamProject { exprs: [$1, $0, $2] }
                       StreamHopWindow { time_col: $1, slide: 00:00:02, size: 00:00:10, output_indices: [0, 3, 2] }
-                        StreamTableScan { table: bid, columns: [auction, datetime, _row_id], pk_indices: [2] }
+                        StreamTableScan { table: bid, columns: [auction, date_time, _row_id], pk_indices: [2] }
             StreamProject { exprs: [$2, $0] }
               StreamHashAgg { group_key: [$0], aggs: [count, max($1)] }
                 StreamExchange { dist: HashShard([0]) }
@@ -226,7 +226,7 @@
                     StreamHashAgg { group_key: [$0, $1], aggs: [count, count] }
                       StreamExchange { dist: HashShard([0, 1]) }
                         StreamHopWindow { time_col: $1, slide: 00:00:02, size: 00:00:10, output_indices: [0, 3, 2] }
-                          StreamTableScan { table: bid, columns: [auction, datetime, _row_id], pk_indices: [2] }
+                          StreamTableScan { table: bid, columns: [auction, date_time, _row_id], pk_indices: [2] }
 - id: nexmark_q6
   before:
     - create_tables
@@ -234,12 +234,12 @@
     SELECT
         Q.seller,
         AVG(Q.final) OVER
-            (PARTITION BY Q.seller ORDER BY Q.dateTime ROWS BETWEEN 10 PRECEDING AND CURRENT ROW)
+            (PARTITION BY Q.seller ORDER BY Q.date_time ROWS BETWEEN 10 PRECEDING AND CURRENT ROW)
         as avg
     FROM (
-        SELECT MAX(B.price) AS final, A.seller, B.dateTime
+        SELECT MAX(B.price) AS final, A.seller, B.date_time
         FROM auction AS A, bid AS B
-        WHERE A.id = B.auction and B.dateTime between A.dateTime and A.expires
+        WHERE A.id = B.auction and B.date_time between A.date_time and A.expires
         GROUP BY A.id, A.seller
     ) AS Q;
   planner_error: 'Invalid input syntax: column must appear in the GROUP BY clause or be used in an aggregate function'
@@ -251,48 +251,48 @@
       B.auction,
       B.price,
       B.bidder,
-      B.dateTime
+      B.date_time
     FROM
       bid B
     JOIN (
       SELECT
         MAX(price) AS maxprice,
-        window_end as dateTime
+        window_end as date_time
       FROM
-        TUMBLE(bid, dateTime, INTERVAL '10' SECOND)
+        TUMBLE(bid, date_time, INTERVAL '10' SECOND)
       GROUP BY
         window_end
     ) B1 ON B.price = B1.maxprice
     WHERE
-      B.dateTime BETWEEN B1.dateTime - INTERVAL '10' SECOND
-      AND B1.dateTime;
+      B.date_time BETWEEN B1.date_time - INTERVAL '10' SECOND
+      AND B1.date_time;
   batch_plan: |
     BatchExchange { order: [], dist: Single }
       BatchProject { exprs: [$0, $2, $1, $3] }
         BatchFilter { predicate: ($3 >= ($5 - '00:00:10':Interval)) AND ($3 <= $5) }
           BatchHashJoin { type: Inner, predicate: $2 = $4, output_indices: all }
             BatchExchange { order: [], dist: HashShard([2]) }
-              BatchScan { table: bid, columns: [auction, bidder, price, datetime] }
+              BatchScan { table: bid, columns: [auction, bidder, price, date_time] }
             BatchExchange { order: [], dist: HashShard([0]) }
               BatchProject { exprs: [$1, $0] }
                 BatchHashAgg { group_key: [$0], aggs: [max($1)] }
                   BatchExchange { order: [], dist: HashShard([0]) }
                     BatchProject { exprs: [(TumbleStart($1, '00:00:10':Interval) + '00:00:10':Interval), $0] }
-                      BatchScan { table: bid, columns: [price, datetime] }
+                      BatchScan { table: bid, columns: [price, date_time] }
   stream_plan: |
-    StreamMaterialize { columns: [auction, price, bidder, datetime, bid._row_id(hidden), (TumbleStart(bid.datetime, '00:00:10':Interval) + '00:00:10':Interval)(hidden)], pk_columns: [bid._row_id, (TumbleStart(bid.datetime, '00:00:10':Interval) + '00:00:10':Interval)] }
+    StreamMaterialize { columns: [auction, price, bidder, date_time, bid._row_id(hidden), (TumbleStart(bid.date_time, '00:00:10':Interval) + '00:00:10':Interval)(hidden)], pk_columns: [bid._row_id, (TumbleStart(bid.date_time, '00:00:10':Interval) + '00:00:10':Interval)] }
       StreamExchange { dist: HashShard([4, 5]) }
         StreamProject { exprs: [$0, $2, $1, $3, $4, $6] }
           StreamFilter { predicate: ($3 >= ($6 - '00:00:10':Interval)) AND ($3 <= $6) }
             StreamHashJoin { type: Inner, predicate: $2 = $5, output_indices: all }
               StreamExchange { dist: HashShard([2]) }
-                StreamTableScan { table: bid, columns: [auction, bidder, price, datetime, _row_id], pk_indices: [4] }
+                StreamTableScan { table: bid, columns: [auction, bidder, price, date_time, _row_id], pk_indices: [4] }
               StreamExchange { dist: HashShard([0]) }
                 StreamProject { exprs: [$2, $0] }
                   StreamHashAgg { group_key: [$0], aggs: [count, max($1)] }
                     StreamExchange { dist: HashShard([0]) }
                       StreamProject { exprs: [(TumbleStart($1, '00:00:10':Interval) + '00:00:10':Interval), $0, $2] }
-                        StreamTableScan { table: bid, columns: [price, datetime, _row_id], pk_indices: [2] }
+                        StreamTableScan { table: bid, columns: [price, date_time, _row_id], pk_indices: [2] }
 - id: nexmark_q8
   before:
     - create_tables
@@ -308,7 +308,7 @@
         window_start AS starttime,
         window_end AS endtime
       FROM
-        TUMBLE(person, dateTime, INTERVAL '10' SECOND)
+        TUMBLE(person, date_time, INTERVAL '10' SECOND)
       GROUP BY
         id,
         name,
@@ -321,7 +321,7 @@
         window_start AS starttime,
         window_end AS endtime
       FROM
-        TUMBLE(auction, dateTime, INTERVAL '10' SECOND)
+        TUMBLE(auction, date_time, INTERVAL '10' SECOND)
       GROUP BY
         seller,
         window_start,
@@ -336,35 +336,35 @@
           BatchHashAgg { group_key: [$0, $1, $2, $3], aggs: [] }
             BatchExchange { order: [], dist: HashShard([0, 1, 2, 3]) }
               BatchProject { exprs: [$0, $1, TumbleStart($2, '00:00:10':Interval), (TumbleStart($2, '00:00:10':Interval) + '00:00:10':Interval)] }
-                BatchScan { table: person, columns: [id, name, datetime] }
+                BatchScan { table: person, columns: [id, name, date_time] }
         BatchHashAgg { group_key: [$0, $1, $2], aggs: [] }
           BatchExchange { order: [], dist: HashShard([0, 1, 2]) }
             BatchProject { exprs: [$1, TumbleStart($0, '00:00:10':Interval), (TumbleStart($0, '00:00:10':Interval) + '00:00:10':Interval)] }
-              BatchScan { table: auction, columns: [datetime, seller] }
+              BatchScan { table: auction, columns: [date_time, seller] }
   stream_plan: |
-    StreamMaterialize { columns: [id, name, starttime, (TumbleStart(person.datetime, '00:00:10':Interval) + '00:00:10':Interval)(hidden), auction.seller(hidden), TumbleStart(auction.datetime, '00:00:10':Interval)(hidden), (TumbleStart(auction.datetime, '00:00:10':Interval) + '00:00:10':Interval)(hidden)], pk_columns: [id, name, starttime, (TumbleStart(person.datetime, '00:00:10':Interval) + '00:00:10':Interval), auction.seller, TumbleStart(auction.datetime, '00:00:10':Interval), (TumbleStart(auction.datetime, '00:00:10':Interval) + '00:00:10':Interval)] }
+    StreamMaterialize { columns: [id, name, starttime, (TumbleStart(person.date_time, '00:00:10':Interval) + '00:00:10':Interval)(hidden), auction.seller(hidden), TumbleStart(auction.date_time, '00:00:10':Interval)(hidden), (TumbleStart(auction.date_time, '00:00:10':Interval) + '00:00:10':Interval)(hidden)], pk_columns: [id, name, starttime, (TumbleStart(person.date_time, '00:00:10':Interval) + '00:00:10':Interval), auction.seller, TumbleStart(auction.date_time, '00:00:10':Interval), (TumbleStart(auction.date_time, '00:00:10':Interval) + '00:00:10':Interval)] }
       StreamHashJoin { type: Inner, predicate: $0 = $5 AND $2 = $6 AND $3 = $7, output_indices: [0, 1, 2, 3, 5, 6, 7] }
         StreamExchange { dist: HashShard([0, 2, 3]) }
           StreamHashAgg { group_key: [$0, $1, $2, $3], aggs: [count] }
             StreamExchange { dist: HashShard([0, 1, 2, 3]) }
               StreamProject { exprs: [$0, $1, TumbleStart($2, '00:00:10':Interval), (TumbleStart($2, '00:00:10':Interval) + '00:00:10':Interval), $3] }
-                StreamTableScan { table: person, columns: [id, name, datetime, _row_id], pk_indices: [3] }
+                StreamTableScan { table: person, columns: [id, name, date_time, _row_id], pk_indices: [3] }
         StreamHashAgg { group_key: [$0, $1, $2], aggs: [count] }
           StreamExchange { dist: HashShard([0, 1, 2]) }
             StreamProject { exprs: [$1, TumbleStart($0, '00:00:10':Interval), (TumbleStart($0, '00:00:10':Interval) + '00:00:10':Interval), $2] }
-              StreamTableScan { table: auction, columns: [datetime, seller, _row_id], pk_indices: [2] }
+              StreamTableScan { table: auction, columns: [date_time, seller, _row_id], pk_indices: [2] }
 - id: nexmark_q9
   before:
     - create_tables
   sql: |
     SELECT
-      id, itemName, description, initialBid, reserve, dateTime, expires, seller, category,
-      auction, bidder, price, bid_dateTime
+      id, item_name, description, initial_bid, reserve, date_time, expires, seller, category,
+      auction, bidder, price, bid_date_time
     FROM (
-      SELECT A.*, B.auction, B.bidder, B.price, B.dateTime AS bid_dateTime,
-        ROW_NUMBER() OVER (PARTITION BY A.id ORDER BY B.price DESC, B.dateTime ASC) AS rownum
+      SELECT A.*, B.auction, B.bidder, B.price, B.date_time AS bid_date_time,
+        ROW_NUMBER() OVER (PARTITION BY A.id ORDER BY B.price DESC, B.date_time ASC) AS rownum
       FROM auction A, bid B
-      WHERE A.id = B.auction AND B.dateTime BETWEEN A.dateTime AND A.expires
+      WHERE A.id = B.auction AND B.date_time BETWEEN A.date_time AND A.expires
     )
     WHERE rownum <= 1;
   binder_error: 'Feature is not yet implemented: unsupported function: "row_number", Tracking issue: https://github.com/singularity-data/risingwave/issues/112'
@@ -372,15 +372,15 @@
   before:
     - create_tables
   sql: |
-    SELECT auction, bidder, price, dateTime, TO_CHAR(dateTime, 'YYYY-MM-DD') as date, TO_CHAR(dateTime, 'HH:MI') as time FROM bid;
+    SELECT auction, bidder, price, date_time, TO_CHAR(date_time, 'YYYY-MM-DD') as date, TO_CHAR(date_time, 'HH:MI') as time FROM bid;
   batch_plan: |
     BatchExchange { order: [], dist: Single }
       BatchProject { exprs: [$0, $1, $2, $3, ToChar($3, 'YYYY-MM-DD':Varchar), ToChar($3, 'HH:MI':Varchar)] }
-        BatchScan { table: bid, columns: [auction, bidder, price, datetime] }
+        BatchScan { table: bid, columns: [auction, bidder, price, date_time] }
   stream_plan: |
-    StreamMaterialize { columns: [auction, bidder, price, datetime, date, time, bid._row_id(hidden)], pk_columns: [bid._row_id] }
+    StreamMaterialize { columns: [auction, bidder, price, date_time, date, time, bid._row_id(hidden)], pk_columns: [bid._row_id] }
       StreamProject { exprs: [$0, $1, $2, $3, ToChar($3, 'YYYY-MM-DD':Varchar), ToChar($3, 'HH:MI':Varchar), $4] }
-        StreamTableScan { table: bid, columns: [auction, bidder, price, datetime, _row_id], pk_indices: [4] }
+        StreamTableScan { table: bid, columns: [auction, bidder, price, date_time, _row_id], pk_indices: [4] }
 - id: nexmark_q11
   before:
     - create_tables
@@ -388,10 +388,10 @@
     SELECT
       B.bidder,
       count(*) as bid_count,
-      SESSION_START(B.dateTime, INTERVAL '10' SECOND) as starttime,
-      SESSION_END(B.dateTime, INTERVAL '10' SECOND) as endtime
+      SESSION_START(B.date_time, INTERVAL '10' SECOND) as starttime,
+      SESSION_END(B.date_time, INTERVAL '10' SECOND) as endtime
     FROM bid B
-    GROUP BY B.bidder, SESSION(B.dateTime, INTERVAL '10' SECOND);
+    GROUP BY B.bidder, SESSION(B.date_time, INTERVAL '10' SECOND);
   binder_error: 'Feature is not yet implemented: unsupported function: "session", Tracking issue: https://github.com/singularity-data/risingwave/issues/112'
 - id: nexmark_q12
   before:
@@ -413,7 +413,7 @@
         B.auction,
         B.bidder,
         B.price,
-        B.dateTime,
+        B.date_time,
         S.value
     FROM (SELECT *, PROCTIME() as p_time FROM bid) B
     JOIN side_input FOR SYSTEM_TIME AS OF B.p_time AS S
@@ -429,16 +429,16 @@
       0.908 * price as price,
       CASE
         WHEN
-          extract(hour from dateTime) >= 8 AND
-          extract(hour from dateTime) <= 18
+          extract(hour from date_time) >= 8 AND
+          extract(hour from date_time) <= 18
         THEN 'dayTime'
         WHEN
-          extract(hour from dateTime) <= 6 OR
-          extract(hour from dateTime) >= 20
+          extract(hour from date_time) <= 6 OR
+          extract(hour from date_time) >= 20
         THEN 'nightTime'
         ELSE 'otherTime'
       END AS bidTimeType,
-      dateTime,
+      date_time,
       extra
       -- TODO: count_char is an UDF, add it back when we support similar functionality.
       -- https://github.com/nexmark/nexmark/blob/master/nexmark-flink/src/main/java/com/github/nexmark/flink/udf/CountChar.java
@@ -449,18 +449,18 @@
     BatchExchange { order: [], dist: Single }
       BatchProject { exprs: [$0, $1, (0.908:Decimal * $2), Case(((Extract('HOUR':Varchar, $3) >= 8:Int32) AND (Extract('HOUR':Varchar, $3) <= 18:Int32)), 'dayTime':Varchar, ((Extract('HOUR':Varchar, $3) <= 6:Int32) OR (Extract('HOUR':Varchar, $3) >= 20:Int32)), 'nightTime':Varchar, 'otherTime':Varchar), $3, $4] }
         BatchFilter { predicate: ((0.908:Decimal * $2) > 1000000:Int32) AND ((0.908:Decimal * $2) < 50000000:Int32) }
-          BatchScan { table: bid, columns: [auction, bidder, price, datetime, extra] }
+          BatchScan { table: bid, columns: [auction, bidder, price, date_time, extra] }
   stream_plan: |
-    StreamMaterialize { columns: [auction, bidder, price, bidtimetype, datetime, extra, bid._row_id(hidden)], pk_columns: [bid._row_id] }
+    StreamMaterialize { columns: [auction, bidder, price, bidtimetype, date_time, extra, bid._row_id(hidden)], pk_columns: [bid._row_id] }
       StreamProject { exprs: [$0, $1, (0.908:Decimal * $2), Case(((Extract('HOUR':Varchar, $3) >= 8:Int32) AND (Extract('HOUR':Varchar, $3) <= 18:Int32)), 'dayTime':Varchar, ((Extract('HOUR':Varchar, $3) <= 6:Int32) OR (Extract('HOUR':Varchar, $3) >= 20:Int32)), 'nightTime':Varchar, 'otherTime':Varchar), $3, $4, $5] }
         StreamFilter { predicate: ((0.908:Decimal * $2) > 1000000:Int32) AND ((0.908:Decimal * $2) < 50000000:Int32) }
-          StreamTableScan { table: bid, columns: [auction, bidder, price, datetime, extra, _row_id], pk_indices: [5] }
+          StreamTableScan { table: bid, columns: [auction, bidder, price, date_time, extra, _row_id], pk_indices: [5] }
 - id: nexmark_q15
   before:
     - create_tables
   sql: |
     SELECT
-        TO_CHAR(dateTime, 'yyyy-MM-dd') as day,
+        TO_CHAR(date_time, 'yyyy-MM-dd') as day,
         count(*) AS total_bids,
         count(*) filter (where price < 10000) AS rank1_bids,
         count(*) filter (where price >= 10000 and price < 1000000) AS rank2_bids,
@@ -474,7 +474,7 @@
         count(distinct auction) filter (where price >= 10000 and price < 1000000) AS rank2_auctions,
         count(distinct auction) filter (where price >= 1000000) AS rank3_auctions
     FROM bid
-    GROUP BY to_char(dateTime, 'yyyy-MM-dd');
+    GROUP BY to_char(date_time, 'yyyy-MM-dd');
   batch_plan: |
     BatchExchange { order: [], dist: Single }
       BatchHashAgg { group_key: [$0], aggs: [sum($10) filter(($9 = 0:Int64)), sum($11) filter(($9 = 0:Int64)), sum($12) filter(($9 = 0:Int64)), sum($13) filter(($9 = 0:Int64)), count($1) filter(($9 = 1:Int64)), count($2) filter((($14 > 0:Int64) AND ($9 = 2:Int64))), count($3) filter((($15 > 0:Int64) AND ($9 = 3:Int64))), count($4) filter((($16 > 0:Int64) AND ($9 = 4:Int64))), count($5) filter(($9 = 5:Int64)), count($6) filter((($17 > 0:Int64) AND ($9 = 6:Int64))), count($7) filter((($18 > 0:Int64) AND ($9 = 7:Int64))), count($8) filter((($19 > 0:Int64) AND ($9 = 8:Int64)))] }
@@ -483,7 +483,7 @@
             BatchExchange { order: [], dist: HashShard([0, 2, 3, 4]) }
               BatchExpand { column_subsets: [[0, 1], [0, 2], [0, 1, 2], [0, 1, 2], [0, 1, 2], [0, 3], [0, 1, 3], [0, 1, 3], [0, 1, 3]] }
                 BatchProject { exprs: [ToChar($3, 'yyyy-MM-dd':Varchar), $2, $1, $0] }
-                  BatchScan { table: bid, columns: [auction, bidder, price, datetime] }
+                  BatchScan { table: bid, columns: [auction, bidder, price, date_time] }
   stream_plan: |
     StreamMaterialize { columns: [day, count(hidden), total_bids, rank1_bids, rank2_bids, rank3_bids, total_bidders, rank1_bidders, rank2_bidders, rank3_bidders, total_auctions, rank1_auctions, rank2_auctions, rank3_auctions], pk_columns: [day] }
       StreamHashAgg { group_key: [$0], aggs: [count, sum($11) filter(($9 = 0:Int64)), sum($12) filter(($9 = 0:Int64)), sum($13) filter(($9 = 0:Int64)), sum($14) filter(($9 = 0:Int64)), count($1) filter(($9 = 1:Int64)), count($2) filter((($15 > 0:Int64) AND ($9 = 2:Int64))), count($3) filter((($16 > 0:Int64) AND ($9 = 3:Int64))), count($4) filter((($17 > 0:Int64) AND ($9 = 4:Int64))), count($5) filter(($9 = 5:Int64)), count($6) filter((($18 > 0:Int64) AND ($9 = 6:Int64))), count($7) filter((($19 > 0:Int64) AND ($9 = 7:Int64))), count($8) filter((($20 > 0:Int64) AND ($9 = 8:Int64)))] }
@@ -492,15 +492,15 @@
             StreamExchange { dist: HashShard([0, 2, 3, 5]) }
               StreamExpand { column_subsets: [[0, 1], [0, 2], [0, 1, 2], [0, 1, 2], [0, 1, 2], [0, 3], [0, 1, 3], [0, 1, 3], [0, 1, 3]] }
                 StreamProject { exprs: [ToChar($3, 'yyyy-MM-dd':Varchar), $2, $1, $0, $4] }
-                  StreamTableScan { table: bid, columns: [auction, bidder, price, datetime, _row_id], pk_indices: [4] }
+                  StreamTableScan { table: bid, columns: [auction, bidder, price, date_time, _row_id], pk_indices: [4] }
 - id: nexmark_q16
   before:
     - create_tables
   sql: |
     SELECT
       channel,
-      to_char(dateTime, 'yyyy-MM-dd') AS day,
-      max(to_char(dateTime, 'HH:mm')) AS minute,
+      to_char(date_time, 'yyyy-MM-dd') AS day,
+      max(to_char(date_time, 'HH:mm')) AS minute,
       count(*) AS total_bids,
       count(*) filter (where price < 10000) AS rank1_bids,
       count(*) filter (where price >= 10000 and price < 1000000) AS rank2_bids,
@@ -514,7 +514,7 @@
       count(distinct auction) filter (where price >= 10000 and price < 1000000) AS rank2_auctions,
       count(distinct auction) filter (where price >= 1000000) AS rank3_auctions
     FROM bid
-    GROUP BY channel, to_char(dateTime, 'yyyy-MM-dd');
+    GROUP BY channel, to_char(date_time, 'yyyy-MM-dd');
   batch_plan: |
     BatchExchange { order: [], dist: Single }
       BatchHashAgg { group_key: [$0, $1], aggs: [max($11) filter(($10 = 0:Int64)), sum($12) filter(($10 = 0:Int64)), sum($13) filter(($10 = 0:Int64)), sum($14) filter(($10 = 0:Int64)), sum($15) filter(($10 = 0:Int64)), count($2) filter(($10 = 1:Int64)), count($3) filter((($16 > 0:Int64) AND ($10 = 2:Int64))), count($4) filter((($17 > 0:Int64) AND ($10 = 3:Int64))), count($5) filter((($18 > 0:Int64) AND ($10 = 4:Int64))), count($6) filter(($10 = 5:Int64)), count($7) filter((($19 > 0:Int64) AND ($10 = 6:Int64))), count($8) filter((($20 > 0:Int64) AND ($10 = 7:Int64))), count($9) filter((($21 > 0:Int64) AND ($10 = 8:Int64)))] }
@@ -523,7 +523,7 @@
             BatchExchange { order: [], dist: HashShard([0, 1, 4, 5, 6]) }
               BatchExpand { column_subsets: [[0, 1, 2, 3], [0, 1, 4], [0, 1, 3, 4], [0, 1, 3, 4], [0, 1, 3, 4], [0, 1, 5], [0, 1, 3, 5], [0, 1, 3, 5], [0, 1, 3, 5]] }
                 BatchProject { exprs: [$3, ToChar($4, 'yyyy-MM-dd':Varchar), ToChar($4, 'HH:mm':Varchar), $2, $1, $0] }
-                  BatchScan { table: bid, columns: [auction, bidder, price, channel, datetime] }
+                  BatchScan { table: bid, columns: [auction, bidder, price, channel, date_time] }
   stream_plan: |
     StreamMaterialize { columns: [channel, day, count(hidden), minute, total_bids, rank1_bids, rank2_bids, rank3_bids, total_bidders, rank1_bidders, rank2_bidders, rank3_bidders, total_auctions, rank1_auctions, rank2_auctions, rank3_auctions], pk_columns: [channel, day] }
       StreamHashAgg { group_key: [$0, $1], aggs: [count, max($12) filter(($10 = 0:Int64)), sum($13) filter(($10 = 0:Int64)), sum($14) filter(($10 = 0:Int64)), sum($15) filter(($10 = 0:Int64)), sum($16) filter(($10 = 0:Int64)), count($2) filter(($10 = 1:Int64)), count($3) filter((($17 > 0:Int64) AND ($10 = 2:Int64))), count($4) filter((($18 > 0:Int64) AND ($10 = 3:Int64))), count($5) filter((($19 > 0:Int64) AND ($10 = 4:Int64))), count($6) filter(($10 = 5:Int64)), count($7) filter((($20 > 0:Int64) AND ($10 = 6:Int64))), count($8) filter((($21 > 0:Int64) AND ($10 = 7:Int64))), count($9) filter((($22 > 0:Int64) AND ($10 = 8:Int64)))] }
@@ -532,14 +532,14 @@
             StreamExchange { dist: HashShard([0, 1, 4, 5, 7]) }
               StreamExpand { column_subsets: [[0, 1, 2, 3], [0, 1, 4], [0, 1, 3, 4], [0, 1, 3, 4], [0, 1, 3, 4], [0, 1, 5], [0, 1, 3, 5], [0, 1, 3, 5], [0, 1, 3, 5]] }
                 StreamProject { exprs: [$3, ToChar($4, 'yyyy-MM-dd':Varchar), ToChar($4, 'HH:mm':Varchar), $2, $1, $0, $5] }
-                  StreamTableScan { table: bid, columns: [auction, bidder, price, channel, datetime, _row_id], pk_indices: [5] }
+                  StreamTableScan { table: bid, columns: [auction, bidder, price, channel, date_time, _row_id], pk_indices: [5] }
 - id: nexmark_q17
   before:
     - create_tables
   sql: |
     SELECT
         auction,
-        to_char(dateTime, 'yyyy-MM-dd') AS day,
+        to_char(date_time, 'yyyy-MM-dd') AS day,
         count(*) AS total_bids,
         count(*) filter (where price < 10000) AS rank1_bids,
         count(*) filter (where price >= 10000 and price < 1000000) AS rank2_bids,
@@ -549,27 +549,27 @@
         avg(price) AS avg_price,
         sum(price) AS sum_price
     FROM bid
-    GROUP BY auction, to_char(dateTime, 'yyyy-MM-dd');
+    GROUP BY auction, to_char(date_time, 'yyyy-MM-dd');
   batch_plan: |
     BatchExchange { order: [], dist: Single }
       BatchProject { exprs: [$0, $1, $2, $3, $4, $5, $6, $7, ($8 / $9), $10] }
         BatchHashAgg { group_key: [$0, $1], aggs: [count, count filter(($2 < 10000:Int32)), count filter((($2 >= 10000:Int32) AND ($2 < 1000000:Int32))), count filter(($2 >= 1000000:Int32)), min($2), max($2), sum($2), count($2), sum($2)] }
           BatchExchange { order: [], dist: HashShard([0, 1]) }
             BatchProject { exprs: [$0, ToChar($2, 'yyyy-MM-dd':Varchar), $1] }
-              BatchScan { table: bid, columns: [auction, price, datetime] }
+              BatchScan { table: bid, columns: [auction, price, date_time] }
   stream_plan: |
     StreamMaterialize { columns: [auction, day, total_bids, rank1_bids, rank2_bids, rank3_bids, min_price, max_price, avg_price, sum_price], pk_columns: [auction, day] }
       StreamProject { exprs: [$0, $1, $3, $4, $5, $6, $7, $8, ($9 / $10), $11] }
         StreamHashAgg { group_key: [$0, $1], aggs: [count, count, count filter(($2 < 10000:Int32)), count filter((($2 >= 10000:Int32) AND ($2 < 1000000:Int32))), count filter(($2 >= 1000000:Int32)), min($2), max($2), sum($2), count($2), sum($2)] }
           StreamExchange { dist: HashShard([0, 1]) }
             StreamProject { exprs: [$0, ToChar($2, 'yyyy-MM-dd':Varchar), $1, $3] }
-              StreamTableScan { table: bid, columns: [auction, price, datetime, _row_id], pk_indices: [3] }
+              StreamTableScan { table: bid, columns: [auction, price, date_time, _row_id], pk_indices: [3] }
 - id: nexmark_q18
   before:
     - create_tables
   sql: |
-    SELECT auction, bidder, price, channel, url, dateTime, extra
-    FROM (SELECT *, ROW_NUMBER() OVER (PARTITION BY bidder, auction ORDER BY dateTime DESC) AS rank_number
+    SELECT auction, bidder, price, channel, url, date_time, extra
+    FROM (SELECT *, ROW_NUMBER() OVER (PARTITION BY bidder, auction ORDER BY date_time DESC) AS rank_number
           FROM bid)
     WHERE rank_number <= 1;
   binder_error: 'Feature is not yet implemented: unsupported function: "row_number", Tracking issue: https://github.com/singularity-data/risingwave/issues/112'
@@ -586,8 +586,8 @@
     - create_tables
   sql: |
     SELECT
-        auction, bidder, price, channel, url, B.dateTime as dateTimeB,
-        itemName, description, initialBid, reserve, A.dateTime as dateTimeA, expires, seller, category
+        auction, bidder, price, channel, url, B.date_time as date_timeB,
+        item_name, description, initial_bid, reserve, A.date_time as date_timeA, expires, seller, category
     FROM
         bid B INNER JOIN auction A on B.auction = A.id
     WHERE A.category = 10;
@@ -595,19 +595,19 @@
     BatchExchange { order: [], dist: Single }
       BatchHashJoin { type: Inner, predicate: $0 = $6, output_indices: [0, 1, 2, 3, 4, 5, 7, 8, 9, 10, 11, 12, 13, 14] }
         BatchExchange { order: [], dist: HashShard([0]) }
-          BatchScan { table: bid, columns: [auction, bidder, price, channel, url, datetime] }
+          BatchScan { table: bid, columns: [auction, bidder, price, channel, url, date_time] }
         BatchExchange { order: [], dist: HashShard([0]) }
           BatchFilter { predicate: ($8 = 10:Int32) }
-            BatchScan { table: auction, columns: [id, itemname, description, initialbid, reserve, datetime, expires, seller, category] }
+            BatchScan { table: auction, columns: [id, item_name, description, initial_bid, reserve, date_time, expires, seller, category] }
   stream_plan: |
-    StreamMaterialize { columns: [auction, bidder, price, channel, url, datetimeb, itemname, description, initialbid, reserve, datetimea, expires, seller, category, bid._row_id(hidden), auction._row_id(hidden)], pk_columns: [bid._row_id, auction._row_id] }
+    StreamMaterialize { columns: [auction, bidder, price, channel, url, date_timeb, item_name, description, initial_bid, reserve, date_timea, expires, seller, category, bid._row_id(hidden), auction._row_id(hidden)], pk_columns: [bid._row_id, auction._row_id] }
       StreamExchange { dist: HashShard([14, 15]) }
         StreamHashJoin { type: Inner, predicate: $0 = $7, output_indices: [0, 1, 2, 3, 4, 5, 8, 9, 10, 11, 12, 13, 14, 15, 6, 16] }
           StreamExchange { dist: HashShard([0]) }
-            StreamTableScan { table: bid, columns: [auction, bidder, price, channel, url, datetime, _row_id], pk_indices: [6] }
+            StreamTableScan { table: bid, columns: [auction, bidder, price, channel, url, date_time, _row_id], pk_indices: [6] }
           StreamExchange { dist: HashShard([0]) }
             StreamFilter { predicate: ($8 = 10:Int32) }
-              StreamTableScan { table: auction, columns: [id, itemname, description, initialbid, reserve, datetime, expires, seller, category, _row_id], pk_indices: [9] }
+              StreamTableScan { table: auction, columns: [id, item_name, description, initial_bid, reserve, date_time, expires, seller, category, _row_id], pk_indices: [9] }
 - id: nexmark_q21
   before:
     - create_tables

--- a/src/tests/sqlsmith/tests/testdata/nexmark.sql
+++ b/src/tests/sqlsmith/tests/testdata/nexmark.sql
@@ -1,20 +1,20 @@
 CREATE TABLE person (
     id BIGINT,
     name VARCHAR,
-    emailAddress VARCHAR,
-    creditCard VARCHAR,
+    email_address VARCHAR,
+    credit_card VARCHAR,
     city VARCHAR,
     state VARCHAR,
-    dateTime TIMESTAMP
+    date_time TIMESTAMP
 );
 
 CREATE TABLE auction (
     id BIGINT,
-    itemName VARCHAR,
+    item_name VARCHAR,
     description VARCHAR,
-    initialBid BIGINT,
+    initial_bid BIGINT,
     reserve BIGINT,
-    dateTime TIMESTAMP,
+    date_time TIMESTAMP,
     expires TIMESTAMP,
     seller BIGINT,
     category BIGINT
@@ -24,5 +24,5 @@ CREATE TABLE bid (
     auction BIGINT,
     bidder BIGINT,
     price BIGINT,
-    dateTime TIMESTAMP
+    date_time TIMESTAMP
 );


### PR DESCRIPTION
I hereby agree to the terms of the [Singularity Data, Inc. Contributor License Agreement](https://gist.github.com/skyzh/0663682a70b0edde7ae991492f2314cb#file-s9y_cla).

## What's changed and what's your intention?

***PLEASE DO NOT LEAVE THIS EMPTY !!!***

It looks a little weired because I just renamed them to camelStyle in a near PR #3917 , but there are several reasons to do this revert:

1. Previously I followed the [nexmark-flink](https://github.com/nexmark/nexmark/tree/master/nexmark-flink/src/main/resources/queries) style, but I found that in the original paper, the style is strange (e.g. `emailaddress` and `credit_card` in the same table) and no one followed it. FlinkSQL just use their own style and we can also have our one.
2. Lowercase is more welcome in pg SQL. We have to use double-quoted field if we really want to use camelcase.
3. **The most important reason** is that the there are one issue related to case-sensitivity, see #4022, which blocks the nexmark testing, bu can be avoided, just let the PR merged.

## Refer to a related PR or issue link (optional)

#3917 
#4022 
#132 