### PR TITLE
feat(frontend): expose `Vnode` function as `__rw_vnode` for easy debugging

### DIFF
--- a/e2e_test/batch/functions/internal.slt.part
+++ b/e2e_test/batch/functions/internal.slt.part
@@ -1,0 +1,17 @@
+statement ok
+SET RW_IMPLICIT_FLUSH TO true;
+
+statement ok
+create table t(v1 varchar, v2 int, v3 int)
+
+statement ok
+select __rw_vnode(_row_id) as vnode, _row_id from t;
+
+statement ok
+insert into t values ('aaa', 1, 1), ('bbb', 0, 2), ('ccc', 0, 5), ('ddd', 1, 4)
+
+statement ok
+select __rw_vnode(_row_id) as vnode, _row_id from t;
+
+statement ok
+drop table t

--- a/src/frontend/src/binder/expr/function.rs
+++ b/src/frontend/src/binder/expr/function.rs
@@ -154,6 +154,7 @@ impl Binder {
             "current_database" if inputs.is_empty() => {
                 return Ok(ExprImpl::literal_varchar(self.db_name.clone()));
             }
+            "__rw_vnode" => ExprType::Vnode,
             _ => {
                 return Err(ErrorCode::NotImplemented(
                     format!("unsupported function: {:?}", function_name),


### PR DESCRIPTION
I hereby agree to the terms of the [Singularity Data, Inc. Contributor License Agreement](https://gist.github.com/skyzh/0663682a70b0edde7ae991492f2314cb#file-s9y_cla).

## What's changed and what's your intention?

Expose `Vnode` function as `__rw_vnode` for debug purpose.

## Checklist

- [x] I have written necessary rustdoc comments
- [x] I have added necessary unit tests and integration tests
- [x] All checks passed in `./risedev check` (or alias, `./risedev c`)

## Refer to a related PR or issue link (optional)

https://github.com/singularity-data/risingwave/pull/4262#pullrequestreview-1053889717