### PR TITLE
refactor(storage): refact keyspace read path with read_options

### DIFF
--- a/src/storage/hummock_test/src/compactor_tests.rs
+++ b/src/storage/hummock_test/src/compactor_tests.rs
@@ -354,11 +354,12 @@ mod tests {
         // 1. add sstables
         let val = Bytes::from(b"0"[..].repeat(1 << 10)); // 1024 Byte value
 
-        let keyspace = Keyspace::table_root(storage.clone(), &TableId::new(1));
+        let existing_table_id: u32 = 1;
+        let keyspace = Keyspace::table_root(storage.clone(), &TableId::new(existing_table_id));
         // Only registered table_ids are accepted in commit_epoch
         register_table_ids_to_compaction_group(
             hummock_manager_ref.compaction_group_manager_ref_for_test(),
-            &[keyspace.table_id().table_id],
+            &[existing_table_id],
             StaticCompactionGroupId::StateDefault.into(),
         )
         .await;
@@ -369,7 +370,7 @@ mod tests {
             epoch += 1;
             let mut write_batch = keyspace.state_store().start_write_batch(WriteOptions {
                 epoch,
-                table_id: keyspace.table_id(),
+                table_id: existing_table_id.into(),
             });
             let mut local = write_batch.prefixify(&keyspace);
 
@@ -385,7 +386,7 @@ mod tests {
         // Mimic dropping table
         unregister_table_ids_from_compaction_group(
             hummock_manager_ref.compaction_group_manager_ref_for_test(),
-            &[keyspace.table_id().table_id],
+            &[existing_table_id],
         )
         .await;
 
@@ -468,14 +469,14 @@ mod tests {
             let keyspace = Keyspace::table_root(storage.clone(), &TableId::new(table_id));
             register_table_ids_to_compaction_group(
                 hummock_manager_ref.compaction_group_manager_ref_for_test(),
-                &[keyspace.table_id().table_id],
+                &[table_id],
                 StaticCompactionGroupId::StateDefault.into(),
             )
             .await;
             epoch += 1;
             let mut write_batch = keyspace.state_store().start_write_batch(WriteOptions {
                 epoch,
-                table_id: keyspace.table_id(),
+                table_id: TableId::from(table_id),
             });
             let mut local = write_batch.prefixify(&keyspace);
 
@@ -621,7 +622,7 @@ mod tests {
         let keyspace = Keyspace::table_root(storage.clone(), &TableId::new(existing_table_id));
         register_table_ids_to_compaction_group(
             hummock_manager_ref.compaction_group_manager_ref_for_test(),
-            &[keyspace.table_id().table_id],
+            &[existing_table_id],
             StaticCompactionGroupId::StateDefault.into(),
         )
         .await;
@@ -631,7 +632,8 @@ mod tests {
             epoch_set.insert(epoch);
             let mut write_batch = keyspace.state_store().start_write_batch(WriteOptions {
                 epoch,
-                table_id: keyspace.table_id(),
+                // table_id: keyspace.table_id(),
+                table_id: TableId::from(existing_table_id),
             });
             let mut local = write_batch.prefixify(&keyspace);
 

--- a/src/storage/hummock_test/src/compactor_tests.rs
+++ b/src/storage/hummock_test/src/compactor_tests.rs
@@ -632,7 +632,6 @@ mod tests {
             epoch_set.insert(epoch);
             let mut write_batch = keyspace.state_store().start_write_batch(WriteOptions {
                 epoch,
-                // table_id: keyspace.table_id(),
                 table_id: TableId::from(existing_table_id),
             });
             let mut local = write_batch.prefixify(&keyspace);

--- a/src/storage/src/keyspace.rs
+++ b/src/storage/src/keyspace.rs
@@ -30,8 +30,6 @@ pub struct Keyspace<S: StateStore> {
 
     /// Encoded representation for all segments.
     prefix: Vec<u8>,
-
-    table_id: TableId,
 }
 
 // FIX: ReadOptions with ttl
@@ -48,7 +46,7 @@ impl<S: StateStore> Keyspace<S> {
         Self {
             store,
             prefix,
-            table_id: *id,
+            // table_id: *id,
         }
     }
 
@@ -60,7 +58,7 @@ impl<S: StateStore> Keyspace<S> {
         Self {
             store: self.store.clone(),
             prefix,
-            table_id: self.table_id,
+            // table_id: self.table_id,
         }
     }
 
@@ -81,17 +79,8 @@ impl<S: StateStore> Keyspace<S> {
 
     /// Treats the keyspace as a single key, and gets its value.
     /// The returned value is based on a snapshot corresponding to the given `epoch`
-    pub async fn value(&self, epoch: u64) -> StorageResult<Option<Bytes>> {
-        self.store
-            .get(
-                &self.prefix,
-                ReadOptions {
-                    epoch,
-                    table_id: Some(self.table_id),
-                    ttl: None,
-                },
-            )
-            .await
+    pub async fn value(&self, read_options: ReadOptions) -> StorageResult<Option<Bytes>> {
+        self.store.get(&self.prefix, read_options).await
     }
 
     /// Concatenates this keyspace and the given key to produce a prefixed key.
@@ -101,17 +90,12 @@ impl<S: StateStore> Keyspace<S> {
 
     /// Gets from the keyspace with the `prefixed_key` of given key.
     /// The returned value is based on a snapshot corresponding to the given `epoch`.
-    pub async fn get(&self, key: impl AsRef<[u8]>, epoch: u64) -> StorageResult<Option<Bytes>> {
-        self.store
-            .get(
-                &self.prefixed_key(key),
-                ReadOptions {
-                    epoch,
-                    table_id: Some(self.table_id),
-                    ttl: None,
-                },
-            )
-            .await
+    pub async fn get(
+        &self,
+        key: impl AsRef<[u8]>,
+        read_options: ReadOptions,
+    ) -> StorageResult<Option<Bytes>> {
+        self.store.get(&self.prefixed_key(key), read_options).await
     }
 
     /// Scans `limit` keys from the keyspace and get their values.
@@ -120,9 +104,10 @@ impl<S: StateStore> Keyspace<S> {
     pub async fn scan(
         &self,
         limit: Option<usize>,
-        epoch: u64,
+        read_optionss: ReadOptions,
     ) -> StorageResult<Vec<(Bytes, Bytes)>> {
-        self.scan_with_range::<_, &[u8]>(.., limit, epoch).await
+        self.scan_with_range::<_, &[u8]>(.., limit, read_optionss)
+            .await
     }
 
     /// Scans `limit` keys from the given `range` in this keyspace and get their values.
@@ -134,25 +119,14 @@ impl<S: StateStore> Keyspace<S> {
         &self,
         range: R,
         limit: Option<usize>,
-        epoch: u64,
+        read_options: ReadOptions,
     ) -> StorageResult<Vec<(Bytes, Bytes)>>
     where
         R: RangeBounds<B> + Send,
         B: AsRef<[u8]> + Send,
     {
         let range = prefixed_range(range, &self.prefix);
-        let mut pairs = self
-            .store
-            .scan(
-                range,
-                limit,
-                ReadOptions {
-                    epoch,
-                    table_id: Some(self.table_id),
-                    ttl: None,
-                },
-            )
-            .await?;
+        let mut pairs = self.store.scan(range, limit, read_options).await?;
         pairs
             .iter_mut()
             .for_each(|(k, _v)| *k = k.slice(self.prefix.len()..));
@@ -161,8 +135,11 @@ impl<S: StateStore> Keyspace<S> {
 
     /// Gets an iterator of this keyspace.
     /// The returned iterator will iterate data from a snapshot corresponding to the given `epoch`.
-    pub async fn iter(&self, epoch: u64) -> StorageResult<StripPrefixIterator<S::Iter>> {
-        self.iter_with_range::<_, &[u8]>(.., epoch).await
+    pub async fn iter(
+        &self,
+        read_options: ReadOptions,
+    ) -> StorageResult<StripPrefixIterator<S::Iter>> {
+        self.iter_with_range::<_, &[u8]>(.., read_options).await
     }
 
     /// Gets an iterator of the given `range` in this keyspace.
@@ -172,24 +149,14 @@ impl<S: StateStore> Keyspace<S> {
     pub async fn iter_with_range<R, B>(
         &self,
         range: R,
-        epoch: u64,
+        read_options: ReadOptions,
     ) -> StorageResult<StripPrefixIterator<S::Iter>>
     where
         R: RangeBounds<B> + Send,
         B: AsRef<[u8]> + Send,
     {
         let range = prefixed_range(range, &self.prefix);
-        let iter = self
-            .store
-            .iter(
-                range,
-                ReadOptions {
-                    epoch,
-                    table_id: Some(self.table_id),
-                    ttl: None,
-                },
-            )
-            .await?;
+        let iter = self.store.iter(range, read_options).await?;
         let strip_prefix_iterator = StripPrefixIterator {
             iter,
             prefix_len: self.prefix.len(),
@@ -200,10 +167,6 @@ impl<S: StateStore> Keyspace<S> {
     /// Gets the underlying state store.
     pub fn state_store(&self) -> S {
         self.store.clone()
-    }
-
-    pub fn table_id(&self) -> TableId {
-        self.table_id
     }
 }
 

--- a/src/storage/src/keyspace.rs
+++ b/src/storage/src/keyspace.rs
@@ -43,11 +43,7 @@ impl<S: StateStore> Keyspace<S> {
     /// Creates a root [`Keyspace`] for a table.
     pub fn table_root(store: S, id: &TableId) -> Self {
         let prefix = table_prefix(id.table_id);
-        Self {
-            store,
-            prefix,
-            // table_id: *id,
-        }
+        Self { store, prefix }
     }
 
     /// Appends more bytes to the prefix and returns a new `Keyspace`
@@ -58,7 +54,6 @@ impl<S: StateStore> Keyspace<S> {
         Self {
             store: self.store.clone(),
             prefix,
-            // table_id: self.table_id,
         }
     }
 

--- a/src/storage/src/table/storage_table.rs
+++ b/src/storage/src/table/storage_table.rs
@@ -864,7 +864,6 @@ impl<S: StateStore, RS: RowSerde> StorageTableIterInner<S, RS> {
         keyspace: &Keyspace<S>,
         table_descs: Arc<ColumnDescMapping>,
         raw_key_range: R,
-        // epoch: u64,
         wait_epoch: bool,
         read_options: ReadOptions,
     ) -> StorageResult<Self>

--- a/src/storage/src/table/storage_table.rs
+++ b/src/storage/src/table/storage_table.rs
@@ -26,7 +26,9 @@ use itertools::Itertools;
 use log::trace;
 use risingwave_common::array::Row;
 use risingwave_common::buffer::Bitmap;
-use risingwave_common::catalog::{ColumnDesc, ColumnId, OrderedColumnDesc, Schema, TableId};
+use risingwave_common::catalog::{
+    ColumnDesc, ColumnId, OrderedColumnDesc, Schema, TableId, TableOption,
+};
 use risingwave_common::error::RwError;
 use risingwave_common::types::{Datum, VirtualNode};
 use risingwave_common::util::hash_util::CRC32FastBuilder;
@@ -44,7 +46,7 @@ use crate::row_serde::{
     serialize_pk, CellBasedRowSerde, ColumnDescMapping, RowDeserialize, RowSerde, RowSerialize,
 };
 use crate::storage_value::StorageValue;
-use crate::store::WriteOptions;
+use crate::store::{ReadOptions, WriteOptions};
 use crate::{Keyspace, StateStore, StateStoreIter};
 
 mod iter_utils;
@@ -112,6 +114,14 @@ pub struct StorageTableBase<S: StateStore, RS: RowSerde, const T: AccessType> {
 
     /// If true, sanity check is disabled on this table.
     disable_sanity_check: bool,
+
+    table_id: TableId,
+
+    /// Used for catalog table_properties
+    table_option: TableOption,
+
+    // TODO: check and build bloom_filter_key by read_pattern_prefix_column
+    _read_pattern_prefix_column: u32,
 }
 
 impl<S: StateStore, RS: RowSerde, const T: AccessType> std::fmt::Debug
@@ -148,6 +158,8 @@ impl<S: StateStore, RS: RowSerde> StorageTableBase<S, RS, READ_ONLY> {
             order_types,
             pk_indices,
             distribution,
+            Default::default(),
+            0,
         )
     }
 }
@@ -173,6 +185,8 @@ impl<S: StateStore, RS: RowSerde> StorageTableBase<S, RS, READ_WRITE> {
             order_types,
             pk_indices,
             distribution,
+            Default::default(),
+            0,
         )
     }
 
@@ -252,6 +266,8 @@ impl<S: StateStore, RS: RowSerde, const T: AccessType> StorageTableBase<S, RS, T
             order_types,
             pk_indices,
             distribution,
+            TableOption::build_table_option(table_catalog.get_properties()),
+            table_catalog.read_pattern_prefix_column,
         )
     }
 
@@ -267,6 +283,8 @@ impl<S: StateStore, RS: RowSerde, const T: AccessType> StorageTableBase<S, RS, T
             dist_key_indices,
             vnodes,
         }: Distribution,
+        table_option: TableOption,
+        read_pattern_prefix_column: u32,
     ) -> Self {
         let row_serializer = RS::create_serializer(&pk_indices, &table_columns, &column_ids);
 
@@ -302,6 +320,9 @@ impl<S: StateStore, RS: RowSerde, const T: AccessType> StorageTableBase<S, RS, T
             dist_key_in_pk_indices,
             vnodes,
             disable_sanity_check: false,
+            table_id,
+            table_option,
+            _read_pattern_prefix_column: read_pattern_prefix_column,
         }
     }
 
@@ -386,16 +407,27 @@ impl<S: StateStore, RS: RowSerde, const T: AccessType> StorageTableBase<S, RS, T
             &SENTINEL_CELL_ID,
         )
         .map_err(err)?;
+
+        let read_options = self.get_read_option(epoch);
         match sentinel_key {
             Some(sentinel_key) => {
-                if self.keyspace.get(&sentinel_key, epoch).await?.is_none() {
+                if self
+                    .keyspace
+                    .get(&sentinel_key, read_options.clone())
+                    .await?
+                    .is_none()
+                {
                     // if sentinel cell is none, this row doesn't exist
                     return Ok(None);
                 };
             }
             // if sentinel cell does not exist, the encoding format is row-based.
             None => {
-                if let Some(value) = self.keyspace.get(&serialized_pk, epoch).await? {
+                if let Some(value) = self
+                    .keyspace
+                    .get(&serialized_pk, read_options.clone())
+                    .await?
+                {
                     let deserialize_res = deserializer
                         .deserialize(&serialized_pk, &value)
                         .map_err(err)?;
@@ -409,7 +441,7 @@ impl<S: StateStore, RS: RowSerde, const T: AccessType> StorageTableBase<S, RS, T
 
         for column_id in self.column_ids() {
             let key = serialize_pk_and_column_id(&serialized_pk, &column_id).map_err(err)?;
-            if let Some(value) = self.keyspace.get(&key, epoch).await? {
+            if let Some(value) = self.keyspace.get(&key, read_options.clone()).await? {
                 let deserialize_res = deserializer.deserialize(&key, &value).map_err(err)?;
                 assert!(deserialize_res.is_none());
             }
@@ -427,9 +459,10 @@ impl<S: StateStore, RS: RowSerde, const T: AccessType> StorageTableBase<S, RS, T
         let serialized_pk = self.serialize_pk_with_vnode(pk);
         let key_range = range_of_prefix(&serialized_pk);
 
+        let read_options = self.get_read_option(epoch);
         let kv_pairs = self
             .keyspace
-            .scan_with_range(key_range, None, epoch)
+            .scan_with_range(key_range, None, read_options.clone())
             .await?;
 
         let mut deserializer = RS::create_deserializer(self.mapping.clone());
@@ -442,6 +475,14 @@ impl<S: StateStore, RS: RowSerde, const T: AccessType> StorageTableBase<S, RS, T
             self.check_vnode_is_set(vnode);
             row
         }))
+    }
+
+    fn get_read_option(&self, epoch: u64) -> ReadOptions {
+        ReadOptions {
+            epoch,
+            table_id: Some(self.table_id),
+            ttl: self.table_option.ttl,
+        }
     }
 }
 
@@ -464,7 +505,7 @@ impl<S: StateStore, RS: RowSerde> StorageTableBase<S, RS, READ_WRITE> {
     ) -> StorageResult<()> {
         let mut batch = self.keyspace.state_store().start_write_batch(WriteOptions {
             epoch,
-            table_id: self.keyspace.table_id(),
+            table_id: self.table_id,
         });
         let mut local = batch.prefixify(&self.keyspace);
 
@@ -647,8 +688,8 @@ impl<S: StateStore, RS: RowSerde, const T: AccessType> StorageTableBase<S, RS, T
                     &self.keyspace,
                     self.mapping.clone(),
                     raw_key_range,
-                    epoch,
                     wait_epoch,
+                    self.get_read_option(epoch),
                 )
                 .await?
                 .into_stream();
@@ -823,20 +864,26 @@ impl<S: StateStore, RS: RowSerde> StorageTableIterInner<S, RS> {
         keyspace: &Keyspace<S>,
         table_descs: Arc<ColumnDescMapping>,
         raw_key_range: R,
-        epoch: u64,
+        // epoch: u64,
         wait_epoch: bool,
+        read_options: ReadOptions,
     ) -> StorageResult<Self>
     where
         R: RangeBounds<B> + Send,
         B: AsRef<[u8]> + Send,
     {
         if wait_epoch {
-            keyspace.state_store().wait_epoch(epoch).await?;
+            keyspace
+                .state_store()
+                .wait_epoch(read_options.epoch)
+                .await?;
         }
 
         let row_deserializer = RS::create_deserializer(table_descs);
 
-        let iter = keyspace.iter_with_range(raw_key_range, epoch).await?;
+        let iter = keyspace
+            .iter_with_range(raw_key_range, read_options)
+            .await?;
         let iter = Self {
             iter,
             row_deserializer,

--- a/src/storage/src/table/storage_table.rs
+++ b/src/storage/src/table/storage_table.rs
@@ -115,8 +115,6 @@ pub struct StorageTableBase<S: StateStore, RS: RowSerde, const T: AccessType> {
     /// If true, sanity check is disabled on this table.
     disable_sanity_check: bool,
 
-    table_id: TableId,
-
     /// Used for catalog table_properties
     table_option: TableOption,
 
@@ -320,7 +318,6 @@ impl<S: StateStore, RS: RowSerde, const T: AccessType> StorageTableBase<S, RS, T
             dist_key_in_pk_indices,
             vnodes,
             disable_sanity_check: false,
-            table_id,
             table_option,
             _read_pattern_prefix_column: read_pattern_prefix_column,
         }
@@ -480,7 +477,7 @@ impl<S: StateStore, RS: RowSerde, const T: AccessType> StorageTableBase<S, RS, T
     fn get_read_option(&self, epoch: u64) -> ReadOptions {
         ReadOptions {
             epoch,
-            table_id: Some(self.table_id),
+            table_id: Some(self.keyspace.table_id()),
             ttl: self.table_option.ttl,
         }
     }
@@ -505,7 +502,7 @@ impl<S: StateStore, RS: RowSerde> StorageTableBase<S, RS, READ_WRITE> {
     ) -> StorageResult<()> {
         let mut batch = self.keyspace.state_store().start_write_batch(WriteOptions {
             epoch,
-            table_id: self.table_id,
+            table_id: self.keyspace.table_id(),
         });
         let mut local = batch.prefixify(&self.keyspace);
 

--- a/src/storage/src/table/storage_table.rs
+++ b/src/storage/src/table/storage_table.rs
@@ -462,7 +462,7 @@ impl<S: StateStore, RS: RowSerde, const T: AccessType> StorageTableBase<S, RS, T
         let read_options = self.get_read_option(epoch);
         let kv_pairs = self
             .keyspace
-            .scan_with_range(key_range, None, read_options.clone())
+            .scan_with_range(key_range, None, read_options)
             .await?;
 
         let mut deserializer = RS::create_deserializer(self.mapping.clone());

--- a/src/stream/src/executor/source/source_executor.rs
+++ b/src/stream/src/executor/source/source_executor.rs
@@ -98,7 +98,7 @@ impl<S: StateStore> SourceExecutor<S> {
             metrics: streaming_metrics,
             stream_source_splits: vec![],
             source_identify: "Table_".to_string() + &source_id.table_id().to_string(),
-            split_state_store: SourceStateHandler::new(keyspace),
+            split_state_store: SourceStateHandler::new(keyspace, source_id),
             state_cache: HashMap::new(),
             expected_barrier_latency_ms,
         })

--- a/src/stream/src/executor/source/source_executor.rs
+++ b/src/stream/src/executor/source/source_executor.rs
@@ -98,7 +98,7 @@ impl<S: StateStore> SourceExecutor<S> {
             metrics: streaming_metrics,
             stream_source_splits: vec![],
             source_identify: "Table_".to_string() + &source_id.table_id().to_string(),
-            split_state_store: SourceStateHandler::new(keyspace, source_id),
+            split_state_store: SourceStateHandler::new(keyspace),
             state_cache: HashMap::new(),
             expected_barrier_latency_ms,
         })


### PR DESCRIPTION
I hereby agree to the terms of the [Singularity Data, Inc. Contributor License Agreement](https://gist.github.com/skyzh/0663682a70b0edde7ae991492f2314cb#file-s9y_cla).

## What's changed and what's your intention?

as tilte

Please explain **IN DETAIL** what the changes are in this PR and why they are needed:

- keyspace read_path use `ReadOptions`
- keyspace remove dependence of table_id

## Checklist

- [x] I have written necessary rustdoc comments
- [x] I have added necessary unit tests and integration tests
- [x] All checks passed in `./risedev check` (or alias, `./risedev c`)

## Refer to a related PR or issue link (optional)
- https://github.com/singularity-data/risingwave/issues/3871