### PR TITLE
refactor(pgwire): move argument states into the struct

### DIFF
--- a/src/utils/pgwire/src/pg_protocol.rs
+++ b/src/utils/pgwire/src/pg_protocol.rs
@@ -38,10 +38,8 @@ pub struct PgProtocol<S, SM>
 where
     SM: SessionManager,
 {
-    /// Used for write/read message in tcp connection.
-    stream: S,
-    /// Write into buffer before flush to stream.
-    buf_out: BytesMut,
+    /// Used for write/read pg messages.
+    stream: PgStream<S>,
     /// Current states of pg connection.
     state: PgProtocolState,
     /// Whether the connection is terminated.
@@ -49,6 +47,11 @@ where
 
     session_mgr: Arc<SM>,
     session: Option<Arc<SM::Session>>,
+
+    unnamed_statement: PgStatement,
+    unnamed_portal: PgPortal,
+    named_statements: HashMap<String, PgStatement>,
+    named_portals: HashMap<String, PgPortal>,
 }
 
 /// States flow happened from top to down.
@@ -57,8 +60,9 @@ enum PgProtocolState {
     Regular,
 }
 
-// Truncate 0 from C string in Bytes and stringify it (returns slice, no allocations)
-// PG protocol strings are always C strings.
+/// Truncate 0 from C string in Bytes and stringify it (returns slice, no allocations).
+///
+/// PG protocol strings are always C strings.
 pub fn cstr_to_str(b: &Bytes) -> Result<&str, Utf8Error> {
     let without_null = if b.last() == Some(&0) {
         &b[..b.len() - 1]
@@ -75,56 +79,29 @@ where
 {
     pub fn new(stream: S, session_mgr: Arc<SM>) -> Self {
         Self {
-            stream,
+            stream: PgStream {
+                stream,
+                write_buf: BytesMut::with_capacity(10 * 1024),
+            },
             is_terminate: false,
             state: PgProtocolState::Startup,
-            buf_out: BytesMut::with_capacity(10 * 1024),
             session_mgr,
             session: None,
+            unnamed_statement: Default::default(),
+            unnamed_portal: Default::default(),
+            named_statements: Default::default(),
+            named_portals: Default::default(),
         }
     }
 
-    pub async fn process(
-        &mut self,
-        unnamed_statement: &mut PgStatement,
-        unnamed_portal: &mut PgPortal,
-        named_statements: &mut HashMap<String, PgStatement>,
-        named_portals: &mut HashMap<String, PgPortal>,
-    ) -> bool {
-        if self
-            .do_process(
-                unnamed_statement,
-                unnamed_portal,
-                named_statements,
-                named_portals,
-            )
-            .await
-        {
-            return true;
-        }
-
-        self.is_terminate()
+    /// Processes one message. Returns true if the connection is terminated.
+    pub async fn process(&mut self) -> bool {
+        self.do_process().await || self.is_terminate
     }
 
-    async fn do_process(
-        &mut self,
-        unnamed_statement: &mut PgStatement,
-        unnamed_portal: &mut PgPortal,
-        named_statements: &mut HashMap<String, PgStatement>,
-        named_portals: &mut HashMap<String, PgPortal>,
-    ) -> bool {
-        match self
-            .do_process_inner(
-                unnamed_statement,
-                unnamed_portal,
-                named_statements,
-                named_portals,
-            )
-            .await
-        {
-            Ok(v) => {
-                return v;
-            }
+    async fn do_process(&mut self) -> bool {
+        match self.do_process_inner().await {
+            Ok(v) => v,
             Err(e) => {
                 tracing::error!("Error: {}", e);
                 match e {
@@ -135,7 +112,8 @@ where
                     }
 
                     PsqlError::StartupError(_) | PsqlError::PasswordError(_) => {
-                        self.write_message_for_error(&BeMessage::ErrorResponse(Box::new(e)));
+                        self.stream
+                            .write_for_error(&BeMessage::ErrorResponse(Box::new(e)));
                         return true;
                     }
 
@@ -143,13 +121,15 @@ where
                         if io_err.kind() == std::io::ErrorKind::UnexpectedEof {
                             return true;
                         }
-                        self.write_message_for_error(&BeMessage::ErrorResponse(Box::new(io_err)));
-                        self.write_message_for_error(&BeMessage::ReadyForQuery);
+                        self.stream
+                            .write_for_error(&BeMessage::ErrorResponse(Box::new(io_err)));
+                        self.stream.write_for_error(&BeMessage::ReadyForQuery);
                     }
 
                     PsqlError::QueryError(_) => {
-                        self.write_message_for_error(&BeMessage::ErrorResponse(Box::new(e)));
-                        self.write_message_for_error(&BeMessage::ReadyForQuery);
+                        self.stream
+                            .write_for_error(&BeMessage::ErrorResponse(Box::new(e)));
+                        self.stream.write_for_error(&BeMessage::ReadyForQuery);
                     }
 
                     PsqlError::CloseError(_)
@@ -157,100 +137,50 @@ where
                     | PsqlError::ParseError(_)
                     | PsqlError::BindError(_)
                     | PsqlError::ExecuteError(_) => {
-                        self.write_message_for_error(&BeMessage::ErrorResponse(Box::new(e)));
+                        self.stream
+                            .write_for_error(&BeMessage::ErrorResponse(Box::new(e)));
                     }
 
                     // Never reach this.
                     PsqlError::CancelMsg(_) => todo!(),
                 }
-                self.flush_for_error().await;
-            }
-        };
-        false
-    }
-
-    async fn do_process_inner(
-        &mut self,
-        unnamed_statement: &mut PgStatement,
-        unnamed_portal: &mut PgPortal,
-        named_statements: &mut HashMap<String, PgStatement>,
-        named_portals: &mut HashMap<String, PgPortal>,
-    ) -> PsqlResult<bool> {
-        let msg = self.read_message().await?;
-        match msg {
-            FeMessage::Ssl => {
-                self.process_ssl_msg()?;
-            }
-            FeMessage::Startup(msg) => {
-                self.process_startup_msg(msg)?;
-                self.state = PgProtocolState::Regular;
-            }
-            FeMessage::Password(msg) => {
-                self.process_password_msg(msg)?;
-                self.state = PgProtocolState::Regular;
-            }
-            FeMessage::Query(query_msg) => {
-                self.process_query_msg(query_msg.get_sql()).await?;
-            }
-            FeMessage::CancelQuery => {
-                self.process_cancel_msg()?;
-            }
-            FeMessage::Terminate => {
-                self.process_terminate();
-            }
-            FeMessage::Parse(m) => {
-                self.process_parse_msg(m, named_statements, unnamed_statement)
-                    .await?;
-            }
-            FeMessage::Bind(m) => {
-                self.process_bind_msg(
-                    m,
-                    named_statements,
-                    unnamed_statement,
-                    named_portals,
-                    unnamed_portal,
-                )
-                .await?;
-            }
-            FeMessage::Execute(m) => {
-                self.process_execute_msg(m, named_portals, unnamed_portal)
-                    .await?;
-            }
-            FeMessage::Describe(m) => {
-                self.process_describe_msg(
-                    m,
-                    named_statements,
-                    unnamed_statement,
-                    named_portals,
-                    unnamed_portal,
-                )
-                .await?;
-            }
-            FeMessage::Sync => {
-                self.write_message(&BeMessage::ReadyForQuery).await?;
-            }
-            FeMessage::Close(m) => {
-                self.process_close_msg(m, named_statements, named_portals)
-                    .await?;
+                self.stream.flush_for_error().await;
+                false
             }
         }
-        self.flush().await?;
+    }
+
+    async fn do_process_inner(&mut self) -> PsqlResult<bool> {
+        let msg = self.read_message().await?;
+        match msg {
+            FeMessage::Ssl => self.process_ssl_msg()?,
+            FeMessage::Startup(msg) => self.process_startup_msg(msg)?,
+            FeMessage::Password(msg) => self.process_password_msg(msg)?,
+            FeMessage::Query(query_msg) => self.process_query_msg(query_msg.get_sql()).await?,
+            FeMessage::CancelQuery => self.process_cancel_msg()?,
+            FeMessage::Terminate => self.process_terminate(),
+            FeMessage::Parse(m) => self.process_parse_msg(m).await?,
+            FeMessage::Bind(m) => self.process_bind_msg(m).await?,
+            FeMessage::Execute(m) => self.process_execute_msg(m).await?,
+            FeMessage::Describe(m) => self.process_describe_msg(m).await?,
+            FeMessage::Sync => self.stream.write(&BeMessage::ReadyForQuery).await?,
+            FeMessage::Close(m) => self.process_close_msg(m).await?,
+        }
+        self.stream.flush().await?;
         Ok(false)
     }
 
     async fn read_message(&mut self) -> PsqlResult<FeMessage> {
         match self.state {
-            PgProtocolState::Startup => FeStartupMessage::read(&mut self.stream)
-                .await
-                .map_err(PsqlError::ReadMsgError),
-            PgProtocolState::Regular => FeMessage::read(&mut self.stream)
-                .await
-                .map_err(PsqlError::ReadMsgError),
+            PgProtocolState::Startup => self.stream.read_startup().await,
+            PgProtocolState::Regular => self.stream.read().await,
         }
+        .map_err(PsqlError::ReadMsgError)
     }
 
     fn process_ssl_msg(&mut self) -> PsqlResult<()> {
-        self.write_message_no_flush(&BeMessage::EncryptionResponse)
+        self.stream
+            .write_no_flush(&BeMessage::EncryptionResponse)
             .map_err(PsqlError::SslError)?;
         Ok(())
     }
@@ -273,23 +203,29 @@ where
             .map_err(PsqlError::StartupError)?;
         match session.user_authenticator() {
             UserAuthenticator::None => {
-                self.write_message_no_flush(&BeMessage::AuthenticationOk)
+                self.stream
+                    .write_no_flush(&BeMessage::AuthenticationOk)
                     .map_err(|err| PsqlError::StartupError(Box::new(err)))?;
-                self.write_parameter_status_msg_no_flush()
+                self.stream
+                    .write_parameter_status_msg_no_flush()
                     .map_err(|err| PsqlError::StartupError(Box::new(err)))?;
-                self.write_message_no_flush(&BeMessage::ReadyForQuery)
+                self.stream
+                    .write_no_flush(&BeMessage::ReadyForQuery)
                     .map_err(|err| PsqlError::StartupError(Box::new(err)))?;
             }
             UserAuthenticator::ClearText(_) => {
-                self.write_message_no_flush(&BeMessage::AuthenticationCleartextPassword)
+                self.stream
+                    .write_no_flush(&BeMessage::AuthenticationCleartextPassword)
                     .map_err(|err| PsqlError::StartupError(Box::new(err)))?;
             }
             UserAuthenticator::MD5WithSalt { salt, .. } => {
-                self.write_message_no_flush(&BeMessage::AuthenticationMD5Password(salt))
+                self.stream
+                    .write_no_flush(&BeMessage::AuthenticationMD5Password(salt))
                     .map_err(|err| PsqlError::StartupError(Box::new(err)))?;
             }
         }
         self.session = Some(session);
+        self.state = PgProtocolState::Regular;
         Ok(())
     }
 
@@ -301,17 +237,22 @@ where
                 "Invalid password",
             )));
         }
