### PR TITLE
fix: use correct column indices for chain & batch lookup join

### DIFF
--- a/proto/batch_plan.proto
+++ b/proto/batch_plan.proto
@@ -196,7 +196,7 @@ message MergeSortExchangeNode {
 message LookupJoinNode {
   plan_common.JoinType join_type = 1;
   expr.ExprNode condition = 2;
-  repeated int32 build_side_key = 3;
+  repeated uint32 build_side_key = 3;
   plan_common.CellBasedTableDesc probe_side_table_desc = 4;
   repeated uint32 probe_side_vnode_mapping = 5;
   repeated int32 probe_side_column_ids = 6;

--- a/proto/stream_plan.proto
+++ b/proto/stream_plan.proto
@@ -256,7 +256,8 @@ message ChainNode {
   uint32 table_id = 1;
   // The schema of input stream, which will be used to build a MergeNode
   repeated plan_common.Field upstream_fields = 2;
-  repeated int32 column_ids = 3;
+  // Which columns from upstream are used in this Chain node.
+  repeated uint64 upstream_column_indices = 3;
   // Generally, the barrier needs to be rearranged during the MV creation process, so that data can
   // be flushed to shared buffer periodically, instead of making the first epoch from batch query extra
   // large. However, in some cases, e.g., shared state, the barrier cannot be rearranged in ChainNode.

--- a/proto/stream_plan.proto
+++ b/proto/stream_plan.proto
@@ -257,7 +257,7 @@ message ChainNode {
   // The schema of input stream, which will be used to build a MergeNode
   repeated plan_common.Field upstream_fields = 2;
   // Which columns from upstream are used in this Chain node.
-  repeated uint64 upstream_column_indices = 3;
+  repeated uint32 upstream_column_indices = 3;
   // Generally, the barrier needs to be rearranged during the MV creation process, so that data can
   // be flushed to shared buffer periodically, instead of making the first epoch from batch query extra
   // large. However, in some cases, e.g., shared state, the barrier cannot be rearranged in ChainNode.

--- a/src/batch/src/executor/join/lookup_join.rs
+++ b/src/batch/src/executor/join/lookup_join.rs
@@ -117,7 +117,7 @@ impl<C: BatchTaskContext> ProbeSideSource<C> {
             .table_desc
             .order_key
             .iter()
-            .map(|col| self.table_desc.columns[col.index as usize].column_id as usize)
+            .map(|col| col.index as _)
             .collect_vec();
 
         let virtual_node = scan_range.try_compute_vnode(&dist_keys, &pk_indices);
@@ -608,7 +608,14 @@ impl BoxedExecutorBuilder for LookupJoinExecutorBuilder {
         let probe_side_schema = Schema {
             fields: probe_side_column_ids
                 .iter()
-                .map(|&i| Field::from(&ColumnDesc::from(table_desc.columns[i as usize].clone())))
+                .map(|&id| {
+                    let column = table_desc
+                        .columns
+                        .iter()
+                        .find(|c| c.column_id == id)
+                        .unwrap();
+                    Field::from(&ColumnDesc::from(column))
+                })
                 .collect_vec(),
         };
 

--- a/src/frontend/src/optimizer/plan_node/batch_lookup_join.rs
+++ b/src/frontend/src/optimizer/plan_node/batch_lookup_join.rs
@@ -160,7 +160,7 @@ impl ToBatchProst for BatchLookupJoin {
                 .eq_join_predicate
                 .left_eq_indexes()
                 .into_iter()
-                .map(|a| a as i32)
+                .map(|a| a as _)
                 .collect(),
             probe_side_table_desc: Some(self.right_table_desc.to_protobuf()),
             probe_side_vnode_mapping: self

--- a/src/frontend/src/optimizer/plan_node/logical_join.rs
+++ b/src/frontend/src/optimizer/plan_node/logical_join.rs
@@ -503,14 +503,17 @@ impl LogicalJoin {
         let eq_col_warn_message = "In Lookup Join, the right columns of the equality join \
         predicates must be the same as the primary key. A different join will be used instead.";
 
-        let order_col_indices = table_desc.order_column_indices();
-        if order_col_indices.len() != predicate.right_eq_indexes().len() {
+        let order_col_ids = table_desc.order_column_ids();
+        if order_col_ids.len() != predicate.right_eq_indexes().len() {
             log::warn!("{}", eq_col_warn_message);
             return None;
         }
 
-        for (i, eq_idx) in predicate.right_eq_indexes().into_iter().enumerate() {
-            if order_col_indices[i] != output_column_ids[eq_idx].get_id() as usize {
+        for (order_col_id, eq_idx) in order_col_ids
+            .into_iter()
+            .zip_eq(predicate.right_eq_indexes())
+        {
+            if order_col_id != output_column_ids[eq_idx] {
                 log::warn!("{}", eq_col_warn_message);
                 return None;
             }

--- a/src/frontend/src/optimizer/plan_node/logical_scan.rs
+++ b/src/frontend/src/optimizer/plan_node/logical_scan.rs
@@ -202,6 +202,10 @@ impl LogicalScan {
             .collect()
     }
 
+    pub fn output_column_indices(&self) -> &[usize] {
+        &self.output_col_idx
+    }
+
     /// Get all indexes on this table
     pub fn indexes(&self) -> &[(String, Rc<TableDesc>)] {
         &self.indexes

--- a/src/frontend/src/optimizer/plan_node/stream_index_scan.rs
+++ b/src/frontend/src/optimizer/plan_node/stream_index_scan.rs
@@ -143,11 +143,11 @@ impl StreamIndexScan {
                     })
                     .collect(),
                 // The column idxs need to be forwarded to the downstream
-                column_ids: self
+                upstream_column_indices: self
                     .logical
-                    .column_descs()
+                    .output_column_indices()
                     .iter()
-                    .map(|x| x.column_id.get_id())
+                    .map(|&i| i as u64)
                     .collect(),
                 is_singleton: false,
             })),

--- a/src/frontend/src/optimizer/plan_node/stream_index_scan.rs
+++ b/src/frontend/src/optimizer/plan_node/stream_index_scan.rs
@@ -147,7 +147,7 @@ impl StreamIndexScan {
                     .logical
                     .output_column_indices()
                     .iter()
-                    .map(|&i| i as u64)
+                    .map(|&i| i as _)
                     .collect(),
                 is_singleton: false,
             })),

--- a/src/frontend/src/optimizer/plan_node/stream_materialize.rs
+++ b/src/frontend/src/optimizer/plan_node/stream_materialize.rs
@@ -25,7 +25,6 @@ use risingwave_pb::stream_plan::stream_node::NodeBody as ProstStreamNode;
 use super::{PlanRef, PlanTreeNodeUnary, ToStreamProst};
 use crate::catalog::column_catalog::ColumnCatalog;
 use crate::catalog::table_catalog::TableCatalog;
-use crate::catalog::ColumnId;
 use crate::optimizer::plan_node::{PlanBase, PlanNode};
 use crate::optimizer::property::{Direction, Distribution, FieldOrder, Order, RequiredDist};
 
@@ -183,13 +182,6 @@ impl StreamMaterialize {
 
     pub fn name(&self) -> &str {
         self.table.name()
-    }
-
-    /// XXX(st1page): this function is used for potential DDL demand in future, and please try your
-    /// best not convert `ColumnId` to `usize(col_index`)
-    #[expect(dead_code)]
-    fn col_id_to_idx(&self, id: ColumnId) -> usize {
-        id.get_id() as usize
     }
 }
 

--- a/src/frontend/src/optimizer/plan_node/stream_materialize.rs
+++ b/src/frontend/src/optimizer/plan_node/stream_materialize.rs
@@ -29,6 +29,11 @@ use crate::catalog::ColumnId;
 use crate::optimizer::plan_node::{PlanBase, PlanNode};
 use crate::optimizer::property::{Direction, Distribution, FieldOrder, Order, RequiredDist};
 
+/// The first column id to allocate for a new materialized view.
+///
+/// Note: not starting from 0 helps us to debug misusing of the column id and the index.
+const COLUMN_ID_BASE: i32 = 1000;
+
 /// Materializes a stream.
 #[derive(Debug, Clone)]
 pub struct StreamMaterialize {
@@ -108,7 +113,10 @@ impl StreamMaterialize {
             .enumerate()
             .map(|(i, field)| {
                 let mut c = ColumnCatalog {
-                    column_desc: ColumnDesc::from_field_with_column_id(field, i as i32),
+                    column_desc: ColumnDesc::from_field_with_column_id(
+                        field,
+                        i as i32 + COLUMN_ID_BASE,
+                    ),
                     is_hidden: !user_cols.contains(i),
                 };
                 c.column_desc.name = if !c.is_hidden {

--- a/src/frontend/src/optimizer/plan_node/stream_table_scan.rs
+++ b/src/frontend/src/optimizer/plan_node/stream_table_scan.rs
@@ -182,11 +182,11 @@ impl StreamTableScan {
                     })
                     .collect(),
                 // The column idxs need to be forwarded to the downstream
-                column_ids: self
+                upstream_column_indices: self
                     .logical
-                    .column_descs()
+                    .output_column_indices()
                     .iter()
-                    .map(|x| x.column_id.get_id())
+                    .map(|&i| i as u64)
                     .collect(),
                 is_singleton: *self.distribution() == Distribution::Single,
             })),

--- a/src/frontend/src/optimizer/plan_node/stream_table_scan.rs
+++ b/src/frontend/src/optimizer/plan_node/stream_table_scan.rs
@@ -186,7 +186,7 @@ impl StreamTableScan {
                     .logical
                     .output_column_indices()
                     .iter()
-                    .map(|&i| i as u64)
+                    .map(|&i| i as _)
                     .collect(),
                 is_singleton: *self.distribution() == Distribution::Single,
             })),

--- a/src/frontend/test_runner/tests/testdata/stream_proto.yaml
+++ b/src/frontend/test_runner/tests/testdata/stream_proto.yaml
@@ -18,19 +18,20 @@
               - columnType:
                   typeName: INT64
                   isNullable: true
+                columnId: 1000
                 name: _row_id
               - columnType:
                   typeName: INT32
                   isNullable: true
-                columnId: 1
+                columnId: 1001
                 name: v1
               orderKey:
               - orderType: ASCENDING
               distKeyIndices:
               - 0
             columnIds:
-            - 1
-            - 0
+            - 1001
+            - 1000
         pkIndices:
         - 1
         fields:
@@ -53,7 +54,7 @@
               typeName: INT32
               isNullable: true
             name: v1
-          columnIds:
+          upstreamColumnIndices:
           - 1
           - 0
       pkIndices:
@@ -111,12 +112,13 @@
             columnType:
               typeName: INT32
               isNullable: true
+            columnId: 1000
             name: v1
         - columnDesc:
             columnType:
               typeName: INT64
               isNullable: true
-            columnId: 1
+            columnId: 1001
             name: t._row_id
           isHidden: true
         orderKey:
@@ -135,12 +137,13 @@
         columnType:
           typeName: INT32
           isNullable: true
+        columnId: 1000
         name: v1
     - columnDesc:
         columnType:
           typeName: INT64
           isNullable: true
-        columnId: 1
+        columnId: 1001
         name: t._row_id
       isHidden: true
     orderKey:
@@ -169,19 +172,20 @@
             - columnType:
                 typeName: INT64
                 isNullable: true
+              columnId: 1000
               name: _row_id
             - columnType:
                 typeName: INT32
                 isNullable: true
-              columnId: 1
+              columnId: 1001
               name: v1
             orderKey:
             - orderType: ASCENDING
             distKeyIndices:
             - 0
           columnIds:
-          - 1
-          - 0
+          - 1001
+          - 1000
       pkIndices:
       - 1
       fields:
@@ -204,7 +208,7 @@
             typeName: INT32
             isNullable: true
           name: v1
-        columnIds:
+        upstreamColumnIndices:
         - 1
         - 0
     pkIndices:
@@ -232,12 +236,13 @@
             columnType:
               typeName: INT32
               isNullable: true
+            columnId: 1000
             name: v1
         - columnDesc:
             columnType:
               typeName: INT64
               isNullable: true
-            columnId: 1
+            columnId: 1001
             name: t._row_id
           isHidden: true
         orderKey:
@@ -256,12 +261,13 @@
         columnType:
           typeName: INT32
           isNullable: true
+        columnId: 1000
         name: v1
     - columnDesc:
         columnType:
           typeName: INT64
           isNullable: true
-        columnId: 1
+        columnId: 1001
         name: t._row_id
       isHidden: true
     orderKey:
@@ -290,24 +296,25 @@
             - columnType:
                 typeName: INT64
                 isNullable: true
+              columnId: 1000
               name: _row_id
             - columnType:
                 typeName: INT32
                 isNullable: true
-              columnId: 1
+              columnId: 1001
               name: v1
             - columnType:
                 typeName: INT32
                 isNullable: true
-              columnId: 2
+              columnId: 1002
               name: v2
             orderKey:
             - orderType: ASCENDING
             distKeyIndices:
             - 0
           columnIds:
-          - 1
-          - 0
+          - 1001
+          - 1000
       pkIndices:
       - 1
       fields:
@@ -334,7 +341,7 @@
             typeName: INT32
             isNullable: true
           name: v2
-        columnIds:
+        upstreamColumnIndices:
         - 1
         - 0
     pkIndices:
@@ -362,12 +369,13 @@
             columnType:
               typeName: INT32
               isNullable: true
+            columnId: 1000
             name: v1
         - columnDesc:
             columnType:
               typeName: INT64
               isNullable: true
-            columnId: 1
+            columnId: 1001
             name: t._row_id
           isHidden: true
         orderKey:
@@ -386,12 +394,13 @@
         columnType:
           typeName: INT32
           isNullable: true
+        columnId: 1000
         name: v1
     - columnDesc:
         columnType:
           typeName: INT64
           isNullable: true
-        columnId: 1
+        columnId: 1001
         name: t._row_id
       isHidden: true
     orderKey:
@@ -423,19 +432,20 @@
                   - columnType:
                       typeName: INT64
                       isNullable: true
+                    columnId: 1000
                     name: _row_id
                   - columnType:
                       typeName: INT32
                       isNullable: true
-                    columnId: 1
+                    columnId: 1001
                     name: v1
                   orderKey:
                   - orderType: ASCENDING
                   distKeyIndices:
                   - 0
                 columnIds:
-                - 1
-                - 0
+                - 1001
+                - 1000
             pkIndices:
             - 1
             fields:
@@ -458,7 +468,7 @@
                   typeName: INT32
                   isNullable: true
                 name: v1
-              columnIds:
+              upstreamColumnIndices:
               - 1
               - 0
           fields:
@@ -597,13 +607,14 @@
             columnType:
               typeName: INT64
               isNullable: true
+            columnId: 1000
             name: sum(count)
           isHidden: true
         - columnDesc:
             columnType:
               typeName: INT64
               isNullable: true
-            columnId: 1
+            columnId: 1001
             name: sum
         owner: 1
     id: 4294967294
@@ -614,13 +625,14 @@
         columnType:
           typeName: INT64
           isNullable: true
+        columnId: 1000
         name: sum(count)
       isHidden: true
     - columnDesc:
         columnType:
           typeName: INT64
           isNullable: true
-        columnId: 1
+        columnId: 1001
         name: sum
     owner: 1
 - sql: |
@@ -645,25 +657,26 @@
                     - columnType:
                         typeName: INT64
                         isNullable: true
+                      columnId: 1000
                       name: _row_id
                     - columnType:
                         typeName: INT32
                         isNullable: true
-                      columnId: 1
+                      columnId: 1001
                       name: v1
                     - columnType:
                         typeName: INT32
                         isNullable: true
-                      columnId: 2
+                      columnId: 1002
                       name: v2
                     orderKey:
                     - orderType: ASCENDING
                     distKeyIndices:
                     - 0
                   columnIds:
-                  - 1
-                  - 2
-                  - 0
+                  - 1001
+                  - 1002
+                  - 1000
               pkIndices:
               - 2
               fields:
@@ -694,7 +707,7 @@
                     typeName: INT32
                     isNullable: true
                   name: v2
-                columnIds:
+                upstreamColumnIndices:
                 - 1
                 - 2
                 - 0
@@ -884,12 +897,13 @@
             columnType:
               typeName: INT64
               isNullable: true
+            columnId: 1000
             name: sum_v1
         - columnDesc:
             columnType:
               typeName: INT32
               isNullable: true
-            columnId: 1
+            columnId: 1001
             name: t.v2
           isHidden: true
         orderKey:
@@ -908,12 +922,13 @@
         columnType:
           typeName: INT64
           isNullable: true
+        columnId: 1000
         name: sum_v1
     - columnDesc:
         columnType:
           typeName: INT32
           isNullable: true
-        columnId: 1
+        columnId: 1001
         name: t.v2
       isHidden: true
     orderKey:

--- a/src/stream/src/from_proto/chain.rs
+++ b/src/stream/src/from_proto/chain.rs
@@ -28,10 +28,11 @@ impl ExecutorBuilder for ChainExecutorBuilder {
         let snapshot = params.input.remove(1);
         let mview = params.input.remove(0);
 
-        // TODO(MrCroxx): Use column_descs to get idx after mv planner can generate stable
-        // column_ids. Now simply treat column_id as column_idx.
-        // TODO(bugen): how can we know the way of mapping?
-        let column_idxs: Vec<usize> = node.column_ids.iter().map(|id| *id as usize).collect();
+        let upstream_indices: Vec<usize> = node
+            .upstream_column_indices
+            .iter()
+            .map(|&i| i as usize)
+            .collect();
 
         // For reporting the progress.
         let progress = stream
@@ -43,11 +44,11 @@ impl ExecutorBuilder for ChainExecutorBuilder {
         let schema = snapshot.schema().clone();
 
         if node.disable_rearrange {
-            let executor = ChainExecutor::new(snapshot, mview, column_idxs, progress, schema);
+            let executor = ChainExecutor::new(snapshot, mview, upstream_indices, progress, schema);
             Ok(executor.boxed())
         } else {
             let executor =
-                RearrangedChainExecutor::new(snapshot, mview, column_idxs, progress, schema);
+                RearrangedChainExecutor::new(snapshot, mview, upstream_indices, progress, schema);
             Ok(executor.boxed())
         }
     }


### PR DESCRIPTION
Signed-off-by: Bugen Zhao <i@bugenzhao.com>

I hereby agree to the terms of the [Singularity Data, Inc. Contributor License Agreement](https://gist.github.com/skyzh/0663682a70b0edde7ae991492f2314cb#file-s9y_cla).

## What's changed and what's your intention?

- Previously we used column ids as indices in the chain executor to remap the columns from the upstream with the Java frontend. This PR fixes this with upstream column indices.
- Batch lookup join directly casts column id to index, which should be avoided.
- This PR makes it allocate column id from `1000`, which helps us to debug these misusing.

## Checklist

- [x] I have written necessary rustdoc comments
- [x] I have added necessary unit tests and integration tests
- [x] All checks passed in `./risedev check` (or alias, `./risedev c`)

## Refer to a related PR or issue link (optional)
