### PR TITLE
feat(sqlsmith): enable eqjoin

### DIFF
--- a/src/tests/sqlsmith/src/lib.rs
+++ b/src/tests/sqlsmith/src/lib.rs
@@ -200,7 +200,7 @@ impl<'a, R: Rng> SqlGenerator<'a, R> {
     /// Generates a query with local context.
     /// Used by `WITH`, (and perhaps subquery should use this too)
     fn gen_local_query(&mut self) -> (Query, Vec<Column>) {
-        let old_ctxt = self.new_local_ctxt();
+        let old_ctxt = self.new_local_context();
         let t = self.gen_query();
         self.restore_context(old_ctxt);
         t

--- a/src/tests/sqlsmith/src/lib.rs
+++ b/src/tests/sqlsmith/src/lib.rs
@@ -73,6 +73,9 @@ struct SqlGenerator<'a, R: Rng> {
     tables: Vec<Table>,
     rng: &'a mut R,
 
+    /// Relation ID used to generate table names and aliases
+    relation_id: u32,
+
     /// is_distinct_allowed - Distinct and Orderby/Approx.. cannot be generated together among agg
     ///                       having and
     /// When this variable is true, it means distinct only
@@ -103,6 +106,7 @@ impl<'a, R: Rng> SqlGenerator<'a, R> {
         SqlGenerator {
             tables,
             rng,
+            relation_id: 0,
             is_distinct_allowed,
             bound_relations: vec![],
             bound_columns: vec![],
@@ -115,6 +119,7 @@ impl<'a, R: Rng> SqlGenerator<'a, R> {
         SqlGenerator {
             tables,
             rng,
+            relation_id: 0,
             is_distinct_allowed: false,
             bound_relations: vec![],
             bound_columns: vec![],
@@ -217,7 +222,7 @@ impl<'a, R: Rng> SqlGenerator<'a, R> {
     }
 
     fn gen_with_inner(&mut self) -> (With, Vec<Table>) {
-        let alias = self.gen_alias_with_prefix("with");
+        let alias = self.gen_table_alias_with_prefix("with");
         let (query, query_schema) = self.gen_local_query();
         let from = None;
         let cte = Cte {

--- a/src/tests/sqlsmith/src/relation.rs
+++ b/src/tests/sqlsmith/src/relation.rs
@@ -70,23 +70,23 @@ impl<'a, R: Rng> SqlGenerator<'a, R> {
         (table_factor, columns)
     }
 
-    fn gen_local_table_factor(&mut self) -> (TableFactor, Vec<Column>) {
+    fn gen_table_factor(&mut self) -> (TableFactor, Vec<Column>) {
         let current_context = self.new_local_context();
-        let factor = self.gen_table_factor();
+        let factor = self.gen_table_factor_inner();
         self.restore_context(current_context);
         factor
     }
 
     /// Generates a table factor, and provides bound columns.
     /// Generated column names should be qualified by table name.
-    fn gen_table_factor(&mut self) -> (TableFactor, Vec<Column>) {
+    fn gen_table_factor_inner(&mut self) -> (TableFactor, Vec<Column>) {
         // TODO: TableFactor::Derived, TableFactor::TableFunction, TableFactor::NestedJoin
         self.gen_simple_table_factor()
     }
 
     fn gen_equijoin_clause(&mut self) -> TableWithJoins {
-        let (left_factor, left_columns) = self.gen_local_table_factor();
-        let (right_factor, right_columns) = self.gen_local_table_factor();
+        let (left_factor, left_columns) = self.gen_table_factor();
+        let (right_factor, right_columns) = self.gen_table_factor();
 
         let mut available_join_on_columns = vec![];
         for left_column in &left_columns {

--- a/src/tests/sqlsmith/src/relation.rs
+++ b/src/tests/sqlsmith/src/relation.rs
@@ -34,12 +34,12 @@ impl<'a, R: Rng> SqlGenerator<'a, R> {
     /// A relation specified in the FROM clause.
     pub(crate) fn gen_from_relation(&mut self) -> TableWithJoins {
         match self.rng.gen_range(0..=9) {
-            0..=8 => self.gen_simple_table(),
-            9..=9 => self.gen_time_window_func(),
+            0..=7 => self.gen_simple_table(),
+            8..=8 => self.gen_time_window_func(),
             // TODO: Enable after resolving: <https://github.com/singularity-data/risingwave/issues/2771>.
-            10..=10 => self.gen_equijoin_clause(),
+            9..=9 => self.gen_equijoin_clause(),
             // TODO: Currently `gen_subquery` will cause panic due to some wrong assertions.
-            11..=11 => self.gen_subquery(),
+            10..=10 => self.gen_subquery(),
             _ => unreachable!(),
         }
     }
@@ -93,6 +93,9 @@ impl<'a, R: Rng> SqlGenerator<'a, R> {
                     available_join_on_columns.push((left_column, right_column))
                 }
             }
+        }
+        if available_join_on_columns.is_empty() {
+            return self.gen_simple_table();
         }
         let i = self.rng.gen_range(0..available_join_on_columns.len());
         let (left_column, right_column) = available_join_on_columns[i];

--- a/src/tests/sqlsmith/src/time_window.rs
+++ b/src/tests/sqlsmith/src/time_window.rs
@@ -39,7 +39,7 @@ impl<'a, R: Rng> SqlGenerator<'a, R> {
         let (source_table_name, time_cols, schema) = tables
             .choose(&mut self.rng)
             .expect("seeded tables all do not have timestamp");
-        let table_name = self.create_table_name_with_prefix("tumble");
+        let table_name = self.gen_table_name_with_prefix("tumble");
         let alias = create_table_alias(&table_name);
 
         let name = Expr::Identifier(source_table_name.as_str().into());
@@ -64,7 +64,7 @@ impl<'a, R: Rng> SqlGenerator<'a, R> {
         let (source_table_name, time_cols, schema) = tables
             .choose(&mut self.rng)
             .expect("seeded tables all do not have timestamp");
-        let table_name = self.create_table_name_with_prefix("hop");
+        let table_name = self.gen_table_name_with_prefix("hop");
         let alias = create_table_alias(&table_name);
 
         let time_col = time_cols.choose(&mut self.rng).unwrap();

--- a/src/tests/sqlsmith/src/utils.rs
+++ b/src/tests/sqlsmith/src/utils.rs
@@ -25,7 +25,7 @@ type Context = (Vec<Column>, Vec<Table>);
 
 /// Context utils
 impl<'a, R: Rng> SqlGenerator<'a, R> {
-    pub(crate) fn new_local_ctxt(&mut self) -> Context {
+    pub(crate) fn new_local_context(&mut self) -> Context {
         let current_bound_relations = mem::take(&mut self.bound_relations);
         let current_bound_columns = mem::take(&mut self.bound_columns);
         (current_bound_columns, current_bound_relations)

--- a/src/tests/sqlsmith/src/utils.rs
+++ b/src/tests/sqlsmith/src/utils.rs
@@ -39,12 +39,18 @@ impl<'a, R: Rng> SqlGenerator<'a, R> {
 
 /// Gen utils
 impl<'a, R: Rng> SqlGenerator<'a, R> {
-    pub(crate) fn create_table_name_with_prefix(&self, prefix: &str) -> String {
-        format!("{}_{}", prefix, &self.bound_relations.len())
+    pub(crate) fn gen_table_name_with_prefix(&mut self, prefix: &str) -> String {
+        format!("{}_{}", prefix, &self.gen_relation_id())
     }
 
-    pub(crate) fn gen_alias_with_prefix(&self, prefix: &str) -> TableAlias {
-        let name = &self.create_table_name_with_prefix(prefix);
+    fn gen_relation_id(&mut self) -> u32 {
+        let id = self.relation_id;
+        self.relation_id += 1;
+        id
+    }
+
+    pub(crate) fn gen_table_alias_with_prefix(&mut self, prefix: &str) -> TableAlias {
+        let name = &self.gen_table_name_with_prefix(prefix);
         create_table_alias(name)
     }
 }


### PR DESCRIPTION
I hereby agree to the terms of the [Singularity Data, Inc. Contributor License Agreement](https://gist.github.com/skyzh/0663682a70b0edde7ae991492f2314cb#file-s9y_cla).

## What's changed and what's your intention?

Waiting for sqlsmith e2e to pass locally.

- Summarize your change (**mandatory**)
  - Use `relation_id` to generate table ids instead. Current implementation uses `self.bound_relations.len()`. This can result in duplicate table ids generated.
    Queries with same number of bound_relations in local context will generate duplicate table ids.
  - Use local context when generating left and right factor of eqjoin.
- How does this PR work? Need a brief introduction for the changed logic (optional)
- Describe clearly one logical change and avoid lazy messages (optional)
- Describe any limitations of the current code (optional)

## Checklist

- [x] I have written necessary rustdoc comments
- [x] I have added necessary unit tests and integration tests
- [x] All checks passed in `./risedev check` (or alias, `./risedev c`)

## Documentation

If your pull request contains user-facing changes, please specify the types of the changes, and create a release note. Otherwise, please feel free to remove this section.

### Types of user-facing changes

Please keep the types that apply to your changes, and remove those that do not apply.

* Installation and deployment 
* Connector (sources & sinks)
* SQL commands, functions, and operators
* RisingWave cluster configuration changes
* Other (please specify in the release note below)

### Release note

Please create a release note for your changes. In the release note, focus on the impact on users, and mention the environment or conditions where the impact may occur.

## Refer to a related PR or issue link (optional)

Closes #4057