### PR TITLE
feat(stream): support `delim` argument in streaming `string_agg`

### DIFF
--- a/e2e_test/streaming/string_agg.slt
+++ b/e2e_test/streaming/string_agg.slt
@@ -8,10 +8,10 @@ statement ok
 insert into t values ('a', 1, 2), ('b', 4, 6);
 
 statement ok
-create materialized view mv1 as select string_agg(a order by a desc) as res from t;
+create materialized view mv1 as select string_agg(a, ',' order by a desc) as res from t;
 
 statement ok
-create materialized view mv2 as select string_agg(a order by b) as res from t group by c;
+create materialized view mv2 as select string_agg(a, b::varchar order by b) as res from t group by c;
 
 statement ok
 flush;
@@ -19,7 +19,7 @@ flush;
 query T
 select * from mv1;
 ----
-ba
+b,a
 
 query T
 select * from mv2 order by res;
@@ -33,13 +33,13 @@ insert into t values ('c', 2, 2), ('d', 3, 6);
 query T
 select * from mv1;
 ----
-dcba
+d,c,b,a
 
 query T
 select * from mv2 order by res;
 ----
-ac
-db
+a2c
+d4b
 
 statement ok
 drop materialized view mv1;


### PR DESCRIPTION
I hereby agree to the terms of the [Singularity Data, Inc. Contributor License Agreement](https://gist.github.com/skyzh/0663682a70b0edde7ae991492f2314cb#file-s9y_cla).

## What's changed and what's your intention?

Support delimiter argument in streaming `string_agg` function.

## Checklist

- [x] I have written necessary rustdoc comments
- [x] I have added necessary unit tests and integration tests
- [x] All checks passed in `./risedev check` (or alias, `./risedev c`)

## Documentation

### Types of user-facing changes

* SQL commands, functions, and operators

### Release note

* Support `delimiter` argument in streaming `string_agg` 

## Refer to a related PR or issue link (optional)

#2868