### PR TITLE
fix(ci): exclude sqlsmith tests from coverage

### DIFF
--- a/ci/scripts/pr.env.sh
+++ b/ci/scripts/pr.env.sh
@@ -8,6 +8,7 @@ set +e
 CHANGED=$(git diff --name-only origin/main | grep "ci/scripts/pr.env.sh\|src/tests/sqlsmith")
 set -e
 
+
 if [[ -n "$CHANGED" ]]; then
     echo "Changes to Sqlsmith source files detected.";
     export RUN_SQLSMITH=1;

--- a/ci/scripts/pr.env.sh
+++ b/ci/scripts/pr.env.sh
@@ -8,7 +8,6 @@ set +e
 CHANGED=$(git diff --name-only origin/main | grep "ci/scripts/pr.env.sh\|src/tests/sqlsmith")
 set -e
 
-
 if [[ -n "$CHANGED" ]]; then
     echo "Changes to Sqlsmith source files detected.";
     export RUN_SQLSMITH=1;

--- a/ci/scripts/run-unit-test.sh
+++ b/ci/scripts/run-unit-test.sh
@@ -3,12 +3,9 @@ set -euo pipefail
 
 echo "+++ Run unit tests with coverage"
 # use tee to disable progress bar
+NEXTEST_PROFILE=ci cargo llvm-cov nextest --lcov --output-path lcov.info --features failpoints 2> >(tee);
 if [[ "$RUN_SQLSMITH" -eq "1" ]]; then
-    echo "Running sqlsmith and unit tests";
-    NEXTEST_PROFILE=ci cargo llvm-cov nextest --lcov --output-path lcov.info --features "failpoints enable_sqlsmith_unit_test" 2> >(tee);
-else
-    echo "Running unit tests";
-    NEXTEST_PROFILE=ci cargo llvm-cov nextest --lcov --output-path lcov.info --features failpoints 2> >(tee);
+    NEXTEST_PROFILE=ci cargo nextest run run_sqlsmith_on_frontend --features "failpoints enable_sqlsmith_unit_test" 2> >(tee);
 fi
 
 echo "--- Codecov upload coverage reports"


### PR DESCRIPTION
I hereby agree to the terms of the [Singularity Data, Inc. Contributor License Agreement](https://gist.github.com/skyzh/0663682a70b0edde7ae991492f2314cb#file-s9y_cla).

## What's changed and what's your intention?

- Exclude sqlsmith tests from coverage by:
  - Running usual test workflow with coverage (no sqlsmith included)
  - Running sqlsmith tests without coverage

## Why is this PR needed?

Currently for code coverage check:
- PRs which do not modify sqlsmith src files will decrease coverage, since sqlsmith tests do not run.
  - See https://github.com/singularity-data/risingwave/pull/4236#issuecomment-1196649361, as well as [88351f0](https://github.com/singularity-data/risingwave/pull/4231/commits/88351f05bdafb53535f1eb2e32bfc2f670d25362) from this PR.
- PRs which modify sqlsmith src files may continue increasing coverage.
- Better to just remove sqlsmith tests from coverage, anyway their code coverage is inconsistent, since queries are generated randomly.

## Does this PR work?

This commit below https://github.com/singularity-data/risingwave/pull/4231/commits/ef57c2b8ae2194051bcb7244311f682a77f501bf checks if the workflow works as expected, when running sqlsmith workflow as well. 
The coverage results from that commit shows that even if new sqlsmith workflow is triggered, they no longer increase coverage.

Coverage result before: https://github.com/singularity-data/risingwave/runs/7538862322, `73.93% (-0.11%) compared to f690d5e`
Coverage result after: https://github.com/singularity-data/risingwave/runs/7542854221, `73.93% (-0.11%) compared to f690d5e`

## Checklist

~~- [x] I have written necessary rustdoc comments~~
~~- [x] I have added necessary unit tests and integration tests~~
~~- [x] All checks passed in `./risedev check` (or alias, `./risedev c`)~~

## Refer to a related PR or issue link (optional)