### PR TITLE
fix(batch fragmenter): fix wrong exchange output cnt

### DIFF
--- a/e2e_test/batch/issue_4213.slt
+++ b/e2e_test/batch/issue_4213.slt
@@ -1,0 +1,23 @@
+# https://github.com/singularity-data/risingwave/issues/4213
+
+statement ok
+create table t1 (v1 int);
+
+statement ok
+create table t2 (v1 int);
+
+statement ok
+create materialized view t3 as select v1 from t2 group by v1;
+
+query I
+select * from t1 join t3 on t1.v1 = t3.v1;
+----
+
+statement ok
+drop materialized view t3;
+
+statement ok
+drop table t2;
+
+statement ok
+drop table t1;

--- a/src/frontend/src/scheduler/distributed/query.rs
+++ b/src/frontend/src/scheduler/distributed/query.rs
@@ -429,6 +429,8 @@ mod tests {
             ctx,
         )
         .to_batch()
+        .unwrap()
+        .to_distributed()
         .unwrap();
         let batch_exchange_node1: PlanRef = BatchExchange::new(
             batch_plan_node.clone(),

--- a/src/frontend/src/scheduler/plan_fragmenter.rs
+++ b/src/frontend/src/scheduler/plan_fragmenter.rs
@@ -26,7 +26,7 @@ use risingwave_pb::common::Buffer;
 use risingwave_pb::plan_common::Field as FieldProst;
 use uuid::Uuid;
 
-use crate::optimizer::plan_node::{BatchSeqScan, PlanNodeId, PlanNodeType};
+use crate::optimizer::plan_node::{PlanNodeId, PlanNodeType};
 use crate::optimizer::property::Distribution;
 use crate::optimizer::PlanRef;
 use crate::scheduler::worker_node_manager::WorkerNodeManagerRef;
@@ -225,7 +225,13 @@ struct QueryStageBuilder {
 }
 
 impl QueryStageBuilder {
-    fn new(id: StageId, query_id: QueryId, parallelism: u32, exchange_info: ExchangeInfo) -> Self {
+    fn new(
+        id: StageId,
+        query_id: QueryId,
+        parallelism: u32,
+        exchange_info: ExchangeInfo,
+        table_scan_info: Option<TableScanInfo>,
+    ) -> Self {
         Self {
             query_id,
             id,
@@ -233,7 +239,7 @@ impl QueryStageBuilder {
             parallelism,
             exchange_info,
             children_stages: vec![],
-            table_scan_info: None,
+            table_scan_info,
         }
     }
 
@@ -243,14 +249,7 @@ impl QueryStageBuilder {
             id: self.id,
             root: self.root.unwrap(),
             exchange_info: self.exchange_info,
-            parallelism: match &self.table_scan_info {
-                None => self.parallelism,
-                Some(info) => info
-                    .partitions
-                    .as_ref()
-                    .map(|m| m.len() as u32)
-                    .unwrap_or(1),
-            },
+            parallelism: self.parallelism,
             table_scan_info: self.table_scan_info,
         });
 
@@ -360,9 +359,23 @@ impl BatchPlanFragmenter {
     fn new_stage(&mut self, root: PlanRef, exchange_info: ExchangeInfo) -> QueryStageRef {
         let next_stage_id = self.next_stage_id;
         self.next_stage_id += 1;
+
+        let table_scan_info = Self::collect_stage_table_scan(root.clone());
         let parallelism = match root.distribution() {
-            Distribution::Single => 1,
-            _ => self.worker_node_manager.worker_node_count(),
+            Distribution::Single => {
+                assert!(
+                    table_scan_info.is_none()
+                        || table_scan_info.as_ref().unwrap().partitions.is_none(),
+                    "The stage has single distribution, but contains a partitioned table scan
+                node.\nplan: {:#?}",
+                    root
+                );
+                1
+            }
+            _ => match &table_scan_info {
+                None => self.worker_node_manager.worker_node_count(),
+                Some(info) => info.partitions.as_ref().map(|m| m.len()).unwrap_or(1),
+            },
         };
 
         let mut builder = QueryStageBuilder::new(
@@ -370,6 +383,7 @@ impl BatchPlanFragmenter {
             self.query_id.clone(),
             parallelism as u32,
             exchange_info,
+            table_scan_info,
         );
 
         self.visit_node(root, &mut builder, None);
@@ -399,27 +413,6 @@ impl BatchPlanFragmenter {
                 } else {
                     builder.root = Some(Arc::new(execution_plan_node));
                 }
-                // Check out the comments for `has_table_scan` in `QueryStage`.
-                let scan_node: Option<&BatchSeqScan> = node.as_batch_seq_scan();
-                if let Some(scan_node) = scan_node {
-                    if builder.table_scan_info.is_some() {
-                        // There is already a scan node in this stage.
-                        // The nodes have the same distribution, but maybe different vnodes
-                        // partition. We just use the same partition for all
-                        // the scan nodes.
-                        return;
-                    }
-
-                    builder.table_scan_info = Some({
-                        let table_desc = scan_node.logical().table_desc();
-
-                        let partitions = table_desc.vnode_mapping.as_ref().map(|vnode_mapping| {
-                            derive_partitions(scan_node.scan_ranges(), table_desc, vnode_mapping)
-                        });
-
-                        TableScanInfo { partitions }
-                    });
-                }
             }
         }
     }
@@ -442,6 +435,33 @@ impl BatchPlanFragmenter {
         }
 
         builder.children_stages.push(child_stage);
+    }
+
+    /// Check whether this stage contains a table scan node and the table's information if so.
+    ///
+    /// If there are multiple scan nodes in this stage, they must have the same distribution, but
+    /// maybe different vnodes partition. We just use the same partition for all
+    /// the scan nodes.
+    fn collect_stage_table_scan(node: PlanRef) -> Option<TableScanInfo> {
+        if node.node_type() == PlanNodeType::BatchExchange {
+            // Do not visit next stage.
+            return None;
+        }
+
+        if let Some(scan_node) = node.as_batch_seq_scan() {
+            Some({
+                let table_desc = scan_node.logical().table_desc();
+                let partitions = table_desc.vnode_mapping.as_ref().map(|vnode_mapping| {
+                    derive_partitions(scan_node.scan_ranges(), table_desc, vnode_mapping)
+                });
+                TableScanInfo { partitions }
+            })
+        } else {
+            node.inputs()
+                .into_iter()
+                .map(Self::collect_stage_table_scan)
+                .find_map(|o| o)
+        }
     }
 }
 
@@ -601,6 +621,8 @@ mod tests {
             ctx,
         )
         .to_batch()
+        .unwrap()
+        .to_distributed()
         .unwrap();
         let batch_filter = BatchFilter::new(LogicalFilter::new(
             batch_plan_node.clone(),


### PR DESCRIPTION
I hereby agree to the terms of the [Singularity Data, Inc. Contributor License Agreement](https://gist.github.com/skyzh/0663682a70b0edde7ae991492f2314cb#file-s9y_cla).

## What's changed and what's your intention?
close https://github.com/singularity-data/risingwave/issues/4213

This happends because:
1. When building the stage containing the HashJoin, the parallism is initially 1.
2. When visiting the Exchange node connecting the stage of Scan(t1), we have 
```rust 
let child_exchange_info = node.distribution().to_prost(builder.parallelism);
```
So the tasks will have 1 outputs.

3. When visiting the other side containing the other scan node, we updated `builder.table_scan_info`
4. When finish building, **we modified the parallelism of the stage**
```rust
parallelism: match &self.table_scan_info {
    None => self.parallelism,
    Some(info) => info
        .partitions
        .as_ref()
        .map(|m| m.len() as u32)
        .unwrap_or(1),
},
```
So we have 8 (the number of partitions of the table) tasks for the fragment containing the HashJoin, but the exchange will only have 1 output, and then it panics.

This can explain why it's OK if both **or neither** sides of the HashJoin have Exchange.

_Originally posted by @xxchan in https://github.com/singularity-data/risingwave/issues/4213#issuecomment-1198227009_

## Checklist

- [x] I have written necessary rustdoc comments
- [x] I have added necessary unit tests and integration tests
- [x] All checks passed in `./risedev check` (or alias, `./risedev c`)

