### PR TITLE
refactor(storage): avoid initialize compactor context in every local compact

### DIFF
--- a/src/storage/src/hummock/shared_buffer/shared_buffer_uploader.rs
+++ b/src/storage/src/hummock/shared_buffer/shared_buffer_uploader.rs
@@ -40,9 +40,9 @@ pub struct SharedBufferUploader {
     hummock_meta_client: Arc<dyn HummockMetaClient>,
     next_local_sstable_id: Arc<AtomicU64>,
     stats: Arc<StateStoreMetrics>,
+    compaction_executor: Option<Arc<CompactionExecutor>>,
     local_object_store_compactor_context: Arc<CompactorContext>,
     remote_object_store_compactor_context: Arc<CompactorContext>,
-    compaction_executor: Option<Arc<CompactionExecutor>>,
 }
 
 impl SharedBufferUploader {


### PR DESCRIPTION
I hereby agree to the terms of the [Singularity Data, Inc. Contributor License Agreement](https://gist.github.com/skyzh/0663682a70b0edde7ae991492f2314cb#file-s9y_cla).

## What's changed and what's your intention?

Currently we re-initialize a compact context for every local compaction task. However, most of field in the context is the same in different compact task. Therefore, we can only initialize the compactor context during initialization.

## Checklist

- [x] I have written necessary rustdoc comments
- [x] I have added necessary unit tests and integration tests
- [x] All checks passed in `./risedev check` (or alias, `./risedev c`)

## Refer to a related PR or issue link (optional)
