### PR TITLE
feat(meta): support manual compaction for specific sst ids from CN

### DIFF
--- a/proto/hummock.proto
+++ b/proto/hummock.proto
@@ -273,6 +273,7 @@ message TriggerManualCompactionRequest {
   KeyRange key_range = 2;
   uint32 table_id = 3;
   uint32 level = 4;
+  repeated uint64 sst_ids = 5;
 }
 
 message TriggerManualCompactionResponse {

--- a/src/meta/src/hummock/compaction/mod.rs
+++ b/src/meta/src/hummock/compaction/mod.rs
@@ -278,6 +278,7 @@ impl CompactStatus {
 
 #[derive(Clone, Debug)]
 pub struct ManualCompactionOption {
+    pub sst_ids: Vec<u64>,
     pub key_range: KeyRange,
     pub internal_table_id: HashSet<u32>,
     pub level: usize,
@@ -286,6 +287,7 @@ pub struct ManualCompactionOption {
 impl Default for ManualCompactionOption {
     fn default() -> Self {
         Self {
+            sst_ids: vec![],
             key_range: KeyRange {
                 left: vec![],
                 right: vec![],

--- a/src/meta/src/rpc/service/hummock_service.rs
+++ b/src/meta/src/rpc/service/hummock_service.rs
@@ -254,6 +254,7 @@ where
         let compaction_group_id = request.compaction_group_id;
         let mut option = ManualCompactionOption {
             level: request.level as usize,
+            sst_ids: request.sst_ids,
             ..Default::default()
         };
 


### PR DESCRIPTION
I hereby agree to the terms of the [Singularity Data, Inc. Contributor License Agreement](https://gist.github.com/skyzh/0663682a70b0edde7ae991492f2314cb#file-s9y_cla).

## What's changed and what's your intention?

support manual compaction for specific sst ids from CN, so as that CNs can trigger L0 intra compaction which exactly contains SSTs that generated by itself. see also #4072 

## Checklist

## Documentation

If your pull request contains user-facing changes, please specify the types of the changes, and create a release note. Otherwise, please feel free to remove this section.

### Types of user-facing changes

Please keep the types that apply to your changes, and remove those that do not apply.

* Installation and deployment 
* Connector (sources & sinks)
* SQL commands, functions, and operators
* RisingWave cluster configuration changes
* Other (please specify in the release note below)

### Release note

Please create a release note for your changes. In the release note, focus on the impact on users, and mention the environment or conditions where the impact may occur.

## Refer to a related PR or issue link (optional)
