### PR TITLE
feat(storage):  add table_id for shared_buffer writebatch

### DIFF
--- a/src/storage/benches/bench_merge_iter.rs
+++ b/src/storage/benches/bench_merge_iter.rs
@@ -45,6 +45,7 @@ fn gen_interleave_shared_buffer_batch_iter(
             2333,
             mpsc::unbounded_channel().0,
             StaticCompactionGroupId::StateDefault.into(),
+            Default::default(),
         );
         iterators.push(Box::new(batch.into_forward_iter()) as BoxedForwardHummockIterator);
     }

--- a/src/storage/hummock_sdk/src/key.rs
+++ b/src/storage/hummock_sdk/src/key.rs
@@ -16,7 +16,7 @@ use std::ops::Bound::*;
 use std::ops::{Bound, RangeBounds};
 use std::{ptr, u64};
 
-use bytes::{Buf, BufMut};
+use bytes::{Buf, BufMut, BytesMut};
 
 use super::version_cmp::VersionedComparator;
 
@@ -209,6 +209,13 @@ pub fn prefixed_range<B: AsRef<[u8]>>(
     };
 
     (start, end)
+}
+
+pub fn table_prefix(table_id: u32) -> Vec<u8> {
+    let mut buf = BytesMut::with_capacity(TABLE_PREFIX_LEN);
+    buf.put_u8(b't');
+    buf.put_u32(table_id);
+    buf.to_vec()
 }
 
 /// [`FullKey`] can be created on either a `Vec<u8>` or a `&[u8]`.

--- a/src/storage/hummock_test/src/local_version_manager_tests.rs
+++ b/src/storage/hummock_test/src/local_version_manager_tests.rs
@@ -68,6 +68,7 @@ async fn test_update_pinned_version() {
                 StaticCompactionGroupId::StateDefault.into(),
                 batches[i].clone(),
                 false,
+                Default::default(),
             )
             .await
             .unwrap();
@@ -151,6 +152,7 @@ async fn test_update_uncommitted_ssts() {
                 StaticCompactionGroupId::StateDefault.into(),
                 kvs[i].clone(),
                 false,
+                Default::default(),
             )
             .await
             .unwrap();
@@ -160,6 +162,7 @@ async fn test_update_uncommitted_ssts() {
             epochs[i],
             mpsc::unbounded_channel().0,
             StaticCompactionGroupId::StateDefault.into(),
+            Default::default(),
         );
         assert_eq!(
             local_version
@@ -354,6 +357,7 @@ async fn test_clear_shared_buffer() {
                 StaticCompactionGroupId::StateDefault.into(),
                 batches[i].clone(),
                 false,
+                Default::default(),
             )
             .await
             .unwrap();

--- a/src/storage/src/hummock/compactor.rs
+++ b/src/storage/src/hummock/compactor.rs
@@ -316,6 +316,24 @@ impl Compactor {
             }
         }
 
