### PR TITLE
fix(optimizer): index out of bounds in `LogicalTopN::prune_col`

### DIFF
--- a/src/frontend/src/optimizer/plan_node/logical_join.rs
+++ b/src/frontend/src/optimizer/plan_node/logical_join.rs
@@ -721,8 +721,6 @@ impl ToBatch for LogicalJoin {
             self.on.clone(),
         );
 
-        log::error!("{:?}", self.join_type);
-
         let left = self.left().to_batch()?;
         let right = self.right().to_batch()?;
         let logical_join = self.clone_with_left_right(left, right);

--- a/src/frontend/src/optimizer/plan_node/logical_topn.rs
+++ b/src/frontend/src/optimizer/plan_node/logical_topn.rs
@@ -177,10 +177,14 @@ impl ColPrunable for LogicalTopN {
         if input_required_cols == required_cols {
             top_n
         } else {
+            let output_required_cols = required_cols
+                .iter()
+                .map(|&idx| mapping.map(idx))
+                .collect_vec();
             let src_size = top_n.schema().len();
             LogicalProject::with_mapping(
                 top_n,
-                ColIndexMapping::with_remaining_columns(required_cols, src_size),
+                ColIndexMapping::with_remaining_columns(&output_required_cols, src_size),
             )
             .into()
         }

--- a/src/frontend/test_runner/tests/testdata/column_pruning.yaml
+++ b/src/frontend/test_runner/tests/testdata/column_pruning.yaml
@@ -45,6 +45,19 @@
     LogicalAgg { aggs: [count($0)] }
       LogicalScan { table: t, output_columns: [v1], required_columns: [$1:v1, $2:v2], predicate: ($2 > 2:Int32) }
 - sql: |
+    /* top n */
+    create table t (v1 int, v2 int, v3 int);
+    select v3 from (select * from t order by v3, v2 limit 2) as s;
+  logical_plan: |
+    LogicalProject { exprs: [$2] }
+      LogicalTopN { order: "[$2 ASC, $1 ASC]", limit: 2, offset: 0 }
+        LogicalProject { exprs: [$1, $2, $3] }
+          LogicalScan { table: t, columns: [_row_id, v1, v2, v3] }
+  optimized_logical_plan: |
+    LogicalProject { exprs: [$1] }
+      LogicalTopN { order: "[$1 ASC, $0 ASC]", limit: 2, offset: 0 }
+        LogicalScan { table: t, columns: [v2, v3] }
+- sql: |
     /* constant */
     create table t (v1 bigint, v2 double precision, v3 int);
     select 1 from t


### PR DESCRIPTION
I hereby agree to the terms of the [Singularity Data, Inc. Contributor License Agreement](https://gist.github.com/skyzh/0663682a70b0edde7ae991492f2314cb#file-s9y_cla).

## What's changed and what's your intention?

`required_cols` refers to indices in the original TopN, while `output_required_cols` refers to indices in the new TopN.

This fix is actually borrowed from LogicalFilter, another node that always has same output schema as its input:
https://github.com/singularity-data/risingwave/blob/661dead78c42f04fba0521a719b87e9c3cd69d23/src/frontend/src/optimizer/plan_node/logical_filter.rs#L145-L161

Seems we need to refactor `prune_col` of each node to reduce the chance of making such errors. But fixing this one first.

## Checklist

- [x] I have written necessary rustdoc comments
- [x] I have added necessary unit tests and integration tests
- [x] All checks passed in `./risedev check` (or alias, `./risedev c`)

## Refer to a related PR or issue link (optional)

Fixes #4025