### PR TITLE
feat(local version manager): let CN record ssts uploaded

### DIFF
--- a/src/storage/src/hummock/local_version.rs
+++ b/src/storage/src/hummock/local_version.rs
@@ -20,7 +20,7 @@ use itertools::Itertools;
 use parking_lot::lock_api::ArcRwLockReadGuard;
 use parking_lot::{RawRwLock, RwLock};
 use risingwave_hummock_sdk::compaction_group::hummock_version_ext::HummockVersionExt;
-use risingwave_hummock_sdk::{CompactionGroupId, HummockEpoch, HummockVersionId};
+use risingwave_hummock_sdk::{CompactionGroupId, HummockEpoch, HummockSSTableId, HummockVersionId};
 use risingwave_pb::hummock::{HummockVersion, Level};
 use tokio::sync::mpsc::UnboundedSender;
 
@@ -28,6 +28,7 @@ use super::shared_buffer::SharedBuffer;
 
 #[derive(Debug, Clone)]
 pub struct LocalVersion {
+    pub uploaded_sst_ids: BTreeMap<HummockEpoch, Vec<HummockSSTableId>>,
     shared_buffer: BTreeMap<HummockEpoch, Arc<RwLock<SharedBuffer>>>,
     pinned_version: Arc<PinnedVersion>,
     pub version_ids_in_use: BTreeSet<HummockVersionId>,
@@ -41,6 +42,7 @@ impl LocalVersion {
         let mut version_ids_in_use = BTreeSet::new();
         version_ids_in_use.insert(version.id);
         Self {
+            uploaded_sst_ids: BTreeMap::default(),
             shared_buffer: BTreeMap::default(),
             pinned_version: Arc::new(PinnedVersion::new(version, unpin_worker_tx)),
             version_ids_in_use,

--- a/src/storage/src/hummock/local_version_manager.rs
+++ b/src/storage/src/hummock/local_version_manager.rs
@@ -496,6 +496,15 @@ impl LocalVersionManager {
             .flush(epoch, is_local, task_payload)
             .await;
 
+        if let Ok(ref ssts) = task_result {
+            let mut local_version_guard = self.local_version.write();
+            local_version_guard
+                .uploaded_sst_ids
+                .entry(epoch)
+                .or_default()
+                .extend(ssts.iter().map(|(_, sstable_info)| sstable_info.id));
+        }
+
         let local_version_guard = self.local_version.read();
         let mut shared_buffer_guard = local_version_guard
             .get_shared_buffer(epoch)


### PR DESCRIPTION
I hereby agree to the terms of the [Singularity Data, Inc. Contributor License Agreement](https://gist.github.com/skyzh/0663682a70b0edde7ae991492f2314cb#file-s9y_cla).

## What's changed and what's your intention?

let CN record ssts uploaded
see also #4072  as reference

## Checklist

## Documentation

If your pull request contains user-facing changes, please specify the types of the changes, and create a release note. Otherwise, please feel free to remove this section.

### Types of user-facing changes

Please keep the types that apply to your changes, and remove those that do not apply.

* Installation and deployment 
* Connector (sources & sinks)
* SQL commands, functions, and operators
* RisingWave cluster configuration changes
* Other (please specify in the release note below)

### Release note

Please create a release note for your changes. In the release note, focus on the impact on users, and mention the environment or conditions where the impact may occur.

## Refer to a related PR or issue link (optional)
