### PR TITLE
chore(storage):  distinguish ReadOptions between store and sstable_iter for readable

### DIFF
--- a/src/storage/src/hummock/compactor.rs
+++ b/src/storage/src/hummock/compactor.rs
@@ -48,10 +48,10 @@ use super::{
     SstableIterator, SstableIteratorType,
 };
 use crate::hummock::compaction_executor::CompactionExecutor;
-use crate::hummock::iterator::ReadOptions;
 use crate::hummock::multi_builder::SealedSstableBuilder;
 use crate::hummock::shared_buffer::shared_buffer_uploader::UploadTaskPayload;
 use crate::hummock::shared_buffer::{build_ordered_merge_iter, UncommittedData};
+use crate::hummock::sstable::SstableIteratorReadOptions;
 use crate::hummock::sstable_store::SstableStoreRef;
 use crate::hummock::state_store::ForwardIter;
 use crate::hummock::utils::can_concat;
@@ -352,7 +352,7 @@ impl Compactor {
                 sstable_store.clone(),
                 stats.clone(),
                 &mut local_stats,
-                Arc::new(ReadOptions::default()),
+                Arc::new(SstableIteratorReadOptions::default()),
             )
             .await? as BoxedForwardHummockIterator;
             let compaction_executor = compactor.context.compaction_executor.as_ref().cloned();
