### PR TITLE
chore(streaming): don't send a barrier to the source actor in the migration

### DIFF
--- a/src/meta/src/barrier/command.rs
+++ b/src/meta/src/barrier/command.rs
@@ -84,6 +84,13 @@ impl Command {
         Self::Plain(Some(Mutation::Resume(ResumeMutation {})))
     }
 
+    pub fn changed_actor_ids(&self) -> Option<Vec<ActorId>> {
+        match self {
+            Command::Plain(Some(Mutation::Update(update))) => Some(update.dropped_actors.clone()),
+            _ => None,
+        }
+    }
+
     pub fn changed_table_id(&self) -> ChangedTableState {
         match self {
             Command::CreateMaterializedView {

--- a/src/meta/src/barrier/mod.rs
+++ b/src/meta/src/barrier/mod.rs
@@ -195,7 +195,7 @@ struct CheckpointControl<S: MetaStore> {
     /// The barrier does not send or collect the actors of these tables, even if they are
     /// `Running`.
     dropping_table_ids: HashSet<TableId>,
-
+    /// A barrier should not be sent for a source actor in migration
     migrating_actor_ids: HashSet<ActorId>,
 }
 

--- a/src/meta/src/stream/meta.rs
+++ b/src/meta/src/stream/meta.rs
@@ -283,7 +283,7 @@ where
     /// collected
     pub async fn load_all_actors(
         &self,
-        check_state: impl Fn(ActorState, &TableId) -> bool,
+        check_state: impl Fn(ActorId, ActorState, &TableId) -> bool,
     ) -> ActorInfos {
         let mut actor_maps = HashMap::new();
         let mut source_actor_ids = HashMap::new();
@@ -292,7 +292,7 @@ where
         for fragments in map.values() {
             for (node_id, actor_states) in fragments.node_actor_states() {
                 for actor_state in actor_states {
-                    if check_state(actor_state.1, &fragments.table_id()) {
+                    if check_state(actor_state.0, actor_state.1, &fragments.table_id()) {
                         actor_maps
                             .entry(node_id)
                             .or_insert_with(Vec::new)
@@ -304,7 +304,7 @@ where
             let source_actors = fragments.node_source_actor_states();
             for (&node_id, actor_states) in &source_actors {
                 for actor_state in actor_states {
-                    if check_state(actor_state.1, &fragments.table_id()) {
+                    if check_state(actor_state.0, actor_state.1, &fragments.table_id()) {
                         source_actor_ids
                             .entry(node_id)
                             .or_insert_with(Vec::new)


### PR DESCRIPTION
I hereby agree to the terms of the [Singularity Data, Inc. Contributor License Agreement](https://gist.github.com/skyzh/0663682a70b0edde7ae991492f2314cb#file-s9y_cla).

## What's changed and what's your intention?

Currently, we are going to use `UpdateMutation` to migrate the actor by creating a new actor, then changing the upstream and downstream, and finally dropping the old actor.

However, when we migrate the source actor, an `UpdateMutation` may be followed by a scheduled barrier (note that the pause command does not stop this behavior), but the source actor is already stopped at that time, so special handling is needed

## Checklist

- [x] I have written necessary rustdoc comments
- [x] I have added necessary unit tests and integration tests
- [x] All checks passed in `./risedev check` (or alias, `./risedev c`)

## Documentation

If your pull request contains user-facing changes, please specify the types of the changes, and create a release note. Otherwise, please feel free to remove this section.

### Types of user-facing changes

Please keep the types that apply to your changes, and remove those that do not apply.

* Installation and deployment 
* Connector (sources & sinks)
* SQL commands, functions, and operators
* RisingWave cluster configuration changes
* Other (please specify in the release note below)

### Release note

Please create a release note for your changes. In the release note, focus on the impact on users, and mention the environment or conditions where the impact may occur.

## Refer to a related PR or issue link (optional)
