### PR TITLE
fix(storage): handle trivial move correctly when deleting SST

### DIFF
--- a/proto/hummock.proto
+++ b/proto/hummock.proto
@@ -67,6 +67,7 @@ message HummockVersionDelta {
   // Snapshots with epoch less than the safe epoch have been GCed.
   // Reads against such an epoch will fail.
   uint64 safe_epoch = 5;
+  bool trivial_move = 6;
 }
 
 message HummockSnapshot {

--- a/src/meta/src/hummock/hummock_manager.rs
+++ b/src/meta/src/hummock/hummock_manager.rs
@@ -216,6 +216,10 @@ impl Versioning {
     ) {
         for (_, delta) in self.hummock_version_deltas.range(delta_range) {
             let mut no_sst_to_delete = true;
+            if delta.trivial_move {
+                self.deltas_to_delete.push(delta.id);
+                continue;
+            }
             for level_deltas in delta.level_deltas.values() {
                 for level_delta in &level_deltas.level_deltas {
                     for sst_id in &level_delta.removed_table_ids {
@@ -826,7 +830,7 @@ where
     pub async fn report_compact_task_impl(
         &self,
         compact_task: &CompactTask,
-        trival_move: bool,
+        trivial_move: bool,
     ) -> Result<bool> {
         let mut compaction_guard = write_lock!(self, compaction).await;
         let start_time = Instant::now();
@@ -845,7 +849,7 @@ where
             .remove(compact_task.task_id)
             .map(|assignment| assignment.context_id);
         // The task is not found.
-        if assignee_context_id.is_none() && !trival_move {
+        if assignee_context_id.is_none() && !trivial_move {
             return Ok(false);
         }
         compact_status.report_compact_task(compact_task);
@@ -860,6 +864,7 @@ where
             let mut version_delta = HummockVersionDelta {
                 prev_id: old_version.id,
                 max_committed_epoch: old_version.max_committed_epoch,
+                trivial_move,
                 ..Default::default()
             };
             let level_deltas = &mut version_delta
@@ -888,7 +893,7 @@ where
             version_delta.id = new_version_id;
             hummock_version_deltas.insert(version_delta.id, version_delta);
 
-            if trival_move {
+            if trivial_move {
                 commit_multi_var!(
                     self,
                     assignee_context_id,
@@ -990,6 +995,7 @@ where
             HummockVersionDelta {
                 prev_id: old_version.id,
                 safe_epoch: old_version.safe_epoch,
+                trivial_move: false,
                 ..Default::default()
             },
         );


### PR DESCRIPTION
I hereby agree to the terms of the [Singularity Data, Inc. Contributor License Agreement](https://gist.github.com/skyzh/0663682a70b0edde7ae991492f2314cb#file-s9y_cla).

## What's changed and what's your intention?

Fix the bug introduced by https://github.com/singularity-data/risingwave/pull/4081, which deletes SSTs generated by trivial move incorrectly.

extend_ssts_to_delete_from_deltas should ignore delta from trivial move.

## Checklist

- [x] I have written necessary rustdoc comments
- [x] I have added necessary unit tests and integration tests
- [x] All checks passed in `./risedev check` (or alias, `./risedev c`)

## Documentation

If your pull request contains user-facing changes, please specify the types of the changes, and create a release note. Otherwise, please feel free to remove this section.

### Types of user-facing changes

Please keep the types that apply to your changes, and remove those that do not apply.

* Installation and deployment 
* Connector (sources & sinks)
* SQL commands, functions, and operators
* RisingWave cluster configuration changes
* Other (please specify in the release note below)

### Release note

Please create a release note for your changes. In the release note, focus on the impact on users, and mention the environment or conditions where the impact may occur.

## Refer to a related PR or issue link (optional)
