### PR TITLE
chore: disable compile ss_bench by default

### DIFF
--- a/src/bench/Cargo.toml
+++ b/src/bench/Cargo.toml
@@ -39,9 +39,6 @@ tokio = { version = "=0.2.0-alpha.5", package = "madsim-tokio", features = [
 toml = "0.5"
 workspace-hack = { version = "0.1", path = "../workspace-hack" }
 
-[[bin]]
-name = "ss-bench"
-path = "ss_bench/main.rs"
 
 [[bin]]
 name = "file-cache-bench"


### PR DESCRIPTION
I hereby agree to the terms of the [Singularity Data, Inc. Contributor License Agreement](https://gist.github.com/skyzh/0663682a70b0edde7ae991492f2314cb#file-s9y_cla).

## What's changed and what's your intention?
As title.

## Checklist

- [x] I have written necessary rustdoc comments
- [x] I have added necessary unit tests and integration tests
- [x] All checks passed in `./risedev check` (or alias, `./risedev c`)

## Documentation

If your pull request contains user-facing changes, please specify the types of the changes, and create a release note. Otherwise, please feel free to remove this section.

### Types of user-facing changes

Please keep the types that apply to your changes, and remove those that do not apply.

* Installation and deployment 
* Connector (sources & sinks)
* SQL commands, functions, and operators
* RisingWave cluster configuration changes
* Other (please specify in the release note below)

### Release note

Please create a release note for your changes. In the release note, focus on the impact on users, and mention the environment or conditions where the impact may occur.

## Refer to a related PR or issue link (optional)
