### PR TITLE
fix(risectl): support key doesn't belong to any table

### DIFF
--- a/src/ctl/src/cmd_impl/hummock/sst_dump.rs
+++ b/src/ctl/src/cmd_impl/hummock/sst_dump.rs
@@ -195,21 +195,29 @@ fn print_kv_pairs(block_data: Bytes, table_data: &TableData) -> anyhow::Result<(
         println!("\t\t      type: {}", if is_put { "Put" } else { "Delete" });
 
         if let Some(table_id) = get_table_id(full_key) {
-            let (table_name, columns) = table_data.get(&table_id).unwrap();
-            println!("\t\t     table: {} - {}", table_id, table_name);
+            print!("\t\t     table: {} - ", table_id);
+            match table_data.get(&table_id) {
+                None => {
+                    println!("(unknown)");
+                }
+                Some((table_name, columns)) => {
+                    println!("{}", table_name);
 
-            // Print stored value.
-            let column_idx = deserialize_column_id(&user_key[user_key.len() - 4..])?.get_id();
-            if is_put && !user_val.is_empty() && column_idx >= 0 {
-                let (data_type, name, is_hidden) = &columns[column_idx as usize];
-                let datum = deserialize_cell(user_val, data_type).unwrap().unwrap();
-                println!(
-                    "\t\t    column: {} {}",
-                    name,
-                    if *is_hidden { "(hidden)" } else { "" }
-                );
-                println!("\t\t     datum: {:?}", datum);
-            }
+                    // Print stored value.
+                    let column_idx =
+                        deserialize_column_id(&user_key[user_key.len() - 4..])?.get_id();
+                    if is_put && !user_val.is_empty() && column_idx >= 0 {
+                        let (data_type, name, is_hidden) = &columns[column_idx as usize];
+                        let datum = deserialize_cell(user_val, data_type).unwrap().unwrap();
+                        println!(
+                            "\t\t    column: {} {}",
+                            name,
+                            if *is_hidden { "(hidden)" } else { "" }
+                        );
+                        println!("\t\t     datum: {:?}", datum);
+                    }
+                }
+            };
         }
 
         println!();


### PR DESCRIPTION
I hereby agree to the terms of the [Singularity Data, Inc. Contributor License Agreement](https://gist.github.com/skyzh/0663682a70b0edde7ae991492f2314cb#file-s9y_cla).

## What's changed and what's your intention?

`./risedev ctl hummock sst-dump` allows to display the content of SSTs and show the stored KV-pairs including interpretation of them. The previous implementation (see PR #3916) assumes that each stored table-ID is known. However, that is not always the case and can cause the code to panic (see Issue #4043).

The current PR fixes that problem. In short, each `Option<T>::unwrap()` added in PR #3916 is replaced with an according logic to handle the case that a table- or column-ID is not know. Errors are still propagated.


## Refer to a related PR or issue link (optional)
Issue #4043 (risectl: support key doesn't belong to any table)
PR #3916 
