### PR TITLE
refactor(streaming): cleanup more stream executor error

### DIFF
--- a/src/batch/src/executor/hop_window.rs
+++ b/src/batch/src/executor/hop_window.rs
@@ -146,7 +146,7 @@ impl HopWindowExecutor {
             .exact_div(&window_slide)
             .and_then(|x| NonZeroUsize::new(usize::try_from(x).ok()?))
             .ok_or_else(|| ExprError::InvalidParam {
-                name: "",
+                name: "window",
                 reason: format!(
                     "window_size {} cannot be divided by window_slide {}",
                     window_size, window_slide

--- a/src/common/src/array/data_chunk_iter.rs
+++ b/src/common/src/array/data_chunk_iter.rs
@@ -217,13 +217,6 @@ impl ops::Index<usize> for Row {
     }
 }
 
-impl AsRef<Row> for Row {
-    #[inline]
-    fn as_ref(&self) -> &Row {
-        self
-    }
-}
-
 // TODO: remove this due to implicit allocation
 impl From<RowRef<'_>> for Row {
     fn from(row_ref: RowRef<'_>) -> Self {

--- a/src/stream/src/executor/aggregation/foldable.rs
+++ b/src/stream/src/executor/aggregation/foldable.rs
@@ -21,11 +21,11 @@ use risingwave_common::array::stream_chunk::Ops;
 use risingwave_common::array::*;
 use risingwave_common::bail;
 use risingwave_common::buffer::Bitmap;
-use risingwave_common::error::{ErrorCode, RwError};
 use risingwave_common::types::{Datum, Scalar, ScalarRef};
+use risingwave_expr::ExprError;
 
 use super::{StreamingAggFunction, StreamingAggState, StreamingAggStateImpl};
-use crate::executor::error::{StreamExecutorError, StreamExecutorResult};
+use crate::executor::error::StreamExecutorResult;
 
 /// A trait over all fold functions.
 ///
@@ -103,8 +103,7 @@ where
         Ok(match (result, input) {
             (Some(x), Some(y)) => Some(
                 x.checked_add(&(y.to_owned_scalar()).into())
-                    .ok_or_else(|| RwError::from(ErrorCode::NumericValueOutOfRange))
-                    .map_err(StreamExecutorError::eval_error)?,
+                    .ok_or(ExprError::NumericOutOfRange)?,
             ),
             (Some(x), None) => Some(x.clone()),
             (None, Some(y)) => Some((y.to_owned_scalar()).into()),
@@ -119,8 +118,7 @@ where
         Ok(match (result, input) {
             (Some(x), Some(y)) => Some(
                 x.checked_sub(&(y.to_owned_scalar()).into())
-                    .ok_or_else(|| RwError::from(ErrorCode::NumericValueOutOfRange))
-                    .map_err(StreamExecutorError::eval_error)?,
+                    .ok_or(ExprError::NumericOutOfRange)?,
             ),
             (Some(x), None) => Some(x.clone()),
             (None, Some(y)) => Some((-y.to_owned_scalar()).into()),

--- a/src/stream/src/executor/error.rs
+++ b/src/stream/src/executor/error.rs
@@ -18,6 +18,7 @@ use either::Either;
 use risingwave_common::array::ArrayError;
 use risingwave_common::error::{BoxedError, Error, ErrorCode, RwError, TrackingIssue};
 use risingwave_expr::ExprError;
+use risingwave_rpc_client::error::RpcError;
 use risingwave_storage::error::StorageError;
 
 use super::Barrier;
@@ -47,7 +48,7 @@ enum StreamExecutorErrorInner {
     SinkError(RwError),
 
     #[error("RPC error: {0}")]
-    RpcError(risingwave_rpc_client::error::RpcError),
+    RpcError(RpcError),
 
     #[error("Channel `{0}` closed")]
     ChannelClosed(String),
@@ -148,8 +149,8 @@ impl From<memcomparable::Error> for StreamExecutorError {
     }
 }
 
-impl From<risingwave_rpc_client::error::RpcError> for StreamExecutorError {
-    fn from(e: risingwave_rpc_client::error::RpcError) -> Self {
+impl From<RpcError> for StreamExecutorError {
+    fn from(e: RpcError) -> Self {
         StreamExecutorErrorInner::RpcError(e).into()
     }
 }

--- a/src/stream/src/executor/error.rs
+++ b/src/stream/src/executor/error.rs
@@ -42,6 +42,7 @@ enum StreamExecutorErrorInner {
     #[error("Source error: {0}")]
     SourceError(RwError),
 
+    // TODO: remove this
     #[error("Sink error: {0}")]
     SinkError(RwError),
 

--- a/src/stream/src/executor/hash_agg.rs
+++ b/src/stream/src/executor/hash_agg.rs
@@ -251,11 +251,7 @@ impl<K: HashKey, S: StateStore> HashAggExecutor<K, S> {
                         Some(s) => s.unwrap(),
                         None => Box::new(
                             generate_managed_agg_state(
-                                Some(
-                                    &key.clone()
-                                        .deserialize(key_data_types.iter())
-                                        .map_err(StreamExecutorError::serde_error)?,
-                                ),
+                                Some(&key.clone().deserialize(key_data_types.iter())?),
                                 agg_calls,
                                 input_pk_data_types.clone(),
                                 epoch,
@@ -371,8 +367,7 @@ impl<K: HashKey, S: StateStore> HashAggExecutor<K, S> {
 
                     for _ in 0..appended {
                         key.clone()
-                            .deserialize_to_builders(&mut builders[..key_indices.len()])
-                            .map_err(StreamExecutorError::serde_error)?;
+                            .deserialize_to_builders(&mut builders[..key_indices.len()])?;
                     }
                 }
 

--- a/src/stream/src/executor/hash_agg.rs
+++ b/src/stream/src/executor/hash_agg.rs
@@ -25,7 +25,6 @@ use risingwave_common::array::{StreamChunk, Vis};
 use risingwave_common::buffer::Bitmap;
 use risingwave_common::catalog::Schema;
 use risingwave_common::collection::evictable::EvictableHashMap;
-use risingwave_common::error::Result;
 use risingwave_common::hash::{HashCode, HashKey};
 use risingwave_common::util::hash_util::CRC32FastBuilder;
 use risingwave_storage::table::state_table::StateTable;
@@ -111,7 +110,7 @@ impl<K: HashKey, S: StateStore> HashAggExecutor<K, S> {
         executor_id: u64,
         key_indices: Vec<usize>,
         mut state_tables: Vec<StateTable<S>>,
-    ) -> Result<Self> {
+    ) -> StreamExecutorResult<Self> {
         let input_info = input.info();
         let schema = generate_agg_schema(input.as_ref(), &agg_calls, Some(&key_indices));
 
@@ -147,7 +146,7 @@ impl<K: HashKey, S: StateStore> HashAggExecutor<K, S> {
         keys: Vec<K>,
         key_hash_codes: Vec<HashCode>,
         visibility: &Option<Bitmap>,
-    ) -> Result<Vec<(K, HashCode, Bitmap)>> {
+    ) -> StreamExecutorResult<Vec<(K, HashCode, Bitmap)>> {
         let total_num_rows = keys.len();
         assert_eq!(key_hash_codes.len(), total_num_rows);
         // Each hash key, e.g. `key1` corresponds to a visibility map that not only shadows
@@ -214,8 +213,7 @@ impl<K: HashKey, S: StateStore> HashAggExecutor<K, S> {
 
         // --- Find unique keys in this batch and generate visibility map for each key ---
         // TODO: this might be inefficient if there are not too many duplicated keys in one batch.
-        let unique_keys = Self::get_unique_keys(keys, hash_codes, &visibility)
-            .map_err(StreamExecutorError::eval_error)?;
+        let unique_keys = Self::get_unique_keys(keys, hash_codes, &visibility)?;
 
         // --- Retrieve all aggregation inputs in advance ---
         // Previously, this is done in `unique_keys` inner loop, which is very inefficient.
@@ -256,7 +254,7 @@ impl<K: HashKey, S: StateStore> HashAggExecutor<K, S> {
                                 Some(
                                     &key.clone()
                                         .deserialize(key_data_types.iter())
-                                        .map_err(StreamExecutorError::eval_error)?,
+                                        .map_err(StreamExecutorError::serde_error)?,
                                 ),
                                 agg_calls,
                                 input_pk_data_types.clone(),
@@ -374,15 +372,16 @@ impl<K: HashKey, S: StateStore> HashAggExecutor<K, S> {
                     for _ in 0..appended {
                         key.clone()
                             .deserialize_to_builders(&mut builders[..key_indices.len()])
-                            .map_err(StreamExecutorError::eval_error)?;
+                            .map_err(StreamExecutorError::serde_error)?;
                     }
                 }
 
                 let columns: Vec<Column> = builders
                     .into_iter()
-                    .map(|builder| -> Result<_> { Ok(Column::new(Arc::new(builder.finish()?))) })
-                    .try_collect()
-                    .map_err(StreamExecutorError::eval_error)?;
+                    .map(|builder| {
+                        Ok::<_, StreamExecutorError>(Column::new(Arc::new(builder.finish()?)))
+                    })
+                    .try_collect()?;
 
                 let chunk = StreamChunk::new(new_ops, columns, None);
 

--- a/src/stream/src/executor/managed_state/join/mod.rs
+++ b/src/stream/src/executor/managed_state/join/mod.rs
@@ -31,7 +31,7 @@ use risingwave_storage::table::state_table::StateTable;
 use risingwave_storage::StateStore;
 use stats_alloc::{SharedStatsAlloc, StatsAlloc};
 
-use crate::executor::error::{StreamExecutorError, StreamExecutorResult};
+use crate::executor::error::StreamExecutorResult;
 use crate::executor::monitor::StreamingMetrics;
 
 type DegreeType = u64;
@@ -278,10 +278,7 @@ impl<K: HashKey, S: StateStore> JoinHashMap<K, S> {
     /// Fetch cache from the state store. Should only be called if the key does not exist in memory.
     /// Will return a empty `JoinEntryState` even when state does not exist in remote.
     async fn fetch_cached_state(&self, key: &K) -> StreamExecutorResult<JoinEntryState> {
-        let key = key
-            .clone()
-            .deserialize(self.join_key_data_types.iter())
-            .map_err(StreamExecutorError::serde_error)?;
+        let key = key.clone().deserialize(self.join_key_data_types.iter())?;
 
         let table_iter = self
             .state_table

--- a/src/stream/src/executor/mod.rs
+++ b/src/stream/src/executor/mod.rs
@@ -17,7 +17,6 @@ use std::fmt::Debug;
 use std::sync::Arc;
 
 use enum_as_inner::EnumAsInner;
-use error::StreamExecutorResult;
 use futures::stream::BoxStream;
 use futures::{Stream, StreamExt};
 use itertools::Itertools;
@@ -89,6 +88,7 @@ pub use chain::ChainExecutor;
 pub use debug::DebugExecutor;
 pub use dispatch::{DispatchExecutor, DispatcherImpl};
 pub use dynamic_filter::DynamicFilterExecutor;
+pub use error::StreamExecutorResult;
 pub use expand::ExpandExecutor;
 pub use filter::FilterExecutor;
 pub use global_simple_agg::GlobalSimpleAggExecutor;

--- a/src/stream/src/executor/source/source_executor.rs
+++ b/src/stream/src/executor/source/source_executor.rs
@@ -163,10 +163,7 @@ impl<S: StateStore> SourceExecutor<S> {
             .collect_vec();
 
         if !cache.is_empty() {
-            self.split_state_store
-                .take_snapshot(cache, epoch)
-                .await
-                .map_err(StreamExecutorError::source_error)?;
+            self.split_state_store.take_snapshot(cache, epoch).await?;
         }
 
         Ok(())
@@ -216,8 +213,7 @@ impl<S: StateStore> SourceExecutor<S> {
             if let Some(recover_state) = self
                 .split_state_store
                 .try_recover_from_state_store(ele, epoch)
-                .await
-                .map_err(StreamExecutorError::source_error)?
+                .await?
             {
                 *ele = recover_state;
             }

--- a/src/stream/src/executor/source/state.rs
+++ b/src/stream/src/executor/source/state.rs
@@ -14,14 +14,16 @@
 
 use std::fmt::Debug;
 
-use anyhow::{anyhow, Result};
 use bytes::Bytes;
 use log::error;
-use risingwave_common::error::{internal_error, Result as RwResult};
+use risingwave_common::bail;
 use risingwave_connector::source::{SplitImpl, SplitMetaData};
 use risingwave_storage::storage_value::StorageValue;
 use risingwave_storage::store::WriteOptions;
 use risingwave_storage::{Keyspace, StateStore};
+
+use crate::executor::error::StreamExecutorError;
+use crate::executor::StreamExecutorResult;
 
 /// `SourceState` Represents an abstraction of state,
 /// e.g. if the Kafka Source state consists of `topic` `partition_id` and `offset`.
@@ -54,13 +56,13 @@ impl<S: StateStore> SourceStateHandler<S> {
     /// and needs to be invoked by the ``SourceReader`` to call it,
     /// and will return the error when the dependent ``StateStore`` handles the error.
     /// The caller should ensure that the passed parameters are not empty.
-    pub async fn take_snapshot<SS>(&self, states: Vec<SS>, epoch: u64) -> Result<()>
+    pub async fn take_snapshot<SS>(&self, states: Vec<SS>, epoch: u64) -> StreamExecutorResult<()>
     where
         SS: SplitMetaData,
     {
         if states.is_empty() {
             // TODO should be a clear Error Code
-            Err(anyhow!("states require not null"))
+            bail!("states require not null");
         } else {
             let mut write_batch = self.keyspace.state_store().start_write_batch(WriteOptions {
                 epoch,
@@ -73,17 +75,14 @@ impl<S: StateStore> SourceStateHandler<S> {
                 local_batch.put(state.id(), StorageValue::new_default_put(value));
             });
             // If an error is returned, the underlying state should be rollback
-            let ingest_rs = write_batch.ingest().await;
-            match ingest_rs {
-                Err(e) => {
-                    error!(
-                        "SourceStateHandler take_snapshot() batch.ingest Error,cause by {:?}",
-                        e
-                    );
-                    Err(anyhow!(e))
-                }
-                _ => Ok(()),
-            }
+            write_batch.ingest().await.inspect_err(|e| {
+                error!(
+                    "SourceStateHandler take_snapshot() batch.ingest Error,cause by {:?}",
+                    e
+                );
+            })?;
+
+            Ok(())
         }
     }
 
@@ -95,26 +94,29 @@ impl<S: StateStore> SourceStateHandler<S> {
         &self,
         state_identifier: String,
         epoch: u64,
-    ) -> Result<Option<Bytes>> {
+    ) -> StreamExecutorResult<Option<Bytes>> {
         self.keyspace
             .get(state_identifier, epoch)
             .await
-            .map_err(|e| anyhow!(e))
+            .map_err(Into::into)
     }
 
     pub async fn try_recover_from_state_store(
         &self,
         stream_source_split: &SplitImpl,
         epoch: u64,
-    ) -> RwResult<Option<SplitImpl>> {
+    ) -> StreamExecutorResult<Option<SplitImpl>> {
         // let connector_type = stream_source_split.get_type();
-        match self.restore_states(stream_source_split.id(), epoch).await {
-            Ok(Some(s)) => Ok(Some(
-                SplitImpl::restore_from_bytes(&s).map_err(|e| internal_error(e.to_string()))?,
-            )),
-            Ok(None) => Ok(None),
-            Err(e) => Err(internal_error(e.to_string())),
-        }
+        let s = self.restore_states(stream_source_split.id(), epoch).await?;
+
+        let split = match s {
+            Some(s) => {
+                Some(SplitImpl::restore_from_bytes(&s).map_err(StreamExecutorError::source_error)?)
+            }
+            None => None,
+        };
+
+        Ok(split)
     }
 }
 
@@ -148,13 +150,13 @@ mod tests {
             Bytes::from(serde_json::to_string(self).unwrap())
         }
 
-        fn restore_from_bytes(bytes: &[u8]) -> Result<Self> {
-            serde_json::from_slice(bytes).map_err(|e| anyhow!(e))
+        fn restore_from_bytes(bytes: &[u8]) -> anyhow::Result<Self> {
+            serde_json::from_slice(bytes).map_err(|e| anyhow::anyhow!(e))
         }
     }
 
     #[test]
-    fn test_state_encode() -> Result<()> {
+    fn test_state_encode() -> anyhow::Result<()> {
         let offset = 100_i64;
         let partition = String::from("p0");
         let state_instance = TestSourceState::new(partition.clone(), offset);
@@ -185,13 +187,13 @@ mod tests {
     async fn take_snapshot_and_get_states(
         state_handler: SourceStateHandler<MemoryStateStore>,
         current_epoch: u64,
-    ) -> (Vec<TestSourceState>, Result<()>) {
+    ) -> (Vec<TestSourceState>, anyhow::Result<()>) {
         let states = test_state_store_vec();
         println!("Vec<TestSourceStat>={:?}", states.clone());
         let rs = state_handler
             .take_snapshot(states.clone(), current_epoch)
             .await;
-        (states, rs)
+        (states, rs.map_err(Into::into))
     }
 
     #[tokio::test]


### PR DESCRIPTION
I hereby agree to the terms of the [Singularity Data, Inc. Contributor License Agreement](https://gist.github.com/skyzh/0663682a70b0edde7ae991492f2314cb#file-s9y_cla).

## What's changed and what's your intention?

As title. After connector introduces its per-crate error, we're able to remove the `SourceError` and `SinkError`.

## Checklist

- [x] I have written necessary rustdoc comments
- [x] I have added necessary unit tests and integration tests
- [x] All checks passed in `./risedev check` (or alias, `./risedev c`)

## Refer to a related PR or issue link (optional)
- #3116 