-        self.write_message_no_flush(&BeMessage::AuthenticationOk)
+        self.stream
+            .write_no_flush(&BeMessage::AuthenticationOk)
             .map_err(PsqlError::PasswordError)?;
-        self.write_parameter_status_msg_no_flush()
+        self.stream
+            .write_parameter_status_msg_no_flush()
             .map_err(PsqlError::PasswordError)?;
-        self.write_message_no_flush(&BeMessage::ReadyForQuery)
+        self.stream
+            .write_no_flush(&BeMessage::ReadyForQuery)
             .map_err(PsqlError::PasswordError)?;
+        self.state = PgProtocolState::Regular;
         Ok(())
     }
 
     fn process_cancel_msg(&mut self) -> PsqlResult<()> {
-        self.write_message_no_flush(&BeMessage::ErrorResponse(Box::new(PsqlError::cancel())))?;
+        self.stream
+            .write_no_flush(&BeMessage::ErrorResponse(Box::new(PsqlError::cancel())))?;
         Ok(())
     }
 
@@ -327,18 +268,19 @@ where
             .map_err(|err| PsqlError::QueryError(err))?;
 
         if res.is_empty() {
-            self.write_message_no_flush(&BeMessage::EmptyQueryResponse)?;
+            self.stream.write_no_flush(&BeMessage::EmptyQueryResponse)?;
         } else if res.is_query() {
             self.process_response_results(res, false).await?;
         } else {
-            self.write_message_no_flush(&BeMessage::CommandComplete(BeCommandCompleteMessage {
-                stmt_type: res.get_stmt_type(),
-                notice: res.get_notice(),
-                rows_cnt: res.get_effected_rows_cnt(),
-            }))?;
+            self.stream
+                .write_no_flush(&BeMessage::CommandComplete(BeCommandCompleteMessage {
+                    stmt_type: res.get_stmt_type(),
+                    notice: res.get_notice(),
+                    rows_cnt: res.get_effected_rows_cnt(),
+                }))?;
         }
 
