### PR TITLE
feat(meta): add get_cluster_info interfaces

### DIFF
--- a/proto/meta.proto
+++ b/proto/meta.proto
@@ -201,8 +201,15 @@ message ResumeRequest {}
 
 message ResumeResponse {}
 
+message GetClusterInfoRequest {}
+
+message GetClusterInfoResponse {
+  repeated TableFragments table_fragments = 1;
+}
+
 service ScaleService {
   // TODO(Kexiang): delete them when config change interface is finished
   rpc Pause(PauseRequest) returns (PauseResponse);
   rpc Resume(ResumeRequest) returns (ResumeResponse);
+  rpc GetClusterInfo(GetClusterInfoRequest) returns (GetClusterInfoResponse);
 }

--- a/src/meta/src/rpc/server.rs
+++ b/src/meta/src/rpc/server.rs
@@ -418,7 +418,8 @@ pub async fn rpc_serve_with_store<S: MetaStore>(
         ddl_lock.clone(),
     );
     let user_srv = UserServiceImpl::<S>::new(catalog_manager.clone(), user_manager.clone());
-    let scale_srv = ScaleServiceImpl::<S>::new(barrier_manager.clone(), ddl_lock);
+    let scale_srv =
+        ScaleServiceImpl::<S>::new(barrier_manager.clone(), fragment_manager.clone(), ddl_lock);
     let cluster_srv = ClusterServiceImpl::<S>::new(cluster_manager.clone());
     let stream_srv = StreamServiceImpl::<S>::new(
         env.clone(),


### PR DESCRIPTION
I hereby agree to the terms of the [Singularity Data, Inc. Contributor License Agreement](https://gist.github.com/skyzh/0663682a70b0edde7ae991492f2314cb#file-s9y_cla).

## What's changed and what's your intention?

Add an interface to get cluster info.
Although we already have a similar function for Dashboard, we tend to add a new independent interface for orchestrator. We may require more info through this interface. A new independent interface is more flexible.

## Checklist

- [x] I have written necessary rustdoc comments
- [x] I have added necessary unit tests and integration tests
- [x] All checks passed in `./risedev check` (or alias, `./risedev c`)

## Documentation

If your pull request contains user-facing changes, please specify the types of the changes, and create a release note. Otherwise, please feel free to remove this section.

### Types of user-facing changes

Please keep the types that apply to your changes, and remove those that do not apply.

* RisingWave cluster configuration changes

### Release note

Add an interface for the orchestrator to get cluster info.

## Refer to a related PR or issue link (optional)