@@ -756,7 +756,7 @@ impl Compactor {
     async fn build_sst_iter(&self) -> HummockResult<BoxedForwardHummockIterator> {
         let mut table_iters: Vec<BoxedForwardHummockIterator> = Vec::new();
         let mut stats = StoreLocalStatistic::default();
-        let read_options = Arc::new(ReadOptions { prefetch: true });
+        let read_options = Arc::new(SstableIteratorReadOptions { prefetch: true });
 
         // TODO: check memory limit
         for level in &self.compact_task.input_ssts {

--- a/src/storage/src/hummock/iterator/backward_concat.rs
+++ b/src/storage/src/hummock/iterator/backward_concat.rs
@@ -28,7 +28,8 @@ mod tests {
         default_builder_opt_for_test, gen_iterator_test_sstable_base, iterator_test_key_of,
         iterator_test_value_of, mock_sstable_store, TEST_KEYS_COUNT,
     };
-    use crate::hummock::iterator::{HummockIterator, ReadOptions};
+    use crate::hummock::iterator::HummockIterator;
+    use crate::hummock::sstable::SstableIteratorReadOptions;
 
     #[tokio::test]
     async fn test_backward_concat_iterator() {
@@ -64,7 +65,7 @@ mod tests {
                 table0.get_sstable_info(),
             ],
             sstable_store,
-            Arc::new(ReadOptions::default()),
+            Arc::new(SstableIteratorReadOptions::default()),
         );
         let mut i = TEST_KEYS_COUNT * 3;
         iter.rewind().await.unwrap();
@@ -130,7 +131,7 @@ mod tests {
                 table1.get_sstable_info(),
             ],
             sstable_store,
-            Arc::new(ReadOptions::default()),
+            Arc::new(SstableIteratorReadOptions::default()),
         );
 
         iter.seek(iterator_test_key_of(2 * TEST_KEYS_COUNT + 1).as_slice())
@@ -217,7 +218,7 @@ mod tests {
                 table0.get_sstable_info(),
             ],
             sstable_store,
-            Arc::new(ReadOptions::default()),
+            Arc::new(SstableIteratorReadOptions::default()),
         );
 
         iter.seek(iterator_test_key_of(TEST_KEYS_COUNT * 2 + 1).as_slice())

--- a/src/storage/src/hummock/iterator/concat_inner.rs
+++ b/src/storage/src/hummock/iterator/concat_inner.rs
@@ -19,9 +19,8 @@ use async_trait::async_trait;
 use risingwave_hummock_sdk::VersionedComparator;
 use risingwave_pb::hummock::SstableInfo;
 
-use crate::hummock::iterator::{
-    DirectionEnum, HummockIterator, HummockIteratorDirection, ReadOptions,
-};
+use crate::hummock::iterator::{DirectionEnum, HummockIterator, HummockIteratorDirection};
+use crate::hummock::sstable::SstableIteratorReadOptions;
 use crate::hummock::value::HummockValue;
 use crate::hummock::{HummockResult, SstableIteratorType, SstableStoreRef};
 use crate::monitor::StoreLocalStatistic;
@@ -40,7 +39,7 @@ pub struct ConcatIteratorInner<TI: SstableIteratorType> {
     sstable_store: SstableStoreRef,
 
     stats: StoreLocalStatistic,
-    read_options: Arc<ReadOptions>,
+    read_options: Arc<SstableIteratorReadOptions>,
 }
 
 impl<TI: SstableIteratorType> ConcatIteratorInner<TI> {
@@ -50,7 +49,7 @@ impl<TI: SstableIteratorType> ConcatIteratorInner<TI> {
     pub fn new(
         tables: Vec<SstableInfo>,
         sstable_store: SstableStoreRef,
-        read_options: Arc<ReadOptions>,
+        read_options: Arc<SstableIteratorReadOptions>,
     ) -> Self {
         Self {
             sstable_iter: None,

--- a/src/storage/src/hummock/iterator/forward_concat.rs
+++ b/src/storage/src/hummock/iterator/forward_concat.rs
@@ -27,7 +27,8 @@ mod tests {
         default_builder_opt_for_test, gen_iterator_test_sstable_base, iterator_test_key_of,
         iterator_test_value_of, mock_sstable_store, TEST_KEYS_COUNT,
     };
-    use crate::hummock::iterator::{ForwardHummockIterator, ReadOptions};
+    use crate::hummock::iterator::ForwardHummockIterator;
+    use crate::hummock::sstable::SstableIteratorReadOptions;
 
     #[tokio::test]
     async fn test_concat_iterator() {
@@ -63,7 +64,7 @@ mod tests {
                 table2.get_sstable_info(),
             ],
             sstable_store,
-            Arc::new(ReadOptions::default()),
+            Arc::new(SstableIteratorReadOptions::default()),
         );
         let mut i = 0;
         iter.rewind().await.unwrap();
@@ -128,7 +129,7 @@ mod tests {
                 table2.get_sstable_info(),
             ],
             sstable_store,
-            Arc::new(ReadOptions::default()),
+            Arc::new(SstableIteratorReadOptions::default()),
         );
 
         iter.seek(iterator_test_key_of(TEST_KEYS_COUNT + 1).as_slice())
@@ -210,7 +211,7 @@ mod tests {
                 table2.get_sstable_info(),
             ],
             sstable_store,
-            Arc::new(ReadOptions::default()),
+            Arc::new(SstableIteratorReadOptions::default()),
         );
 
         iter.seek(iterator_test_key_of(TEST_KEYS_COUNT + 1).as_slice())

--- a/src/storage/src/hummock/iterator/forward_merge.rs
+++ b/src/storage/src/hummock/iterator/forward_merge.rs
@@ -30,8 +30,10 @@ mod test {
         gen_merge_iterator_interleave_test_sstable_iters, iterator_test_key_of,
         iterator_test_value_of, mock_sstable_store, TEST_KEYS_COUNT,
     };
-    use crate::hummock::iterator::{BoxedForwardHummockIterator, HummockIterator, ReadOptions};
-    use crate::hummock::sstable::{SstableIterator, SstableIteratorType};
+    use crate::hummock::iterator::{BoxedForwardHummockIterator, HummockIterator};
+    use crate::hummock::sstable::{
+        SstableIterator, SstableIteratorReadOptions, SstableIteratorType,
+    };
     use crate::hummock::test_utils::{create_small_table_cache, gen_test_sstable};
     use crate::hummock::value::HummockValue;
     use crate::monitor::StateStoreMetrics;
@@ -132,7 +134,7 @@ mod test {
     #[tokio::test]
     async fn test_merge_invalidate_reset() {
         let sstable_store = mock_sstable_store();
-        let read_options = Arc::new(ReadOptions::default());
+        let read_options = Arc::new(SstableIteratorReadOptions::default());
         let table0 = Box::new(
             gen_iterator_test_sstable_base(
                 0,
@@ -213,7 +215,7 @@ mod test {
     #[tokio::test]
     async fn test_ordered_merge_iter() {
         let sstable_store = mock_sstable_store();
-        let read_options = Arc::new(ReadOptions::default());
+        let read_options = Arc::new(SstableIteratorReadOptions::default());
 
         let non_overlapped_sstable = Box::new(
             gen_test_sstable(

--- a/src/storage/src/hummock/iterator/forward_user.rs
+++ b/src/storage/src/hummock/iterator/forward_user.rs
@@ -314,8 +314,10 @@ mod tests {
         iterator_test_key_of, iterator_test_key_of_epoch, iterator_test_value_of,
         mock_sstable_store, TEST_KEYS_COUNT,
     };
-    use crate::hummock::iterator::{BoxedForwardHummockIterator, ReadOptions};
-    use crate::hummock::sstable::{SstableIterator, SstableIteratorType};
+    use crate::hummock::iterator::BoxedForwardHummockIterator;
+    use crate::hummock::sstable::{
+        SstableIterator, SstableIteratorReadOptions, SstableIteratorType,
+    };
     use crate::hummock::test_utils::create_small_table_cache;
     use crate::hummock::value::HummockValue;
     use crate::monitor::StateStoreMetrics;
@@ -323,7 +325,7 @@ mod tests {
     #[tokio::test]
     async fn test_basic() {
         let sstable_store = mock_sstable_store();
-        let read_options = Arc::new(ReadOptions::default());
+        let read_options = Arc::new(SstableIteratorReadOptions::default());
         let table0 = gen_iterator_test_sstable_base(
             0,
             default_builder_opt_for_test(),
@@ -414,7 +416,7 @@ mod tests {
             TEST_KEYS_COUNT,
         )
         .await;
-        let read_options = Arc::new(ReadOptions::default());
+        let read_options = Arc::new(SstableIteratorReadOptions::default());
         let cache = create_small_table_cache();
         let iters: Vec<BoxedForwardHummockIterator> = vec![
             Box::new(SstableIterator::create(
@@ -503,7 +505,7 @@ mod tests {
         let table1 =
             gen_iterator_test_sstable_from_kv_pair(1, kv_pairs, sstable_store.clone()).await;
 
-        let read_options = Arc::new(ReadOptions::default());
+        let read_options = Arc::new(SstableIteratorReadOptions::default());
         let cache = create_small_table_cache();
         let iters: Vec<BoxedForwardHummockIterator> = vec![
             Box::new(SstableIterator::create(
@@ -557,7 +559,7 @@ mod tests {
         let table =
             gen_iterator_test_sstable_from_kv_pair(0, kv_pairs, sstable_store.clone()).await;
         let cache = create_small_table_cache();
-        let read_options = Arc::new(ReadOptions::default());
+        let read_options = Arc::new(SstableIteratorReadOptions::default());
         let iters: Vec<BoxedForwardHummockIterator> = vec![Box::new(SstableIterator::create(
             cache.insert(table.id, table.id, 1, Box::new(table)),
             sstable_store,
@@ -640,7 +642,7 @@ mod tests {
         let table =
             gen_iterator_test_sstable_from_kv_pair(0, kv_pairs, sstable_store.clone()).await;
         let cache = create_small_table_cache();
-        let read_options = Arc::new(ReadOptions::default());
+        let read_options = Arc::new(SstableIteratorReadOptions::default());
         let iters: Vec<BoxedForwardHummockIterator> = vec![Box::new(SstableIterator::create(
             cache.insert(table.id, table.id, 1, Box::new(table)),
             sstable_store,
@@ -724,7 +726,7 @@ mod tests {
         let table =
             gen_iterator_test_sstable_from_kv_pair(0, kv_pairs, sstable_store.clone()).await;
         let cache = create_small_table_cache();
-        let read_options = Arc::new(ReadOptions::default());
+        let read_options = Arc::new(SstableIteratorReadOptions::default());
         let iters: Vec<BoxedForwardHummockIterator> = vec![Box::new(SstableIterator::create(
             cache.insert(table.id, table.id, 1, Box::new(table)),
             sstable_store,
@@ -810,7 +812,7 @@ mod tests {
         let table =
             gen_iterator_test_sstable_from_kv_pair(0, kv_pairs, sstable_store.clone()).await;
         let cache = create_small_table_cache();
-        let read_options = Arc::new(ReadOptions::default());
+        let read_options = Arc::new(SstableIteratorReadOptions::default());
         let iters: Vec<BoxedForwardHummockIterator> = vec![Box::new(SstableIterator::create(
             cache.insert(table.id, table.id, 1, Box::new(table)),
             sstable_store,
@@ -879,7 +881,7 @@ mod tests {
     #[tokio::test]
     async fn test_min_epoch() {
         let sstable_store = mock_sstable_store();
-        let read_options = Arc::new(ReadOptions::default());
+        let read_options = Arc::new(SstableIteratorReadOptions::default());
         let table0 = gen_iterator_test_sstable_with_incr_epoch(
             0,
             default_builder_opt_for_test(),

--- a/src/storage/src/hummock/iterator/mod.rs
+++ b/src/storage/src/hummock/iterator/mod.rs
@@ -144,8 +144,3 @@ impl HummockIteratorDirection for Backward {
         DirectionEnum::Backward
     }
 }
-
-#[derive(Default)]
-pub struct ReadOptions {
-    pub prefetch: bool,
-}

--- a/src/storage/src/hummock/iterator/test_utils.rs
+++ b/src/storage/src/hummock/iterator/test_utils.rs
@@ -21,7 +21,8 @@ use risingwave_object_store::object::{
     InMemObjectStore, ObjectStore, ObjectStoreImpl, ObjectStoreRef,
 };
 
-use crate::hummock::iterator::{BoxedForwardHummockIterator, ReadOptions};
+use crate::hummock::iterator::BoxedForwardHummockIterator;
+use crate::hummock::sstable::SstableIteratorReadOptions;
 use crate::hummock::sstable_store::SstableStore;
 pub use crate::hummock::test_utils::default_builder_opt_for_test;
 use crate::hummock::test_utils::{create_small_table_cache, gen_test_sstable};
@@ -137,7 +138,7 @@ pub async fn gen_merge_iterator_interleave_test_sstable_iters(
         result.push(Box::new(SstableIterator::create(
             handle,
             sstable_store.clone(),
-            Arc::new(ReadOptions::default()),
+            Arc::new(SstableIteratorReadOptions::default()),
         )) as BoxedForwardHummockIterator);
     }
     result

--- a/src/storage/src/hummock/mod.rs
+++ b/src/storage/src/hummock/mod.rs
@@ -25,7 +25,7 @@ use risingwave_rpc_client::HummockMetaClient;
 
 mod block_cache;
 pub use block_cache::*;
-mod sstable;
+pub mod sstable;
 pub use sstable::*;
 
 pub mod compaction_executor;
@@ -65,10 +65,11 @@ pub use self::state_store::HummockStateStoreIter;
 use super::monitor::StateStoreMetrics;
 use crate::hummock::compaction_group_client::CompactionGroupClient;
 use crate::hummock::conflict_detector::ConflictDetector;
-use crate::hummock::iterator::ReadOptions;
 use crate::hummock::local_version_manager::LocalVersionManager;
+use crate::hummock::sstable::SstableIteratorReadOptions;
 use crate::hummock::sstable_store::{SstableStoreRef, TableHolder};
 use crate::monitor::StoreLocalStatistic;
+use crate::store::ReadOptions;
 
 /// Hummock is the state store backend.
 #[derive(Clone)]
@@ -147,16 +148,23 @@ impl HummockStorage {
         sstable: TableHolder,
         internal_key: &[u8],
         key: &[u8],
-        read_options: Arc<ReadOptions>,
+        _read_options: &ReadOptions,
         stats: &mut StoreLocalStatistic,
     ) -> HummockResult<Option<Option<Bytes>>> {
+        // TODO: via read_options to determine whether to check bloom_filter next PR
         if sstable.value().surely_not_have_user_key(key) {
             stats.bloom_filter_true_negative_count += 1;
             return Ok(None);
         }
         // Might have the key, take it as might positive.
         stats.bloom_filter_might_positive_count += 1;
-        let mut iter = SstableIterator::create(sstable, self.sstable_store.clone(), read_options);
+        // TODO: now SstableIterator not use prefect through SstableIteratorReadOptions, so use
+        // default before refine
+        let mut iter = SstableIterator::create(
+            sstable,
+            self.sstable_store.clone(),
+            Arc::new(SstableIteratorReadOptions::default()),
+        );
         iter.seek(internal_key).await?;
         // Iterator has seeked passed the borders.
         if !iter.is_valid() {

--- a/src/storage/src/hummock/mod.rs
+++ b/src/storage/src/hummock/mod.rs
@@ -158,8 +158,8 @@ impl HummockStorage {
         }
         // Might have the key, take it as might positive.
         stats.bloom_filter_might_positive_count += 1;
-        // TODO: now SstableIterator not use prefect through SstableIteratorReadOptions, so use
-        // default before refine
+        // TODO: now SstableIterator does not use prefetch through SstableIteratorReadOptions, so we
+        // use default before refinement.
         let mut iter = SstableIterator::create(
             sstable,
             self.sstable_store.clone(),

--- a/src/storage/src/hummock/shared_buffer/mod.rs
+++ b/src/storage/src/hummock/shared_buffer/mod.rs
@@ -32,9 +32,10 @@ use tokio::task::JoinHandle;
 
 use self::shared_buffer_batch::SharedBufferBatch;
 use crate::hummock::iterator::{
-    BoxedHummockIterator, OrderedMergeIteratorInner, ReadOptions, UnorderedMergeIteratorInner,
+    BoxedHummockIterator, OrderedMergeIteratorInner, UnorderedMergeIteratorInner,
 };
 use crate::hummock::shared_buffer::shared_buffer_uploader::UploadTaskPayload;
+use crate::hummock::sstable::SstableIteratorReadOptions;
 use crate::hummock::state_store::HummockIteratorType;
 use crate::hummock::utils::{filter_single_sst, range_overlap};
 use crate::hummock::{HummockResult, SstableIteratorType, SstableStore};
@@ -107,7 +108,7 @@ pub(crate) async fn build_ordered_merge_iter<T: HummockIteratorType>(
     sstable_store: Arc<SstableStore>,
     stats: Arc<StateStoreMetrics>,
     local_stats: &mut StoreLocalStatistic,
-    read_options: Arc<ReadOptions>,
+    read_options: Arc<SstableIteratorReadOptions>,
 ) -> HummockResult<BoxedHummockIterator<T::Direction>> {
     let mut ordered_iters = Vec::with_capacity(uncommitted_data.len());
     for data_list in uncommitted_data {

--- a/src/storage/src/hummock/sstable/backward_sstable_iterator.rs
+++ b/src/storage/src/hummock/sstable/backward_sstable_iterator.rs
@@ -18,7 +18,8 @@ use std::sync::Arc;
 use async_trait::async_trait;
 use risingwave_hummock_sdk::VersionedComparator;
 
-use crate::hummock::iterator::{Backward, HummockIterator, ReadOptions};
+use crate::hummock::iterator::{Backward, HummockIterator};
+use crate::hummock::sstable::SstableIteratorReadOptions;
 use crate::hummock::value::HummockValue;
 use crate::hummock::{
     BlockIterator, HummockResult, SstableIteratorType, SstableStoreRef, TableHolder,
@@ -150,7 +151,11 @@ impl HummockIterator for BackwardSstableIterator {
 }
 
 impl SstableIteratorType for BackwardSstableIterator {
-    fn create(sstable: TableHolder, sstable_store: SstableStoreRef, _: Arc<ReadOptions>) -> Self {
+    fn create(
+        sstable: TableHolder,
+        sstable_store: SstableStoreRef,
+        _: Arc<SstableIteratorReadOptions>,
+    ) -> Self {
         BackwardSstableIterator::new(sstable, sstable_store)
     }
 }

--- a/src/storage/src/hummock/sstable/mod.rs
+++ b/src/storage/src/hummock/sstable/mod.rs
@@ -273,6 +273,11 @@ impl SstableMeta {
     }
 }
 
+#[derive(Default)]
+pub struct SstableIteratorReadOptions {
+    pub prefetch: bool,
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/src/storage/src/hummock/sstable_store.rs
+++ b/src/storage/src/hummock/sstable_store.rs
@@ -305,7 +305,8 @@ mod tests {
     use std::sync::Arc;
 
     use crate::hummock::iterator::test_utils::{iterator_test_key_of, mock_sstable_store};
-    use crate::hummock::iterator::{HummockIterator, ReadOptions};
+    use crate::hummock::iterator::HummockIterator;
+    use crate::hummock::sstable::SstableIteratorReadOptions;
     use crate::hummock::test_utils::{default_builder_opt_for_test, gen_test_sstable_data};
     use crate::hummock::value::HummockValue;
     use crate::hummock::{CachePolicy, Sstable, SstableIterator};
@@ -339,8 +340,11 @@ mod tests {
             holder.value().blocks.len()
         );
         assert!(!holder.value().blocks.is_empty());
-        let mut iter =
-            SstableIterator::new(holder, sstable_store, Arc::new(ReadOptions::default()));
+        let mut iter = SstableIterator::new(
+            holder,
+            sstable_store,
+            Arc::new(SstableIteratorReadOptions::default()),
+        );
         iter.rewind().await.unwrap();
         for i in 0..100 {
             let key = iter.key();

--- a/src/storage/src/storage_failpoints/test_iterator.rs
+++ b/src/storage/src/storage_failpoints/test_iterator.rs
@@ -24,8 +24,9 @@ use crate::hummock::iterator::test_utils::{
 use crate::hummock::iterator::{
     Backward, BackwardConcatIterator, BackwardMergeIterator, BackwardUserIterator,
     BoxedBackwardHummockIterator, BoxedForwardHummockIterator, ConcatIterator, Forward,
-    HummockIterator, MergeIterator, ReadOptions, UserIterator,
+    HummockIterator, MergeIterator, UserIterator,
 };
+use crate::hummock::sstable::SstableIteratorReadOptions;
 use crate::hummock::test_utils::default_builder_opt_for_test;
 use crate::hummock::{BackwardSstableIterator, SstableIterator};
 use crate::monitor::{StateStoreMetrics, StoreLocalStatistic};
@@ -56,7 +57,7 @@ async fn test_failpoints_concat_read_err() {
     let mut iter = ConcatIterator::new(
         vec![table0.get_sstable_info(), table1.get_sstable_info()],
         sstable_store,
-        Arc::new(ReadOptions::default()),
+        Arc::new(SstableIteratorReadOptions::default()),
     );
     iter.rewind().await.unwrap();
     fail::cfg(mem_read_err, "return").unwrap();
@@ -117,7 +118,7 @@ async fn test_failpoints_backward_concat_read_err() {
     let mut iter = BackwardConcatIterator::new(
         vec![table1.get_sstable_info(), table0.get_sstable_info()],
         sstable_store.clone(),
-        Arc::new(ReadOptions::default()),
+        Arc::new(SstableIteratorReadOptions::default()),
     );
     iter.rewind().await.unwrap();
     fail::cfg(mem_read_err, "return").unwrap();
@@ -182,7 +183,7 @@ async fn test_failpoints_merge_invalid_key() {
                         .await
                         .unwrap(),
                     sstable_store.clone(),
-                    Arc::new(ReadOptions::default()),
+                    Arc::new(SstableIteratorReadOptions::default()),
                 ))
                     as Box<dyn HummockIterator<Direction = Forward>>);
             }
@@ -287,12 +288,12 @@ async fn test_failpoints_user_read_err() {
         Box::new(SstableIterator::new(
             sstable_store.sstable(table0.id, &mut stats).await.unwrap(),
             sstable_store.clone(),
-            Arc::new(ReadOptions::default()),
+            Arc::new(SstableIteratorReadOptions::default()),
         )),
         Box::new(SstableIterator::new(
             sstable_store.sstable(table1.id, &mut stats).await.unwrap(),
             sstable_store.clone(),
-            Arc::new(ReadOptions::default()),
+            Arc::new(SstableIteratorReadOptions::default()),
         )),
     ];
 

--- a/src/storage/src/storage_failpoints/test_sstable.rs
+++ b/src/storage/src/storage_failpoints/test_sstable.rs
@@ -18,7 +18,8 @@ use risingwave_hummock_sdk::key::key_with_epoch;
 
 use crate::assert_bytes_eq;
 use crate::hummock::iterator::test_utils::mock_sstable_store;
-use crate::hummock::iterator::{HummockIterator, ReadOptions};
+use crate::hummock::iterator::HummockIterator;
+use crate::hummock::sstable::SstableIteratorReadOptions;
 use crate::hummock::test_utils::{
     default_builder_opt_for_test, gen_test_sstable_data, test_key_of, test_value_of,
     TEST_KEYS_COUNT,
@@ -52,7 +53,7 @@ async fn test_failpoints_table_read() {
     let mut sstable_iter = SstableIterator::create(
         sstable_store.sstable(0, &mut stats).await.unwrap(),
         sstable_store,
-        Arc::new(ReadOptions::default()),
+        Arc::new(SstableIteratorReadOptions::default()),
     );
     sstable_iter.rewind().await.unwrap();
 
@@ -123,7 +124,7 @@ async fn test_failpoints_vacuum_and_metadata() {
     let mut sstable_iter = SstableIterator::create(
         sstable_store.sstable(table_id, &mut stats).await.unwrap(),
         sstable_store,
-        Arc::new(ReadOptions::default()),
+        Arc::new(SstableIteratorReadOptions::default()),
     );
     let mut cnt = 0;
     sstable_iter.rewind().await.unwrap();


### PR DESCRIPTION
I hereby agree to the terms of the [Singularity Data, Inc. Contributor License Agreement](https://gist.github.com/skyzh/0663682a70b0edde7ae991492f2314cb#file-s9y_cla).

## What's changed and what's your intention?

- fix get_from_table to use store_read_options instead of sstable_read_options (the reason is that currently we do not use sstable_read_options for point_get via sstable_iterator, but we need to use store_read_options to judge whether we need to check bloom_filter)
- distinguish ReadOptions between store and sstable_iter for making the code more readable and reduce errors using read_options

- thanks for @hzxa21 suggesstion