### PR TITLE
feat(meta): refine compute node id assignment

### DIFF
--- a/src/meta/src/cluster/mod.rs
+++ b/src/meta/src/cluster/mod.rs
@@ -108,7 +108,7 @@ where
                 let worker_id = match r#type {
                     WorkerType::ComputeNode => core
                         .next_available_cn_id()
-                        .ok_or(internal_error("failed to generate next compute node id")),
+                        .ok_or_else(|| internal_error("failed to generate next compute node id")),
                     WorkerType::Generic => unreachable!(),
                     _ => self
                         .env

--- a/src/meta/src/cluster/mod.rs
+++ b/src/meta/src/cluster/mod.rs
@@ -154,6 +154,10 @@ where
         worker.worker_node.state = State::Running as i32;
         worker.insert(self.env.meta_store()).await?;
 
+        self.env
+            .stream_client_pool()
+            .invalidate(&worker.worker_node)
+            .await;
         core.update_worker_node(worker.clone());
 
         // Notify frontends of new compute node.
@@ -176,6 +180,10 @@ where
         // Persist deletion.
         Worker::delete(self.env.meta_store(), &host_address).await?;
 
+        self.env
+            .stream_client_pool()
+            .invalidate(&worker.worker_node)
+            .await;
         // Update core.
         core.delete_worker_node(worker);
 

--- a/src/meta/src/cluster/mod.rs
+++ b/src/meta/src/cluster/mod.rs
@@ -424,6 +424,9 @@ impl ClusterManagerCore {
     }
 
     fn delete_worker_node(&mut self, worker: Worker) {
+        if worker.worker_type() == WorkerType::ComputeNode {
+            self.cn_available_ids.push_back(worker.worker_node.id);
+        }
         worker
             .worker_node
             .parallel_units

--- a/src/rpc_client/src/stream_client_pool.rs
+++ b/src/rpc_client/src/stream_client_pool.rs
@@ -65,6 +65,11 @@ impl StreamClientPool {
             .await
             .map_err(|e| anyhow!("failed to create compute client: {:?}", e).into())
     }
+
+    /// Invalidate the stream service client for the given node.
+    pub async fn invalidate(&self, node: &WorkerNode) {
+        self.clients.invalidate(&node.id).await
+    }
 }
 
 pub type StreamClientPoolRef = Arc<StreamClientPool>;

--- a/src/source/src/row_id.rs
+++ b/src/source/src/row_id.rs
@@ -41,11 +41,11 @@ pub type RowId = i64;
 
 impl RowIdGenerator {
     pub fn new(worker_id: u32) -> Self {
-        assert!(worker_id < WORKER_ID_UPPER_BOUND);
         Self::with_epoch(worker_id, UNIX_EPOCH)
     }
 
     pub fn with_epoch(worker_id: u32, epoch: SystemTime) -> Self {
+        assert!(worker_id < WORKER_ID_UPPER_BOUND);
         Self {
             epoch,
             last_duration_ms: epoch.elapsed().unwrap().as_millis() as i64,


### PR DESCRIPTION
I hereby agree to the terms of the [Singularity Data, Inc. Contributor License Agreement](https://gist.github.com/skyzh/0663682a70b0edde7ae991492f2314cb#file-s9y_cla).

## What's changed and what's your intention?

As title, generate CN node id in range [0,1024), and make it re-usable. When allocating id, give high priority to the node that has not been used for the longest time.

`migrate_actors` in recovery should also take node id reuse into consideration. I will fix this in next PR.

## Checklist

- [x] I have written necessary rustdoc comments
- [x] I have added necessary unit tests and integration tests
- [x] All checks passed in `./risedev check` (or alias, `./risedev c`)

## Documentation

If your pull request contains user-facing changes, please specify the types of the changes, and create a release note. Otherwise, please feel free to remove this section.

### Types of user-facing changes

Please keep the types that apply to your changes, and remove those that do not apply.

* Installation and deployment 
* Connector (sources & sinks)
* SQL commands, functions, and operators
* RisingWave cluster configuration changes
* Other (please specify in the release note below)

### Release note

Please create a release note for your changes. In the release note, focus on the impact on users, and mention the environment or conditions where the impact may occur.

## Refer to a related PR or issue link (optional)
Resolve #4131 