### PR TITLE
feat(optimizer): support push down apply until reaching a fix-point

### DIFF
--- a/src/frontend/src/optimizer/heuristic.rs
+++ b/src/frontend/src/optimizer/heuristic.rs
@@ -30,14 +30,14 @@ pub enum ApplyOrder {
 // TODO: we should have a builder of HeuristicOptimizer here
 /// A rule-based heuristic optimizer, which traverses every plan nodes and tries to
 /// apply each rule on them.
-pub struct HeuristicOptimizer {
-    apply_order: ApplyOrder,
-    rules: Vec<BoxedRule>,
+pub struct HeuristicOptimizer<'a> {
+    apply_order: &'a ApplyOrder,
+    rules: &'a Vec<BoxedRule>,
     stats: Stats,
 }
 
-impl HeuristicOptimizer {
-    pub fn new(apply_order: ApplyOrder, rules: Vec<BoxedRule>) -> Self {
+impl<'a> HeuristicOptimizer<'a> {
+    pub fn new(apply_order: &'a ApplyOrder, rules: &'a Vec<BoxedRule>) -> Self {
         Self {
             apply_order,
             rules,
@@ -46,7 +46,7 @@ impl HeuristicOptimizer {
     }
 
     fn optimize_node(&mut self, mut plan: PlanRef) -> PlanRef {
-        for rule in &self.rules {
+        for rule in self.rules {
             if let Some(applied) = rule.apply(plan.clone()) {
                 plan = applied;
                 self.stats.count_rule(rule);

--- a/src/frontend/test_runner/tests/testdata/subquery_expr_correlated.yaml
+++ b/src/frontend/test_runner/tests/testdata/subquery_expr_correlated.yaml
@@ -536,3 +536,18 @@
           LogicalAgg { group_key: [$0], aggs: [] }
             LogicalScan { table: t1, columns: [y] }
           LogicalScan { table: t3, columns: [x, y] }
+- sql: |
+    create table t1(x int, y int);
+    create table t2(x int, y int);
+    create table t3(x int, y int);
+    select * from t1 where exists(select x from t2 where t1.x = t2.x and t2.y in (select t3.y + t2.y from t3 where t1.x = t3.x));
+  optimized_logical_plan: |
+    LogicalJoin { type: LeftSemi, on: ($0 = $2), output_indices: all }
+      LogicalScan { table: t1, columns: [x, y] }
+      LogicalJoin { type: LeftSemi, on: ($1 = $4) AND ($1 = $3) AND ($0 = $2), output_indices: [0] }
+        LogicalScan { table: t2, columns: [x, y] }
+        LogicalProject { exprs: [$1, $0, ($2 + $0)] }
+          LogicalJoin { type: Inner, on: true, output_indices: all }
+            LogicalAgg { group_key: [$0], aggs: [] }
+              LogicalScan { table: t2, columns: [y] }
+            LogicalScan { table: t3, columns: [x, y] }


### PR DESCRIPTION
I hereby agree to the terms of the [Singularity Data, Inc. Contributor License Agreement](https://gist.github.com/skyzh/0663682a70b0edde7ae991492f2314cb#file-s9y_cla).

## What's changed and what's your intention?

This PR is separated from #4085 for better code review.

Support push down apply until reaching a fix-point.
For some plans contain multi `Apply`, one round of heuristic optimizer is not enough. We need to reach a fix-point which means all apply need to be pushed down and eliminated.


Here is the example needed multiple round of applying transformation rules:
```sql
explain verbose trace select * from t1 where exists(select x from t2 where t1.x = t2.x and t2.y in (select t3.y + t2.y from t3 where t1.x = t3.x));

 General Unnesting(Translate Apply):

 apply TranslateApplyRule 2 time(s)

 LogicalProject { exprs: [t1.x, t1.y] }
   LogicalJoin { type: LeftSemi, on: (t1.x = t1.x), output_indices: all }
     LogicalScan { table: t1, columns: [t1._row_id, t1.x, t1.y] }
     LogicalApply { type: Inner, on: true, correlated_id: 1 }
       LogicalAgg { group_key: [t1.x], aggs: [] }
         LogicalProject { exprs: [t1.x] }
           LogicalScan { table: t1, columns: [t1.x] }
       LogicalProject { exprs: [t2.x] }
         LogicalFilter { predicate: (CorrelatedInputRef { index: 1, correlated_id: 1 } = t2.x) }
           LogicalJoin { type: LeftSemi, on: (t2.y = (t3.y + CorrelatedInputRef { index: 2, correlated_id: 2 })) AND (t2.y = t2.y), output_indices: all }
             LogicalScan { table: t2, columns: [t2._row_id, t2.x, t2.y] }
             LogicalApply { type: Inner, on: true, correlated_id: 2 }
               LogicalAgg { group_key: [t2.y], aggs: [] }
                 LogicalProject { exprs: [t2.y] }
                   LogicalScan { table: t2, columns: [t2.y] }
               LogicalProject { exprs: [(t3.y + CorrelatedInputRef { index: 2, correlated_id: 2 })] }
                 LogicalFilter { predicate: (CorrelatedInputRef { index: 1, correlated_id: 1 } = t3.x) }
                   LogicalScan { table: t3, columns: [t3._row_id, t3.x, t3.y] }

 General Unnesting(Push Down Apply):

 apply ApplyJoinRule 1 time(s)
 apply ApplyScanRule 2 time(s)
 apply ApplyFilterRule 2 time(s)
 apply ApplyProjRule 2 time(s)

 LogicalProject { exprs: [t1.x, t1.y] }
   LogicalJoin { type: LeftSemi, on: (t1.x = t2.x), output_indices: all }
     LogicalScan { table: t1, columns: [t1._row_id, t1.x, t1.y] }
     LogicalProject { exprs: [t2.x, t2.x] }
       LogicalFilter { predicate: true }
         LogicalJoin { type: LeftSemi, on: (t2.y = (t3.y + t2.y)) AND (t2.y = t2.y) AND (t2.x = t1.x), output_indices: all }
           LogicalProject { exprs: [t2.x, t2._row_id, t2.x, t2.y] }
             LogicalScan { table: t2, columns: [t2._row_id, t2.x, t2.y] }
           LogicalApply { type: Inner, on: true, correlated_id: 1 }
             LogicalAgg { group_key: [t1.x], aggs: [] }
               LogicalProject { exprs: [t1.x] }
                 LogicalScan { table: t1, columns: [t1.x] }
             LogicalProject { exprs: [t2.y, (t3.y + t2.y)] }
               LogicalFilter { predicate: (CorrelatedInputRef { index: 1, correlated_id: 1 } = t3.x) }
                 LogicalJoin { type: Inner, on: true, output_indices: all }
                   LogicalAgg { group_key: [t2.y], aggs: [] }
                     LogicalProject { exprs: [t2.y] }
                       LogicalScan { table: t2, columns: [t2.y] }
                   LogicalScan { table: t3, columns: [t3._row_id, t3.x, t3.y] }

 General Unnesting(Push Down Apply):

 apply ApplyFilterRule 1 time(s)
 apply ApplyProjRule 1 time(s)
 apply ApplyScanRule 1 time(s)

 LogicalProject { exprs: [t1.x, t1.y] }
   LogicalJoin { type: LeftSemi, on: (t1.x = t2.x), output_indices: all }
     LogicalScan { table: t1, columns: [t1._row_id, t1.x, t1.y] }
     LogicalProject { exprs: [t2.x, t2.x] }
       LogicalFilter { predicate: true }
         LogicalJoin { type: LeftSemi, on: (t2.y = (t3.y + t2.y)) AND (t2.y = t2.y) AND (t2.x = t3.x), output_indices: all }
           LogicalProject { exprs: [t2.x, t2._row_id, t2.x, t2.y] }
             LogicalScan { table: t2, columns: [t2._row_id, t2.x, t2.y] }
           LogicalProject { exprs: [t3.x, t2.y, (t3.y + t2.y)] }
             LogicalFilter { predicate: true }
               LogicalProject { exprs: [t3.x, t2.y, t3._row_id, t3.x, t3.y] }
                 LogicalJoin { type: Inner, on: true, output_indices: all }
                   LogicalAgg { group_key: [t2.y], aggs: [] }
                     LogicalProject { exprs: [t2.y] }
                       LogicalScan { table: t2, columns: [t2.y] }
                   LogicalScan { table: t3, columns: [t3._row_id, t3.x, t3.y] }
```


## Checklist

- [x] I have written necessary rustdoc comments
- [x] I have added necessary unit tests and integration tests
- [x] All checks passed in `./risedev check` (or alias, `./risedev c`)

## Refer to a related PR or issue link (optional)

Related Issue: #3842 #3862 #3860 #3976
