### PR TITLE
fix(meta): fix broadcast source for observer

### DIFF
--- a/src/compute/src/compute_observer/observer_manager.rs
+++ b/src/compute/src/compute_observer/observer_manager.rs
@@ -19,9 +19,9 @@ use parking_lot::RwLock;
 use risingwave_common::error::{ErrorCode, Result};
 use risingwave_common_service::observer_manager::ObserverNodeImpl;
 use risingwave_hummock_sdk::slice_transform::{
-    DummySliceTransform, SchemaSliceTransform, SliceTransformImpl,
+    FullKeySliceTransform, SchemaSliceTransform, SliceTransformImpl,
 };
-use risingwave_pb::catalog::Table;
+use risingwave_pb::catalog::{Source, Table};
 use risingwave_pb::meta::subscribe_response::{Info, Operation};
 use risingwave_pb::meta::SubscribeResponse;
 
@@ -41,6 +41,11 @@ impl ObserverNodeImpl for ComputeObserverNode {
             Info::Table(table_catalog) => {
                 self.handle_catalog_notification(resp.operation(), table_catalog);
             }
+
+            Info::Source(source_catalog) => {
+                self.handle_source_notification(resp.operation(), source_catalog);
+            }
+
             _ => {
                 panic!("error type notification");
             }
@@ -89,8 +94,8 @@ impl ComputeObserverNode {
             Operation::Add | Operation::Update => {
                 let slice_transform = if table_catalog.read_pattern_prefix_column < 1 {
                     // for now frontend had not infer the table_id_to_slice_transform, so we use
-                    // DummySliceTransform
-                    SliceTransformImpl::Dummy(DummySliceTransform::default())
+                    // FullKeySliceTransform
+                    SliceTransformImpl::FullKey(FullKeySliceTransform::default())
                 } else {
                     SliceTransformImpl::Schema(SchemaSliceTransform::new(&table_catalog))
                 };
@@ -99,6 +104,24 @@ impl ComputeObserverNode {
 
             Operation::Delete => {
                 guard.remove(&table_catalog.id);
+            }
+
+            _ => panic!("receive an unsupported notify {:?}", operation),
+        }
+    }
+
+    fn handle_source_notification(&mut self, operation: Operation, source_catalog: Source) {
+        let mut guard = self.table_id_to_slice_transform.write();
+        match operation {
+            Operation::Add | Operation::Update => {
+                guard.insert(
+                    source_catalog.id,
+                    SliceTransformImpl::FullKey(FullKeySliceTransform::default()),
+                );
+            }
+
+            Operation::Delete => {
+                guard.remove(&source_catalog.id);
             }
 
             _ => panic!("receive an unsupported notify {:?}", operation),


### PR DESCRIPTION
I hereby agree to the terms of the [Singularity Data, Inc. Contributor License Agreement](https://gist.github.com/skyzh/0663682a70b0edde7ae991492f2314cb#file-s9y_cla).

## What's changed and what's your intention?

as title

Please explain **IN DETAIL** what the changes are in this PR and why they are needed:

- broadcast source to cn and compactor
- fix observer handle logic for source
- use FullKeySliceTransform as default

## Checklist

- [x] I have written necessary rustdoc comments
- [x] I have added necessary unit tests and integration tests
- [x] All checks passed in `./risedev check` (or alias, `./risedev c`)

## Refer to a related PR or issue link (optional)
- https://github.com/singularity-data/risingwave/issues/4027
