### PR TITLE
fix(frontend): only schedule dml to cn which contain table source writer

### DIFF
--- a/src/frontend/src/binder/insert.rs
+++ b/src/frontend/src/binder/insert.rs
@@ -53,9 +53,10 @@ impl Binder {
             .collect();
 
         let vnode_mapping = self
-            .bind_table(&schema_name, &table_name, None)?
-            .table_catalog
-            .vnode_mapping;
+            .catalog
+            .get_table_by_name(&self.db_name, &schema_name, &table_name)?
+            .vnode_mapping
+            .clone();
 
         // When the column types of `source` query does not match `expected_types`, casting is
         // needed.

--- a/src/frontend/src/binder/insert.rs
+++ b/src/frontend/src/binder/insert.rs
@@ -14,7 +14,7 @@
 
 use itertools::Itertools;
 use risingwave_common::error::{ErrorCode, Result};
-use risingwave_common::types::DataType;
+use risingwave_common::types::{DataType, ParallelUnitId};
 use risingwave_sqlparser::ast::{Ident, ObjectName, Query, SetExpr};
 
 use super::{BoundQuery, BoundSetExpr};
@@ -25,6 +25,9 @@ use crate::expr::{Expr, ExprImpl, ExprType, FunctionCall, InputRef, Literal};
 pub struct BoundInsert {
     /// Used for injecting deletion chunks to the source.
     pub table_source: BoundTableSource,
+
+    /// Used for scheduling.
+    pub vnode_mapping: Option<Vec<ParallelUnitId>>,
 
     pub source: BoundQuery,
 
@@ -40,6 +43,7 @@ impl Binder {
         _columns: Vec<Ident>,
         source: Query,
     ) -> Result<BoundInsert> {
+        let (schema_name, table_name) = Self::resolve_table_name(source_name.clone())?;
         let table_source = self.bind_table_source(source_name)?;
 
         let expected_types = table_source
@@ -47,6 +51,11 @@ impl Binder {
             .iter()
             .map(|c| c.data_type.clone())
             .collect();
+
+        let vnode_mapping = self
+            .bind_table(&schema_name, &table_name, None)?
+            .table_catalog
+            .vnode_mapping;
 
         // When the column types of `source` query does not match `expected_types`, casting is
         // needed.
@@ -112,6 +121,7 @@ impl Binder {
 
         let insert = BoundInsert {
             table_source,
+            vnode_mapping,
             source,
             cast_exprs,
         };

--- a/src/frontend/src/binder/update.rs
+++ b/src/frontend/src/binder/update.rs
@@ -49,7 +49,6 @@ impl Binder {
         assignments: Vec<Assignment>,
         selection: Option<Expr>,
     ) -> Result<BoundUpdate> {
-        ensure!(table.joins.is_empty());
         let table_source = {
             ensure!(table.joins.is_empty());
             let name = match &table.relation {

--- a/src/frontend/src/handler/dml.rs
+++ b/src/frontend/src/handler/dml.rs
@@ -17,7 +17,7 @@ use pgwire::pg_response::{PgResponse, StatementType};
 use risingwave_common::error::Result;
 use risingwave_sqlparser::ast::Statement;
 
-use crate::binder::Binder;
+use crate::binder::{Binder, BoundStatement};
 use crate::handler::privilege::{check_privileges, resolve_privileges};
 use crate::handler::util::{to_pg_field, to_pg_rows};
 use crate::planner::Planner;
@@ -39,6 +39,13 @@ pub async fn handle_dml(context: OptimizerContext, stmt: Statement) -> Result<Pg
     let check_items = resolve_privileges(&bound);
     check_privileges(&session, &check_items)?;
 
+    let vnodes = match &bound {
+        BoundStatement::Insert(insert) => insert.vnode_mapping.clone(),
+        BoundStatement::Update(update) => update.vnode_mapping.clone(),
+        BoundStatement::Delete(delete) => delete.table.table_catalog.vnode_mapping.clone(),
+        BoundStatement::Query(_) => unreachable!(),
+    };
+
     let (plan, pg_descs) = {
         // Subblock to make sure PlanRef (an Rc) is dropped before `await` below.
         let root = Planner::new(context.into()).plan(bound)?;
@@ -54,7 +61,7 @@ pub async fn handle_dml(context: OptimizerContext, stmt: Statement) -> Result<Pg
     let mut rows = vec![];
     #[for_await]
     for chunk in query_manager
-        .schedule_single(execution_context, plan)
+        .schedule_single(execution_context, plan, vnodes)
         .await?
     {
         rows.extend(to_pg_rows(chunk?, false));

--- a/src/frontend/src/scheduler/distributed/query_manager.rs
+++ b/src/frontend/src/scheduler/distributed/query_manager.rs
@@ -17,7 +17,7 @@ use std::fmt::{Debug, Formatter};
 use futures::StreamExt;
 use futures_async_stream::try_stream;
 use log::debug;
-use rand::distributions::{Distribution as RandDistribution, Uniform};
+use rand::seq::SliceRandom;
 use risingwave_common::array::DataChunk;
 use risingwave_common::error::RwError;
 use risingwave_common::types::ParallelUnitId;
@@ -82,10 +82,8 @@ impl QueryManager {
                 let candidates = self
                     .worker_node_manager
                     .get_workers_by_parallel_unit_ids(&parallel_unit_ids)?;
-                let mut rng = rand::thread_rng();
-                let die = Uniform::from(0..candidates.len());
                 candidates
-                    .get(die.sample(&mut rng))
+                    .choose(&mut rand::thread_rng())
                     .unwrap()
                     .clone()
                     .host


### PR DESCRIPTION
I hereby agree to the terms of the [Singularity Data, Inc. Contributor License Agreement](https://gist.github.com/skyzh/0663682a70b0edde7ae991492f2314cb#file-s9y_cla).

## What's changed and what's your intention?

As title, we should only schedule dml to CNs which contains table source writer. When new CN joined, schedule dml to new node will failed due to no writer and downstream mview exist.

Note that, I will move `vnode_mapping` out of `TableCatalog` described in #3449 in next PR and modify schedule single/multi policy together.

## Checklist

- [x] I have written necessary rustdoc comments
- [x] I have added necessary unit tests and integration tests
- [x] All checks passed in `./risedev check` (or alias, `./risedev c`)

## Documentation

If your pull request contains user-facing changes, please specify the types of the changes, and create a release note. Otherwise, please feel free to remove this section.

### Types of user-facing changes

Please keep the types that apply to your changes, and remove those that do not apply.

* Installation and deployment 
* Connector (sources & sinks)
* SQL commands, functions, and operators
* RisingWave cluster configuration changes
* Other (please specify in the release note below)

### Release note

Please create a release note for your changes. In the release note, focus on the impact on users, and mention the environment or conditions where the impact may occur.

## Refer to a related PR or issue link (optional)
Resolve #4328