### PR TITLE
fix(sqlsmith): handle unwraps properly

### DIFF
--- a/src/tests/sqlsmith/src/bin/main.rs
+++ b/src/tests/sqlsmith/src/bin/main.rs
@@ -91,7 +91,10 @@ async fn create_tables(
 
     for stmt in statements.iter() {
         let create_sql = format!("{}", stmt);
-        client.execute(&create_sql, &[]).await.unwrap();
+        client
+            .execute(&create_sql, &[])
+            .await
+            .unwrap_or_else(|_| panic!("Failed to execute SQL: {}", create_sql));
     }
     let mut tables = statements
         .into_iter()
@@ -109,7 +112,10 @@ async fn create_tables(
     // of being queried.
     for i in 0..n_statements {
         let (create_sql, table) = mview_sql_gen(rng, tables.clone(), &format!("m{}", i));
-        client.execute(&create_sql, &[]).await.unwrap();
+        client
+            .execute(&create_sql, &[])
+            .await
+            .unwrap_or_else(|_| panic!("Failed to execute SQL: {}", create_sql));
         tables.push(table.clone());
         mviews.push(table);
     }
@@ -132,7 +138,10 @@ async fn drop_tables(mviews: &[Table], opt: &TestOptions, client: &tokio_postgre
         .collect::<String>();
 
     for stmt in sql.lines() {
-        client.execute(stmt, &[]).await.unwrap();
+        client
+            .execute(stmt, &[])
+            .await
+            .unwrap_or_else(|_| panic!("Failed to execute SQL: {}", stmt));
     }
 }
 

--- a/src/tests/sqlsmith/tests/test_runner.rs
+++ b/src/tests/sqlsmith/tests/test_runner.rs
@@ -46,7 +46,9 @@ async fn create_tables(session: Arc<SessionImpl>, rng: &mut impl Rng) -> Vec<Tab
             } => {
                 let name = name.0[0].value.clone();
                 let columns = columns.iter().map(|c| c.clone().into()).collect();
-                handler::handle(session.clone(), s, &sql).await.unwrap();
+                handler::handle(session.clone(), s, &sql)
+                    .await
+                    .unwrap_or_else(|_| panic!("Failed to handle SQL: {}", sql));
                 tables.push(Table { name, columns })
             }
             _ => panic!("Unexpected statement: {}", s),
@@ -60,7 +62,9 @@ async fn create_tables(session: Arc<SessionImpl>, rng: &mut impl Rng) -> Vec<Tab
         let stmts =
             Parser::parse_sql(&sql).unwrap_or_else(|_| panic!("Failed to parse SQL: {}", sql));
         let stmt = stmts[0].clone();
-        handler::handle(session.clone(), stmt, &sql).await.unwrap();
+        handler::handle(session.clone(), stmt, &sql)
+            .await
+            .unwrap_or_else(|_| panic!("Failed to handle SQL: {}", sql));
         tables.push(table);
     }
     tables


### PR DESCRIPTION
I hereby agree to the terms of the [Singularity Data, Inc. Contributor License Agreement](https://gist.github.com/skyzh/0663682a70b0edde7ae991492f2314cb#file-s9y_cla).

## What's changed and what's your intention?

***PLEASE DO NOT LEAVE THIS EMPTY !!!***

- Summarize your change (**mandatory**)
  -  As seen from https://buildkite.com/singularity-data/main/builds/864#01821ef1-20eb-46fb-8605-d0a4e478c7ab.
     Causes CI job on main to fail. Cannot debug because errors not printing sql.
  - Error source is mview.
  - Need to handle panics too.

- Describe any limitations of the current code (optional)
  - Should use `Result` type to ensure errors are handled explicitly. Tracked: #4065 

## Checklist

- [ ] I have written necessary rustdoc comments
- [ ] I have added necessary unit tests and integration tests
- [ ] All checks passed in `./risedev check` (or alias, `./risedev c`)

## Documentation

If your pull request contains user-facing changes, please specify the types of the changes, and create a release note. Otherwise, please feel free to remove this section.

### Types of user-facing changes

Please keep the types that apply to your changes, and remove those that do not apply.

* Installation and deployment 
* Connector (sources & sinks)
* SQL commands, functions, and operators
* RisingWave cluster configuration changes
* Other (please specify in the release note below)

### Release note

Please create a release note for your changes. In the release note, focus on the impact on users, and mention the environment or conditions where the impact may occur.

## Refer to a related PR or issue link (optional)