-        self.write_message_no_flush(&BeMessage::ReadyForQuery)?;
+        self.stream.write_no_flush(&BeMessage::ReadyForQuery)?;
         Ok(())
     }
 
@@ -346,12 +288,7 @@ where
         self.is_terminate = true;
     }
 
-    async fn process_parse_msg(
-        &mut self,
-        msg: FeParseMessage,
-        named_statements: &mut HashMap<String, PgStatement>,
-        unnamed_statement: &mut PgStatement,
-    ) -> PsqlResult<()> {
+    async fn process_parse_msg(&mut self, msg: FeParseMessage) -> PsqlResult<()> {
         let query = cstr_to_str(&msg.query_string).unwrap();
         tracing::trace!("(extended query)parse query: {}", query);
         // 1. Create the types description.
@@ -409,31 +346,24 @@ where
         // 4. Insert the statement.
         let name = statement.name();
         if name.is_empty() {
-            *unnamed_statement = statement;
+            self.unnamed_statement = statement;
         } else {
-            named_statements.insert(name, statement);
+            self.named_statements.insert(name, statement);
         }
-        self.write_message(&BeMessage::ParseComplete).await?;
+        self.stream.write(&BeMessage::ParseComplete).await?;
         Ok(())
     }
 
-    async fn process_bind_msg(
-        &mut self,
-        msg: FeBindMessage,
-        named_statements: &mut HashMap<String, PgStatement>,
-        unnamed_statement: &mut PgStatement,
-        named_portals: &mut HashMap<String, PgPortal>,
-        unnamed_portal: &mut PgPortal,
-    ) -> PsqlResult<()> {
+    async fn process_bind_msg(&mut self, msg: FeBindMessage) -> PsqlResult<()> {
         let statement_name = cstr_to_str(&msg.statement_name).unwrap().to_string();
         // 1. Get statement.
         let statement = if statement_name.is_empty() {
-            unnamed_statement
+            &self.unnamed_statement
         } else {
             // NOTE Error handle method may need to modified.
             // Postgresql doc needs write ErrorResponse if name not found. We may revisit
             // this part if needed.
-            named_statements.get(&statement_name).expect("statement_name managed by client_driver, hence assume statement name always valid.")
+            self.named_statements.get(&statement_name).expect("statement_name managed by client_driver, hence assume statement name always valid.")
         };
 
         // 2. Instance the statement to get the portal.
@@ -449,27 +379,22 @@ where
 
         // 3. Insert the Portal.
         if portal_name.is_empty() {
-            *unnamed_portal = portal;
+            self.unnamed_portal = portal;
         } else {
-            named_portals.insert(portal_name, portal);
+            self.named_portals.insert(portal_name, portal);
         }
-        self.write_message(&BeMessage::BindComplete).await?;
+        self.stream.write(&BeMessage::BindComplete).await?;
         Ok(())
     }
 
-    async fn process_execute_msg(
-        &mut self,
-        msg: FeExecuteMessage,
-        named_portals: &mut HashMap<String, PgPortal>,
-        unnamed_portal: &mut PgPortal,
-    ) -> PsqlResult<()> {
+    async fn process_execute_msg(&mut self, msg: FeExecuteMessage) -> PsqlResult<()> {
         // 1. Get portal.
         let portal_name = cstr_to_str(&msg.portal_name).unwrap().to_string();
         let portal = if msg.portal_name.is_empty() {
-            unnamed_portal
+            &mut self.unnamed_portal
         } else {
             // NOTE Error handle need modify later.
-            named_portals.get_mut(&portal_name).expect(
+            self.named_portals.get_mut(&portal_name).expect(
                 "portal_name managed by client_driver, hence assume portal name always valid",
             )
         };
@@ -487,29 +412,23 @@ where
             .map_err(PsqlError::ExecuteError)?;
 
         if res.is_empty() {
-            self.write_message_no_flush(&BeMessage::EmptyQueryResponse)?;
+            self.stream.write_no_flush(&BeMessage::EmptyQueryResponse)?;
         } else if res.is_query() {
             self.process_response_results(res, true).await?;
         } else {
-            self.write_message_no_flush(&BeMessage::CommandComplete(BeCommandCompleteMessage {
-                stmt_type: res.get_stmt_type(),
-                notice: res.get_notice(),
-                rows_cnt: res.get_effected_rows_cnt(),
-            }))?;
+            self.stream
+                .write_no_flush(&BeMessage::CommandComplete(BeCommandCompleteMessage {
+                    stmt_type: res.get_stmt_type(),
+                    notice: res.get_notice(),
+                    rows_cnt: res.get_effected_rows_cnt(),
+                }))?;
         }
 
         // NOTE there is no ReadyForQuery message.
         Ok(())
     }
 
-    async fn process_describe_msg(
-        &mut self,
-        msg: FeDescribeMessage,
-        named_statements: &mut HashMap<String, PgStatement>,
-        unnamed_statement: &mut PgStatement,
-        named_portals: &mut HashMap<String, PgPortal>,
-        unnamed_portal: &mut PgPortal,
-    ) -> PsqlResult<()> {
+    async fn process_describe_msg(&mut self, msg: FeDescribeMessage) -> PsqlResult<()> {
         // m.kind indicates the Describe type:
         //  b'S' => Statement
         //  b'P' => Portal
@@ -517,49 +436,47 @@ where
         if msg.kind == b'S' {
             let name = cstr_to_str(&msg.query_name).unwrap().to_string();
             let statement = if name.is_empty() {
-                unnamed_statement
+                &self.unnamed_statement
             } else {
                 // NOTE Error handle need modify later.
-                named_statements.get(&name).unwrap()
+                self.named_statements.get(&name).unwrap()
             };
 
             // 1. Send parameter description.
-            self.write_message(&BeMessage::ParameterDescription(&statement.type_desc()))
+            self.stream
+                .write(&BeMessage::ParameterDescription(&statement.type_desc()))
                 .await?;
 
             // 2. Send row description.
-            self.write_message(&BeMessage::RowDescription(&statement.row_desc()))
+            self.stream
+                .write(&BeMessage::RowDescription(&statement.row_desc()))
                 .await?;
         } else if msg.kind == b'P' {
             let name = cstr_to_str(&msg.query_name).unwrap().to_string();
             let portal = if name.is_empty() {
-                unnamed_portal
+                &self.unnamed_portal
             } else {
                 // NOTE Error handle need modify later.
-                named_portals.get(&name).unwrap()
+                self.named_portals.get(&name).unwrap()
             };
 
             // 3. Send row description.
-            self.write_message(&BeMessage::RowDescription(&portal.row_desc()))
+            self.stream
+                .write(&BeMessage::RowDescription(&portal.row_desc()))
                 .await?;
         }
         Ok(())
     }
 
-    async fn process_close_msg(
-        &mut self,
-        msg: FeCloseMessage,
-        named_statements: &mut HashMap<String, PgStatement>,
-        named_portals: &mut HashMap<String, PgPortal>,
-    ) -> PsqlResult<()> {
+    async fn process_close_msg(&mut self, msg: FeCloseMessage) -> PsqlResult<()> {
         let name = cstr_to_str(&msg.query_name).unwrap().to_string();
         assert!(msg.kind == b'S' || msg.kind == b'P');
         if msg.kind == b'S' {
-            named_statements.remove_entry(&name);
+            self.named_statements.remove_entry(&name);
         } else if msg.kind == b'P' {
-            named_portals.remove_entry(&name);
+            self.named_portals.remove_entry(&name);
         }
-        self.write_message(&BeMessage::CloseComplete).await?;
+        self.stream.write(&BeMessage::CloseComplete).await?;
         Ok(())
     }
 
@@ -573,14 +490,15 @@ where
         // RowDescription to be issued.
         // Quoted from: https://www.postgresql.org/docs/current/protocol-flow.html#PROTOCOL-FLOW-EXT-QUERY
         if !extended {
-            self.write_message(&BeMessage::RowDescription(&res.get_row_desc()))
+            self.stream
+                .write(&BeMessage::RowDescription(&res.get_row_desc()))
                 .await?;
         }
 
         let mut rows_cnt = 0;
         let iter = res.iter();
         for val in iter {
-            self.write_message(&BeMessage::DataRow(val)).await?;
+            self.stream.write(&BeMessage::DataRow(val)).await?;
             rows_cnt += 1;
         }
 
@@ -592,29 +510,47 @@ where
         // source SQL command is not sent until the portal's execution is completed.
         // Quote from: https://www.postgresql.org/docs/current/protocol-flow.html#PROTOCOL-FLOW-EXT-QUERY:~:text=Once%20a%20portal,ErrorResponse%2C%20or%20PortalSuspended
         if !extended || res.is_row_end() {
-            self.write_message_no_flush(&BeMessage::CommandComplete(BeCommandCompleteMessage {
-                stmt_type: res.get_stmt_type(),
-                notice: res.get_notice(),
-                rows_cnt,
-            }))?;
+            self.stream
+                .write_no_flush(&BeMessage::CommandComplete(BeCommandCompleteMessage {
+                    stmt_type: res.get_stmt_type(),
+                    notice: res.get_notice(),
+                    rows_cnt,
+                }))?;
         } else {
-            self.write_message(&BeMessage::PortalSuspended).await?;
+            self.stream.write(&BeMessage::PortalSuspended).await?;
         }
         Ok(())
     }
+}
 
-    fn is_terminate(&self) -> bool {
-        self.is_terminate
+/// Wraps a byte stream and read/write pg messages.
+struct PgStream<S> {
+    /// The underlying stream.
+    stream: S,
+    /// Write into buffer before flush to stream.
+    write_buf: BytesMut,
+}
+
+impl<S> PgStream<S>
+where
+    S: AsyncWrite + AsyncRead + Unpin,
+{
+    async fn read_startup(&mut self) -> io::Result<FeMessage> {
+        FeStartupMessage::read(&mut self.stream).await
+    }
+
+    async fn read(&mut self) -> io::Result<FeMessage> {
+        FeMessage::read(&mut self.stream).await
     }
 
     fn write_parameter_status_msg_no_flush(&mut self) -> io::Result<()> {
-        self.write_message_no_flush(&BeMessage::ParameterStatus(
+        self.write_no_flush(&BeMessage::ParameterStatus(
             BeParameterStatusMessage::ClientEncoding("UTF8"),
         ))?;
-        self.write_message_no_flush(&BeMessage::ParameterStatus(
+        self.write_no_flush(&BeMessage::ParameterStatus(
             BeParameterStatusMessage::StandardConformingString("on"),
         ))?;
-        self.write_message_no_flush(&BeMessage::ParameterStatus(
+        self.write_no_flush(&BeMessage::ParameterStatus(
             BeParameterStatusMessage::ServerVersion("9.5.0"),
         ))?;
         Ok(())
@@ -624,8 +560,8 @@ where
     // The write() interface of this kind of message must be send sucesssfully or "unwrap" when it
     // failed. Hence we can dirtyly unwrap write_message_no_flush, it must return Ok(),
     // otherwise system will panic and it never return.
-    fn write_message_for_error(&mut self, message: &BeMessage<'_>) {
-        self.write_message_no_flush(message).unwrap_or_else(|e| {
+    fn write_for_error(&mut self, message: &BeMessage<'_>) {
+        self.write_no_flush(message).unwrap_or_else(|e| {
             tracing::error!("Error: {}", e);
         });
     }
@@ -639,19 +575,19 @@ where
         });
     }
 
-    fn write_message_no_flush(&mut self, message: &BeMessage<'_>) -> io::Result<()> {
-        BeMessage::write(&mut self.buf_out, message)
+    fn write_no_flush(&mut self, message: &BeMessage<'_>) -> io::Result<()> {
+        BeMessage::write(&mut self.write_buf, message)
     }
 
-    async fn write_message(&mut self, message: &BeMessage<'_>) -> io::Result<()> {
-        self.write_message_no_flush(message)?;
+    async fn write(&mut self, message: &BeMessage<'_>) -> io::Result<()> {
+        self.write_no_flush(message)?;
         self.flush().await?;
         Ok(())
     }
 
     async fn flush(&mut self) -> io::Result<()> {
-        self.stream.write_all(&self.buf_out).await?;
-        self.buf_out.clear();
+        self.stream.write_all(&self.write_buf).await?;
+        self.write_buf.clear();
         self.stream.flush().await?;
         Ok(())
     }


### PR DESCRIPTION
I hereby agree to the terms of the [Singularity Data, Inc. Contributor License Agreement](https://gist.github.com/skyzh/0663682a70b0edde7ae991492f2314cb#file-s9y_cla).

## What's changed and what's your intention?

Inside the `PgProtocol` struct, we move `stream` and `buf_out` to a new `PgStream` struct.
So that states such as `unnamed_statement` can be moved from argument into struct, without causing errors in borrow checker.

## Checklist

- [x] I have written necessary rustdoc comments
- [x] I have added necessary unit tests and integration tests
- [x] All checks passed in `./risedev check` (or alias, `./risedev c`)

## Refer to a related PR or issue link (optional)
