### PR TITLE
fix(ci): main workflow use latest unit test script

### DIFF
--- a/ci/workflows/main.yml
+++ b/ci/workflows/main.yml
@@ -125,7 +125,7 @@ steps:
     retry: *auto-retry
 
   - label: "unit test"
-    command: "ci/scripts/unit-test.sh"
+    command: "ci/scripts/pr-unit-test.sh"
     plugins:
       - ./ci/plugins/swapfile
       - gencer/cache#v2.4.10: *cargo-cache


### PR DESCRIPTION
I hereby agree to the terms of the [Singularity Data, Inc. Contributor License Agreement](https://gist.github.com/skyzh/0663682a70b0edde7ae991492f2314cb#file-s9y_cla).

## What's changed and what's your intention?

***PLEASE DO NOT LEAVE THIS EMPTY !!!***

Should use same unit test script as PR. `main` workflow should not run sqlsmith tests too, see https://github.com/singularity-data/risingwave/issues/4139, https://github.com/singularity-data/risingwave/pull/4134.

## Checklist

## Documentation

If your pull request contains user-facing changes, please specify the types of the changes, and create a release note. Otherwise, please feel free to remove this section.

### Types of user-facing changes

Please keep the types that apply to your changes, and remove those that do not apply.

* Installation and deployment 
* Connector (sources & sinks)
* SQL commands, functions, and operators
* RisingWave cluster configuration changes
* Other (please specify in the release note below)

### Release note

Please create a release note for your changes. In the release note, focus on the impact on users, and mention the environment or conditions where the impact may occur.

## Refer to a related PR or issue link (optional)
