### PR TITLE
fix(stream): stream_join_total_lookup_count -> stream_join_lookup_total_count

### DIFF
--- a/src/stream/src/executor/monitor/streaming_stats.rs
+++ b/src/stream/src/executor/monitor/streaming_stats.rs
@@ -226,7 +226,7 @@ impl StreamingMetrics {
         .unwrap();
 
         let join_total_lookup_count = register_int_counter_vec_with_registry!(
-            "stream_join_total_lookup_count",
+            "stream_join_lookup_total_count",
             "Join executor lookup total operation",
             &["actor_id", "side"],
             registry


### PR DESCRIPTION
I hereby agree to the terms of the [Singularity Data, Inc. Contributor License Agreement](https://gist.github.com/skyzh/0663682a70b0edde7ae991492f2314cb#file-s9y_cla).

## What's changed and what's your intention?

***PLEASE DO NOT LEAVE THIS EMPTY !!!***

1. It's inconsistent.
2. It's correct in grafana so the graph can't display it.

## Checklist

- [x] I have written necessary rustdoc comments
- [x] I have added necessary unit tests and integration tests
- [x] All checks passed in `./risedev check` (or alias, `./risedev c`)

## Refer to a related PR or issue link (optional)