+        let existing_table_ids: Vec<u32> = payload
+            .iter()
+            .flat_map(|data_list| {
+                data_list
+                    .iter()
+                    .flat_map(|uncommitted_data| match uncommitted_data {
+                        UncommittedData::Sst(local_sst_info) => local_sst_info.1.table_ids.clone(),
+
+                        UncommittedData::Batch(shared_buffer_write_batch) => {
+                            vec![shared_buffer_write_batch.table_id]
+                        }
+                    })
+            })
+            .dedup()
+            .collect();
+
+        assert!(!existing_table_ids.is_empty());
+
         // Local memory compaction looks at all key ranges.
         let compact_task = CompactTask {
             input_ssts: vec![],
@@ -327,7 +345,7 @@ impl Compactor {
             gc_delete_keys: false,
             task_status: false,
             compaction_group_id: StaticCompactionGroupId::SharedBuffer.into(),
-            existing_table_ids: vec![],
+            existing_table_ids,
             target_file_size: context.options.sstable_size_mb as u64 * (1 << 20),
             compression_algorithm: 0,
             compaction_filter_mask: 0,

--- a/src/storage/src/hummock/local_version_manager.rs
+++ b/src/storage/src/hummock/local_version_manager.rs
@@ -343,6 +343,7 @@ impl LocalVersionManager {
         compaction_group_id: CompactionGroupId,
         kv_pairs: Vec<(Bytes, StorageValue)>,
         is_remote_batch: bool,
+        table_id: u32,
     ) -> HummockResult<usize> {
         let sorted_items = Self::build_shared_buffer_item_batches(kv_pairs, epoch);
 
@@ -351,6 +352,7 @@ impl LocalVersionManager {
             epoch,
             self.buffer_tracker.buffer_event_sender.clone(),
             compaction_group_id,
+            table_id,
         );
         let batch_size = batch.size();
         if self.buffer_tracker.try_write(batch_size) {

--- a/src/storage/src/hummock/shared_buffer/mod.rs
+++ b/src/storage/src/hummock/shared_buffer/mod.rs
@@ -545,6 +545,7 @@ mod tests {
             epoch,
             mpsc::unbounded_channel().0,
             StaticCompactionGroupId::StateDefault.into(),
+            Default::default(),
         );
         if is_replicate {
             shared_buffer.replicate_batch(batch.clone());

--- a/src/storage/src/hummock/shared_buffer/shared_buffer_batch.rs
+++ b/src/storage/src/hummock/shared_buffer/shared_buffer_batch.rs
@@ -80,6 +80,7 @@ pub struct SharedBufferBatch {
     inner: Arc<SharedBufferBatchInner>,
     epoch: HummockEpoch,
     compaction_group_id: CompactionGroupId,
+    pub table_id: u32,
 }
 
 impl SharedBufferBatch {
@@ -88,6 +89,7 @@ impl SharedBufferBatch {
         epoch: HummockEpoch,
         buffer_release_notifier: mpsc::UnboundedSender<SharedBufferEvent>,
         compaction_group_id: CompactionGroupId,
+        table_id: u32,
     ) -> Self {
         let size: usize = Self::measure_batch_size(&sorted_items);
         Self {
@@ -98,6 +100,7 @@ impl SharedBufferBatch {
             }),
             epoch,
             compaction_group_id,
+            table_id,
         }
     }
 
@@ -313,6 +316,7 @@ mod tests {
             epoch,
             mpsc::unbounded_channel().0,
             StaticCompactionGroupId::StateDefault.into(),
+            Default::default(),
         );
 
         // Sketch
@@ -390,6 +394,7 @@ mod tests {
             epoch,
             mpsc::unbounded_channel().0,
             StaticCompactionGroupId::StateDefault.into(),
+            Default::default(),
         );
 
         // FORWARD: Seek to a key < 1st key, expect all three items to return

--- a/src/storage/src/hummock/shared_buffer/shared_buffer_batch.rs
+++ b/src/storage/src/hummock/shared_buffer/shared_buffer_batch.rs
@@ -19,6 +19,7 @@ use std::sync::Arc;
 
 use async_trait::async_trait;
 use bytes::Bytes;
+use risingwave_hummock_sdk::key::table_prefix;
 use risingwave_hummock_sdk::CompactionGroupId;
 use tokio::sync::mpsc;
 use tracing::error;
@@ -92,6 +93,12 @@ impl SharedBufferBatch {
         table_id: u32,
     ) -> Self {
         let size: usize = Self::measure_batch_size(&sorted_items);
+
+        #[cfg(debug_assertions)]
+        {
+            Self::check_table_prefix(table_id, &sorted_items)
+        }
+
         Self {
             inner: Arc::new(SharedBufferBatchInner {
                 payload: sorted_items,
@@ -173,6 +180,20 @@ impl SharedBufferBatch {
 
     pub fn compaction_group_id(&self) -> CompactionGroupId {
         self.compaction_group_id
+    }
+
+    #[cfg(debug_assertions)]
+    fn check_table_prefix(check_table_id: u32, sorted_items: &Vec<SharedBufferItem>) {
+        if check_table_id == 0 {
+            // for unit-test
+            return;
+        }
+
+        let prefix = table_prefix(check_table_id);
+
+        for (key, _value) in sorted_items {
+            assert!(prefix == key[0..prefix.len()]);
+        }
     }
 }
 

--- a/src/storage/src/hummock/state_store.rs
+++ b/src/storage/src/hummock/state_store.rs
@@ -395,7 +395,13 @@ impl StateStore for HummockStorage {
             // compaction_group_id in read/write path.
             let size = self
                 .local_version_manager
-                .write_shared_buffer(epoch, compaction_group_id, kv_pairs, false)
+                .write_shared_buffer(
+                    epoch,
+                    compaction_group_id,
+                    kv_pairs,
+                    false,
+                    write_options.table_id.into(),
+                )
                 .await?;
             Ok(size)
         }
@@ -413,7 +419,13 @@ impl StateStore for HummockStorage {
             // See comments in HummockStorage::iter_inner for details about using
             // compaction_group_id in read/write path.
             self.local_version_manager
-                .write_shared_buffer(epoch, compaction_group_id, kv_pairs, true)
+                .write_shared_buffer(
+                    epoch,
+                    compaction_group_id,
+                    kv_pairs,
+                    true,
+                    write_options.table_id.into(),
+                )
                 .await?;
 
             Ok(())

--- a/src/storage/src/keyspace.rs
+++ b/src/storage/src/keyspace.rs
@@ -15,9 +15,9 @@
 use std::future::Future;
 use std::ops::RangeBounds;
 
-use bytes::{BufMut, Bytes, BytesMut};
+use bytes::Bytes;
 use risingwave_common::catalog::TableId;
-use risingwave_hummock_sdk::key::{prefixed_range, TABLE_PREFIX_LEN};
+use risingwave_hummock_sdk::key::{prefixed_range, table_prefix};
 
 use crate::error::StorageResult;
 use crate::store::ReadOptions;
@@ -44,12 +44,7 @@ impl<S: StateStore> Keyspace<S> {
 
     /// Creates a root [`Keyspace`] for a table.
     pub fn table_root(store: S, id: &TableId) -> Self {
-        let prefix = {
-            let mut buf = BytesMut::with_capacity(TABLE_PREFIX_LEN);
-            buf.put_u8(b't');
-            buf.put_u32(id.table_id);
-            buf.to_vec()
-        };
+        let prefix = table_prefix(id.table_id);
         Self {
             store,
             prefix,


### PR DESCRIPTION
I hereby agree to the terms of the [Singularity Data, Inc. Contributor License Agreement](https://gist.github.com/skyzh/0663682a70b0edde7ae991492f2314cb#file-s9y_cla).

## What's changed and what's your intention?

shared_buffer writebatch add table_id to support schema-ful

Please explain **IN DETAIL** what the changes are in this PR and why they are needed:

- SharedBufferBatch add table_id 
- compactor filter uncommitted data and build the exisiting_table_ids

## Checklist

- [x] I have written necessary rustdoc comments
- [x] I have added necessary unit tests and integration tests
- [x] All checks passed in `./risedev check` (or alias, `./risedev c`)

## Refer to a related PR or issue link (optional)
- https://github.com/singularity-data/risingwave/issues/3871