### PR TITLE
fix(risedev): cannot `d` after adding shared in-memory hummock support 

### DIFF
--- a/src/cmd_all/src/playground.rs
+++ b/src/cmd_all/src/playground.rs
@@ -19,8 +19,8 @@ use std::process::Command;
 use anyhow::{anyhow, Result};
 use clap::StructOpt;
 use risedev::{
-    CompactorService, ComputeNodeService, ConfigExpander, FrontendService, MetaNodeService,
-    ServiceConfig,
+    CompactorService, ComputeNodeService, ConfigExpander, FrontendService, HummockInMemoryStrategy,
+    MetaNodeService, ServiceConfig,
 };
 use tokio::fs::File;
 use tokio::io::AsyncReadExt;
@@ -71,7 +71,11 @@ pub async fn playground() -> Result<()> {
                 match services.get(&step).expect("service not found") {
                     ServiceConfig::ComputeNode(c) => {
                         let mut command = Command::new("compute-node");
-                        ComputeNodeService::apply_command_args(&mut command, c)?;
+                        ComputeNodeService::apply_command_args(
+                            &mut command,
+                            c,
+                            HummockInMemoryStrategy::Shared,
+                        )?;
                         rw_services.push(RisingWaveService::Compute(
                             command.get_args().map(ToOwned::to_owned).collect(),
                         ));

--- a/src/cmd_all/src/playground.rs
+++ b/src/cmd_all/src/playground.rs
@@ -66,15 +66,30 @@ pub async fn playground() -> Result<()> {
                 profile
             );
             tracing::info!("steps: {:?}", steps);
+
+            let steps: Vec<_> = steps
+                .into_iter()
+                .map(|step| services.get(&step).expect("service not found"))
+                .collect();
+
+            let compute_node_count = steps
+                .iter()
+                .filter(|s| matches!(s, ServiceConfig::ComputeNode(_)))
+                .count();
+
             let mut rw_services = vec![];
             for step in steps {
-                match services.get(&step).expect("service not found") {
+                match step {
                     ServiceConfig::ComputeNode(c) => {
                         let mut command = Command::new("compute-node");
                         ComputeNodeService::apply_command_args(
                             &mut command,
                             c,
-                            HummockInMemoryStrategy::Shared,
+                            if compute_node_count > 1 {
+                                HummockInMemoryStrategy::Shared
+                            } else {
+                                HummockInMemoryStrategy::Isolated
+                            },
                         )?;
                         rw_services.push(RisingWaveService::Compute(
                             command.get_args().map(ToOwned::to_owned).collect(),
@@ -102,7 +117,7 @@ pub async fn playground() -> Result<()> {
                         ));
                     }
                     _ => {
-                        return Err(anyhow!("unsupported service: {}", step));
+                        return Err(anyhow!("unsupported service: {:?}", step));
                     }
                 }
             }

--- a/src/compute/src/server.rs
+++ b/src/compute/src/server.rs
@@ -142,7 +142,9 @@ pub async fn compute_node_serve(
         let memory_limiter = Arc::new(MemoryLimiter::new(
             storage_config.compactor_memory_limit_mb as u64 * 1024 * 1024,
         ));
-        if opts.state_store.starts_with("hummock+memory")
+        // Note: we treat `hummock+memory-shared` as a shared storage, so we won't start the
+        // compactor along with compute node.
+        if opts.state_store == "hummock+memory"
             || opts.state_store.starts_with("hummock+disk")
             || storage_config.disable_remote_compactor
         {

--- a/src/risedevtool/src/compose.rs
+++ b/src/risedevtool/src/compose.rs
@@ -23,9 +23,9 @@ use serde::{Deserialize, Serialize};
 
 use crate::{
     CompactorConfig, CompactorService, ComputeNodeConfig, ComputeNodeService, EtcdConfig,
-    EtcdService, FrontendConfig, FrontendService, GrafanaConfig, GrafanaGen, MetaNodeConfig,
-    MetaNodeService, MinioConfig, MinioService, PrometheusConfig, PrometheusGen, PrometheusService,
-    RedPandaConfig,
+    EtcdService, FrontendConfig, FrontendService, GrafanaConfig, GrafanaGen,
+    HummockInMemoryStrategy, MetaNodeConfig, MetaNodeService, MinioConfig, MinioService,
+    PrometheusConfig, PrometheusGen, PrometheusService, RedPandaConfig,
 };
 
 #[serde_with::skip_serializing_none]
@@ -150,7 +150,11 @@ fn health_check_port(port: u16) -> HealthCheck {
 impl Compose for ComputeNodeConfig {
     fn compose(&self, config: &ComposeConfig) -> Result<ComposeService> {
         let mut command = Command::new("compute-node");
-        ComputeNodeService::apply_command_args(&mut command, self)?;
+        ComputeNodeService::apply_command_args(
+            &mut command,
+            self,
+            HummockInMemoryStrategy::Disallowed,
+        )?;
         command.arg("--config-path").arg("/risingwave.toml");
 
         std::fs::copy(

--- a/src/risedevtool/src/task/compute_node_service.rs
+++ b/src/risedevtool/src/task/compute_node_service.rs
@@ -96,7 +96,7 @@ impl ComputeNodeService {
         let provide_compactor = config.provide_compactor.as_ref().unwrap();
         if is_shared_backend && provide_compactor.is_empty() {
             return Err(anyhow!(
-                "When minio or aws-s3 is enabled, at least one compactor is required. Consider adding `use: compactor` in risedev config."
+                "When using a shared backend (minio, aws-s3, or shared in-memory with `risedev playground`), at least one compactor is required. Consider adding `use: compactor` in risedev config."
             ));
         }
 

--- a/src/risedevtool/src/task/compute_node_service.rs
+++ b/src/risedevtool/src/task/compute_node_service.rs
@@ -42,7 +42,11 @@ impl ComputeNodeService {
     }
 
     /// Apply command args accroding to config
-    pub fn apply_command_args(cmd: &mut Command, config: &ComputeNodeConfig) -> Result<()> {
+    pub fn apply_command_args(
+        cmd: &mut Command,
+        config: &ComputeNodeConfig,
+        hummock_in_memory_strategy: HummockInMemoryStrategy,
+    ) -> Result<()> {
         cmd.arg("--host")
             .arg(format!("{}:{}", config.listen_address, config.port))
             .arg("--prometheus-listener-addr")
@@ -77,7 +81,7 @@ impl ComputeNodeService {
             &config.id,
             provide_minio,
             provide_aws_s3,
-            HummockInMemoryStrategy::Shared,
+            hummock_in_memory_strategy,
             cmd,
         )?;
         if provide_compute_node.len() > 1 && !is_shared_backend {
@@ -121,7 +125,7 @@ impl Task for ComputeNodeService {
         }
         cmd.arg("--config-path")
             .arg(Path::new(&prefix_config).join("risingwave.toml"));
-        Self::apply_command_args(&mut cmd, &self.config)?;
+        Self::apply_command_args(&mut cmd, &self.config, HummockInMemoryStrategy::Isolated)?;
 
         if !self.config.user_managed {
             ctx.run_command(ctx.tmux_run(cmd)?)?;


### PR DESCRIPTION
I hereby agree to the terms of the [Singularity Data, Inc. Contributor License Agreement](https://gist.github.com/skyzh/0663682a70b0edde7ae991492f2314cb#file-s9y_cla).

## What's changed and what's your intention?

As title.

## Checklist

- [x] I have written necessary rustdoc comments
- [x] I have added necessary unit tests and integration tests
- [x] All checks passed in `./risedev check` (or alias, `./risedev c`)

## Refer to a related PR or issue link (optional)
- Close #4351 
- Resolve the comments about compactor in #4332 