### PR TITLE
feat(sqlsmith): Remove `CROSS JOIN` workaround for `with_tables`

### DIFF
--- a/src/tests/sqlsmith/src/lib.rs
+++ b/src/tests/sqlsmith/src/lib.rs
@@ -338,22 +338,22 @@ impl<'a, R: Rng> SqlGenerator<'a, R> {
     }
 
     fn gen_from(&mut self, with_tables: Vec<Table>) -> Vec<TableWithJoins> {
-        // Cross join with `with` fails. Hence we generate it in isolation.
-        // Tracked in: <https://github.com/singularity-data/risingwave/issues/4025>
-        if !with_tables.is_empty() {
+        let mut from = if !with_tables.is_empty() {
             let with_table = with_tables
                 .choose(&mut self.rng)
                 .expect("with tables should not be empty");
-            return vec![create_table_with_joins_from_table(with_table)];
-        }
+            vec![create_table_with_joins_from_table(with_table)]
+        } else {
+            vec![self.gen_from_relation()]
+        };
+
         if self.is_mview {
             // TODO: These constraints are workarounds required by mview.
             // Tracked by: <https://github.com/singularity-data/risingwave/issues/4024>.
             assert!(!self.tables.is_empty());
-            return vec![self.gen_from_relation()];
+            return from;
         }
 
-        let mut from = vec![];
         for _ in 0..self.tables.len() {
             if self.flip_coin() {
                 from.push(self.gen_from_relation());


### PR DESCRIPTION
I hereby agree to the terms of the [Singularity Data, Inc. Contributor License Agreement](https://gist.github.com/skyzh/0663682a70b0edde7ae991492f2314cb#file-s9y_cla).

## What's changed and what's your intention?

Enable generation of `CTE`s from `WITH` clause in implicit `CROSS JOIN`:
```sql
FROM with_table, t0, t1, ...
```

Able to remove this workaround as #4025 has been resolved.

## Checklist

- [x] I have written necessary rustdoc comments
- [x] I have added necessary unit tests and integration tests
- [x] All checks passed in `./risedev check` (or alias, `./risedev c`)

## Documentation

If your pull request contains user-facing changes, please specify the types of the changes, and create a release note. Otherwise, please feel free to remove this section.

### Types of user-facing changes

Please keep the types that apply to your changes, and remove those that do not apply.

* Installation and deployment 
* Connector (sources & sinks)
* SQL commands, functions, and operators
* RisingWave cluster configuration changes
* Other (please specify in the release note below)

### Release note

Please create a release note for your changes. In the release note, focus on the impact on users, and mention the environment or conditions where the impact may occur.

## Refer to a related PR or issue link (optional)

Closes #4058 