### PR TITLE
fix(sqlsmith): handle system panics [DEMO]

### DIFF
--- a/src/frontend/src/catalog/table_catalog.rs
+++ b/src/frontend/src/catalog/table_catalog.rs
@@ -178,12 +178,11 @@ impl From<ProstTable> for TableCatalog {
         let mut col_names = HashSet::new();
         let mut col_index: HashMap<i32, usize> = HashMap::new();
         let columns: Vec<ColumnCatalog> = tb.columns.into_iter().map(ColumnCatalog::from).collect();
-        panic!("test");
         for (idx, catalog) in columns.clone().into_iter().enumerate() {
             for col_desc in catalog.column_desc.flatten() {
                 let col_name = col_desc.name.clone();
-                if !col_names.insert(col_name.clone()) {
-                    panic!("duplicated column name {} in table {} ", col_name, tb.name)
+                if col_names.insert(col_name.clone()) {
+                    panic!("test");
                 }
             }
 

--- a/src/frontend/src/catalog/table_catalog.rs
+++ b/src/frontend/src/catalog/table_catalog.rs
@@ -178,6 +178,7 @@ impl From<ProstTable> for TableCatalog {
         let mut col_names = HashSet::new();
         let mut col_index: HashMap<i32, usize> = HashMap::new();
         let columns: Vec<ColumnCatalog> = tb.columns.into_iter().map(ColumnCatalog::from).collect();
+        panic!("test");
         for (idx, catalog) in columns.clone().into_iter().enumerate() {
             for col_desc in catalog.column_desc.flatten() {
                 let col_name = col_desc.name.clone();

--- a/src/tests/sqlsmith/src/bin/main.rs
+++ b/src/tests/sqlsmith/src/bin/main.rs
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use std::panic;
+use core::panic;
 use std::time::Duration;
 
 use clap::Parser as ClapParser;

--- a/src/tests/sqlsmith/src/bin/main.rs
+++ b/src/tests/sqlsmith/src/bin/main.rs
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use core::panic;
+use std::panic;
 use std::time::Duration;
 
 use clap::Parser as ClapParser;

--- a/src/tests/sqlsmith/tests/test_runner.rs
+++ b/src/tests/sqlsmith/tests/test_runner.rs
@@ -25,6 +25,17 @@ use risingwave_sqlparser::ast::Statement;
 use risingwave_sqlparser::parser::Parser;
 use risingwave_sqlsmith::{mview_sql_gen, sql_gen, Table};
 
+/// Executes and catches system panics to recover
+/// NOTE: It cannot deal with aborts
+async fn sqlsmith_handle(session: Arc<SessionImpl>, stmt: Statement, sql: &str) {
+    let res = panic::catch_unwind(|| async {
+        handler::handle(session.clone(), stmt, sql).await
+    });
+    match res {
+        Ok(Ok(_)) => {}
+    }
+}
+
 /// Create the tables defined in testdata.
 async fn create_tables(session: Arc<SessionImpl>, rng: &mut impl Rng) -> Vec<Table> {
     let seed_files = vec!["tests/testdata/tpch.sql", "tests/testdata/nexmark.sql"];
@@ -38,6 +49,7 @@ async fn create_tables(session: Arc<SessionImpl>, rng: &mut impl Rng) -> Vec<Tab
 
     let mut tables = vec![];
     for s in statements.into_iter() {
+        let stmt_sql = &s.to_string();
         match s {
             Statement::CreateTable {
                 ref name,
@@ -46,7 +58,7 @@ async fn create_tables(session: Arc<SessionImpl>, rng: &mut impl Rng) -> Vec<Tab
             } => {
                 let name = name.0[0].value.clone();
                 let columns = columns.iter().map(|c| c.clone().into()).collect();
-                handler::handle(session.clone(), s, &sql).await.unwrap();
+                handler::handle(session.clone(), s, &stmt_sql).await.unwrap();
                 tables.push(Table { name, columns })
             }
             _ => panic!("Unexpected statement: {}", s),

--- a/src/tests/sqlsmith/tests/test_runner.rs
+++ b/src/tests/sqlsmith/tests/test_runner.rs
@@ -37,6 +37,16 @@ async fn sqlsmith_handle(session: Arc<SessionImpl>, stmt: Statement, sql: String
     }
 }
 
+/// test abort
+async fn abort_proc() {
+    std::process::abort();
+}
+
+/// test normal panic
+async fn panic_proc() {
+    panic!("")
+}
+
 /// Create the tables defined in testdata.
 async fn create_tables(session: Arc<SessionImpl>, rng: &mut impl Rng) -> Vec<Table> {
     let seed_files = vec!["tests/testdata/tpch.sql", "tests/testdata/nexmark.sql"];
@@ -59,6 +69,7 @@ async fn create_tables(session: Arc<SessionImpl>, rng: &mut impl Rng) -> Vec<Tab
             } => {
                 let name = name.0[0].value.clone();
                 let columns = columns.iter().map(|c| c.clone().into()).collect();
+                sqlsmith_handle(session.clone(), s, &stmt_sql).await;
                 handler::handle(session.clone(), s, &stmt_sql).await.unwrap();
                 tables.push(Table { name, columns })
             }

--- a/src/tests/sqlsmith/tests/test_runner.rs
+++ b/src/tests/sqlsmith/tests/test_runner.rs
@@ -27,12 +27,13 @@ use risingwave_sqlsmith::{mview_sql_gen, sql_gen, Table};
 
 /// Executes and catches system panics to recover
 /// NOTE: It cannot deal with aborts
-async fn sqlsmith_handle(session: Arc<SessionImpl>, stmt: Statement, sql: &str) {
-    let res = panic::catch_unwind(|| async {
-        handler::handle(session.clone(), stmt, sql).await
-    });
+async fn sqlsmith_handle(session: Arc<SessionImpl>, stmt: Statement, sql: String) {
+    let res = tokio::spawn(async move {
+        handler::handle(session.clone(), stmt, &sql).await
+    }).await;
     match res {
-        Ok(Ok(_)) => {}
+        Ok(Ok(_)) => {},
+        _ => {}
     }
 }
 

--- a/src/tests/sqlsmith/tests/test_runner.rs
+++ b/src/tests/sqlsmith/tests/test_runner.rs
@@ -34,8 +34,8 @@ async fn sqlsmith_handle(session: Arc<SessionImpl>, stmt: Statement, sql: String
             .await;
     match res {
         Ok(Ok(_)) => {}
-        Ok(Err(e)) => println!("Encountered error while running SQL: {}\nERROR: {}", sql, e),
-        Err(e) => println!("Panic while running SQL: {}\nERROR: {}", sql, e),
+        Ok(Err(e)) => panic!("Encountered error while running SQL: {}\nERROR: {}", sql, e),
+        Err(e) => panic!("Panic while running SQL: {}\nERROR: {}", sql, e),
     }
 }
 

--- a/src/tests/sqlsmith/tests/test_runner.rs
+++ b/src/tests/sqlsmith/tests/test_runner.rs
@@ -25,8 +25,8 @@ use risingwave_sqlparser::ast::Statement;
 use risingwave_sqlparser::parser::Parser;
 use risingwave_sqlsmith::{mview_sql_gen, sql_gen, Table};
 
-/// Executes and catches system panics to recover
-/// NOTE: It cannot deal with aborts
+/// Executes sql queries
+/// It captures panics so it can recover and print failing sql query.
 async fn sqlsmith_handle(session: Arc<SessionImpl>, stmt: Statement, sql: String) {
     let sql_for_thread = sql.clone();
     let res =

--- a/src/tests/sqlsmith/tests/test_runner.rs
+++ b/src/tests/sqlsmith/tests/test_runner.rs
@@ -27,7 +27,7 @@ use risingwave_sqlsmith::{mview_sql_gen, sql_gen, Table};
 
 /// Executes sql queries
 /// It captures panics so it can recover and print failing sql query.
-async fn sqlsmith_handle(session: Arc<SessionImpl>, stmt: Statement, sql: String) {
+async fn handle(session: Arc<SessionImpl>, stmt: Statement, sql: String) {
     let sql_for_thread = sql.clone();
     let res =
         tokio::spawn(async move { handler::handle(session.clone(), stmt, &sql_for_thread).await })
@@ -61,7 +61,7 @@ async fn create_tables(session: Arc<SessionImpl>, rng: &mut impl Rng) -> Vec<Tab
             } => {
                 let name = name.0[0].value.clone();
                 let columns = columns.iter().map(|c| c.clone().into()).collect();
-                sqlsmith_handle(session.clone(), s, stmt_sql).await;
+                handle(session.clone(), s, stmt_sql).await;
                 tables.push(Table { name, columns })
             }
             _ => panic!("Unexpected statement: {}", s),
@@ -75,7 +75,7 @@ async fn create_tables(session: Arc<SessionImpl>, rng: &mut impl Rng) -> Vec<Tab
         let stmts =
             Parser::parse_sql(&sql).unwrap_or_else(|_| panic!("Failed to parse SQL: {}", sql));
         let stmt = stmts[0].clone();
-        handler::handle(session.clone(), stmt, &sql).await.unwrap();
+        handle(session.clone(), stmt, sql).await;
         tables.push(table);
     }
     tables

--- a/src/tests/sqlsmith/tests/test_runner.rs
+++ b/src/tests/sqlsmith/tests/test_runner.rs
@@ -34,8 +34,8 @@ async fn sqlsmith_handle(session: Arc<SessionImpl>, stmt: Statement, sql: String
             .await;
     match res {
         Ok(Ok(_)) => {}
-        Ok(Err(e)) => println!("Encountered error: {}", e),
-        Err(e) => println!("Panic while running sql: {}\n error: {}", sql, e),
+        Ok(Err(e)) => println!("Encountered error while running SQL: {}\nERROR: {}", sql, e),
+        Err(e) => println!("Panic while running SQL: {}\nERROR: {}", sql, e),
     }
 }
 


### PR DESCRIPTION
I hereby agree to the terms of the [Singularity Data, Inc. Contributor License Agreement](https://gist.github.com/skyzh/0663682a70b0edde7ae991492f2314cb#file-s9y_cla).

## What's changed and what's your intention?

**DO NOT MERGE**

See logs where panic is handled (https://buildkite.com/singularity-data/pull-request/builds/4082#01822046-b576-4b78-902b-b418e6ab7c69/137-2282)

Test panic handling for #4075 .
Throws a panic in same function as per the CI issue: https://github.com/singularity-data/risingwave/issues/4069
In future CI runs, potentially show which query caused #4069 .

## Checklist

- [ ] I have written necessary rustdoc comments
- [ ] I have added necessary unit tests and integration tests
- [ ] All checks passed in `./risedev check` (or alias, `./risedev c`)

## Documentation

If your pull request contains user-facing changes, please specify the types of the changes, and create a release note. Otherwise, please feel free to remove this section.

### Types of user-facing changes

Please keep the types that apply to your changes, and remove those that do not apply.

* Installation and deployment 
* Connector (sources & sinks)
* SQL commands, functions, and operators
* RisingWave cluster configuration changes
* Other (please specify in the release note below)

### Release note

Please create a release note for your changes. In the release note, focus on the impact on users, and mention the environment or conditions where the impact may occur.

## Refer to a related PR or issue link (optional)
