### PR TITLE
feat(planner): Use explain verbose for all planner tests

### DIFF
--- a/src/frontend/test_runner/src/lib.rs
+++ b/src/frontend/test_runner/src/lib.rs
@@ -19,6 +19,7 @@ mod resolve_id;
 
 use std::collections::{BTreeMap, HashMap};
 use std::sync::Arc;
+use std::sync::atomic::Ordering;
 
 use anyhow::{anyhow, Result};
 pub use resolve_id::*;
@@ -262,6 +263,7 @@ impl TestCase {
         let statements = Parser::parse_sql(sql).unwrap();
         for stmt in statements {
             let context = OptimizerContext::new(session.clone(), Arc::from(sql));
+            context.explain_verbose.store(true, Ordering::Relaxed); // use explain verbose in planner tests
             match stmt.clone() {
                 Statement::Query(_)
                 | Statement::Insert { .. }

--- a/src/frontend/test_runner/src/lib.rs
+++ b/src/frontend/test_runner/src/lib.rs
@@ -18,8 +18,8 @@
 mod resolve_id;
 
 use std::collections::{BTreeMap, HashMap};
-use std::sync::Arc;
 use std::sync::atomic::Ordering;
+use std::sync::Arc;
 
 use anyhow::{anyhow, Result};
 pub use resolve_id::*;

--- a/src/frontend/test_runner/tests/testdata/agg.yaml
+++ b/src/frontend/test_runner/tests/testdata/agg.yaml
@@ -23,18 +23,18 @@
       BatchProject { exprs: [t.v1, (min(t.v2) + (max(t.v3) * count(t.v1)))] }
         BatchHashAgg { group_key: [t.v1], aggs: [min(t.v2), max(t.v3), count(t.v1)] }
           BatchExchange { order: [], dist: HashShard(t.v1) }
-            BatchScan { table: t, columns: [v1, v2, v3] }
+            BatchScan { table: t, columns: [t.v1, t.v2, t.v3], distribution: SomeShard }
   batch_local_plan: |
     BatchProject { exprs: [t.v1, (min(t.v2) + (max(t.v3) * count(t.v1)))] }
       BatchHashAgg { group_key: [t.v1], aggs: [min(t.v2), max(t.v3), count(t.v1)] }
         BatchExchange { order: [], dist: Single }
-          BatchScan { table: t, columns: [v1, v2, v3] }
+          BatchScan { table: t, columns: [t.v1, t.v2, t.v3], distribution: SomeShard }
   stream_plan: |
     StreamMaterialize { columns: [v1, agg], pk_columns: [v1] }
       StreamProject { exprs: [t.v1, (min(t.v2) + (max(t.v3) * count(t.v1)))] }
         StreamHashAgg { group_key: [t.v1], aggs: [count, min(t.v2), max(t.v3), count(t.v1)] }
           StreamExchange { dist: HashShard(t.v1) }
-            StreamTableScan { table: t, columns: [v1, v2, v3, _row_id] }
+            StreamTableScan { table: t, columns: [t.v1, t.v2, t.v3, t._row_id], pk: [t._row_id], distribution: HashShard(t._row_id) }
 - sql: |
     create table t(v1 int, v2 int, v3 int);
     select min(v1) + max(v2) * count(v3) as agg from t;
@@ -43,18 +43,18 @@
       BatchSimpleAgg { aggs: [min(min(t.v1)), max(max(t.v2)), sum(count(t.v3))] }
         BatchExchange { order: [], dist: Single }
           BatchSimpleAgg { aggs: [min(t.v1), max(t.v2), count(t.v3)] }
-            BatchScan { table: t, columns: [v1, v2, v3] }
+            BatchScan { table: t, columns: [t.v1, t.v2, t.v3], distribution: SomeShard }
   batch_local_plan: |
     BatchProject { exprs: [(min(t.v1) + (max(t.v2) * count(t.v3)))] }
       BatchSimpleAgg { aggs: [min(t.v1), max(t.v2), count(t.v3)] }
         BatchExchange { order: [], dist: Single }
-          BatchScan { table: t, columns: [v1, v2, v3] }
+          BatchScan { table: t, columns: [t.v1, t.v2, t.v3], distribution: SomeShard }
   stream_plan: |
     StreamMaterialize { columns: [agg], pk_columns: [] }
       StreamProject { exprs: [(min(t.v1) + (max(t.v2) * count(t.v3)))] }
         StreamGlobalSimpleAgg { aggs: [count, min(t.v1), max(t.v2), count(t.v3)] }
           StreamExchange { dist: Single }
-            StreamTableScan { table: t, columns: [v1, v2, v3, _row_id] }
+            StreamTableScan { table: t, columns: [t.v1, t.v2, t.v3, t._row_id], pk: [t._row_id], distribution: HashShard(t._row_id) }
 - sql: |
     create table t(v1 int, v2 int);
     select v1 from t group by v2;
@@ -74,20 +74,20 @@
         BatchHashAgg { group_key: [t.v3], aggs: [min(t.v1), sum((t.v1 + t.v2)), count((t.v1 + t.v2))] }
           BatchExchange { order: [], dist: HashShard(t.v3) }
             BatchProject { exprs: [t.v3, t.v1, (t.v1 + t.v2)] }
-              BatchScan { table: t, columns: [v1, v2, v3] }
+              BatchScan { table: t, columns: [t.v1, t.v2, t.v3], distribution: SomeShard }
   batch_local_plan: |
     BatchProject { exprs: [t.v3, (min(t.v1) * (sum((t.v1 + t.v2))::Decimal / count((t.v1 + t.v2))))] }
       BatchHashAgg { group_key: [t.v3], aggs: [min(t.v1), sum((t.v1 + t.v2)), count((t.v1 + t.v2))] }
         BatchExchange { order: [], dist: Single }
           BatchProject { exprs: [t.v3, t.v1, (t.v1 + t.v2)] }
-            BatchScan { table: t, columns: [v1, v2, v3] }
+            BatchScan { table: t, columns: [t.v1, t.v2, t.v3], distribution: SomeShard }
   stream_plan: |
     StreamMaterialize { columns: [v3, agg], pk_columns: [v3] }
       StreamProject { exprs: [t.v3, (min(t.v1) * (sum((t.v1 + t.v2))::Decimal / count((t.v1 + t.v2))))] }
         StreamHashAgg { group_key: [t.v3], aggs: [count, min(t.v1), sum((t.v1 + t.v2)), count((t.v1 + t.v2))] }
           StreamExchange { dist: HashShard(t.v3) }
             StreamProject { exprs: [t.v3, t.v1, (t.v1 + t.v2), t._row_id] }
-              StreamTableScan { table: t, columns: [v1, v2, v3, _row_id] }
+              StreamTableScan { table: t, columns: [t.v1, t.v2, t.v3, t._row_id], pk: [t._row_id], distribution: HashShard(t._row_id) }
 - sql: |
     /* test logical_agg with complex group expression */
     create table t(v1 int, v2 int);
@@ -96,7 +96,7 @@
     LogicalProject { exprs: [min(t.v1), sum((t.v1 + t.v2))] }
       LogicalAgg { group_key: [(t.v1 + t.v2)], aggs: [min(t.v1), sum((t.v1 + t.v2))] }
         LogicalProject { exprs: [(t.v1 + t.v2), t.v1] }
-          LogicalScan { table: t, columns: [_row_id, v1, v2] }
+          LogicalScan { table: t, columns: [t._row_id, t.v1, t.v2] }
 - sql: |
     /* test logical_agg with complex group expression */
     create table t(v1 int, v2 int, v3 int);
@@ -105,7 +105,7 @@
     LogicalProject { exprs: [t.v1, sum((t.v1 * t.v2))] }
       LogicalAgg { group_key: [((t.v1 + t.v2) / t.v3), t.v1], aggs: [sum((t.v1 * t.v2))] }
         LogicalProject { exprs: [((t.v1 + t.v2) / t.v3), t.v1, (t.v1 * t.v2)] }
-          LogicalScan { table: t, columns: [_row_id, v1, v2, v3] }
+          LogicalScan { table: t, columns: [t._row_id, t.v1, t.v2, t.v3] }
 - sql: |
     /* test logical_agg with complex group expression */
     create table t(v1 int, v2 int);
@@ -114,7 +114,7 @@
     LogicalProject { exprs: [(t.v1 + t.v2)] }
       LogicalAgg { group_key: [(t.v1 + t.v2)], aggs: [] }
         LogicalProject { exprs: [(t.v1 + t.v2)] }
-          LogicalScan { table: t, columns: [_row_id, v1, v2] }
+          LogicalScan { table: t, columns: [t._row_id, t.v1, t.v2] }
 - sql: |
     /* test logical_agg with complex group expression */
     /* should complain about nested agg call */
@@ -129,7 +129,7 @@
     LogicalProject { exprs: [(t.v1 + t.v2)] }
       LogicalAgg { group_key: [t.v1, t.v2], aggs: [] }
         LogicalProject { exprs: [t.v1, t.v2] }
-          LogicalScan { table: t, columns: [_row_id, v1, v2] }
+          LogicalScan { table: t, columns: [t._row_id, t.v1, t.v2] }
 - sql: |
     create table t(v1 int, v2 int);
     select v1 from t group by v1 + v2;
@@ -143,19 +143,19 @@
       BatchExchange { order: [], dist: Single }
         BatchSimpleAgg { aggs: [count((t.v1 + t.v2)), sum((t.v1 + t.v2))] }
           BatchProject { exprs: [(t.v1 + t.v2)] }
-            BatchScan { table: t, columns: [v1, v2] }
+            BatchScan { table: t, columns: [t.v1, t.v2], distribution: SomeShard }
   batch_local_plan: |
     BatchSimpleAgg { aggs: [count((t.v1 + t.v2)), sum((t.v1 + t.v2))] }
       BatchExchange { order: [], dist: Single }
         BatchProject { exprs: [(t.v1 + t.v2)] }
-          BatchScan { table: t, columns: [v1, v2] }
+          BatchScan { table: t, columns: [t.v1, t.v2], distribution: SomeShard }
   stream_plan: |
     StreamMaterialize { columns: [sum(count)(hidden), cnt, sum], pk_columns: [] }
       StreamGlobalSimpleAgg { aggs: [sum(count), sum(count((t.v1 + t.v2))), sum(sum((t.v1 + t.v2)))] }
         StreamExchange { dist: Single }
           StreamLocalSimpleAgg { aggs: [count, count((t.v1 + t.v2)), sum((t.v1 + t.v2))] }
             StreamProject { exprs: [(t.v1 + t.v2), t._row_id] }
-              StreamTableScan { table: t, columns: [v1, v2, _row_id] }
+              StreamTableScan { table: t, columns: [t.v1, t.v2, t._row_id], pk: [t._row_id], distribution: HashShard(t._row_id) }
 - sql: |
     create table t(v1 int, v2 int, v3 int);
     select v1, sum(v2 + v3) / count(v2 + v3) + max(v1) as agg from t group by v1;
@@ -165,14 +165,14 @@
         BatchHashAgg { group_key: [t.v1], aggs: [sum((t.v2 + t.v3)), count((t.v2 + t.v3)), max(t.v1)] }
           BatchExchange { order: [], dist: HashShard(t.v1) }
             BatchProject { exprs: [t.v1, (t.v2 + t.v3)] }
-              BatchScan { table: t, columns: [v1, v2, v3] }
+              BatchScan { table: t, columns: [t.v1, t.v2, t.v3], distribution: SomeShard }
   stream_plan: |
     StreamMaterialize { columns: [v1, agg], pk_columns: [v1] }
       StreamProject { exprs: [t.v1, ((sum((t.v2 + t.v3)) / count((t.v2 + t.v3))) + max(t.v1))] }
         StreamHashAgg { group_key: [t.v1], aggs: [count, sum((t.v2 + t.v3)), count((t.v2 + t.v3)), max(t.v1)] }
           StreamExchange { dist: HashShard(t.v1) }
             StreamProject { exprs: [t.v1, (t.v2 + t.v3), t._row_id] }
-              StreamTableScan { table: t, columns: [v1, v2, v3, _row_id] }
+              StreamTableScan { table: t, columns: [t.v1, t.v2, t.v3, t._row_id], pk: [t._row_id], distribution: HashShard(t._row_id) }
 - sql: |
     create table t (v1 real not null);
     select v1, count(*) from t group by v1;
@@ -180,7 +180,7 @@
     BatchExchange { order: [], dist: Single }
       BatchHashAgg { group_key: [t.v1], aggs: [count] }
         BatchExchange { order: [], dist: HashShard(t.v1) }
-          BatchScan { table: t, columns: [v1] }
+          BatchScan { table: t, columns: [t.v1], distribution: SomeShard }
 - sql: |
     create table t (v1 real not null);
     select count(*) from t;
@@ -188,7 +188,7 @@
     BatchSimpleAgg { aggs: [sum(count)] }
       BatchExchange { order: [], dist: Single }
         BatchSimpleAgg { aggs: [count] }
-          BatchScan { table: t, columns: [] }
+          BatchScan { table: t, columns: [], distribution: SomeShard }
 - sql: |
     /* having with agg call */
     create table t (v1 real not null);
@@ -199,7 +199,7 @@
         BatchSimpleAgg { aggs: [sum(sum(t.v1))] }
           BatchExchange { order: [], dist: Single }
             BatchSimpleAgg { aggs: [sum(t.v1)] }
-              BatchScan { table: t, columns: [v1] }
+              BatchScan { table: t, columns: [t.v1], distribution: SomeShard }
 - sql: |
     /* having with group column */
     create table t (v1 real not null);
@@ -209,7 +209,7 @@
       LogicalFilter { predicate: (t.v1 > 5:Int32) }
         LogicalAgg { group_key: [t.v1], aggs: [] }
           LogicalProject { exprs: [t.v1] }
-            LogicalScan { table: t, columns: [_row_id, v1] }
+            LogicalScan { table: t, columns: [t._row_id, t.v1] }
 - sql: |
     /* having with non-group column */
     create table t (v1 real not null, v2 int);
@@ -223,7 +223,7 @@
   logical_plan: |
     LogicalAgg { group_key: [t.v1], aggs: [] }
       LogicalProject { exprs: [t.v1] }
-        LogicalScan { table: t, columns: [_row_id, v1, v2] }
+        LogicalScan { table: t, columns: [t._row_id, t.v1, t.v2] }
 - sql: |
     /* distinct with agg */
     create table t (v1 int, v2 int);
@@ -233,7 +233,7 @@
       LogicalProject { exprs: [sum(t.v1)] }
         LogicalAgg { group_key: [t.v2], aggs: [sum(t.v1)] }
           LogicalProject { exprs: [t.v2, t.v1] }
-            LogicalScan { table: t, columns: [_row_id, v1, v2] }
+            LogicalScan { table: t, columns: [t._row_id, t.v1, t.v2] }
 - sql: |
     /* arguments out-of-order */
     create table t(v1 int, v2 int, v3 int);
@@ -243,7 +243,7 @@
       BatchExchange { order: [], dist: Single }
         BatchSimpleAgg { aggs: [count(t.v3), min(t.v2), max(t.v1)] }
           BatchProject { exprs: [t.v3, t.v2, t.v1] }
-            BatchScan { table: t, columns: [v1, v2, v3] }
+            BatchScan { table: t, columns: [t.v1, t.v2, t.v3], distribution: SomeShard }
 - sql: |
     /* simple-agg arguments out-of-order */
     create table t(v1 int, v2 int, v3 int);
@@ -254,14 +254,14 @@
         BatchExchange { order: [], dist: Single }
           BatchSimpleAgg { aggs: [min(t.v1), max(t.v3), count(t.v2)] }
             BatchProject { exprs: [t.v1, t.v3, t.v2] }
-              BatchScan { table: t, columns: [v1, v2, v3] }
+              BatchScan { table: t, columns: [t.v1, t.v2, t.v3], distribution: SomeShard }
   stream_plan: |
     StreamMaterialize { columns: [agg], pk_columns: [] }
       StreamProject { exprs: [(min(t.v1) + (max(t.v3) * count(t.v2)))] }
         StreamGlobalSimpleAgg { aggs: [count, min(t.v1), max(t.v3), count(t.v2)] }
           StreamExchange { dist: Single }
             StreamProject { exprs: [t.v1, t.v3, t.v2, t._row_id] }
-              StreamTableScan { table: t, columns: [v1, v2, v3, _row_id] }
+              StreamTableScan { table: t, columns: [t.v1, t.v2, t.v3, t._row_id], pk: [t._row_id], distribution: HashShard(t._row_id) }
 - sql: |
     /* simple-agg with single distribution */
     create table t(v1 int);
@@ -271,14 +271,14 @@
       BatchSimpleAgg { aggs: [sum(sum(t.v1))] }
         BatchExchange { order: [], dist: Single }
           BatchSimpleAgg { aggs: [sum(t.v1)] }
-            BatchScan { table: t, columns: [v1] }
+            BatchScan { table: t, columns: [t.v1], distribution: SomeShard }
   stream_plan: |
     StreamMaterialize { columns: [count(hidden), s1], pk_columns: [] }
       StreamGlobalSimpleAgg { aggs: [count, sum(sum(sum(t.v1)))] }
         StreamGlobalSimpleAgg { aggs: [sum(count), sum(sum(t.v1))] }
           StreamExchange { dist: Single }
             StreamLocalSimpleAgg { aggs: [count, sum(t.v1)] }
-              StreamTableScan { table: t, columns: [v1, _row_id] }
+              StreamTableScan { table: t, columns: [t.v1, t._row_id], pk: [t._row_id], distribution: HashShard(t._row_id) }
 - sql: |
     /* simple-agg with some shard distribution */
     create table t(v1 int);
@@ -287,13 +287,13 @@
     BatchSimpleAgg { aggs: [sum(sum(t.v1))] }
       BatchExchange { order: [], dist: Single }
         BatchSimpleAgg { aggs: [sum(t.v1)] }
-          BatchScan { table: t, columns: [v1] }
+          BatchScan { table: t, columns: [t.v1], distribution: SomeShard }
   stream_plan: |
     StreamMaterialize { columns: [sum(count)(hidden), s1], pk_columns: [] }
       StreamGlobalSimpleAgg { aggs: [sum(count), sum(sum(t.v1))] }
         StreamExchange { dist: Single }
           StreamLocalSimpleAgg { aggs: [count, sum(t.v1)] }
-            StreamTableScan { table: t, columns: [v1, _row_id] }
+            StreamTableScan { table: t, columns: [t.v1, t._row_id], pk: [t._row_id], distribution: HashShard(t._row_id) }
 - sql: |
     /* simple-agg with hash shard distribution */
     create table t(v1 int, v2 int);
@@ -305,7 +305,7 @@
           BatchProject { exprs: [sum(t.v2)] }
             BatchHashAgg { group_key: [t.v1], aggs: [sum(t.v2)] }
               BatchExchange { order: [], dist: HashShard(t.v1) }
-                BatchScan { table: t, columns: [v1, v2] }
+                BatchScan { table: t, columns: [t.v1, t.v2], distribution: SomeShard }
   stream_plan: |
     StreamMaterialize { columns: [sum(count)(hidden), s1], pk_columns: [] }
       StreamGlobalSimpleAgg { aggs: [sum(count), sum(sum(sum(t.v2)))] }
@@ -314,7 +314,7 @@
             StreamProject { exprs: [sum(t.v2), t.v1] }
               StreamHashAgg { group_key: [t.v1], aggs: [count, sum(t.v2)] }
                 StreamExchange { dist: HashShard(t.v1) }
-                  StreamTableScan { table: t, columns: [v1, v2, _row_id] }
+                  StreamTableScan { table: t, columns: [t.v1, t.v2, t._row_id], pk: [t._row_id], distribution: HashShard(t._row_id) }
 - sql: |
     /* simple-stream-agg with append-only min-max should use 2-phase-agg */
     create table t(v1 int, v2 int) with (appendonly = true);
@@ -323,7 +323,7 @@
     StreamMaterialize { columns: [count(hidden), a1, a2], pk_columns: [] }
       StreamAppendOnlyGlobalSimpleAgg { aggs: [count, min(t.v1), max(t.v2)] }
         StreamExchange { dist: Single }
-          StreamTableScan { table: t, columns: [v1, v2, _row_id] }
+          StreamTableScan { table: t, columns: [t.v1, t.v2, t._row_id], pk: [t._row_id], distribution: HashShard(t._row_id) }
 - sql: |
     /* simple-stream-agg with non-append-only min-max should use 1-phase agg */
     create table t(v1 int, v2 int) with (appendonly = false);
@@ -332,7 +332,7 @@
     StreamMaterialize { columns: [count(hidden), s1, a1, a2], pk_columns: [] }
       StreamGlobalSimpleAgg { aggs: [count, sum(t.v1), min(t.v1), max(t.v2)] }
         StreamExchange { dist: Single }
-          StreamTableScan { table: t, columns: [v1, v2, _row_id] }
+          StreamTableScan { table: t, columns: [t.v1, t.v2, t._row_id], pk: [t._row_id], distribution: HashShard(t._row_id) }
 - sql: |
     /* dup group key */
     create table t(v1 int) with (appendonly = false);
@@ -341,17 +341,17 @@
     LogicalProject { exprs: [t.v1] }
       LogicalAgg { group_key: [t.v1, t.v1], aggs: [] }
         LogicalProject { exprs: [t.v1] }
-          LogicalScan { table: t, columns: [_row_id, v1] }
+          LogicalScan { table: t, columns: [t._row_id, t.v1] }
   optimized_logical_plan: |
     LogicalProject { exprs: [t.v1] }
       LogicalAgg { group_key: [t.v1, t.v1], aggs: [] }
-        LogicalScan { table: t, columns: [v1] }
+        LogicalScan { table: t, columns: [t.v1] }
   stream_plan: |
     StreamMaterialize { columns: [v1, t.v1(hidden)], pk_columns: [v1, t.v1] }
       StreamProject { exprs: [t.v1, t.v1] }
         StreamHashAgg { group_key: [t.v1, t.v1], aggs: [count] }
           StreamExchange { dist: HashShard(t.v1) }
-            StreamTableScan { table: t, columns: [v1, _row_id] }
+            StreamTableScan { table: t, columns: [t.v1, t._row_id], pk: [t._row_id], distribution: HashShard(t._row_id) }
 - sql: |
     /* dup group key */
     create table t(v1 int, v2 int, v3 int) with (appendonly = false);
@@ -360,19 +360,19 @@
     LogicalProject { exprs: [t.v2, min(t.v1), t.v3, max(t.v1)] }
       LogicalAgg { group_key: [t.v3, t.v2, t.v2], aggs: [min(t.v1), max(t.v1)] }
         LogicalProject { exprs: [t.v3, t.v2, t.v1] }
-          LogicalScan { table: t, columns: [_row_id, v1, v2, v3] }
+          LogicalScan { table: t, columns: [t._row_id, t.v1, t.v2, t.v3] }
   optimized_logical_plan: |
     LogicalProject { exprs: [t.v2, min(t.v1), t.v3, max(t.v1)] }
       LogicalAgg { group_key: [t.v3, t.v2, t.v2], aggs: [min(t.v1), max(t.v1)] }
         LogicalProject { exprs: [t.v3, t.v2, t.v1] }
-          LogicalScan { table: t, columns: [v1, v2, v3] }
+          LogicalScan { table: t, columns: [t.v1, t.v2, t.v3] }
   stream_plan: |
     StreamMaterialize { columns: [v2, min_v1, v3, max_v1, t.v2(hidden)], pk_columns: [v3, v2, t.v2] }
       StreamProject { exprs: [t.v2, min(t.v1), t.v3, max(t.v1), t.v2] }
         StreamHashAgg { group_key: [t.v3, t.v2, t.v2], aggs: [count, min(t.v1), max(t.v1)] }
           StreamExchange { dist: HashShard(t.v3, t.v2) }
             StreamProject { exprs: [t.v3, t.v2, t.v1, t._row_id] }
-              StreamTableScan { table: t, columns: [v1, v2, v3, _row_id] }
+              StreamTableScan { table: t, columns: [t.v1, t.v2, t.v3, t._row_id], pk: [t._row_id], distribution: HashShard(t._row_id) }
 - sql: |
     /* order by agg input */
     create table t(v1 int);
@@ -381,16 +381,16 @@
     LogicalProject { exprs: [sum(t.v1)] }
       LogicalAgg { aggs: [sum(t.v1)] }
         LogicalProject { exprs: [t.v1] }
-          LogicalScan { table: t, columns: [_row_id, v1] }
+          LogicalScan { table: t, columns: [t._row_id, t.v1] }
   optimized_logical_plan: |
     LogicalAgg { aggs: [sum(t.v1)] }
-      LogicalScan { table: t, columns: [v1] }
+      LogicalScan { table: t, columns: [t.v1] }
   stream_plan: |
     StreamMaterialize { columns: [sum(count)(hidden), s1], pk_columns: [] }
       StreamGlobalSimpleAgg { aggs: [sum(count), sum(sum(t.v1))] }
         StreamExchange { dist: Single }
           StreamLocalSimpleAgg { aggs: [count, sum(t.v1)] }
-            StreamTableScan { table: t, columns: [v1, _row_id] }
+            StreamTableScan { table: t, columns: [t.v1, t._row_id], pk: [t._row_id], distribution: HashShard(t._row_id) }
 - sql: |
     /* order by other columns */
     create table t(v1 int, v2 varchar);
@@ -399,16 +399,16 @@
     LogicalProject { exprs: [sum(t.v1)] }
       LogicalAgg { aggs: [sum(t.v1)] }
         LogicalProject { exprs: [t.v1] }
-          LogicalScan { table: t, columns: [_row_id, v1, v2] }
+          LogicalScan { table: t, columns: [t._row_id, t.v1, t.v2] }
   optimized_logical_plan: |
     LogicalAgg { aggs: [sum(t.v1)] }
-      LogicalScan { table: t, columns: [v1] }
+      LogicalScan { table: t, columns: [t.v1] }
   stream_plan: |
     StreamMaterialize { columns: [sum(count)(hidden), s1], pk_columns: [] }
       StreamGlobalSimpleAgg { aggs: [sum(count), sum(sum(t.v1))] }
         StreamExchange { dist: Single }
           StreamLocalSimpleAgg { aggs: [count, sum(t.v1)] }
-            StreamTableScan { table: t, columns: [v1, _row_id] }
+            StreamTableScan { table: t, columns: [t.v1, t._row_id], pk: [t._row_id], distribution: HashShard(t._row_id) }
 - sql: |
     /* order by ASC/DESC and default */
     create table t(v1 int, v2 varchar, v3 int);
@@ -417,16 +417,16 @@
     LogicalProject { exprs: [sum(t.v1)] }
       LogicalAgg { aggs: [sum(t.v1)] }
         LogicalProject { exprs: [t.v1] }
-          LogicalScan { table: t, columns: [_row_id, v1, v2, v3] }
+          LogicalScan { table: t, columns: [t._row_id, t.v1, t.v2, t.v3] }
   optimized_logical_plan: |
     LogicalAgg { aggs: [sum(t.v1)] }
-      LogicalScan { table: t, columns: [v1] }
+      LogicalScan { table: t, columns: [t.v1] }
   stream_plan: |
     StreamMaterialize { columns: [sum(count)(hidden), s1], pk_columns: [] }
       StreamGlobalSimpleAgg { aggs: [sum(count), sum(sum(t.v1))] }
         StreamExchange { dist: Single }
           StreamLocalSimpleAgg { aggs: [count, sum(t.v1)] }
-            StreamTableScan { table: t, columns: [v1, _row_id] }
+            StreamTableScan { table: t, columns: [t.v1, t._row_id], pk: [t._row_id], distribution: HashShard(t._row_id) }
 - sql: |
     /* order by NULLS FIRST/LAST and default */
     create table t(v1 int, v2 varchar, v3 int);
@@ -435,16 +435,16 @@
     LogicalProject { exprs: [sum(t.v1)] }
       LogicalAgg { aggs: [sum(t.v1)] }
         LogicalProject { exprs: [t.v1] }
-          LogicalScan { table: t, columns: [_row_id, v1, v2, v3] }
+          LogicalScan { table: t, columns: [t._row_id, t.v1, t.v2, t.v3] }
   optimized_logical_plan: |
     LogicalAgg { aggs: [sum(t.v1)] }
-      LogicalScan { table: t, columns: [v1] }
+      LogicalScan { table: t, columns: [t.v1] }
   stream_plan: |
     StreamMaterialize { columns: [sum(count)(hidden), s1], pk_columns: [] }
       StreamGlobalSimpleAgg { aggs: [sum(count), sum(sum(t.v1))] }
         StreamExchange { dist: Single }
           StreamLocalSimpleAgg { aggs: [count, sum(t.v1)] }
-            StreamTableScan { table: t, columns: [v1, _row_id] }
+            StreamTableScan { table: t, columns: [t.v1, t._row_id], pk: [t._row_id], distribution: HashShard(t._row_id) }
 - sql: |
     /* order by complex expressions */
     create table t(v1 int, v2 varchar, v3 int);
@@ -453,16 +453,16 @@
     LogicalProject { exprs: [sum(t.v1)] }
       LogicalAgg { aggs: [sum(t.v1)] }
         LogicalProject { exprs: [t.v1] }
-          LogicalScan { table: t, columns: [_row_id, v1, v2, v3] }
+          LogicalScan { table: t, columns: [t._row_id, t.v1, t.v2, t.v3] }
   optimized_logical_plan: |
     LogicalAgg { aggs: [sum(t.v1)] }
-      LogicalScan { table: t, columns: [v1] }
+      LogicalScan { table: t, columns: [t.v1] }
   stream_plan: |
     StreamMaterialize { columns: [sum(count)(hidden), s1], pk_columns: [] }
       StreamGlobalSimpleAgg { aggs: [sum(count), sum(sum(t.v1))] }
         StreamExchange { dist: Single }
           StreamLocalSimpleAgg { aggs: [count, sum(t.v1)] }
-            StreamTableScan { table: t, columns: [v1, _row_id] }
+            StreamTableScan { table: t, columns: [t.v1, t._row_id], pk: [t._row_id], distribution: HashShard(t._row_id) }
 - sql: |
     /* filter clause */
     create table t(v1 int);
@@ -471,16 +471,16 @@
     LogicalProject { exprs: [sum(t.v1) filter((t.v1 > 0:Int32))] }
       LogicalAgg { aggs: [sum(t.v1) filter((t.v1 > 0:Int32))] }
         LogicalProject { exprs: [t.v1] }
-          LogicalScan { table: t, columns: [_row_id, v1] }
+          LogicalScan { table: t, columns: [t._row_id, t.v1] }
   optimized_logical_plan: |
     LogicalAgg { aggs: [sum(t.v1) filter((t.v1 > 0:Int32))] }
-      LogicalScan { table: t, columns: [v1] }
+      LogicalScan { table: t, columns: [t.v1] }
   stream_plan: |
     StreamMaterialize { columns: [sum(count)(hidden), sa], pk_columns: [] }
       StreamGlobalSimpleAgg { aggs: [sum(count), sum(sum(t.v1) filter((t.v1 > 0:Int32)))] }
         StreamExchange { dist: Single }
           StreamLocalSimpleAgg { aggs: [count, sum(t.v1) filter((t.v1 > 0:Int32))] }
-            StreamTableScan { table: t, columns: [v1, _row_id] }
+            StreamTableScan { table: t, columns: [t.v1, t._row_id], pk: [t._row_id], distribution: HashShard(t._row_id) }
 - sql: |
     /* filter clause */
     /* extra calculation, should reuse result from project */
@@ -490,11 +490,11 @@
     LogicalProject { exprs: [sum((t.a * t.b)) filter(((t.a * t.b) > 0:Int32))] }
       LogicalAgg { aggs: [sum((t.a * t.b)) filter(((t.a * t.b) > 0:Int32))] }
         LogicalProject { exprs: [t.a, t.b, (t.a * t.b)] }
-          LogicalScan { table: t, columns: [_row_id, a, b] }
+          LogicalScan { table: t, columns: [t._row_id, t.a, t.b] }
   optimized_logical_plan: |
     LogicalAgg { aggs: [sum((t.a * t.b)) filter(((t.a * t.b) > 0:Int32))] }
       LogicalProject { exprs: [t.a, t.b, (t.a * t.b)] }
-        LogicalScan { table: t, columns: [a, b] }
+        LogicalScan { table: t, columns: [t.a, t.b] }
 - sql: |
     /* complex filter clause */
     create table t(a int, b int);
@@ -503,17 +503,17 @@
     LogicalProject { exprs: [max((t.a * t.b)) filter((t.a < t.b) AND ((t.a + t.b) < 100:Int32) AND ((t.a * t.b) <> ((t.a + t.b) - 1:Int32)))] }
       LogicalAgg { aggs: [max((t.a * t.b)) filter((t.a < t.b) AND ((t.a + t.b) < 100:Int32) AND ((t.a * t.b) <> ((t.a + t.b) - 1:Int32)))] }
         LogicalProject { exprs: [t.a, t.b, (t.a * t.b)] }
-          LogicalScan { table: t, columns: [_row_id, a, b] }
+          LogicalScan { table: t, columns: [t._row_id, t.a, t.b] }
   optimized_logical_plan: |
     LogicalAgg { aggs: [max((t.a * t.b)) filter((t.a < t.b) AND ((t.a + t.b) < 100:Int32) AND ((t.a * t.b) <> ((t.a + t.b) - 1:Int32)))] }
       LogicalProject { exprs: [t.a, t.b, (t.a * t.b)] }
-        LogicalScan { table: t, columns: [a, b] }
+        LogicalScan { table: t, columns: [t.a, t.b] }
   stream_plan: |
     StreamMaterialize { columns: [count(hidden), sab], pk_columns: [] }
       StreamGlobalSimpleAgg { aggs: [count, max((t.a * t.b)) filter((t.a < t.b) AND ((t.a + t.b) < 100:Int32) AND ((t.a * t.b) <> ((t.a + t.b) - 1:Int32)))] }
         StreamExchange { dist: Single }
           StreamProject { exprs: [t.a, t.b, (t.a * t.b), t._row_id] }
-            StreamTableScan { table: t, columns: [a, b, _row_id] }
+            StreamTableScan { table: t, columns: [t.a, t.b, t._row_id], pk: [t._row_id], distribution: HashShard(t._row_id) }
 - sql: |
     /* avg filter clause + group by */
     create table t(a int, b int);
@@ -522,19 +522,19 @@
     LogicalProject { exprs: [(sum(t.a) filter((t.a > t.b))::Decimal / count(t.a) filter((t.a > t.b)))] }
       LogicalAgg { group_key: [t.b], aggs: [sum(t.a) filter((t.a > t.b)), count(t.a) filter((t.a > t.b))] }
         LogicalProject { exprs: [t.b, t.a] }
-          LogicalScan { table: t, columns: [_row_id, a, b] }
+          LogicalScan { table: t, columns: [t._row_id, t.a, t.b] }
   optimized_logical_plan: |
     LogicalProject { exprs: [(sum(t.a) filter((t.a > t.b))::Decimal / count(t.a) filter((t.a > t.b)))] }
       LogicalAgg { group_key: [t.b], aggs: [sum(t.a) filter((t.a > t.b)), count(t.a) filter((t.a > t.b))] }
         LogicalProject { exprs: [t.b, t.a] }
-          LogicalScan { table: t, columns: [a, b] }
+          LogicalScan { table: t, columns: [t.a, t.b] }
   stream_plan: |
     StreamMaterialize { columns: [avga, t.b(hidden)], pk_columns: [t.b] }
       StreamProject { exprs: [(sum(t.a) filter((t.a > t.b))::Decimal / count(t.a) filter((t.a > t.b))), t.b] }
         StreamHashAgg { group_key: [t.b], aggs: [count, sum(t.a) filter((t.a > t.b)), count(t.a) filter((t.a > t.b))] }
           StreamExchange { dist: HashShard(t.b) }
             StreamProject { exprs: [t.b, t.a, t._row_id] }
-              StreamTableScan { table: t, columns: [a, b, _row_id] }
+              StreamTableScan { table: t, columns: [t.a, t.b, t._row_id], pk: [t._row_id], distribution: HashShard(t._row_id) }
 - sql: |
     /* count filter clause */
     create table t(a int, b int);
@@ -543,16 +543,16 @@
     LogicalProject { exprs: [count filter((t.a > t.b))] }
       LogicalAgg { aggs: [count filter((t.a > t.b))] }
         LogicalProject { exprs: [t.a, t.b] }
-          LogicalScan { table: t, columns: [_row_id, a, b] }
+          LogicalScan { table: t, columns: [t._row_id, t.a, t.b] }
   optimized_logical_plan: |
     LogicalAgg { aggs: [count filter((t.a > t.b))] }
-      LogicalScan { table: t, columns: [a, b] }
+      LogicalScan { table: t, columns: [t.a, t.b] }
   stream_plan: |
     StreamMaterialize { columns: [sum(count)(hidden), cnt_agb], pk_columns: [] }
       StreamGlobalSimpleAgg { aggs: [sum(count), sum(count filter((t.a > t.b)))] }
         StreamExchange { dist: Single }
           StreamLocalSimpleAgg { aggs: [count, count filter((t.a > t.b))] }
-            StreamTableScan { table: t, columns: [a, b, _row_id] }
+            StreamTableScan { table: t, columns: [t.a, t.b, t._row_id], pk: [t._row_id], distribution: HashShard(t._row_id) }
 - sql: |
     /* filter clause + non-boolean function */
     create table t(a int, b int);
@@ -584,13 +584,13 @@
     BatchSimpleAgg { aggs: [sum(sum(t.v2) filter((t.v2 < 5:Int32)))] }
       BatchExchange { order: [], dist: Single }
         BatchSimpleAgg { aggs: [sum(t.v2) filter((t.v2 < 5:Int32))] }
-          BatchScan { table: t, columns: [v2] }
+          BatchScan { table: t, columns: [t.v2], distribution: SomeShard }
   stream_plan: |
     StreamMaterialize { columns: [sum(count)(hidden), b], pk_columns: [] }
       StreamGlobalSimpleAgg { aggs: [sum(count), sum(sum(t.v2) filter((t.v2 < 5:Int32)))] }
         StreamExchange { dist: Single }
           StreamLocalSimpleAgg { aggs: [count, sum(t.v2) filter((t.v2 < 5:Int32))] }
-            StreamTableScan { table: t, columns: [v2, _row_id] }
+            StreamTableScan { table: t, columns: [t.v2, t._row_id], pk: [t._row_id], distribution: HashShard(t._row_id) }
 - sql: |
     /* only distinct agg */
     create table t(a int, b int, c int);
@@ -599,7 +599,7 @@
     LogicalAgg { group_key: [t.a], aggs: [count(t.b) filter((flag = 0:Int64)), sum(t.c) filter((count filter((t.c < 100:Int32)) > 0:Int64) AND (flag = 1:Int64))] }
       LogicalAgg { group_key: [t.a, t.b, t.c, flag], aggs: [count filter((t.c < 100:Int32))] }
         LogicalExpand { column_subsets: [[t.a, t.b], [t.a, t.c]] }
-          LogicalScan { table: t, columns: [a, b, c] }
+          LogicalScan { table: t, columns: [t.a, t.b, t.c] }
 - sql: |
     /* distinct agg and non-disintct agg */
     create table t(a int, b int, c int);
@@ -608,7 +608,7 @@
     LogicalAgg { group_key: [t.a], aggs: [count(t.b) filter((flag = 1:Int64)), sum(sum(t.c)) filter((flag = 0:Int64))] }
       LogicalAgg { group_key: [t.a, t.b, flag], aggs: [sum(t.c)] }
         LogicalExpand { column_subsets: [[t.a, t.c], [t.a, t.b]] }
-          LogicalScan { table: t, columns: [a, b, c] }
+          LogicalScan { table: t, columns: [t.a, t.b, t.c] }
   stream_plan: |
     StreamMaterialize { columns: [a, count(hidden), distinct_b_num, sum_c], pk_columns: [a] }
       StreamHashAgg { group_key: [t.a], aggs: [count, count(t.b) filter((flag = 1:Int64)), sum(sum(t.c)) filter((flag = 0:Int64))] }
@@ -616,7 +616,7 @@
           StreamHashAgg { group_key: [t.a, t.b, flag], aggs: [count, sum(t.c)] }
             StreamExchange { dist: HashShard(t.a, t.b, flag) }
               StreamExpand { column_subsets: [[t.a, t.c], [t.a, t.b]] }
-                StreamTableScan { table: t, columns: [a, b, c, _row_id] }
+                StreamTableScan { table: t, columns: [t.a, t.b, t.c, t._row_id], pk: [t._row_id], distribution: HashShard(t._row_id) }
 - sql: |
     /* distinct agg with filter */
     create table t(a int, b int, c int);
@@ -625,7 +625,7 @@
     LogicalAgg { group_key: [t.a], aggs: [count(t.b) filter((count filter((t.b < 100:Int32)) > 0:Int64) AND (flag = 1:Int64)), sum(sum(t.c)) filter((flag = 0:Int64))] }
       LogicalAgg { group_key: [t.a, t.b, flag], aggs: [count filter((t.b < 100:Int32)), sum(t.c)] }
         LogicalExpand { column_subsets: [[t.a, t.c], [t.a, t.b]] }
-          LogicalScan { table: t, columns: [a, b, c] }
+          LogicalScan { table: t, columns: [t.a, t.b, t.c] }
 - sql: |
     /* non-distinct agg with filter */
     create table t(a int, b int, c int);
@@ -634,7 +634,7 @@
     LogicalAgg { group_key: [t.a], aggs: [count(t.b) filter((flag = 1:Int64)), sum(sum(t.c) filter((t.b < 100:Int32))) filter((flag = 0:Int64))] }
       LogicalAgg { group_key: [t.a, t.b, flag], aggs: [sum(t.c) filter((t.b < 100:Int32))] }
         LogicalExpand { column_subsets: [[t.a, t.b, t.c], [t.a, t.b]] }
-          LogicalScan { table: t, columns: [a, b, c] }
+          LogicalScan { table: t, columns: [t.a, t.b, t.c] }
 - sql: |
     /* combined order by & filter clauses */
     create table t(a varchar, b int);
@@ -643,18 +643,18 @@
     LogicalProject { exprs: [sum((Length(t.a) * t.b)) filter((t.b < 100:Int32) AND ((t.b * 2:Int32) > 10:Int32))] }
       LogicalAgg { aggs: [sum((Length(t.a) * t.b)) filter((t.b < 100:Int32) AND ((t.b * 2:Int32) > 10:Int32))] }
         LogicalProject { exprs: [t.b, (Length(t.a) * t.b)] }
-          LogicalScan { table: t, columns: [_row_id, a, b] }
+          LogicalScan { table: t, columns: [t._row_id, t.a, t.b] }
   optimized_logical_plan: |
     LogicalAgg { aggs: [sum((Length(t.a) * t.b)) filter((t.b < 100:Int32) AND ((t.b * 2:Int32) > 10:Int32))] }
       LogicalProject { exprs: [t.b, (Length(t.a) * t.b)] }
-        LogicalScan { table: t, columns: [a, b] }
+        LogicalScan { table: t, columns: [t.a, t.b] }
   stream_plan: |
     StreamMaterialize { columns: [sum(count)(hidden), s1], pk_columns: [] }
       StreamGlobalSimpleAgg { aggs: [sum(count), sum(sum((Length(t.a) * t.b)) filter((t.b < 100:Int32) AND ((t.b * 2:Int32) > 10:Int32)))] }
         StreamExchange { dist: Single }
           StreamLocalSimpleAgg { aggs: [count, sum((Length(t.a) * t.b)) filter((t.b < 100:Int32) AND ((t.b * 2:Int32) > 10:Int32))] }
             StreamProject { exprs: [t.b, (Length(t.a) * t.b), t._row_id] }
-              StreamTableScan { table: t, columns: [a, b, _row_id] }
+              StreamTableScan { table: t, columns: [t.a, t.b, t._row_id], pk: [t._row_id], distribution: HashShard(t._row_id) }
 - sql: |
     create table t(x int, y varchar);
     select string_agg(y, ',' order by y), count(distinct x) from t;
@@ -672,4 +672,4 @@
     LogicalAgg { aggs: [count(t.v1) filter((flag = 1:Int64))] }
       LogicalAgg { group_key: [t.v1, flag], aggs: [] }
         LogicalExpand { column_subsets: [[], [t.v1]] }
-          LogicalScan { table: t, columns: [v1] }
+          LogicalScan { table: t, columns: [t.v1] }

--- a/src/frontend/test_runner/tests/testdata/append_only.yaml
+++ b/src/frontend/test_runner/tests/testdata/append_only.yaml
@@ -6,7 +6,7 @@
     StreamMaterialize { columns: [v1, count(hidden), mx2], pk_columns: [v1] }
       StreamAppendOnlyHashAgg { group_key: [t1.v1], aggs: [count, max(t1.v2)] }
         StreamExchange { dist: HashShard(t1.v1) }
-          StreamTableScan { table: t1, columns: [v1, v2, _row_id] }
+          StreamTableScan { table: t1, columns: [t1.v1, t1.v2, t1._row_id], pk: [t1._row_id], distribution: HashShard(t1._row_id) }
 - sql: |
     create table t1 (v1 int, v2 int) with (appendonly = true);
     create table t2 (v1 int, v3 int) with (appendonly = true);
@@ -14,11 +14,11 @@
   stream_plan: |
     StreamMaterialize { columns: [id, v2, v3, t1._row_id(hidden), t2._row_id(hidden)], pk_columns: [t1._row_id, t2._row_id] }
       StreamExchange { dist: HashShard(t1._row_id, t2._row_id) }
-        StreamAppendOnlyHashJoin { type: Inner, predicate: t1.v1 = t2.v1, append_only: true }
+        StreamAppendOnlyHashJoin { type: Inner, predicate: t1.v1 = t2.v1, append_only: true, output: [t1.v1, t1.v2, t2.v3, t1._row_id, t2._row_id] }
           StreamExchange { dist: HashShard(t1.v1) }
-            StreamTableScan { table: t1, columns: [v1, v2, _row_id] }
+            StreamTableScan { table: t1, columns: [t1.v1, t1.v2, t1._row_id], pk: [t1._row_id], distribution: HashShard(t1._row_id) }
           StreamExchange { dist: HashShard(t2.v1) }
-            StreamTableScan { table: t2, columns: [v1, v3, _row_id] }
+            StreamTableScan { table: t2, columns: [t2.v1, t2.v3, t2._row_id], pk: [t2._row_id], distribution: HashShard(t2._row_id) }
 - sql: |
     create table t1 (v1 int, v2 int) with (appendonly = true);
     select v1 from t1 order by v1 limit 3 offset 3;
@@ -26,7 +26,7 @@
     StreamMaterialize { columns: [v1, t1._row_id(hidden)], pk_columns: [t1._row_id], order_descs: [v1, t1._row_id] }
       StreamAppendOnlyTopN { order: "[t1.v1 ASC]", limit: 3, offset: 3 }
         StreamExchange { dist: Single }
-          StreamTableScan { table: t1, columns: [v1, _row_id] }
+          StreamTableScan { table: t1, columns: [t1.v1, t1._row_id], pk: [t1._row_id], distribution: HashShard(t1._row_id) }
 - sql: |
     create table t1 (v1 int, v2 int) with (appendonly = true);
     select max(v1) as max_v1 from t1;
@@ -34,4 +34,4 @@
     StreamMaterialize { columns: [count(hidden), max_v1], pk_columns: [] }
       StreamAppendOnlyGlobalSimpleAgg { aggs: [count, max(t1.v1)] }
         StreamExchange { dist: Single }
-          StreamTableScan { table: t1, columns: [v1, _row_id] }
+          StreamTableScan { table: t1, columns: [t1.v1, t1._row_id], pk: [t1._row_id], distribution: HashShard(t1._row_id) }

--- a/src/frontend/test_runner/tests/testdata/array.yaml
+++ b/src/frontend/test_runner/tests/testdata/array.yaml
@@ -16,11 +16,11 @@
     select (ARRAY[1, v1]) from t;
   logical_plan: |
     LogicalProject { exprs: [Array(1:Int32, t.v1)] }
-      LogicalScan { table: t, columns: [_row_id, v1] }
+      LogicalScan { table: t, columns: [t._row_id, t.v1] }
   batch_plan: |
     BatchExchange { order: [], dist: Single }
       BatchProject { exprs: [Array(1:Int32, t.v1)] }
-        BatchScan { table: t, columns: [v1] }
+        BatchScan { table: t, columns: [t.v1], distribution: SomeShard }
 - sql: |
     select ARRAY[null];
   logical_plan: |

--- a/src/frontend/test_runner/tests/testdata/basic_query.yaml
+++ b/src/frontend/test_runner/tests/testdata/basic_query.yaml
@@ -9,10 +9,10 @@
     select * from t;
   batch_plan: |
     BatchExchange { order: [], dist: Single }
-      BatchScan { table: t, columns: [v1, v2] }
+      BatchScan { table: t, columns: [t.v1, t.v2], distribution: SomeShard }
   stream_plan: |
     StreamMaterialize { columns: [v1, v2, t._row_id(hidden)], pk_columns: [t._row_id] }
-      StreamTableScan { table: t, columns: [v1, v2, _row_id] }
+      StreamTableScan { table: t, columns: [t.v1, t.v2, t._row_id], pk: [t._row_id], distribution: HashShard(t._row_id) }
 - sql: |
     create table t (v1 bigint, v2 double precision);
     select t2.* from t;
@@ -23,22 +23,22 @@
   batch_plan: |
     BatchExchange { order: [], dist: Single }
       BatchFilter { predicate: (1:Int32 = 1:Int32) AND ((((1:Int32 > 2:Int32) AND (3:Int32 < 1:Int32)) AND (4:Int32 <> 1:Int32)) OR ((2:Int32 >= 1:Int32) AND (1:Int32 <= 2:Int32))) }
-        BatchScan { table: t, columns: [] }
+        BatchScan { table: t, columns: [], distribution: SomeShard }
   stream_plan: |
     StreamMaterialize { columns: [t._row_id(hidden)], pk_columns: [t._row_id] }
       StreamFilter { predicate: (1:Int32 = 1:Int32) AND ((((1:Int32 > 2:Int32) AND (3:Int32 < 1:Int32)) AND (4:Int32 <> 1:Int32)) OR ((2:Int32 >= 1:Int32) AND (1:Int32 <= 2:Int32))) }
-        StreamTableScan { table: t, columns: [_row_id] }
+        StreamTableScan { table: t, columns: [t._row_id], pk: [t._row_id], distribution: HashShard(t._row_id) }
 - sql: |
     create table t (v1 int);
     select * from t where v1<1;
   batch_plan: |
     BatchExchange { order: [], dist: Single }
       BatchFilter { predicate: (t.v1 < 1:Int32) }
-        BatchScan { table: t, columns: [v1] }
+        BatchScan { table: t, columns: [t.v1], distribution: SomeShard }
   stream_plan: |
     StreamMaterialize { columns: [v1, t._row_id(hidden)], pk_columns: [t._row_id] }
       StreamFilter { predicate: (t.v1 < 1:Int32) }
-        StreamTableScan { table: t, columns: [v1, _row_id] }
+        StreamTableScan { table: t, columns: [t.v1, t._row_id], pk: [t._row_id], distribution: HashShard(t._row_id) }
 - sql: |
     /* test boolean expression common factor extraction */
     create table t (v1 Boolean, v2 Boolean, v3 Boolean);
@@ -46,7 +46,7 @@
   batch_plan: |
     BatchExchange { order: [], dist: Single }
       BatchFilter { predicate: t.v1 AND t.v2 AND (t.v1 OR t.v3) }
-        BatchScan { table: t, columns: [v1, v2, v3] }
+        BatchScan { table: t, columns: [t.v1, t.v2, t.v3], distribution: SomeShard }
 - sql: |
     /* test boolean expression simplification */
     create table t (v1 Boolean, v2 Boolean, v3 Boolean);
@@ -54,7 +54,7 @@
   batch_plan: |
     BatchExchange { order: [], dist: Single }
       BatchFilter { predicate: t.v1 AND Not(t.v1) AND Not(t.v2) AND t.v2 }
-        BatchScan { table: t, columns: [v1, v2, v3] }
+        BatchScan { table: t, columns: [t.v1, t.v2, t.v3], distribution: SomeShard }
 - sql: |
     /* test boolean expression simplification */
     create table t (v1 Boolean, v2 Boolean);
@@ -62,7 +62,7 @@
   batch_plan: |
     BatchExchange { order: [], dist: Single }
       BatchFilter { predicate: t.v1 AND t.v2 }
-        BatchScan { table: t, columns: [v1, v2] }
+        BatchScan { table: t, columns: [t.v1, t.v2], distribution: SomeShard }
 - sql: |
     /* constant folding for IS TRUE, IS FALSE, IS NULL*/
     create table t(a Boolean);
@@ -70,7 +70,7 @@
   logical_plan: |
     LogicalProject { exprs: [t.a] }
       LogicalFilter { predicate: t.a }
-        LogicalScan { table: t, columns: [_row_id, a] }
+        LogicalScan { table: t, columns: [t._row_id, t.a] }
 - sql: |
     /* constant folding for IS NOT TRUE, IS NOT FALSE */
     create table t(a Boolean);
@@ -78,7 +78,7 @@
   logical_plan: |
     LogicalProject { exprs: [t.a] }
       LogicalFilter { predicate: IsNotTrue(t.a) }
-        LogicalScan { table: t, columns: [_row_id, a] }
+        LogicalScan { table: t, columns: [t._row_id, t.a] }
 - sql: |
     /* constant folding IS NOT NULL */
     create table t(a double precision);
@@ -86,16 +86,16 @@
   logical_plan: |
     LogicalProject { exprs: [t.a] }
       LogicalFilter { predicate: IsNotNull(t.a) }
-        LogicalScan { table: t, columns: [_row_id, a] }
+        LogicalScan { table: t, columns: [t._row_id, t.a] }
 - sql: |
     create table t (v1 int, v2 int);
     select v1 from t;
   batch_plan: |
     BatchExchange { order: [], dist: Single }
-      BatchScan { table: t, columns: [v1] }
+      BatchScan { table: t, columns: [t.v1], distribution: SomeShard }
   stream_plan: |
     StreamMaterialize { columns: [v1, t._row_id(hidden)], pk_columns: [t._row_id] }
-      StreamTableScan { table: t, columns: [v1, _row_id] }
+      StreamTableScan { table: t, columns: [t.v1, t._row_id], pk: [t._row_id], distribution: HashShard(t._row_id) }
 - sql: select 1
   batch_plan: |
     BatchProject { exprs: [1:Int32] }
@@ -105,20 +105,20 @@
     select a from t as t2(a);
   batch_plan: |
     BatchExchange { order: [], dist: Single }
-      BatchScan { table: t, columns: [v1] }
+      BatchScan { table: t, columns: [t.v1], distribution: SomeShard }
 - sql: |
     create table t (v1 int, v2 int);
     delete from t;
   batch_plan: |
     BatchDelete { table: t }
-      BatchScan { table: t, columns: [_row_id, v1, v2] }
+      BatchScan { table: t, columns: [t._row_id, t.v1, t.v2], distribution: HashShard(t._row_id) }
 - sql: |
     create table t (v1 int, v2 int);
     delete from t where v1 = 1;
   batch_plan: |
     BatchDelete { table: t }
       BatchFilter { predicate: (t.v1 = 1:Int32) }
-        BatchScan { table: t, columns: [_row_id, v1, v2] }
+        BatchScan { table: t, columns: [t._row_id, t.v1, t.v2], distribution: HashShard(t._row_id) }
 - sql: |
     select * from generate_series('2'::INT,'10'::INT,'2'::INT);
   batch_plan: |

--- a/src/frontend/test_runner/tests/testdata/column_pruning.yaml
+++ b/src/frontend/test_runner/tests/testdata/column_pruning.yaml
@@ -4,9 +4,9 @@
     select v1 from t
   logical_plan: |
     LogicalProject { exprs: [t.v1] }
-      LogicalScan { table: t, columns: [_row_id, v1, v2] }
+      LogicalScan { table: t, columns: [t._row_id, t.v1, t.v2] }
   optimized_logical_plan: |
-    LogicalScan { table: t, columns: [v1] }
+    LogicalScan { table: t, columns: [t.v1] }
 - sql: |
     /* filter */
     create table t (v1 bigint, v2 double precision, v3 int);
@@ -14,9 +14,9 @@
   logical_plan: |
     LogicalProject { exprs: [t.v1] }
       LogicalFilter { predicate: (t.v2 > 2:Int32) }
-        LogicalScan { table: t, columns: [_row_id, v1, v2, v3] }
+        LogicalScan { table: t, columns: [t._row_id, t.v1, t.v2, t.v3] }
   optimized_logical_plan: |
-    LogicalScan { table: t, output_columns: [v1], required_columns: [v1, v2], predicate: (t.v2 > 2:Int32) }
+    LogicalScan { table: t, output_columns: [t.v1], required_columns: [v1, v2], predicate: (t.v2 > 2:Int32) }
 - sql: |
     /* join */
     create table t1 (v1 int not null, v2 int not null, v3 int);
@@ -24,13 +24,13 @@
     select t1.v1, t2.v1 from t1 join t2 on t1.v2 = t2.v2;
   logical_plan: |
     LogicalProject { exprs: [t1.v1, t2.v1] }
-      LogicalJoin { type: Inner, on: (t1.v2 = t2.v2) }
-        LogicalScan { table: t1, columns: [_row_id, v1, v2, v3] }
-        LogicalScan { table: t2, columns: [_row_id, v1, v2, v3] }
+      LogicalJoin { type: Inner, on: (t1.v2 = t2.v2), output: all }
+        LogicalScan { table: t1, columns: [t1._row_id, t1.v1, t1.v2, t1.v3] }
+        LogicalScan { table: t2, columns: [t2._row_id, t2.v1, t2.v2, t2.v3] }
   optimized_logical_plan: |
-    LogicalJoin { type: Inner, on: (t1.v2 = t2.v2) }
-      LogicalScan { table: t1, columns: [v1, v2] }
-      LogicalScan { table: t2, columns: [v1, v2] }
+    LogicalJoin { type: Inner, on: (t1.v2 = t2.v2), output: [t1.v1, t2.v1] }
+      LogicalScan { table: t1, columns: [t1.v1, t1.v2] }
+      LogicalScan { table: t2, columns: [t2.v1, t2.v2] }
 - sql: |
     /* agg */
     create table t (v1 bigint, v2 double precision, v3 int);
@@ -40,10 +40,10 @@
       LogicalAgg { aggs: [count(t.v1)] }
         LogicalProject { exprs: [t.v1] }
           LogicalFilter { predicate: (t.v2 > 2:Int32) }
-            LogicalScan { table: t, columns: [_row_id, v1, v2, v3] }
+            LogicalScan { table: t, columns: [t._row_id, t.v1, t.v2, t.v3] }
   optimized_logical_plan: |
     LogicalAgg { aggs: [count(t.v1)] }
-      LogicalScan { table: t, output_columns: [v1], required_columns: [v1, v2], predicate: (t.v2 > 2:Int32) }
+      LogicalScan { table: t, output_columns: [t.v1], required_columns: [v1, v2], predicate: (t.v2 > 2:Int32) }
 - sql: |
     /* top n */
     create table t (v1 int, v2 int, v3 int);
@@ -52,18 +52,18 @@
     LogicalProject { exprs: [t.v3] }
       LogicalTopN { order: "[t.v3 ASC, t.v2 ASC]", limit: 2, offset: 0 }
         LogicalProject { exprs: [t.v1, t.v2, t.v3] }
-          LogicalScan { table: t, columns: [_row_id, v1, v2, v3] }
+          LogicalScan { table: t, columns: [t._row_id, t.v1, t.v2, t.v3] }
   optimized_logical_plan: |
     LogicalProject { exprs: [t.v3] }
       LogicalTopN { order: "[t.v3 ASC, t.v2 ASC]", limit: 2, offset: 0 }
-        LogicalScan { table: t, columns: [v2, v3] }
+        LogicalScan { table: t, columns: [t.v2, t.v3] }
 - sql: |
     /* constant */
     create table t (v1 bigint, v2 double precision, v3 int);
     select 1 from t
   logical_plan: |
     LogicalProject { exprs: [1:Int32] }
-      LogicalScan { table: t, columns: [_row_id, v1, v2, v3] }
+      LogicalScan { table: t, columns: [t._row_id, t.v1, t.v2, t.v3] }
   optimized_logical_plan: |
     LogicalProject { exprs: [1:Int32] }
       LogicalScan { table: t, columns: [] }
@@ -74,7 +74,7 @@
   logical_plan: |
     LogicalProject { exprs: [1:Int32] }
       LogicalFilter { predicate: (t.v2 > 1:Int32) }
-        LogicalScan { table: t, columns: [_row_id, v1, v2, v3] }
+        LogicalScan { table: t, columns: [t._row_id, t.v1, t.v2, t.v3] }
   optimized_logical_plan: |
     LogicalProject { exprs: [1:Int32] }
       LogicalScan { table: t, output_columns: [], required_columns: [v2], predicate: (t.v2 > 1:Int32) }
@@ -86,7 +86,7 @@
     LogicalProject { exprs: [count(1:Int32)] }
       LogicalAgg { aggs: [count(1:Int32)] }
         LogicalProject { exprs: [1:Int32] }
-          LogicalScan { table: t, columns: [_row_id, v1, v2, v3] }
+          LogicalScan { table: t, columns: [t._row_id, t.v1, t.v2, t.v3] }
   optimized_logical_plan: |
     LogicalAgg { aggs: [count(1:Int32)] }
       LogicalProject { exprs: [1:Int32] }
@@ -100,7 +100,7 @@
       LogicalAgg { aggs: [count(1:Int32)] }
         LogicalProject { exprs: [1:Int32] }
           LogicalFilter { predicate: (t.v2 > 1:Int32) }
-            LogicalScan { table: t, columns: [_row_id, v1, v2, v3] }
+            LogicalScan { table: t, columns: [t._row_id, t.v1, t.v2, t.v3] }
   optimized_logical_plan: |
     LogicalAgg { aggs: [count(1:Int32)] }
       LogicalProject { exprs: [1:Int32] }
@@ -113,13 +113,13 @@
   logical_plan: |
     LogicalProject { exprs: [t1.v1, t2.v1] }
       LogicalFilter { predicate: (t1.v3 < 1:Int32) }
-        LogicalJoin { type: Inner, on: (t1.v2 = t2.v2) }
-          LogicalScan { table: t1, columns: [_row_id, v1, v2, v3] }
-          LogicalScan { table: t2, columns: [_row_id, v1, v2, v3] }
+        LogicalJoin { type: Inner, on: (t1.v2 = t2.v2), output: all }
+          LogicalScan { table: t1, columns: [t1._row_id, t1.v1, t1.v2, t1.v3] }
+          LogicalScan { table: t2, columns: [t2._row_id, t2.v1, t2.v2, t2.v3] }
   optimized_logical_plan: |
-    LogicalJoin { type: Inner, on: (t1.v2 = t2.v2) }
-      LogicalScan { table: t1, output_columns: [v1, v2], required_columns: [v1, v2, v3], predicate: (t1.v3 < 1:Int32) }
-      LogicalScan { table: t2, columns: [v1, v2] }
+    LogicalJoin { type: Inner, on: (t1.v2 = t2.v2), output: [t1.v1, t2.v1] }
+      LogicalScan { table: t1, output_columns: [t1.v1, t1.v2], required_columns: [v1, v2, v3], predicate: (t1.v3 < 1:Int32) }
+      LogicalScan { table: t2, columns: [t2.v1, t2.v2] }
 - sql: |
     /* mixed */
     create table t (v1 bigint, v2 double precision, v3 int);
@@ -129,11 +129,11 @@
       LogicalAgg { aggs: [count(1:Int32), count(t.v1)] }
         LogicalProject { exprs: [1:Int32, t.v1] }
           LogicalFilter { predicate: (t.v2 > 1:Int32) }
-            LogicalScan { table: t, columns: [_row_id, v1, v2, v3] }
+            LogicalScan { table: t, columns: [t._row_id, t.v1, t.v2, t.v3] }
   optimized_logical_plan: |
     LogicalAgg { aggs: [count(1:Int32), count(t.v1)] }
       LogicalProject { exprs: [1:Int32, t.v1] }
-        LogicalScan { table: t, output_columns: [v1], required_columns: [v1, v2], predicate: (t.v2 > 1:Int32) }
+        LogicalScan { table: t, output_columns: [t.v1], required_columns: [v1, v2], predicate: (t.v2 > 1:Int32) }
 - sql: |
     /* hop window, time_col not selected */
     create table t1 (a int, b int, created_at timestamp);
@@ -141,15 +141,15 @@
   logical_plan: |
     LogicalProject { exprs: [t1.a, window_end] }
       LogicalHopWindow { time_col: t1.created_at, slide: 00:15:00, size: 00:30:00, output: all }
-        LogicalScan { table: t1, columns: [_row_id, a, b, created_at] }
+        LogicalScan { table: t1, columns: [t1._row_id, t1.a, t1.b, t1.created_at] }
   optimized_logical_plan: |
     LogicalHopWindow { time_col: t1.created_at, slide: 00:15:00, size: 00:30:00, output: [t1.a, window_end] }
-      LogicalScan { table: t1, columns: [a, created_at] }
+      LogicalScan { table: t1, columns: [t1.a, t1.created_at] }
   batch_plan: |
     BatchHopWindow { time_col: t1.created_at, slide: 00:15:00, size: 00:30:00, output: [t1.a, window_end] }
       BatchExchange { order: [], dist: Single }
-        BatchScan { table: t1, columns: [a, created_at] }
+        BatchScan { table: t1, columns: [t1.a, t1.created_at], distribution: SomeShard }
   stream_plan: |
     StreamMaterialize { columns: [a, window_end, t1._row_id(hidden)], pk_columns: [t1._row_id, window_end] }
       StreamHopWindow { time_col: t1.created_at, slide: 00:15:00, size: 00:30:00, output: [t1.a, window_end, t1._row_id] }
-        StreamTableScan { table: t1, columns: [a, created_at, _row_id] }
+        StreamTableScan { table: t1, columns: [t1.a, t1.created_at, t1._row_id], pk: [t1._row_id], distribution: HashShard(t1._row_id) }

--- a/src/frontend/test_runner/tests/testdata/common_table_expressions.yaml
+++ b/src/frontend/test_runner/tests/testdata/common_table_expressions.yaml
@@ -5,28 +5,28 @@
   logical_plan: |
     LogicalProject { exprs: [t1.v1] }
       LogicalProject { exprs: [t1.v1, t1.v2] }
-        LogicalScan { table: t1, columns: [_row_id, v1, v2] }
+        LogicalScan { table: t1, columns: [t1._row_id, t1.v1, t1.v2] }
   stream_plan: |
     StreamMaterialize { columns: [v1, t1._row_id(hidden)], pk_columns: [t1._row_id] }
-      StreamTableScan { table: t1, columns: [v1, _row_id] }
+      StreamTableScan { table: t1, columns: [t1.v1, t1._row_id], pk: [t1._row_id], distribution: HashShard(t1._row_id) }
 - sql: |
     create table t1 (v1 int, v2 int);
     create table t2 (v3 int, v4 int);
     with cte as (select v1 from t1) select * from t2 inner join cte on t2.v3 = cte.v1;
   logical_plan: |
     LogicalProject { exprs: [t2.v3, t2.v4, t1.v1] }
-      LogicalJoin { type: Inner, on: (t2.v3 = t1.v1) }
-        LogicalScan { table: t2, columns: [_row_id, v3, v4] }
+      LogicalJoin { type: Inner, on: (t2.v3 = t1.v1), output: all }
+        LogicalScan { table: t2, columns: [t2._row_id, t2.v3, t2.v4] }
         LogicalProject { exprs: [t1.v1] }
-          LogicalScan { table: t1, columns: [_row_id, v1, v2] }
+          LogicalScan { table: t1, columns: [t1._row_id, t1.v1, t1.v2] }
   stream_plan: |
     StreamMaterialize { columns: [v3, v4, v1, t2._row_id(hidden), t1._row_id(hidden)], pk_columns: [t2._row_id, t1._row_id] }
       StreamExchange { dist: HashShard(t2._row_id, t1._row_id) }
-        StreamHashJoin { type: Inner, predicate: t2.v3 = t1.v1 }
+        StreamHashJoin { type: Inner, predicate: t2.v3 = t1.v1, output: [t2.v3, t2.v4, t1.v1, t2._row_id, t1._row_id] }
           StreamExchange { dist: HashShard(t2.v3) }
-            StreamTableScan { table: t2, columns: [v3, v4, _row_id] }
+            StreamTableScan { table: t2, columns: [t2.v3, t2.v4, t2._row_id], pk: [t2._row_id], distribution: HashShard(t2._row_id) }
           StreamExchange { dist: HashShard(t1.v1) }
-            StreamTableScan { table: t1, columns: [v1, _row_id] }
+            StreamTableScan { table: t1, columns: [t1.v1, t1._row_id], pk: [t1._row_id], distribution: HashShard(t1._row_id) }
 - sql: |
     create table t1 (v1 int, v2 int);
     create table t2 (v3 int, v4 int);
@@ -35,7 +35,7 @@
     LogicalProject { exprs: [t1.v1] }
       LogicalProject { exprs: [t1.v1] }
         LogicalProject { exprs: [t1.v1, t1.v2] }
-          LogicalScan { table: t1, columns: [_row_id, v1, v2] }
+          LogicalScan { table: t1, columns: [t1._row_id, t1.v1, t1.v2] }
   stream_plan: |
     StreamMaterialize { columns: [v1, t1._row_id(hidden)], pk_columns: [t1._row_id] }
-      StreamTableScan { table: t1, columns: [v1, _row_id] }
+      StreamTableScan { table: t1, columns: [t1.v1, t1._row_id], pk: [t1._row_id], distribution: HashShard(t1._row_id) }

--- a/src/frontend/test_runner/tests/testdata/distribution_derive.yaml
+++ b/src/frontend/test_runner/tests/testdata/distribution_derive.yaml
@@ -18,7 +18,7 @@
             BatchProject { exprs: [t.a, count] }
               BatchHashAgg { group_key: [t.a, t.b], aggs: [count] }
                 BatchExchange { order: [], dist: HashShard(t.a, t.b) }
-                  BatchScan { table: t, columns: [a, b] }
+                  BatchScan { table: t, columns: [t.a, t.b], distribution: SomeShard }
   stream_plan: |
     StreamMaterialize { columns: [max_num, a], pk_columns: [a] }
       StreamProject { exprs: [max(count), t.a] }
@@ -27,7 +27,7 @@
             StreamProject { exprs: [t.a, count, t.b] }
               StreamHashAgg { group_key: [t.a, t.b], aggs: [count, count] }
                 StreamExchange { dist: HashShard(t.a, t.b) }
-                  StreamTableScan { table: t, columns: [a, b, _row_id] }
+                  StreamTableScan { table: t, columns: [t.a, t.b, t._row_id], pk: [t._row_id], distribution: HashShard(t._row_id) }
 - sql: |
     create table t(a int, b int);
     select
@@ -44,29 +44,29 @@
         BatchHashAgg { group_key: [(t.a + t.b)], aggs: [max(t.a)] }
           BatchExchange { order: [], dist: HashShard((t.a + t.b)) }
             BatchProject { exprs: [(t.a + t.b), t.a] }
-              BatchScan { table: t, columns: [a, b] }
+              BatchScan { table: t, columns: [t.a, t.b], distribution: SomeShard }
   stream_plan: |
     StreamMaterialize { columns: [max_a, (t.a + t.b)(hidden)], pk_columns: [(t.a + t.b)] }
       StreamProject { exprs: [max(t.a), (t.a + t.b)] }
         StreamHashAgg { group_key: [(t.a + t.b)], aggs: [count, max(t.a)] }
           StreamExchange { dist: HashShard((t.a + t.b)) }
             StreamProject { exprs: [(t.a + t.b), t.a, t._row_id] }
-              StreamTableScan { table: t, columns: [a, b, _row_id] }
+              StreamTableScan { table: t, columns: [t.a, t.b, t._row_id], pk: [t._row_id], distribution: HashShard(t._row_id) }
 - sql: |
     create table t1 (row_id int, uid int, v int, created_at timestamp);
     select * from hop(t1, created_at, interval '15' minute, interval '30' minute);
   logical_plan: |
     LogicalProject { exprs: [t1.row_id, t1.uid, t1.v, t1.created_at, window_start, window_end] }
       LogicalHopWindow { time_col: t1.created_at, slide: 00:15:00, size: 00:30:00, output: all }
-        LogicalScan { table: t1, columns: [_row_id, row_id, uid, v, created_at] }
+        LogicalScan { table: t1, columns: [t1._row_id, t1.row_id, t1.uid, t1.v, t1.created_at] }
   optimized_logical_plan: |
     LogicalHopWindow { time_col: t1.created_at, slide: 00:15:00, size: 00:30:00, output: all }
-      LogicalScan { table: t1, columns: [row_id, uid, v, created_at] }
+      LogicalScan { table: t1, columns: [t1.row_id, t1.uid, t1.v, t1.created_at] }
   batch_plan: |
     BatchHopWindow { time_col: t1.created_at, slide: 00:15:00, size: 00:30:00, output: all }
       BatchExchange { order: [], dist: Single }
-        BatchScan { table: t1, columns: [row_id, uid, v, created_at] }
+        BatchScan { table: t1, columns: [t1.row_id, t1.uid, t1.v, t1.created_at], distribution: SomeShard }
   stream_plan: |
     StreamMaterialize { columns: [row_id, uid, v, created_at, window_start, window_end, t1._row_id(hidden)], pk_columns: [t1._row_id, window_start] }
       StreamHopWindow { time_col: t1.created_at, slide: 00:15:00, size: 00:30:00, output: [t1.row_id, t1.uid, t1.v, t1.created_at, window_start, window_end, t1._row_id] }
-        StreamTableScan { table: t1, columns: [row_id, uid, v, created_at, _row_id] }
+        StreamTableScan { table: t1, columns: [t1.row_id, t1.uid, t1.v, t1.created_at, t1._row_id], pk: [t1._row_id], distribution: HashShard(t1._row_id) }

--- a/src/frontend/test_runner/tests/testdata/expr.yaml
+++ b/src/frontend/test_runner/tests/testdata/expr.yaml
@@ -29,7 +29,7 @@
   batch_plan: |
     BatchExchange { order: [], dist: Single }
       BatchProject { exprs: [IsNull(IsNotNull(IsFalse(IsNotFalse(IsTrue(IsNotTrue(false:Boolean))))))] }
-        BatchScan { table: t, columns: [] }
+        BatchScan { table: t, columns: [], distribution: SomeShard }
 - sql: |
     /* bind between */
     SELECT 1 between 2 and 3
@@ -73,7 +73,7 @@
       BatchSimpleAgg { aggs: [min(min(t.v1))] }
         BatchExchange { order: [], dist: Single }
           BatchSimpleAgg { aggs: [min(t.v1)] }
-            BatchScan { table: t, columns: [v1] }
+            BatchScan { table: t, columns: [t.v1], distribution: SomeShard }
 - sql: |
     /* in-list with non-const: scalar subquery */
     create table t (v1 int);
@@ -82,25 +82,25 @@
   batch_plan: |
     BatchProject { exprs: [b.b2] }
       BatchFilter { predicate: (In(1:Int32::Decimal, 3:Int32::Decimal, 1.0:Decimal) OR (1:Int32 = min(min(t.v1)))) }
-        BatchNestedLoopJoin { type: LeftOuter, predicate: true }
+        BatchNestedLoopJoin { type: LeftOuter, predicate: true, output: all }
           BatchExchange { order: [], dist: Single }
-            BatchScan { table: b, columns: [b2] }
+            BatchScan { table: b, columns: [b.b2], distribution: SomeShard }
           BatchSimpleAgg { aggs: [min(min(t.v1))] }
             BatchExchange { order: [], dist: Single }
               BatchSimpleAgg { aggs: [min(t.v1)] }
-                BatchScan { table: t, columns: [v1] }
+                BatchScan { table: t, columns: [t.v1], distribution: SomeShard }
 - sql: |
     /* in-list with non-const: correlated ref */
     create table t (v1 int);
     create table b (b1 int, b2 int);
     SELECT b2 from b where exists (select 2 from t where v1 in (3, 1.0, b1));
   batch_plan: |
-    BatchNestedLoopJoin { type: LeftSemi, predicate: (In(t.v1::Decimal, 3:Int32::Decimal, 1.0:Decimal) OR (t.v1 = b.b1)) }
+    BatchNestedLoopJoin { type: LeftSemi, predicate: (In(t.v1::Decimal, 3:Int32::Decimal, 1.0:Decimal) OR (t.v1 = b.b1)), output: [b.b2] }
       BatchExchange { order: [], dist: Single }
-        BatchScan { table: b, columns: [b1, b2] }
+        BatchScan { table: b, columns: [b.b1, b.b2], distribution: SomeShard }
       BatchExchange { order: [], dist: Single }
         BatchProject { exprs: [t.v1, t.v1] }
-          BatchScan { table: t, columns: [v1] }
+          BatchScan { table: t, columns: [t.v1], distribution: SomeShard }
 - sql: |
     select +1.0, -2.0;
   batch_plan: |
@@ -162,11 +162,11 @@
   batch_plan: |
     BatchExchange { order: [], dist: Single }
       BatchProject { exprs: [Case((t.v1 = 1:Int32), 1:Int32::Decimal, (t.v1 = 2:Int32), 2:Int32::Decimal, 0.0:Decimal)] }
-        BatchScan { table: t, columns: [v1] }
+        BatchScan { table: t, columns: [t.v1], distribution: SomeShard }
   stream_plan: |
     StreamMaterialize { columns: [expr, t._row_id(hidden)], pk_columns: [t._row_id] }
       StreamProject { exprs: [Case((t.v1 = 1:Int32), 1:Int32::Decimal, (t.v1 = 2:Int32), 2:Int32::Decimal, 0.0:Decimal), t._row_id] }
-        StreamTableScan { table: t, columns: [v1, _row_id] }
+        StreamTableScan { table: t, columns: [t.v1, t._row_id], pk: [t._row_id], distribution: HashShard(t._row_id) }
 - sql: |
     /* case searched form without else */
     create table t (v1 int);
@@ -174,7 +174,7 @@
   batch_plan: |
     BatchExchange { order: [], dist: Single }
       BatchProject { exprs: [Case((t.v1 = 1:Int32), 1:Int32::Decimal, (t.v1 = 2:Int32), 2.1:Decimal)] }
-        BatchScan { table: t, columns: [v1] }
+        BatchScan { table: t, columns: [t.v1], distribution: SomeShard }
 - sql: |
     /* case simple form */
     create table t (v1 int);
@@ -182,7 +182,7 @@
   batch_plan: |
     BatchExchange { order: [], dist: Single }
       BatchProject { exprs: [Case((t.v1 = 1:Int32), 1:Int32::Decimal, (t.v1 = 2.0:Decimal), 2:Int32::Decimal, 0.0:Decimal)] }
-        BatchScan { table: t, columns: [v1] }
+        BatchScan { table: t, columns: [t.v1], distribution: SomeShard }
 - sql: |
     /* case misaligned result types */
     create table t (v1 int);
@@ -200,11 +200,11 @@
   batch_plan: |
     BatchExchange { order: [], dist: Single }
       BatchProject { exprs: [Case((t.v1 = 1:Int32), null:Int32, t.v1)] }
-        BatchScan { table: t, columns: [v1] }
+        BatchScan { table: t, columns: [t.v1], distribution: SomeShard }
   stream_plan: |
     StreamMaterialize { columns: [expr, t._row_id(hidden)], pk_columns: [t._row_id] }
       StreamProject { exprs: [Case((t.v1 = 1:Int32), null:Int32, t.v1), t._row_id] }
-        StreamTableScan { table: t, columns: [v1, _row_id] }
+        StreamTableScan { table: t, columns: [t.v1, t._row_id], pk: [t._row_id], distribution: HashShard(t._row_id) }
 - sql: |
     create table t (v1 int);
     select nullif(v1, 1, 2) from t;
@@ -220,18 +220,18 @@
   batch_plan: |
     BatchExchange { order: [], dist: Single }
       BatchProject { exprs: [Coalesce(t.v1, 1:Int32)] }
-        BatchScan { table: t, columns: [v1] }
+        BatchScan { table: t, columns: [t.v1], distribution: SomeShard }
   stream_plan: |
     StreamMaterialize { columns: [expr, t._row_id(hidden)], pk_columns: [t._row_id] }
       StreamProject { exprs: [Coalesce(t.v1, 1:Int32), t._row_id] }
-        StreamTableScan { table: t, columns: [v1, _row_id] }
+        StreamTableScan { table: t, columns: [t.v1, t._row_id], pk: [t._row_id], distribution: HashShard(t._row_id) }
 - sql: |
     create table t (v1 int);
     select coalesce(v1, 1.2) from t;
   batch_plan: |
     BatchExchange { order: [], dist: Single }
       BatchProject { exprs: [Coalesce(t.v1::Decimal, 1.2:Decimal)] }
-        BatchScan { table: t, columns: [v1] }
+        BatchScan { table: t, columns: [t.v1], distribution: SomeShard }
 - sql: |
     create table t (v1 int);
     select coalesce() from t;
@@ -246,18 +246,18 @@
   batch_plan: |
     BatchExchange { order: [], dist: Single }
       BatchProject { exprs: [ConcatWs(t.v1, 1:Int32::Varchar)] }
-        BatchScan { table: t, columns: [v1] }
+        BatchScan { table: t, columns: [t.v1], distribution: SomeShard }
   stream_plan: |
     StreamMaterialize { columns: [expr, t._row_id(hidden)], pk_columns: [t._row_id] }
       StreamProject { exprs: [ConcatWs(t.v1, 1:Int32::Varchar), t._row_id] }
-        StreamTableScan { table: t, columns: [v1, _row_id] }
+        StreamTableScan { table: t, columns: [t.v1, t._row_id], pk: [t._row_id], distribution: HashShard(t._row_id) }
 - sql: |
     create table t (v1 varchar);
     select concat_ws(v1, 1.2) from t;
   batch_plan: |
     BatchExchange { order: [], dist: Single }
       BatchProject { exprs: [ConcatWs(t.v1, 1.2:Decimal::Varchar)] }
-        BatchScan { table: t, columns: [v1] }
+        BatchScan { table: t, columns: [t.v1], distribution: SomeShard }
 - sql: |
     create table t (v1 int);
     select concat_ws(v1, 1.2) from t;
@@ -272,18 +272,18 @@
   batch_plan: |
     BatchExchange { order: [], dist: Single }
       BatchProject { exprs: [ConcatWs('':Varchar, t.v1, t.v2::Varchar, t.v3::Varchar, 1:Int32::Varchar)] }
-        BatchScan { table: t, columns: [v1, v2, v3] }
+        BatchScan { table: t, columns: [t.v1, t.v2, t.v3], distribution: SomeShard }
   stream_plan: |
     StreamMaterialize { columns: [expr, t._row_id(hidden)], pk_columns: [t._row_id] }
       StreamProject { exprs: [ConcatWs('':Varchar, t.v1, t.v2::Varchar, t.v3::Varchar, 1:Int32::Varchar), t._row_id] }
-        StreamTableScan { table: t, columns: [v1, v2, v3, _row_id] }
+        StreamTableScan { table: t, columns: [t.v1, t.v2, t.v3, t._row_id], pk: [t._row_id], distribution: HashShard(t._row_id) }
 - sql: |
     create table t (v1 float);
     select concat(v1) from t;
   batch_plan: |
     BatchExchange { order: [], dist: Single }
       BatchProject { exprs: [ConcatWs('':Varchar, t.v1::Varchar)] }
-        BatchScan { table: t, columns: [v1] }
+        BatchScan { table: t, columns: [t.v1], distribution: SomeShard }
 - sql: |
     create table t (v1 int);
     select concat() from t;

--- a/src/frontend/test_runner/tests/testdata/index.yaml
+++ b/src/frontend/test_runner/tests/testdata/index.yaml
@@ -10,8 +10,8 @@
     StreamMaterialize { columns: [v1, v2, v3, v4, v5, t1_v1.t1._row_id(hidden), t2_v3.t2._row_id(hidden)], pk_columns: [t1_v1.t1._row_id, t2_v3.t2._row_id] }
       StreamExchange { dist: HashShard(t1_v1.t1._row_id, t2_v3.t2._row_id) }
         StreamDeltaJoin { type: Inner, predicate: t1_v1.v1 = t2_v3.v3, output_indices: [0, 1, 3, 4, 5, 2, 6] }
-          StreamIndexScan { index: t1_v1, columns: [v1, v2, t1._row_id], pk_indices: [2] }
-          StreamIndexScan { index: t2_v3, columns: [v3, v4, v5, t2._row_id], pk_indices: [3] }
+          StreamIndexScan { index: t1_v1, columns: [t1_v1.v1, t1_v1.v2, t1_v1.t1._row_id], pk_indices: [2] }
+          StreamIndexScan { index: t2_v3, columns: [t2_v3.v3, t2_v3.v4, t2_v3.v5, t2_v3.t2._row_id], pk_indices: [3] }
 - id: index_slt
   sql: |
     create table iii_t1 (v1 int, v2 int);
@@ -28,8 +28,8 @@
     StreamMaterialize { columns: [v1, v2, v3, v4, iii_index_1.iii_t1._row_id(hidden), iii_index_2.iii_t2._row_id(hidden)], pk_columns: [iii_index_1.iii_t1._row_id, iii_index_2.iii_t2._row_id] }
       StreamExchange { dist: HashShard(iii_index_1.iii_t1._row_id, iii_index_2.iii_t2._row_id) }
         StreamDeltaJoin { type: Inner, predicate: iii_index_1.v1 = iii_index_2.v3, output_indices: [0, 1, 3, 4, 2, 5] }
-          StreamIndexScan { index: iii_index_1, columns: [v1, v2, iii_t1._row_id], pk_indices: [2] }
-          StreamIndexScan { index: iii_index_2, columns: [v3, v4, iii_t2._row_id], pk_indices: [2] }
+          StreamIndexScan { index: iii_index_1, columns: [iii_index_1.v1, iii_index_1.v2, iii_index_1.iii_t1._row_id], pk_indices: [2] }
+          StreamIndexScan { index: iii_index_2, columns: [iii_index_2.v3, iii_index_2.v4, iii_index_2.iii_t2._row_id], pk_indices: [2] }
 - before:
   - index_slt
   sql: |
@@ -38,5 +38,5 @@
     StreamMaterialize { columns: [v4, iii_index_1.iii_t1._row_id(hidden), iii_index_2.iii_t2._row_id(hidden)], pk_columns: [iii_index_1.iii_t1._row_id, iii_index_2.iii_t2._row_id] }
       StreamExchange { dist: HashShard(iii_index_1.iii_t1._row_id, iii_index_2.iii_t2._row_id) }
         StreamDeltaJoin { type: Inner, predicate: iii_index_1.v1 = iii_index_2.v3, output_indices: [3, 1, 4] }
-          StreamIndexScan { index: iii_index_1, columns: [v1, iii_t1._row_id], pk_indices: [1] }
-          StreamIndexScan { index: iii_index_2, columns: [v3, v4, iii_t2._row_id], pk_indices: [2] }
+          StreamIndexScan { index: iii_index_1, columns: [iii_index_1.v1, iii_index_1.iii_t1._row_id], pk_indices: [1] }
+          StreamIndexScan { index: iii_index_2, columns: [iii_index_2.v3, iii_index_2.v4, iii_index_2.iii_t2._row_id], pk_indices: [2] }

--- a/src/frontend/test_runner/tests/testdata/insert.yaml
+++ b/src/frontend/test_runner/tests/testdata/insert.yaml
@@ -67,7 +67,7 @@
     insert into t select v1 from t;
   batch_plan: |
     BatchInsert { table: t }
-      BatchScan { table: t, columns: [v1] }
+      BatchScan { table: t, columns: [t.v1], distribution: SomeShard }
 - sql: |
     /* insert into select with cast */
     create table t (v1 time, v2 int, v3 real);
@@ -75,7 +75,7 @@
   batch_plan: |
     BatchInsert { table: t }
       BatchProject { exprs: ['2020-01-01 01:02:03':Varchar::Timestamp::Time, 11:Int32, 4.5:Decimal::Float32] }
-        BatchScan { table: t, columns: [] }
+        BatchScan { table: t, columns: [], distribution: SomeShard }
 - sql: |
     /* insert into select with cast error */
     create table t (v1 timestamp, v2 real);

--- a/src/frontend/test_runner/tests/testdata/join.yaml
+++ b/src/frontend/test_runner/tests/testdata/join.yaml
@@ -7,39 +7,39 @@
   logical_plan: |
     LogicalProject { exprs: [t1.v1, t1.v2, t2.v3, t2.v4, t3.v5, t3.v6] }
       LogicalFilter { predicate: (t1.v1 = t2.v3) AND (t1.v1 = t3.v5) }
-        LogicalJoin { type: Inner, on: true }
-          LogicalJoin { type: Inner, on: true }
-            LogicalScan { table: t1, columns: [_row_id, v1, v2] }
-            LogicalScan { table: t2, columns: [_row_id, v3, v4] }
-          LogicalScan { table: t3, columns: [_row_id, v5, v6] }
+        LogicalJoin { type: Inner, on: true, output: all }
+          LogicalJoin { type: Inner, on: true, output: all }
+            LogicalScan { table: t1, columns: [t1._row_id, t1.v1, t1.v2] }
+            LogicalScan { table: t2, columns: [t2._row_id, t2.v3, t2.v4] }
+          LogicalScan { table: t3, columns: [t3._row_id, t3.v5, t3.v6] }
   stream_plan: |
     StreamMaterialize { columns: [v1, v2, v3, v4, v5, v6, t1._row_id(hidden), t2._row_id(hidden), t3._row_id(hidden)], pk_columns: [t1._row_id, t2._row_id, t3._row_id] }
       StreamExchange { dist: HashShard(t1._row_id, t2._row_id, t3._row_id) }
-        StreamHashJoin { type: Inner, predicate: t1.v1 = t3.v5 }
-          StreamHashJoin { type: Inner, predicate: t1.v1 = t2.v3 }
+        StreamHashJoin { type: Inner, predicate: t1.v1 = t3.v5, output: [t1.v1, t1.v2, t2.v3, t2.v4, t3.v5, t3.v6, t1._row_id, t2._row_id, t3._row_id] }
+          StreamHashJoin { type: Inner, predicate: t1.v1 = t2.v3, output: [t1.v1, t1.v2, t2.v3, t2.v4, t1._row_id, t2._row_id] }
             StreamExchange { dist: HashShard(t1.v1) }
-              StreamTableScan { table: t1, columns: [v1, v2, _row_id] }
+              StreamTableScan { table: t1, columns: [t1.v1, t1.v2, t1._row_id], pk: [t1._row_id], distribution: HashShard(t1._row_id) }
             StreamExchange { dist: HashShard(t2.v3) }
-              StreamTableScan { table: t2, columns: [v3, v4, _row_id] }
+              StreamTableScan { table: t2, columns: [t2.v3, t2.v4, t2._row_id], pk: [t2._row_id], distribution: HashShard(t2._row_id) }
           StreamExchange { dist: HashShard(t3.v5) }
-            StreamTableScan { table: t3, columns: [v5, v6, _row_id] }
+            StreamTableScan { table: t3, columns: [t3.v5, t3.v6, t3._row_id], pk: [t3._row_id], distribution: HashShard(t3._row_id) }
 - sql: |
     /* self join */
     create table t (v1 int, v2 int);
     select t1.v1 as t1v1, t2.v1 as t2v1 from t t1 join t t2 on t1.v1 = t2.v1;
   logical_plan: |
     LogicalProject { exprs: [t.v1, t.v1] }
-      LogicalJoin { type: Inner, on: (t.v1 = t.v1) }
-        LogicalScan { table: t, columns: [_row_id, v1, v2] }
-        LogicalScan { table: t, columns: [_row_id, v1, v2] }
+      LogicalJoin { type: Inner, on: (t.v1 = t.v1), output: all }
+        LogicalScan { table: t, columns: [t._row_id, t.v1, t.v2] }
+        LogicalScan { table: t, columns: [t._row_id, t.v1, t.v2] }
   stream_plan: |
     StreamMaterialize { columns: [t1v1, t2v1, t._row_id(hidden), t._row_id#1(hidden)], pk_columns: [t._row_id, t._row_id#1] }
       StreamExchange { dist: HashShard(t._row_id, t._row_id) }
-        StreamHashJoin { type: Inner, predicate: t.v1 = t.v1 }
+        StreamHashJoin { type: Inner, predicate: t.v1 = t.v1, output: [t.v1, t.v1, t._row_id, t._row_id] }
           StreamExchange { dist: HashShard(t.v1) }
-            StreamTableScan { table: t, columns: [v1, _row_id] }
+            StreamTableScan { table: t, columns: [t.v1, t._row_id], pk: [t._row_id], distribution: HashShard(t._row_id) }
           StreamExchange { dist: HashShard(t.v1) }
-            StreamTableScan { table: t, columns: [v1, _row_id] }
+            StreamTableScan { table: t, columns: [t.v1, t._row_id], pk: [t._row_id], distribution: HashShard(t._row_id) }
 - sql: |
     create table t1 (v1 int, v2 int);
     create table t2 (v1 int, v2 int);
@@ -47,79 +47,79 @@
     select t1.v1 as t1_v1, t1.v2 as t1_v2, t2.v1 as t2_v1, t2.v2 as t2_v2, t3.v1 as t3_v1, t3.v2 as t3_v2 from t1 join t2 on (t1.v1 = t2.v1) join t3 on (t2.v2 = t3.v2);
   batch_plan: |
     BatchExchange { order: [], dist: Single }
-      BatchHashJoin { type: Inner, predicate: t2.v2 = t3.v2 }
+      BatchHashJoin { type: Inner, predicate: t2.v2 = t3.v2, output: all }
         BatchExchange { order: [], dist: HashShard(t2.v2) }
-          BatchHashJoin { type: Inner, predicate: t1.v1 = t2.v1 }
+          BatchHashJoin { type: Inner, predicate: t1.v1 = t2.v1, output: all }
             BatchExchange { order: [], dist: HashShard(t1.v1) }
-              BatchScan { table: t1, columns: [v1, v2] }
+              BatchScan { table: t1, columns: [t1.v1, t1.v2], distribution: SomeShard }
             BatchExchange { order: [], dist: HashShard(t2.v1) }
-              BatchScan { table: t2, columns: [v1, v2] }
+              BatchScan { table: t2, columns: [t2.v1, t2.v2], distribution: SomeShard }
         BatchExchange { order: [], dist: HashShard(t3.v2) }
-          BatchScan { table: t3, columns: [v1, v2] }
+          BatchScan { table: t3, columns: [t3.v1, t3.v2], distribution: SomeShard }
   batch_local_plan: |
-    BatchHashJoin { type: Inner, predicate: t2.v2 = t3.v2 }
-      BatchHashJoin { type: Inner, predicate: t1.v1 = t2.v1 }
+    BatchHashJoin { type: Inner, predicate: t2.v2 = t3.v2, output: all }
+      BatchHashJoin { type: Inner, predicate: t1.v1 = t2.v1, output: all }
         BatchExchange { order: [], dist: Single }
-          BatchScan { table: t1, columns: [v1, v2] }
+          BatchScan { table: t1, columns: [t1.v1, t1.v2], distribution: SomeShard }
         BatchExchange { order: [], dist: Single }
-          BatchScan { table: t2, columns: [v1, v2] }
+          BatchScan { table: t2, columns: [t2.v1, t2.v2], distribution: SomeShard }
       BatchExchange { order: [], dist: Single }
-        BatchScan { table: t3, columns: [v1, v2] }
+        BatchScan { table: t3, columns: [t3.v1, t3.v2], distribution: SomeShard }
   stream_plan: |
     StreamMaterialize { columns: [t1_v1, t1_v2, t2_v1, t2_v2, t3_v1, t3_v2, t1._row_id(hidden), t2._row_id(hidden), t3._row_id(hidden)], pk_columns: [t1._row_id, t2._row_id, t3._row_id] }
       StreamExchange { dist: HashShard(t1._row_id, t2._row_id, t3._row_id) }
-        StreamHashJoin { type: Inner, predicate: t2.v2 = t3.v2 }
+        StreamHashJoin { type: Inner, predicate: t2.v2 = t3.v2, output: [t1.v1, t1.v2, t2.v1, t2.v2, t3.v1, t3.v2, t1._row_id, t2._row_id, t3._row_id] }
           StreamExchange { dist: HashShard(t2.v2) }
-            StreamHashJoin { type: Inner, predicate: t1.v1 = t2.v1 }
+            StreamHashJoin { type: Inner, predicate: t1.v1 = t2.v1, output: [t1.v1, t1.v2, t2.v1, t2.v2, t1._row_id, t2._row_id] }
               StreamExchange { dist: HashShard(t1.v1) }
-                StreamTableScan { table: t1, columns: [v1, v2, _row_id] }
+                StreamTableScan { table: t1, columns: [t1.v1, t1.v2, t1._row_id], pk: [t1._row_id], distribution: HashShard(t1._row_id) }
               StreamExchange { dist: HashShard(t2.v1) }
-                StreamTableScan { table: t2, columns: [v1, v2, _row_id] }
+                StreamTableScan { table: t2, columns: [t2.v1, t2.v2, t2._row_id], pk: [t2._row_id], distribution: HashShard(t2._row_id) }
           StreamExchange { dist: HashShard(t3.v2) }
-            StreamTableScan { table: t3, columns: [v1, v2, _row_id] }
+            StreamTableScan { table: t3, columns: [t3.v1, t3.v2, t3._row_id], pk: [t3._row_id], distribution: HashShard(t3._row_id) }
 - sql: |
     create table t1 (v1 int not null, v2 int not null);
     create table t2 (v1 int not null, v2 int not null);
     select t1.v2 as t1_v2, t2.v2 as t2_v2 from t1 join t2 on t1.v1 = t2.v1;
   batch_plan: |
     BatchExchange { order: [], dist: Single }
-      BatchHashJoin { type: Inner, predicate: t1.v1 = t2.v1 }
+      BatchHashJoin { type: Inner, predicate: t1.v1 = t2.v1, output: [t1.v2, t2.v2] }
         BatchExchange { order: [], dist: HashShard(t1.v1) }
-          BatchScan { table: t1, columns: [v1, v2] }
+          BatchScan { table: t1, columns: [t1.v1, t1.v2], distribution: SomeShard }
         BatchExchange { order: [], dist: HashShard(t2.v1) }
-          BatchScan { table: t2, columns: [v1, v2] }
+          BatchScan { table: t2, columns: [t2.v1, t2.v2], distribution: SomeShard }
   batch_local_plan: |
-    BatchHashJoin { type: Inner, predicate: t1.v1 = t2.v1 }
+    BatchHashJoin { type: Inner, predicate: t1.v1 = t2.v1, output: [t1.v2, t2.v2] }
       BatchExchange { order: [], dist: Single }
-        BatchScan { table: t1, columns: [v1, v2] }
+        BatchScan { table: t1, columns: [t1.v1, t1.v2], distribution: SomeShard }
       BatchExchange { order: [], dist: Single }
-        BatchScan { table: t2, columns: [v1, v2] }
+        BatchScan { table: t2, columns: [t2.v1, t2.v2], distribution: SomeShard }
   stream_plan: |
     StreamMaterialize { columns: [t1_v2, t2_v2, t1._row_id(hidden), t2._row_id(hidden)], pk_columns: [t1._row_id, t2._row_id] }
       StreamExchange { dist: HashShard(t1._row_id, t2._row_id) }
-        StreamHashJoin { type: Inner, predicate: t1.v1 = t2.v1 }
+        StreamHashJoin { type: Inner, predicate: t1.v1 = t2.v1, output: [t1.v2, t2.v2, t1._row_id, t2._row_id] }
           StreamExchange { dist: HashShard(t1.v1) }
-            StreamTableScan { table: t1, columns: [v1, v2, _row_id] }
+            StreamTableScan { table: t1, columns: [t1.v1, t1.v2, t1._row_id], pk: [t1._row_id], distribution: HashShard(t1._row_id) }
           StreamExchange { dist: HashShard(t2.v1) }
-            StreamTableScan { table: t2, columns: [v1, v2, _row_id] }
+            StreamTableScan { table: t2, columns: [t2.v1, t2.v2, t2._row_id], pk: [t2._row_id], distribution: HashShard(t2._row_id) }
 - sql: |
     create table t1 (v1 int not null, v2 int not null);
     create table t2 (v1 int not null, v2 int not null);
     select t1.v2 as t1_v2, t2.v2 as t2_v2 from t1 join t2 on t1.v1 > t2.v1 and t1.v2 < 10;
   batch_plan: |
-    BatchNestedLoopJoin { type: Inner, predicate: (t1.v1 > t2.v1) }
+    BatchNestedLoopJoin { type: Inner, predicate: (t1.v1 > t2.v1), output: [t1.v2, t2.v2] }
       BatchExchange { order: [], dist: Single }
         BatchFilter { predicate: (t1.v2 < 10:Int32) }
-          BatchScan { table: t1, columns: [v1, v2] }
+          BatchScan { table: t1, columns: [t1.v1, t1.v2], distribution: SomeShard }
       BatchExchange { order: [], dist: Single }
-        BatchScan { table: t2, columns: [v1, v2] }
+        BatchScan { table: t2, columns: [t2.v1, t2.v2], distribution: SomeShard }
   batch_local_plan: |
-    BatchNestedLoopJoin { type: Inner, predicate: (t1.v1 > t2.v1) }
+    BatchNestedLoopJoin { type: Inner, predicate: (t1.v1 > t2.v1), output: [t1.v2, t2.v2] }
       BatchExchange { order: [], dist: Single }
         BatchFilter { predicate: (t1.v2 < 10:Int32) }
-          BatchScan { table: t1, columns: [v1, v2] }
+          BatchScan { table: t1, columns: [t1.v1, t1.v2], distribution: SomeShard }
       BatchExchange { order: [], dist: Single }
-        BatchScan { table: t2, columns: [v1, v2] }
+        BatchScan { table: t2, columns: [t2.v1, t2.v2], distribution: SomeShard }
 - sql: |
     create table t1 (v1 int, v2 float);
     create table t2 (v3 int, v4 numeric, v5 bigint);
@@ -127,11 +127,11 @@
   stream_plan: |
     StreamMaterialize { columns: [v1, v2, v3, v4, v5, t1._row_id(hidden), t2._row_id(hidden)], pk_columns: [t1._row_id, t2._row_id] }
       StreamExchange { dist: HashShard(t1._row_id, t2._row_id) }
-        StreamDeltaHashJoin { type: Inner, predicate: t1.v1 = t2.v3 }
+        StreamDeltaHashJoin { type: Inner, predicate: t1.v1 = t2.v3, output: [t1.v1, t1.v2, t2.v3, t2.v4, t2.v5, t1._row_id, t2._row_id] }
           StreamExchange { dist: HashShard(t1.v1) }
-            StreamTableScan { table: t1, columns: [v1, v2, _row_id] }
+            StreamTableScan { table: t1, columns: [t1.v1, t1.v2, t1._row_id], pk: [t1._row_id], distribution: HashShard(t1._row_id) }
           StreamExchange { dist: HashShard(t2.v3) }
-            StreamTableScan { table: t2, columns: [v3, v4, v5, _row_id] }
+            StreamTableScan { table: t2, columns: [t2.v3, t2.v4, t2.v5, t2._row_id], pk: [t2._row_id], distribution: HashShard(t2._row_id) }
   with_config_map:
     RW_FORCE_DELTA_JOIN: 'true'
 - sql: |
@@ -140,11 +140,11 @@
     select * from t1 join t2 using(v1);
   batch_plan: |
     BatchExchange { order: [], dist: Single }
-      BatchHashJoin { type: Inner, predicate: t1.v1 = t2.v1 }
+      BatchHashJoin { type: Inner, predicate: t1.v1 = t2.v1, output: all }
         BatchExchange { order: [], dist: HashShard(t1.v1) }
-          BatchScan { table: t1, columns: [v1, v2] }
+          BatchScan { table: t1, columns: [t1.v1, t1.v2], distribution: SomeShard }
         BatchExchange { order: [], dist: HashShard(t2.v1) }
-          BatchScan { table: t2, columns: [v1, v3] }
+          BatchScan { table: t2, columns: [t2.v1, t2.v3], distribution: SomeShard }
 - sql: |
     create table ab (a int, b int);
     create table bc (b int, c int);
@@ -152,42 +152,42 @@
     select * from ab join bc using(b) join ca using(c);
   batch_plan: |
     BatchExchange { order: [], dist: Single }
-      BatchHashJoin { type: Inner, predicate: bc.c = ca.c }
+      BatchHashJoin { type: Inner, predicate: bc.c = ca.c, output: all }
         BatchExchange { order: [], dist: HashShard(bc.c) }
-          BatchHashJoin { type: Inner, predicate: ab.b = bc.b }
+          BatchHashJoin { type: Inner, predicate: ab.b = bc.b, output: all }
             BatchExchange { order: [], dist: HashShard(ab.b) }
-              BatchScan { table: ab, columns: [a, b] }
+              BatchScan { table: ab, columns: [ab.a, ab.b], distribution: SomeShard }
             BatchExchange { order: [], dist: HashShard(bc.b) }
-              BatchScan { table: bc, columns: [b, c] }
+              BatchScan { table: bc, columns: [bc.b, bc.c], distribution: SomeShard }
         BatchExchange { order: [], dist: HashShard(ca.c) }
-          BatchScan { table: ca, columns: [c, a] }
+          BatchScan { table: ca, columns: [ca.c, ca.a], distribution: SomeShard }
 - sql: |
     /* Only push to left */
     create table t1 (v1 int, v2 int);
     create table t2 (v1 int, v2 int);
     select * from t1 left join t2 where t1.v2 > 100;
   optimized_logical_plan: |
-    LogicalJoin { type: LeftOuter, on: true }
-      LogicalScan { table: t1, output_columns: [v1, v2], required_columns: [v1, v2], predicate: (t1.v2 > 100:Int32) }
-      LogicalScan { table: t2, columns: [v1, v2] }
+    LogicalJoin { type: LeftOuter, on: true, output: all }
+      LogicalScan { table: t1, output_columns: [t1.v1, t1.v2], required_columns: [v1, v2], predicate: (t1.v2 > 100:Int32) }
+      LogicalScan { table: t2, columns: [t2.v1, t2.v2] }
 - sql: |
     /* Only push to right */
     create table t1 (v1 int, v2 int);
     create table t2 (v1 int, v2 int);
     select * from t1 right join t2 where t2.v2 > 100;
   optimized_logical_plan: |
-    LogicalJoin { type: RightOuter, on: true }
-      LogicalScan { table: t1, columns: [v1, v2] }
-      LogicalScan { table: t2, output_columns: [v1, v2], required_columns: [v1, v2], predicate: (t2.v2 > 100:Int32) }
+    LogicalJoin { type: RightOuter, on: true, output: all }
+      LogicalScan { table: t1, columns: [t1.v1, t1.v2] }
+      LogicalScan { table: t2, output_columns: [t2.v1, t2.v2], required_columns: [v1, v2], predicate: (t2.v2 > 100:Int32) }
 - sql: |
     /* Push to left, right and on */
     create table t1 (v1 int, v2 int);
     create table t2 (v1 int, v2 int);
     select * from t1, t2 where t1.v1 > 100 and t2.v1 < 1000 and t1.v2 = t2.v2;
   optimized_logical_plan: |
-    LogicalJoin { type: Inner, on: (t1.v2 = t2.v2) }
-      LogicalScan { table: t1, output_columns: [v1, v2], required_columns: [v1, v2], predicate: (t1.v1 > 100:Int32) }
-      LogicalScan { table: t2, output_columns: [v1, v2], required_columns: [v1, v2], predicate: (t2.v1 < 1000:Int32) }
+    LogicalJoin { type: Inner, on: (t1.v2 = t2.v2), output: all }
+      LogicalScan { table: t1, output_columns: [t1.v1, t1.v2], required_columns: [v1, v2], predicate: (t1.v1 > 100:Int32) }
+      LogicalScan { table: t2, output_columns: [t2.v1, t2.v2], required_columns: [v1, v2], predicate: (t2.v1 < 1000:Int32) }
 - sql: |
     /* Left & right has same distribution. There should be no exchange below hash join */
     create table t(x int);
@@ -195,9 +195,9 @@
     select * from i join i as ii on i.x=ii.x;
   batch_plan: |
     BatchExchange { order: [], dist: Single }
-      BatchHashJoin { type: Inner, predicate: i.x = i.x }
-        BatchScan { table: i, columns: [x] }
-        BatchScan { table: i, columns: [x] }
+      BatchHashJoin { type: Inner, predicate: i.x = i.x, output: all }
+        BatchScan { table: i, columns: [i.x], distribution: HashShard(i.x) }
+        BatchScan { table: i, columns: [i.x], distribution: HashShard(i.x) }
 - sql: |
     /* Use lookup join */
     create table t1 (v1 int, v2 int);
@@ -205,9 +205,9 @@
     create materialized view t3 as select v1, count(v2) as v2 from t2 group by v1;
     select * from t1 join t3 where t1.v2 = t3.v1;
   batch_local_plan: |
-    BatchLookupJoin { type: Inner, predicate: t1.v2 = t3.v1 }
+    BatchLookupJoin { type: Inner, predicate: t1.v2 = t3.v1, output: all }
       BatchExchange { order: [], dist: Single }
-        BatchScan { table: t1, columns: [v1, v2] }
+        BatchScan { table: t1, columns: [t1.v1, t1.v2], distribution: SomeShard }
   with_config_map:
     QUERY_MODE: local
     RW_BATCH_ENABLE_LOOKUP_JOIN: 'true'
@@ -219,11 +219,11 @@
     select * from t3, t1 join t2 using (v1);
   logical_plan: |
     LogicalProject { exprs: [t3.v2, t1.v1, t2.v1] }
-      LogicalJoin { type: Inner, on: true }
-        LogicalScan { table: t3, columns: [_row_id, v2] }
-        LogicalJoin { type: Inner, on: (t1.v1 = t2.v1) }
-          LogicalScan { table: t1, columns: [_row_id, v1] }
-          LogicalScan { table: t2, columns: [_row_id, v1] }
+      LogicalJoin { type: Inner, on: true, output: all }
+        LogicalScan { table: t3, columns: [t3._row_id, t3.v2] }
+        LogicalJoin { type: Inner, on: (t1.v1 = t2.v1), output: all }
+          LogicalScan { table: t1, columns: [t1._row_id, t1.v1] }
+          LogicalScan { table: t2, columns: [t2._row_id, t2.v1] }
 - sql: |
     /* Ensure correct binding of join with ON clause */
     create table t1(v1 varchar);
@@ -232,11 +232,11 @@
     select * from t3, t1 join t2 on v1 = v2;
   logical_plan: |
     LogicalProject { exprs: [t3.v3, t1.v1, t2.v2] }
-      LogicalJoin { type: Inner, on: true }
-        LogicalScan { table: t3, columns: [_row_id, v3] }
-        LogicalJoin { type: Inner, on: (t1.v1 = t2.v2) }
-          LogicalScan { table: t1, columns: [_row_id, v1] }
-          LogicalScan { table: t2, columns: [_row_id, v2] }
+      LogicalJoin { type: Inner, on: true, output: all }
+        LogicalScan { table: t3, columns: [t3._row_id, t3.v3] }
+        LogicalJoin { type: Inner, on: (t1.v1 = t2.v2), output: all }
+          LogicalScan { table: t1, columns: [t1._row_id, t1.v1] }
+          LogicalScan { table: t2, columns: [t2._row_id, t2.v2] }
 - sql: |
     /* Ensure correct binding with USING clause with left outer join */
     create table t1(v1 varchar);
@@ -245,11 +245,11 @@
     select * from t3, t1 left join t2 using (v1);
   logical_plan: |
     LogicalProject { exprs: [t3.v2, t1.v1, t2.v1] }
-      LogicalJoin { type: Inner, on: true }
-        LogicalScan { table: t3, columns: [_row_id, v2] }
-        LogicalJoin { type: LeftOuter, on: (t1.v1 = t2.v1) }
-          LogicalScan { table: t1, columns: [_row_id, v1] }
-          LogicalScan { table: t2, columns: [_row_id, v1] }
+      LogicalJoin { type: Inner, on: true, output: all }
+        LogicalScan { table: t3, columns: [t3._row_id, t3.v2] }
+        LogicalJoin { type: LeftOuter, on: (t1.v1 = t2.v1), output: all }
+          LogicalScan { table: t1, columns: [t1._row_id, t1.v1] }
+          LogicalScan { table: t2, columns: [t2._row_id, t2.v1] }
 - sql: |
     /* Ensure correct binding with ON clause with left outer join */
     create table t1(v1 varchar);
@@ -258,11 +258,11 @@
     select * from t3, t1 left join t2 on v1 = v2;
   logical_plan: |
     LogicalProject { exprs: [t3.v3, t1.v1, t2.v2] }
-      LogicalJoin { type: Inner, on: true }
-        LogicalScan { table: t3, columns: [_row_id, v3] }
-        LogicalJoin { type: LeftOuter, on: (t1.v1 = t2.v2) }
-          LogicalScan { table: t1, columns: [_row_id, v1] }
-          LogicalScan { table: t2, columns: [_row_id, v2] }
+      LogicalJoin { type: Inner, on: true, output: all }
+        LogicalScan { table: t3, columns: [t3._row_id, t3.v3] }
+        LogicalJoin { type: LeftOuter, on: (t1.v1 = t2.v2), output: all }
+          LogicalScan { table: t1, columns: [t1._row_id, t1.v1] }
+          LogicalScan { table: t2, columns: [t2._row_id, t2.v2] }
 - sql: |
     /* Ensure that ON clause cannot reference correlated columns */
     create table a(a1 int);

--- a/src/frontend/test_runner/tests/testdata/limit.yaml
+++ b/src/frontend/test_runner/tests/testdata/limit.yaml
@@ -5,14 +5,14 @@
   logical_plan: |
     LogicalLimit { limit: 4, offset: 0 }
       LogicalProject { exprs: [t.v] }
-        LogicalScan { table: t, columns: [_row_id, v] }
+        LogicalScan { table: t, columns: [t._row_id, t.v] }
 - sql: |
     create table t (v int not null);
     select * from t offset 4;
   logical_plan: |
     LogicalLimit { limit: 9223372036854775807, offset: 4 }
       LogicalProject { exprs: [t.v] }
-        LogicalScan { table: t, columns: [_row_id, v] }
+        LogicalScan { table: t, columns: [t._row_id, t.v] }
 - sql: |
     create table t (v int not null);
     select * from ( select * from t limit 5 ) limit 4;
@@ -21,4 +21,4 @@
       LogicalProject { exprs: [t.v] }
         LogicalLimit { limit: 5, offset: 0 }
           LogicalProject { exprs: [t.v] }
-            LogicalScan { table: t, columns: [_row_id, v] }
+            LogicalScan { table: t, columns: [t._row_id, t.v] }

--- a/src/frontend/test_runner/tests/testdata/mv_on_mv.yaml
+++ b/src/frontend/test_runner/tests/testdata/mv_on_mv.yaml
@@ -13,11 +13,11 @@
   stream_plan: |
     StreamMaterialize { columns: [m1v1, m1v2, m2v1, m2v2, m1.t1._row_id(hidden), m2.t1._row_id(hidden)], pk_columns: [m1.t1._row_id, m2.t1._row_id] }
       StreamExchange { dist: HashShard(m1.t1._row_id, m2.t1._row_id) }
-        StreamHashJoin { type: Inner, predicate: m1.v1 = m2.v1 }
+        StreamHashJoin { type: Inner, predicate: m1.v1 = m2.v1, output: [m1.v1, m1.v2, m2.v1, m2.v2, m1.t1._row_id, m2.t1._row_id] }
           StreamExchange { dist: HashShard(m1.v1) }
-            StreamTableScan { table: m1, columns: [v1, v2, t1._row_id] }
+            StreamTableScan { table: m1, columns: [m1.v1, m1.v2, m1.t1._row_id], pk: [m1.t1._row_id], distribution: HashShard(m1.t1._row_id) }
           StreamExchange { dist: HashShard(m2.v1) }
-            StreamTableScan { table: m2, columns: [v1, v2, t1._row_id] }
+            StreamTableScan { table: m2, columns: [m2.v1, m2.v2, m2.t1._row_id], pk: [m2.t1._row_id], distribution: HashShard(m2.t1._row_id) }
 - id: create_singleton_mv
   sql: |
     create table t (v int);
@@ -29,7 +29,7 @@
     select v from mv; -- FIXME: there should not be a `Single` exchange here
   batch_plan: |
     BatchExchange { order: [], dist: Single }
-      BatchScan { table: mv, columns: [v] }
+      BatchScan { table: mv, columns: [mv.v], distribution: HashShard() }
 - id: single_fragment_mv_on_singleton_mv
   before:
   - create_singleton_mv
@@ -37,7 +37,7 @@
     select v from mv;
   stream_plan: |
     StreamMaterialize { columns: [v, mv.t._row_id(hidden)], pk_columns: [mv.t._row_id] }
-      StreamTableScan { table: mv, columns: [v, t._row_id] }
+      StreamTableScan { table: mv, columns: [mv.v, mv.t._row_id], pk: [mv.t._row_id], distribution: Single }
 - id: mv_on_singleton_mv
   before:
   - create_singleton_mv
@@ -46,8 +46,8 @@
   stream_plan: |
     StreamMaterialize { columns: [v, mv.t._row_id(hidden), mv.t._row_id#1(hidden)], pk_columns: [mv.t._row_id, mv.t._row_id#1] }
       StreamExchange { dist: HashShard(mv.t._row_id, mv.t._row_id) }
-        StreamHashJoin { type: Inner, predicate: mv.v = mv.v }
+        StreamHashJoin { type: Inner, predicate: mv.v = mv.v, output: [mv.v, mv.t._row_id, mv.t._row_id] }
           StreamExchange { dist: HashShard(mv.v) }
-            StreamTableScan { table: mv, columns: [v, t._row_id] }
+            StreamTableScan { table: mv, columns: [mv.v, mv.t._row_id], pk: [mv.t._row_id], distribution: Single }
           StreamExchange { dist: HashShard(mv.v) }
-            StreamTableScan { table: mv, columns: [v, t._row_id] }
+            StreamTableScan { table: mv, columns: [mv.v, mv.t._row_id], pk: [mv.t._row_id], distribution: Single }

--- a/src/frontend/test_runner/tests/testdata/nexmark.yaml
+++ b/src/frontend/test_runner/tests/testdata/nexmark.yaml
@@ -46,10 +46,10 @@
     SELECT auction, bidder, price, date_time FROM bid;
   batch_plan: |
     BatchExchange { order: [], dist: Single }
-      BatchScan { table: bid, columns: [auction, bidder, price, date_time] }
+      BatchScan { table: bid, columns: [bid.auction, bid.bidder, bid.price, bid.date_time], distribution: SomeShard }
   stream_plan: |
     StreamMaterialize { columns: [auction, bidder, price, date_time, bid._row_id(hidden)], pk_columns: [bid._row_id] }
-      StreamTableScan { table: bid, columns: [auction, bidder, price, date_time, _row_id] }
+      StreamTableScan { table: bid, columns: [bid.auction, bid.bidder, bid.price, bid.date_time, bid._row_id], pk: [bid._row_id], distribution: HashShard(bid._row_id) }
 - id: nexmark_q1
   before:
   - create_tables
@@ -63,11 +63,11 @@
   batch_plan: |
     BatchExchange { order: [], dist: Single }
       BatchProject { exprs: [bid.auction, bid.bidder, (0.908:Decimal * bid.price), bid.date_time] }
-        BatchScan { table: bid, columns: [auction, bidder, price, date_time] }
+        BatchScan { table: bid, columns: [bid.auction, bid.bidder, bid.price, bid.date_time], distribution: SomeShard }
   stream_plan: |
     StreamMaterialize { columns: [auction, bidder, price, date_time, bid._row_id(hidden)], pk_columns: [bid._row_id] }
       StreamProject { exprs: [bid.auction, bid.bidder, (0.908:Decimal * bid.price), bid.date_time, bid._row_id] }
-        StreamTableScan { table: bid, columns: [auction, bidder, price, date_time, _row_id] }
+        StreamTableScan { table: bid, columns: [bid.auction, bid.bidder, bid.price, bid.date_time, bid._row_id], pk: [bid._row_id], distribution: HashShard(bid._row_id) }
 - id: nexmark_q2
   before:
   - create_tables
@@ -76,11 +76,11 @@
   batch_plan: |
     BatchExchange { order: [], dist: Single }
       BatchFilter { predicate: (((((bid.auction = 1007:Int32) OR (bid.auction = 1020:Int32)) OR (bid.auction = 2001:Int32)) OR (bid.auction = 2019:Int32)) OR (bid.auction = 2087:Int32)) }
-        BatchScan { table: bid, columns: [auction, price] }
+        BatchScan { table: bid, columns: [bid.auction, bid.price], distribution: SomeShard }
   stream_plan: |
     StreamMaterialize { columns: [auction, price, bid._row_id(hidden)], pk_columns: [bid._row_id] }
       StreamFilter { predicate: (((((bid.auction = 1007:Int32) OR (bid.auction = 1020:Int32)) OR (bid.auction = 2001:Int32)) OR (bid.auction = 2019:Int32)) OR (bid.auction = 2087:Int32)) }
-        StreamTableScan { table: bid, columns: [auction, price, _row_id] }
+        StreamTableScan { table: bid, columns: [bid.auction, bid.price, bid._row_id], pk: [bid._row_id], distribution: HashShard(bid._row_id) }
 - id: nexmark_q3
   before:
   - create_tables
@@ -94,26 +94,26 @@
   batch_plan: |
     BatchExchange { order: [], dist: Single }
       BatchProject { exprs: [person.name, person.city, person.state, auction.id] }
-        BatchHashJoin { type: Inner, predicate: auction.seller = person.id }
+        BatchHashJoin { type: Inner, predicate: auction.seller = person.id, output: [auction.id, person.name, person.city, person.state] }
           BatchExchange { order: [], dist: HashShard(auction.seller) }
             BatchProject { exprs: [auction.id, auction.seller] }
               BatchFilter { predicate: (auction.category = 10:Int32) }
-                BatchScan { table: auction, columns: [id, seller, category] }
+                BatchScan { table: auction, columns: [auction.id, auction.seller, auction.category], distribution: SomeShard }
           BatchExchange { order: [], dist: HashShard(person.id) }
             BatchFilter { predicate: (((person.state = 'or':Varchar) OR (person.state = 'id':Varchar)) OR (person.state = 'ca':Varchar)) }
-              BatchScan { table: person, columns: [id, name, city, state] }
+              BatchScan { table: person, columns: [person.id, person.name, person.city, person.state], distribution: SomeShard }
   stream_plan: |
     StreamMaterialize { columns: [name, city, state, id, auction._row_id(hidden), person._row_id(hidden)], pk_columns: [auction._row_id, person._row_id] }
       StreamExchange { dist: HashShard(auction._row_id, person._row_id) }
         StreamProject { exprs: [person.name, person.city, person.state, auction.id, auction._row_id, person._row_id] }
-          StreamHashJoin { type: Inner, predicate: auction.seller = person.id }
+          StreamHashJoin { type: Inner, predicate: auction.seller = person.id, output: [auction.id, person.name, person.city, person.state, auction._row_id, person._row_id] }
             StreamExchange { dist: HashShard(auction.seller) }
               StreamProject { exprs: [auction.id, auction.seller, auction._row_id] }
                 StreamFilter { predicate: (auction.category = 10:Int32) }
-                  StreamTableScan { table: auction, columns: [id, seller, _row_id, category] }
+                  StreamTableScan { table: auction, columns: [auction.id, auction.seller, auction._row_id, auction.category], pk: [auction._row_id], distribution: HashShard(auction._row_id) }
             StreamExchange { dist: HashShard(person.id) }
               StreamFilter { predicate: (((person.state = 'or':Varchar) OR (person.state = 'id':Varchar)) OR (person.state = 'ca':Varchar)) }
-                StreamTableScan { table: person, columns: [id, name, city, state, _row_id] }
+                StreamTableScan { table: person, columns: [person.id, person.name, person.city, person.state, person._row_id], pk: [person._row_id], distribution: HashShard(person._row_id) }
 - id: nexmark_q4
   before:
   - create_tables
@@ -137,11 +137,11 @@
               BatchHashAgg { group_key: [auction.id, auction.category], aggs: [max(bid.price)] }
                 BatchProject { exprs: [auction.id, auction.category, bid.price] }
                   BatchFilter { predicate: (bid.date_time >= auction.date_time) AND (bid.date_time <= auction.expires) }
-                    BatchHashJoin { type: Inner, predicate: auction.id = bid.auction }
+                    BatchHashJoin { type: Inner, predicate: auction.id = bid.auction, output: all }
                       BatchExchange { order: [], dist: HashShard(auction.id) }
-                        BatchScan { table: auction, columns: [id, date_time, expires, category] }
+                        BatchScan { table: auction, columns: [auction.id, auction.date_time, auction.expires, auction.category], distribution: SomeShard }
                       BatchExchange { order: [], dist: HashShard(bid.auction) }
-                        BatchScan { table: bid, columns: [auction, price, date_time] }
+                        BatchScan { table: bid, columns: [bid.auction, bid.price, bid.date_time], distribution: SomeShard }
   stream_plan: |
     StreamMaterialize { columns: [category, avg], pk_columns: [category] }
       StreamProject { exprs: [auction.category, (sum(max(bid.price)) / count(max(bid.price)))] }
@@ -151,11 +151,11 @@
               StreamHashAgg { group_key: [auction.id, auction.category], aggs: [count, max(bid.price)] }
                 StreamProject { exprs: [auction.id, auction.category, bid.price, auction._row_id, bid._row_id] }
                   StreamFilter { predicate: (bid.date_time >= auction.date_time) AND (bid.date_time <= auction.expires) }
-                    StreamHashJoin { type: Inner, predicate: auction.id = bid.auction }
+                    StreamHashJoin { type: Inner, predicate: auction.id = bid.auction, output: all }
                       StreamExchange { dist: HashShard(auction.id) }
-                        StreamTableScan { table: auction, columns: [id, date_time, expires, category, _row_id] }
+                        StreamTableScan { table: auction, columns: [auction.id, auction.date_time, auction.expires, auction.category, auction._row_id], pk: [auction._row_id], distribution: HashShard(auction._row_id) }
                       StreamExchange { dist: HashShard(bid.auction) }
-                        StreamTableScan { table: bid, columns: [auction, price, date_time, _row_id] }
+                        StreamTableScan { table: bid, columns: [bid.auction, bid.price, bid.date_time, bid._row_id], pk: [bid._row_id], distribution: HashShard(bid._row_id) }
 - id: nexmark_q5
   before:
   - create_tables
@@ -192,14 +192,14 @@
     BatchExchange { order: [], dist: Single }
       BatchProject { exprs: [bid.auction, count] }
         BatchFilter { predicate: (count >= max(count)) }
-          BatchHashJoin { type: Inner, predicate: window_start = window_start }
+          BatchHashJoin { type: Inner, predicate: window_start = window_start, output: all }
             BatchExchange { order: [], dist: HashShard(window_start) }
               BatchProject { exprs: [bid.auction, count, window_start] }
                 BatchHashAgg { group_key: [window_start, bid.auction], aggs: [count] }
                   BatchExchange { order: [], dist: HashShard(window_start, bid.auction) }
                     BatchProject { exprs: [window_start, bid.auction] }
                       BatchHopWindow { time_col: bid.date_time, slide: 00:00:02, size: 00:00:10, output: [bid.auction, window_start] }
-                        BatchScan { table: bid, columns: [auction, date_time] }
+                        BatchScan { table: bid, columns: [bid.auction, bid.date_time], distribution: SomeShard }
             BatchProject { exprs: [max(count), window_start] }
               BatchHashAgg { group_key: [window_start], aggs: [max(count)] }
                 BatchExchange { order: [], dist: HashShard(window_start) }
@@ -207,19 +207,19 @@
                     BatchHashAgg { group_key: [bid.auction, window_start], aggs: [count] }
                       BatchHopWindow { time_col: bid.date_time, slide: 00:00:02, size: 00:00:10, output: [bid.auction, window_start] }
                         BatchExchange { order: [], dist: HashShard(bid.auction) }
-                          BatchScan { table: bid, columns: [auction, date_time] }
+                          BatchScan { table: bid, columns: [bid.auction, bid.date_time], distribution: SomeShard }
   stream_plan: |
     StreamMaterialize { columns: [auction, num, window_start(hidden), window_start#1(hidden)], pk_columns: [window_start, auction, window_start#1] }
       StreamProject { exprs: [bid.auction, count, window_start, window_start] }
         StreamFilter { predicate: (count >= max(count)) }
-          StreamHashJoin { type: Inner, predicate: window_start = window_start }
+          StreamHashJoin { type: Inner, predicate: window_start = window_start, output: all }
             StreamExchange { dist: HashShard(window_start) }
               StreamProject { exprs: [bid.auction, count, window_start] }
                 StreamHashAgg { group_key: [window_start, bid.auction], aggs: [count, count] }
                   StreamExchange { dist: HashShard(window_start, bid.auction) }
                     StreamProject { exprs: [window_start, bid.auction, bid._row_id] }
                       StreamHopWindow { time_col: bid.date_time, slide: 00:00:02, size: 00:00:10, output: [bid.auction, window_start, bid._row_id] }
-                        StreamTableScan { table: bid, columns: [auction, date_time, _row_id] }
+                        StreamTableScan { table: bid, columns: [bid.auction, bid.date_time, bid._row_id], pk: [bid._row_id], distribution: HashShard(bid._row_id) }
             StreamProject { exprs: [max(count), window_start] }
               StreamHashAgg { group_key: [window_start], aggs: [count, max(count)] }
                 StreamExchange { dist: HashShard(window_start) }
@@ -227,7 +227,7 @@
                     StreamHashAgg { group_key: [bid.auction, window_start], aggs: [count, count] }
                       StreamExchange { dist: HashShard(bid.auction, window_start) }
                         StreamHopWindow { time_col: bid.date_time, slide: 00:00:02, size: 00:00:10, output: [bid.auction, window_start, bid._row_id] }
-                          StreamTableScan { table: bid, columns: [auction, date_time, _row_id] }
+                          StreamTableScan { table: bid, columns: [bid.auction, bid.date_time, bid._row_id], pk: [bid._row_id], distribution: HashShard(bid._row_id) }
 - id: nexmark_q6
   before:
   - create_tables
@@ -272,29 +272,29 @@
     BatchExchange { order: [], dist: Single }
       BatchProject { exprs: [bid.auction, bid.price, bid.bidder, bid.date_time] }
         BatchFilter { predicate: (bid.date_time >= ((TumbleStart(bid.date_time, '00:00:10':Interval) + '00:00:10':Interval) - '00:00:10':Interval)) AND (bid.date_time <= (TumbleStart(bid.date_time, '00:00:10':Interval) + '00:00:10':Interval)) }
-          BatchHashJoin { type: Inner, predicate: bid.price = max(bid.price) }
+          BatchHashJoin { type: Inner, predicate: bid.price = max(bid.price), output: all }
             BatchExchange { order: [], dist: HashShard(bid.price) }
-              BatchScan { table: bid, columns: [auction, bidder, price, date_time] }
+              BatchScan { table: bid, columns: [bid.auction, bid.bidder, bid.price, bid.date_time], distribution: SomeShard }
             BatchExchange { order: [], dist: HashShard(max(bid.price)) }
               BatchProject { exprs: [max(bid.price), (TumbleStart(bid.date_time, '00:00:10':Interval) + '00:00:10':Interval)] }
                 BatchHashAgg { group_key: [(TumbleStart(bid.date_time, '00:00:10':Interval) + '00:00:10':Interval)], aggs: [max(bid.price)] }
                   BatchExchange { order: [], dist: HashShard((TumbleStart(bid.date_time, '00:00:10':Interval) + '00:00:10':Interval)) }
                     BatchProject { exprs: [(TumbleStart(bid.date_time, '00:00:10':Interval) + '00:00:10':Interval), bid.price] }
-                      BatchScan { table: bid, columns: [price, date_time] }
+                      BatchScan { table: bid, columns: [bid.price, bid.date_time], distribution: SomeShard }
   stream_plan: |
     StreamMaterialize { columns: [auction, price, bidder, date_time, bid._row_id(hidden), (TumbleStart(bid.date_time, '00:00:10':Interval) + '00:00:10':Interval)(hidden)], pk_columns: [bid._row_id, (TumbleStart(bid.date_time, '00:00:10':Interval) + '00:00:10':Interval)] }
       StreamExchange { dist: HashShard(bid._row_id, (TumbleStart(bid.date_time, '00:00:10':Interval) + '00:00:10':Interval)) }
         StreamProject { exprs: [bid.auction, bid.price, bid.bidder, bid.date_time, bid._row_id, (TumbleStart(bid.date_time, '00:00:10':Interval) + '00:00:10':Interval)] }
           StreamFilter { predicate: (bid.date_time >= ((TumbleStart(bid.date_time, '00:00:10':Interval) + '00:00:10':Interval) - '00:00:10':Interval)) AND (bid.date_time <= (TumbleStart(bid.date_time, '00:00:10':Interval) + '00:00:10':Interval)) }
-            StreamHashJoin { type: Inner, predicate: bid.price = max(bid.price) }
+            StreamHashJoin { type: Inner, predicate: bid.price = max(bid.price), output: all }
               StreamExchange { dist: HashShard(bid.price) }
-                StreamTableScan { table: bid, columns: [auction, bidder, price, date_time, _row_id] }
+                StreamTableScan { table: bid, columns: [bid.auction, bid.bidder, bid.price, bid.date_time, bid._row_id], pk: [bid._row_id], distribution: HashShard(bid._row_id) }
               StreamExchange { dist: HashShard(max(bid.price)) }
                 StreamProject { exprs: [max(bid.price), (TumbleStart(bid.date_time, '00:00:10':Interval) + '00:00:10':Interval)] }
                   StreamHashAgg { group_key: [(TumbleStart(bid.date_time, '00:00:10':Interval) + '00:00:10':Interval)], aggs: [count, max(bid.price)] }
                     StreamExchange { dist: HashShard((TumbleStart(bid.date_time, '00:00:10':Interval) + '00:00:10':Interval)) }
                       StreamProject { exprs: [(TumbleStart(bid.date_time, '00:00:10':Interval) + '00:00:10':Interval), bid.price, bid._row_id] }
-                        StreamTableScan { table: bid, columns: [price, date_time, _row_id] }
+                        StreamTableScan { table: bid, columns: [bid.price, bid.date_time, bid._row_id], pk: [bid._row_id], distribution: HashShard(bid._row_id) }
 - id: nexmark_q8
   before:
   - create_tables
@@ -333,28 +333,28 @@
       AND P.endtime = A.endtime;
   batch_plan: |
     BatchExchange { order: [], dist: Single }
-      BatchHashJoin { type: Inner, predicate: person.id = auction.seller AND TumbleStart(person.date_time, '00:00:10':Interval) = TumbleStart(auction.date_time, '00:00:10':Interval) AND (TumbleStart(person.date_time, '00:00:10':Interval) + '00:00:10':Interval) = (TumbleStart(auction.date_time, '00:00:10':Interval) + '00:00:10':Interval) }
+      BatchHashJoin { type: Inner, predicate: person.id = auction.seller AND TumbleStart(person.date_time, '00:00:10':Interval) = TumbleStart(auction.date_time, '00:00:10':Interval) AND (TumbleStart(person.date_time, '00:00:10':Interval) + '00:00:10':Interval) = (TumbleStart(auction.date_time, '00:00:10':Interval) + '00:00:10':Interval), output: [person.id, person.name, TumbleStart(person.date_time, '00:00:10':Interval)] }
         BatchExchange { order: [], dist: HashShard(person.id, TumbleStart(person.date_time, '00:00:10':Interval), (TumbleStart(person.date_time, '00:00:10':Interval) + '00:00:10':Interval)) }
           BatchHashAgg { group_key: [person.id, person.name, TumbleStart(person.date_time, '00:00:10':Interval), (TumbleStart(person.date_time, '00:00:10':Interval) + '00:00:10':Interval)], aggs: [] }
             BatchExchange { order: [], dist: HashShard(person.id, person.name, TumbleStart(person.date_time, '00:00:10':Interval), (TumbleStart(person.date_time, '00:00:10':Interval) + '00:00:10':Interval)) }
               BatchProject { exprs: [person.id, person.name, TumbleStart(person.date_time, '00:00:10':Interval), (TumbleStart(person.date_time, '00:00:10':Interval) + '00:00:10':Interval)] }
-                BatchScan { table: person, columns: [id, name, date_time] }
+                BatchScan { table: person, columns: [person.id, person.name, person.date_time], distribution: SomeShard }
         BatchHashAgg { group_key: [auction.seller, TumbleStart(auction.date_time, '00:00:10':Interval), (TumbleStart(auction.date_time, '00:00:10':Interval) + '00:00:10':Interval)], aggs: [] }
           BatchExchange { order: [], dist: HashShard(auction.seller, TumbleStart(auction.date_time, '00:00:10':Interval), (TumbleStart(auction.date_time, '00:00:10':Interval) + '00:00:10':Interval)) }
             BatchProject { exprs: [auction.seller, TumbleStart(auction.date_time, '00:00:10':Interval), (TumbleStart(auction.date_time, '00:00:10':Interval) + '00:00:10':Interval)] }
-              BatchScan { table: auction, columns: [date_time, seller] }
+              BatchScan { table: auction, columns: [auction.date_time, auction.seller], distribution: SomeShard }
   stream_plan: |
     StreamMaterialize { columns: [id, name, starttime, (TumbleStart(person.date_time, '00:00:10':Interval) + '00:00:10':Interval)(hidden), auction.seller(hidden), TumbleStart(auction.date_time, '00:00:10':Interval)(hidden), (TumbleStart(auction.date_time, '00:00:10':Interval) + '00:00:10':Interval)(hidden)], pk_columns: [id, name, starttime, (TumbleStart(person.date_time, '00:00:10':Interval) + '00:00:10':Interval), auction.seller, TumbleStart(auction.date_time, '00:00:10':Interval), (TumbleStart(auction.date_time, '00:00:10':Interval) + '00:00:10':Interval)] }
-      StreamHashJoin { type: Inner, predicate: person.id = auction.seller AND TumbleStart(person.date_time, '00:00:10':Interval) = TumbleStart(auction.date_time, '00:00:10':Interval) AND (TumbleStart(person.date_time, '00:00:10':Interval) + '00:00:10':Interval) = (TumbleStart(auction.date_time, '00:00:10':Interval) + '00:00:10':Interval) }
+      StreamHashJoin { type: Inner, predicate: person.id = auction.seller AND TumbleStart(person.date_time, '00:00:10':Interval) = TumbleStart(auction.date_time, '00:00:10':Interval) AND (TumbleStart(person.date_time, '00:00:10':Interval) + '00:00:10':Interval) = (TumbleStart(auction.date_time, '00:00:10':Interval) + '00:00:10':Interval), output: [person.id, person.name, TumbleStart(person.date_time, '00:00:10':Interval), (TumbleStart(person.date_time, '00:00:10':Interval) + '00:00:10':Interval), auction.seller, TumbleStart(auction.date_time, '00:00:10':Interval), (TumbleStart(auction.date_time, '00:00:10':Interval) + '00:00:10':Interval)] }
         StreamExchange { dist: HashShard(person.id, TumbleStart(person.date_time, '00:00:10':Interval), (TumbleStart(person.date_time, '00:00:10':Interval) + '00:00:10':Interval)) }
           StreamHashAgg { group_key: [person.id, person.name, TumbleStart(person.date_time, '00:00:10':Interval), (TumbleStart(person.date_time, '00:00:10':Interval) + '00:00:10':Interval)], aggs: [count] }
             StreamExchange { dist: HashShard(person.id, person.name, TumbleStart(person.date_time, '00:00:10':Interval), (TumbleStart(person.date_time, '00:00:10':Interval) + '00:00:10':Interval)) }
               StreamProject { exprs: [person.id, person.name, TumbleStart(person.date_time, '00:00:10':Interval), (TumbleStart(person.date_time, '00:00:10':Interval) + '00:00:10':Interval), person._row_id] }
-                StreamTableScan { table: person, columns: [id, name, date_time, _row_id] }
+                StreamTableScan { table: person, columns: [person.id, person.name, person.date_time, person._row_id], pk: [person._row_id], distribution: HashShard(person._row_id) }
         StreamHashAgg { group_key: [auction.seller, TumbleStart(auction.date_time, '00:00:10':Interval), (TumbleStart(auction.date_time, '00:00:10':Interval) + '00:00:10':Interval)], aggs: [count] }
           StreamExchange { dist: HashShard(auction.seller, TumbleStart(auction.date_time, '00:00:10':Interval), (TumbleStart(auction.date_time, '00:00:10':Interval) + '00:00:10':Interval)) }
             StreamProject { exprs: [auction.seller, TumbleStart(auction.date_time, '00:00:10':Interval), (TumbleStart(auction.date_time, '00:00:10':Interval) + '00:00:10':Interval), auction._row_id] }
-              StreamTableScan { table: auction, columns: [date_time, seller, _row_id] }
+              StreamTableScan { table: auction, columns: [auction.date_time, auction.seller, auction._row_id], pk: [auction._row_id], distribution: HashShard(auction._row_id) }
 - id: nexmark_q9
   before:
   - create_tables
@@ -379,11 +379,11 @@
   batch_plan: |
     BatchExchange { order: [], dist: Single }
       BatchProject { exprs: [bid.auction, bid.bidder, bid.price, bid.date_time, ToChar(bid.date_time, 'YYYY-MM-DD':Varchar), ToChar(bid.date_time, 'HH:MI':Varchar)] }
-        BatchScan { table: bid, columns: [auction, bidder, price, date_time] }
+        BatchScan { table: bid, columns: [bid.auction, bid.bidder, bid.price, bid.date_time], distribution: SomeShard }
   stream_plan: |
     StreamMaterialize { columns: [auction, bidder, price, date_time, date, time, bid._row_id(hidden)], pk_columns: [bid._row_id] }
       StreamProject { exprs: [bid.auction, bid.bidder, bid.price, bid.date_time, ToChar(bid.date_time, 'YYYY-MM-DD':Varchar), ToChar(bid.date_time, 'HH:MI':Varchar), bid._row_id] }
-        StreamTableScan { table: bid, columns: [auction, bidder, price, date_time, _row_id] }
+        StreamTableScan { table: bid, columns: [bid.auction, bid.bidder, bid.price, bid.date_time, bid._row_id], pk: [bid._row_id], distribution: HashShard(bid._row_id) }
 - id: nexmark_q11
   before:
   - create_tables
@@ -454,12 +454,12 @@
     BatchExchange { order: [], dist: Single }
       BatchProject { exprs: [bid.auction, bid.bidder, (0.908:Decimal * bid.price), Case(((Extract('HOUR':Varchar, bid.date_time) >= 8:Int32) AND (Extract('HOUR':Varchar, bid.date_time) <= 18:Int32)), 'dayTime':Varchar, ((Extract('HOUR':Varchar, bid.date_time) <= 6:Int32) OR (Extract('HOUR':Varchar, bid.date_time) >= 20:Int32)), 'nightTime':Varchar, 'otherTime':Varchar), bid.date_time, bid.extra] }
         BatchFilter { predicate: ((0.908:Decimal * bid.price) > 1000000:Int32) AND ((0.908:Decimal * bid.price) < 50000000:Int32) }
-          BatchScan { table: bid, columns: [auction, bidder, price, date_time, extra] }
+          BatchScan { table: bid, columns: [bid.auction, bid.bidder, bid.price, bid.date_time, bid.extra], distribution: SomeShard }
   stream_plan: |
     StreamMaterialize { columns: [auction, bidder, price, bidtimetype, date_time, extra, bid._row_id(hidden)], pk_columns: [bid._row_id] }
       StreamProject { exprs: [bid.auction, bid.bidder, (0.908:Decimal * bid.price), Case(((Extract('HOUR':Varchar, bid.date_time) >= 8:Int32) AND (Extract('HOUR':Varchar, bid.date_time) <= 18:Int32)), 'dayTime':Varchar, ((Extract('HOUR':Varchar, bid.date_time) <= 6:Int32) OR (Extract('HOUR':Varchar, bid.date_time) >= 20:Int32)), 'nightTime':Varchar, 'otherTime':Varchar), bid.date_time, bid.extra, bid._row_id] }
         StreamFilter { predicate: ((0.908:Decimal * bid.price) > 1000000:Int32) AND ((0.908:Decimal * bid.price) < 50000000:Int32) }
-          StreamTableScan { table: bid, columns: [auction, bidder, price, date_time, extra, _row_id] }
+          StreamTableScan { table: bid, columns: [bid.auction, bid.bidder, bid.price, bid.date_time, bid.extra, bid._row_id], pk: [bid._row_id], distribution: HashShard(bid._row_id) }
 - id: nexmark_q15
   before:
   - create_tables
@@ -489,7 +489,7 @@
               BatchExchange { order: [], dist: HashShard(ToChar(bid.date_time, 'yyyy-MM-dd':Varchar), bid.bidder, bid.auction, flag) }
                 BatchExpand { column_subsets: [[ToChar(bid.date_time, 'yyyy-MM-dd':Varchar), bid.price], [ToChar(bid.date_time, 'yyyy-MM-dd':Varchar), bid.bidder], [ToChar(bid.date_time, 'yyyy-MM-dd':Varchar), bid.price, bid.bidder], [ToChar(bid.date_time, 'yyyy-MM-dd':Varchar), bid.price, bid.bidder], [ToChar(bid.date_time, 'yyyy-MM-dd':Varchar), bid.price, bid.bidder], [ToChar(bid.date_time, 'yyyy-MM-dd':Varchar), bid.auction], [ToChar(bid.date_time, 'yyyy-MM-dd':Varchar), bid.price, bid.auction], [ToChar(bid.date_time, 'yyyy-MM-dd':Varchar), bid.price, bid.auction], [ToChar(bid.date_time, 'yyyy-MM-dd':Varchar), bid.price, bid.auction]] }
                   BatchProject { exprs: [ToChar(bid.date_time, 'yyyy-MM-dd':Varchar), bid.price, bid.bidder, bid.auction] }
-                    BatchScan { table: bid, columns: [auction, bidder, price, date_time] }
+                    BatchScan { table: bid, columns: [bid.auction, bid.bidder, bid.price, bid.date_time], distribution: SomeShard }
   stream_plan: |
     StreamMaterialize { columns: [day, total_bids, rank1_bids, rank2_bids, rank3_bids, total_bidders, rank1_bidders, rank2_bidders, rank3_bidders, total_auctions, rank1_auctions, rank2_auctions, rank3_auctions], pk_columns: [day] }
       StreamProject { exprs: [ToChar(bid.date_time, 'yyyy-MM-dd':Varchar), Coalesce(sum(count) filter((flag = 0:Int64)), 0:Int64), Coalesce(sum(count filter((bid.price < 10000:Int32))) filter((flag = 0:Int64)), 0:Int64), Coalesce(sum(count filter((bid.price >= 10000:Int32) AND (bid.price < 1000000:Int32))) filter((flag = 0:Int64)), 0:Int64), Coalesce(sum(count filter((bid.price >= 1000000:Int32))) filter((flag = 0:Int64)), 0:Int64), count(bid.bidder) filter((flag = 1:Int64)), count(bid.bidder) filter((count filter((bid.price < 10000:Int32)) > 0:Int64) AND (flag = 2:Int64)), count(bid.bidder) filter((count filter((bid.price >= 10000:Int32) AND (bid.price < 1000000:Int32)) > 0:Int64) AND (flag = 3:Int64)), count(bid.bidder) filter((count filter((bid.price >= 1000000:Int32)) > 0:Int64) AND (flag = 4:Int64)), count(bid.auction) filter((flag = 5:Int64)), count(bid.auction) filter((count filter((bid.price < 10000:Int32)) > 0:Int64) AND (flag = 6:Int64)), count(bid.auction) filter((count filter((bid.price >= 10000:Int32) AND (bid.price < 1000000:Int32)) > 0:Int64) AND (flag = 7:Int64)), count(bid.auction) filter((count filter((bid.price >= 1000000:Int32)) > 0:Int64) AND (flag = 8:Int64))] }
@@ -499,7 +499,7 @@
               StreamExchange { dist: HashShard(ToChar(bid.date_time, 'yyyy-MM-dd':Varchar), bid.bidder, bid.auction, flag) }
                 StreamExpand { column_subsets: [[ToChar(bid.date_time, 'yyyy-MM-dd':Varchar), bid.price], [ToChar(bid.date_time, 'yyyy-MM-dd':Varchar), bid.bidder], [ToChar(bid.date_time, 'yyyy-MM-dd':Varchar), bid.price, bid.bidder], [ToChar(bid.date_time, 'yyyy-MM-dd':Varchar), bid.price, bid.bidder], [ToChar(bid.date_time, 'yyyy-MM-dd':Varchar), bid.price, bid.bidder], [ToChar(bid.date_time, 'yyyy-MM-dd':Varchar), bid.auction], [ToChar(bid.date_time, 'yyyy-MM-dd':Varchar), bid.price, bid.auction], [ToChar(bid.date_time, 'yyyy-MM-dd':Varchar), bid.price, bid.auction], [ToChar(bid.date_time, 'yyyy-MM-dd':Varchar), bid.price, bid.auction]] }
                   StreamProject { exprs: [ToChar(bid.date_time, 'yyyy-MM-dd':Varchar), bid.price, bid.bidder, bid.auction, bid._row_id] }
-                    StreamTableScan { table: bid, columns: [auction, bidder, price, date_time, _row_id] }
+                    StreamTableScan { table: bid, columns: [bid.auction, bid.bidder, bid.price, bid.date_time, bid._row_id], pk: [bid._row_id], distribution: HashShard(bid._row_id) }
 - id: nexmark_q16
   before:
   - create_tables
@@ -531,7 +531,7 @@
               BatchExchange { order: [], dist: HashShard(bid.channel, ToChar(bid.date_time, 'yyyy-MM-dd':Varchar), bid.bidder, bid.auction, flag) }
                 BatchExpand { column_subsets: [[bid.channel, ToChar(bid.date_time, 'yyyy-MM-dd':Varchar), ToChar(bid.date_time, 'HH:mm':Varchar), bid.price], [bid.channel, ToChar(bid.date_time, 'yyyy-MM-dd':Varchar), bid.bidder], [bid.channel, ToChar(bid.date_time, 'yyyy-MM-dd':Varchar), bid.price, bid.bidder], [bid.channel, ToChar(bid.date_time, 'yyyy-MM-dd':Varchar), bid.price, bid.bidder], [bid.channel, ToChar(bid.date_time, 'yyyy-MM-dd':Varchar), bid.price, bid.bidder], [bid.channel, ToChar(bid.date_time, 'yyyy-MM-dd':Varchar), bid.auction], [bid.channel, ToChar(bid.date_time, 'yyyy-MM-dd':Varchar), bid.price, bid.auction], [bid.channel, ToChar(bid.date_time, 'yyyy-MM-dd':Varchar), bid.price, bid.auction], [bid.channel, ToChar(bid.date_time, 'yyyy-MM-dd':Varchar), bid.price, bid.auction]] }
                   BatchProject { exprs: [bid.channel, ToChar(bid.date_time, 'yyyy-MM-dd':Varchar), ToChar(bid.date_time, 'HH:mm':Varchar), bid.price, bid.bidder, bid.auction] }
-                    BatchScan { table: bid, columns: [auction, bidder, price, channel, date_time] }
+                    BatchScan { table: bid, columns: [bid.auction, bid.bidder, bid.price, bid.channel, bid.date_time], distribution: SomeShard }
   stream_plan: |
     StreamMaterialize { columns: [channel, day, minute, total_bids, rank1_bids, rank2_bids, rank3_bids, total_bidders, rank1_bidders, rank2_bidders, rank3_bidders, total_auctions, rank1_auctions, rank2_auctions, rank3_auctions], pk_columns: [channel, day] }
       StreamProject { exprs: [bid.channel, ToChar(bid.date_time, 'yyyy-MM-dd':Varchar), max(max(ToChar(bid.date_time, 'HH:mm':Varchar))) filter((flag = 0:Int64)), Coalesce(sum(count) filter((flag = 0:Int64)), 0:Int64), Coalesce(sum(count filter((bid.price < 10000:Int32))) filter((flag = 0:Int64)), 0:Int64), Coalesce(sum(count filter((bid.price >= 10000:Int32) AND (bid.price < 1000000:Int32))) filter((flag = 0:Int64)), 0:Int64), Coalesce(sum(count filter((bid.price >= 1000000:Int32))) filter((flag = 0:Int64)), 0:Int64), count(bid.bidder) filter((flag = 1:Int64)), count(bid.bidder) filter((count filter((bid.price < 10000:Int32)) > 0:Int64) AND (flag = 2:Int64)), count(bid.bidder) filter((count filter((bid.price >= 10000:Int32) AND (bid.price < 1000000:Int32)) > 0:Int64) AND (flag = 3:Int64)), count(bid.bidder) filter((count filter((bid.price >= 1000000:Int32)) > 0:Int64) AND (flag = 4:Int64)), count(bid.auction) filter((flag = 5:Int64)), count(bid.auction) filter((count filter((bid.price < 10000:Int32)) > 0:Int64) AND (flag = 6:Int64)), count(bid.auction) filter((count filter((bid.price >= 10000:Int32) AND (bid.price < 1000000:Int32)) > 0:Int64) AND (flag = 7:Int64)), count(bid.auction) filter((count filter((bid.price >= 1000000:Int32)) > 0:Int64) AND (flag = 8:Int64))] }
@@ -541,7 +541,7 @@
               StreamExchange { dist: HashShard(bid.channel, ToChar(bid.date_time, 'yyyy-MM-dd':Varchar), bid.bidder, bid.auction, flag) }
                 StreamExpand { column_subsets: [[bid.channel, ToChar(bid.date_time, 'yyyy-MM-dd':Varchar), ToChar(bid.date_time, 'HH:mm':Varchar), bid.price], [bid.channel, ToChar(bid.date_time, 'yyyy-MM-dd':Varchar), bid.bidder], [bid.channel, ToChar(bid.date_time, 'yyyy-MM-dd':Varchar), bid.price, bid.bidder], [bid.channel, ToChar(bid.date_time, 'yyyy-MM-dd':Varchar), bid.price, bid.bidder], [bid.channel, ToChar(bid.date_time, 'yyyy-MM-dd':Varchar), bid.price, bid.bidder], [bid.channel, ToChar(bid.date_time, 'yyyy-MM-dd':Varchar), bid.auction], [bid.channel, ToChar(bid.date_time, 'yyyy-MM-dd':Varchar), bid.price, bid.auction], [bid.channel, ToChar(bid.date_time, 'yyyy-MM-dd':Varchar), bid.price, bid.auction], [bid.channel, ToChar(bid.date_time, 'yyyy-MM-dd':Varchar), bid.price, bid.auction]] }
                   StreamProject { exprs: [bid.channel, ToChar(bid.date_time, 'yyyy-MM-dd':Varchar), ToChar(bid.date_time, 'HH:mm':Varchar), bid.price, bid.bidder, bid.auction, bid._row_id] }
-                    StreamTableScan { table: bid, columns: [auction, bidder, price, channel, date_time, _row_id] }
+                    StreamTableScan { table: bid, columns: [bid.auction, bid.bidder, bid.price, bid.channel, bid.date_time, bid._row_id], pk: [bid._row_id], distribution: HashShard(bid._row_id) }
 - id: nexmark_q17
   before:
   - create_tables
@@ -565,14 +565,14 @@
         BatchHashAgg { group_key: [bid.auction, ToChar(bid.date_time, 'yyyy-MM-dd':Varchar)], aggs: [count, count filter((bid.price < 10000:Int32)), count filter((bid.price >= 10000:Int32) AND (bid.price < 1000000:Int32)), count filter((bid.price >= 1000000:Int32)), min(bid.price), max(bid.price), sum(bid.price), count(bid.price), sum(bid.price)] }
           BatchExchange { order: [], dist: HashShard(bid.auction, ToChar(bid.date_time, 'yyyy-MM-dd':Varchar)) }
             BatchProject { exprs: [bid.auction, ToChar(bid.date_time, 'yyyy-MM-dd':Varchar), bid.price] }
-              BatchScan { table: bid, columns: [auction, price, date_time] }
+              BatchScan { table: bid, columns: [bid.auction, bid.price, bid.date_time], distribution: SomeShard }
   stream_plan: |
     StreamMaterialize { columns: [auction, day, total_bids, rank1_bids, rank2_bids, rank3_bids, min_price, max_price, avg_price, sum_price], pk_columns: [auction, day] }
       StreamProject { exprs: [bid.auction, ToChar(bid.date_time, 'yyyy-MM-dd':Varchar), count, count filter((bid.price < 10000:Int32)), count filter((bid.price >= 10000:Int32) AND (bid.price < 1000000:Int32)), count filter((bid.price >= 1000000:Int32)), min(bid.price), max(bid.price), (sum(bid.price) / count(bid.price)), sum(bid.price)] }
         StreamHashAgg { group_key: [bid.auction, ToChar(bid.date_time, 'yyyy-MM-dd':Varchar)], aggs: [count, count, count filter((bid.price < 10000:Int32)), count filter((bid.price >= 10000:Int32) AND (bid.price < 1000000:Int32)), count filter((bid.price >= 1000000:Int32)), min(bid.price), max(bid.price), sum(bid.price), count(bid.price), sum(bid.price)] }
           StreamExchange { dist: HashShard(bid.auction, ToChar(bid.date_time, 'yyyy-MM-dd':Varchar)) }
             StreamProject { exprs: [bid.auction, ToChar(bid.date_time, 'yyyy-MM-dd':Varchar), bid.price, bid._row_id] }
-              StreamTableScan { table: bid, columns: [auction, price, date_time, _row_id] }
+              StreamTableScan { table: bid, columns: [bid.auction, bid.price, bid.date_time, bid._row_id], pk: [bid._row_id], distribution: HashShard(bid._row_id) }
 - id: nexmark_q18
   before:
   - create_tables
@@ -604,21 +604,21 @@
     WHERE A.category = 10;
   batch_plan: |
     BatchExchange { order: [], dist: Single }
-      BatchHashJoin { type: Inner, predicate: bid.auction = auction.id }
+      BatchHashJoin { type: Inner, predicate: bid.auction = auction.id, output: [bid.auction, bid.bidder, bid.price, bid.channel, bid.url, bid.date_time, auction.item_name, auction.description, auction.initial_bid, auction.reserve, auction.date_time, auction.expires, auction.seller, auction.category] }
         BatchExchange { order: [], dist: HashShard(bid.auction) }
-          BatchScan { table: bid, columns: [auction, bidder, price, channel, url, date_time] }
+          BatchScan { table: bid, columns: [bid.auction, bid.bidder, bid.price, bid.channel, bid.url, bid.date_time], distribution: SomeShard }
         BatchExchange { order: [], dist: HashShard(auction.id) }
           BatchFilter { predicate: (auction.category = 10:Int32) }
-            BatchScan { table: auction, columns: [id, item_name, description, initial_bid, reserve, date_time, expires, seller, category] }
+            BatchScan { table: auction, columns: [auction.id, auction.item_name, auction.description, auction.initial_bid, auction.reserve, auction.date_time, auction.expires, auction.seller, auction.category], distribution: SomeShard }
   stream_plan: |
     StreamMaterialize { columns: [auction, bidder, price, channel, url, date_timeb, item_name, description, initial_bid, reserve, date_timea, expires, seller, category, bid._row_id(hidden), auction._row_id(hidden)], pk_columns: [bid._row_id, auction._row_id] }
       StreamExchange { dist: HashShard(bid._row_id, auction._row_id) }
-        StreamHashJoin { type: Inner, predicate: bid.auction = auction.id }
+        StreamHashJoin { type: Inner, predicate: bid.auction = auction.id, output: [bid.auction, bid.bidder, bid.price, bid.channel, bid.url, bid.date_time, auction.item_name, auction.description, auction.initial_bid, auction.reserve, auction.date_time, auction.expires, auction.seller, auction.category, bid._row_id, auction._row_id] }
           StreamExchange { dist: HashShard(bid.auction) }
-            StreamTableScan { table: bid, columns: [auction, bidder, price, channel, url, date_time, _row_id] }
+            StreamTableScan { table: bid, columns: [bid.auction, bid.bidder, bid.price, bid.channel, bid.url, bid.date_time, bid._row_id], pk: [bid._row_id], distribution: HashShard(bid._row_id) }
           StreamExchange { dist: HashShard(auction.id) }
             StreamFilter { predicate: (auction.category = 10:Int32) }
-              StreamTableScan { table: auction, columns: [id, item_name, description, initial_bid, reserve, date_time, expires, seller, category, _row_id] }
+              StreamTableScan { table: auction, columns: [auction.id, auction.item_name, auction.description, auction.initial_bid, auction.reserve, auction.date_time, auction.expires, auction.seller, auction.category, auction._row_id], pk: [auction._row_id], distribution: HashShard(auction._row_id) }
 - id: nexmark_q21
   before:
   - create_tables
@@ -649,8 +649,8 @@
   batch_plan: |
     BatchExchange { order: [], dist: Single }
       BatchProject { exprs: [bid.auction, bid.bidder, bid.price, bid.channel, SplitPart(bid.url, '/':Varchar, 4:Int32), SplitPart(bid.url, '/':Varchar, 5:Int32), SplitPart(bid.url, '/':Varchar, 6:Int32)] }
-        BatchScan { table: bid, columns: [auction, bidder, price, channel, url] }
+        BatchScan { table: bid, columns: [bid.auction, bid.bidder, bid.price, bid.channel, bid.url], distribution: SomeShard }
   stream_plan: |
     StreamMaterialize { columns: [auction, bidder, price, channel, dir1, dir2, dir3, bid._row_id(hidden)], pk_columns: [bid._row_id] }
       StreamProject { exprs: [bid.auction, bid.bidder, bid.price, bid.channel, SplitPart(bid.url, '/':Varchar, 4:Int32), SplitPart(bid.url, '/':Varchar, 5:Int32), SplitPart(bid.url, '/':Varchar, 6:Int32), bid._row_id] }
-        StreamTableScan { table: bid, columns: [auction, bidder, price, channel, url, _row_id] }
+        StreamTableScan { table: bid, columns: [bid.auction, bid.bidder, bid.price, bid.channel, bid.url, bid._row_id], pk: [bid._row_id], distribution: HashShard(bid._row_id) }

--- a/src/frontend/test_runner/tests/testdata/order_by.yaml
+++ b/src/frontend/test_runner/tests/testdata/order_by.yaml
@@ -6,10 +6,10 @@
   batch_plan: |
     BatchExchange { order: [t.v1 DESC], dist: Single }
       BatchSort { order: [t.v1 DESC] }
-        BatchScan { table: t, columns: [v1, v2] }
+        BatchScan { table: t, columns: [t.v1, t.v2], distribution: SomeShard }
   stream_plan: |
     StreamMaterialize { columns: [v1, v2, t._row_id(hidden)], pk_columns: [t._row_id], order_descs: [v1, t._row_id] }
-      StreamTableScan { table: t, columns: [v1, v2, _row_id] }
+      StreamTableScan { table: t, columns: [t.v1, t.v2, t._row_id], pk: [t._row_id], distribution: HashShard(t._row_id) }
 - sql: |
     /* output names are not quailified after table names */
     create table t (v1 bigint, v2 double precision);
@@ -17,7 +17,7 @@
   batch_plan: |
     BatchExchange { order: [t.v1 ASC], dist: Single }
       BatchSort { order: [t.v1 ASC] }
-        BatchScan { table: t, columns: [v1, v2] }
+        BatchScan { table: t, columns: [t.v1, t.v2], distribution: SomeShard }
 - sql: |
     create table t (v1 bigint, v2 double precision);
     select v1, v1+1 from t order by v1;
@@ -25,14 +25,14 @@
     BatchExchange { order: [t.v1 ASC], dist: Single }
       BatchSort { order: [t.v1 ASC] }
         BatchProject { exprs: [t.v1, (t.v1 + 1:Int32)] }
-          BatchScan { table: t, columns: [v1] }
+          BatchScan { table: t, columns: [t.v1], distribution: SomeShard }
 - sql: |
     create table t (v1 bigint, v2 double precision);
     select t.v1 from t order by v1;
   batch_plan: |
     BatchExchange { order: [t.v1 ASC], dist: Single }
       BatchSort { order: [t.v1 ASC] }
-        BatchScan { table: t, columns: [v1] }
+        BatchScan { table: t, columns: [t.v1], distribution: SomeShard }
 - sql: |
     /* order by output alias */
     create table t (v1 bigint, v2 double precision);
@@ -40,7 +40,7 @@
   batch_plan: |
     BatchExchange { order: [t.v1 ASC], dist: Single }
       BatchSort { order: [t.v1 ASC] }
-        BatchScan { table: t, columns: [v1] }
+        BatchScan { table: t, columns: [t.v1], distribution: SomeShard }
 - sql: |
     /* order by ambiguous */
     create table t (v1 bigint, v2 double precision);
@@ -53,7 +53,7 @@
   batch_plan: |
     BatchExchange { order: [t.v2 ASC], dist: Single }
       BatchSort { order: [t.v2 ASC] }
-        BatchScan { table: t, columns: [v1, v2] }
+        BatchScan { table: t, columns: [t.v1, t.v2], distribution: SomeShard }
 - sql: |
     create table t (v1 bigint, v2 double precision);
     select * from t order by 1+1;
@@ -62,11 +62,11 @@
       BatchExchange { order: [(1:Int32 + 1:Int32) ASC], dist: Single }
         BatchSort { order: [(1:Int32 + 1:Int32) ASC] }
           BatchProject { exprs: [t.v1, t.v2, (1:Int32 + 1:Int32)] }
-            BatchScan { table: t, columns: [v1, v2] }
+            BatchScan { table: t, columns: [t.v1, t.v2], distribution: SomeShard }
   stream_plan: |
     StreamMaterialize { columns: [v1, v2, (1:Int32 + 1:Int32)(hidden), t._row_id(hidden)], pk_columns: [t._row_id], order_descs: [(1:Int32 + 1:Int32), t._row_id] }
       StreamProject { exprs: [t.v1, t.v2, (1:Int32 + 1:Int32), t._row_id] }
-        StreamTableScan { table: t, columns: [v1, v2, _row_id] }
+        StreamTableScan { table: t, columns: [t.v1, t.v2, t._row_id], pk: [t._row_id], distribution: HashShard(t._row_id) }
 - sql: |
     create table t (v1 bigint, v2 double precision);
     select * from t order by v;
@@ -78,12 +78,12 @@
     BatchTopN { order: "[t.v1 DESC]", limit: 5, offset: 0 }
       BatchExchange { order: [], dist: Single }
         BatchTopN { order: "[t.v1 DESC]", limit: 5, offset: 0 }
-          BatchScan { table: t, columns: [v1, v2] }
+          BatchScan { table: t, columns: [t.v1, t.v2], distribution: SomeShard }
   stream_plan: |
     StreamMaterialize { columns: [v1, v2, t._row_id(hidden)], pk_columns: [t._row_id], order_descs: [v1, t._row_id] }
       StreamTopN { order: "[t.v1 DESC]", limit: 5, offset: 0 }
         StreamExchange { dist: Single }
-          StreamTableScan { table: t, columns: [v1, v2, _row_id] }
+          StreamTableScan { table: t, columns: [t.v1, t.v2, t._row_id], pk: [t._row_id], distribution: HashShard(t._row_id) }
 - sql: |
     create table t (v1 bigint, v2 double precision);
     select * from t limit 3 offset 4;
@@ -91,7 +91,7 @@
     BatchLimit { limit: 3, offset: 4 }
       BatchExchange { order: [], dist: Single }
         BatchLimit { limit: 7, offset: 0 }
-          BatchScan { table: t, columns: [v1, v2] }
+          BatchScan { table: t, columns: [t.v1, t.v2], distribution: SomeShard }
 - sql: |
     create table t (v1 bigint, v2 double precision);
     select * from t limit 5;
@@ -99,7 +99,7 @@
     BatchLimit { limit: 5, offset: 0 }
       BatchExchange { order: [], dist: Single }
         BatchLimit { limit: 5, offset: 0 }
-          BatchScan { table: t, columns: [v1, v2] }
+          BatchScan { table: t, columns: [t.v1, t.v2], distribution: SomeShard }
 - sql: |
     create table t (v1 bigint, v2 double precision);
     select * from t order by v1 desc limit 5 offset 7;
@@ -107,39 +107,39 @@
     BatchTopN { order: "[t.v1 DESC]", limit: 5, offset: 7 }
       BatchExchange { order: [], dist: Single }
         BatchTopN { order: "[t.v1 DESC]", limit: 12, offset: 0 }
-          BatchScan { table: t, columns: [v1, v2] }
+          BatchScan { table: t, columns: [t.v1, t.v2], distribution: SomeShard }
   stream_plan: |
     StreamMaterialize { columns: [v1, v2, t._row_id(hidden)], pk_columns: [t._row_id], order_descs: [v1, t._row_id] }
       StreamTopN { order: "[t.v1 DESC]", limit: 5, offset: 7 }
         StreamExchange { dist: Single }
-          StreamTableScan { table: t, columns: [v1, v2, _row_id] }
+          StreamTableScan { table: t, columns: [t.v1, t.v2, t._row_id], pk: [t._row_id], distribution: HashShard(t._row_id) }
 - sql: |
     /* order by expression that would be valid in select list */
     create table t (x int, y int, z int);
     select x, y from t order by x + y, z;
   optimized_logical_plan: |
     LogicalProject { exprs: [t.x, t.y, (t.x + t.y), t.z] }
-      LogicalScan { table: t, columns: [x, y, z] }
+      LogicalScan { table: t, columns: [t.x, t.y, t.z] }
   batch_plan: |
     BatchProject { exprs: [t.x, t.y] }
       BatchExchange { order: [(t.x + t.y) ASC, t.z ASC], dist: Single }
         BatchSort { order: [(t.x + t.y) ASC, t.z ASC] }
           BatchProject { exprs: [t.x, t.y, (t.x + t.y), t.z] }
-            BatchScan { table: t, columns: [x, y, z] }
+            BatchScan { table: t, columns: [t.x, t.y, t.z], distribution: SomeShard }
   stream_plan: |
     StreamMaterialize { columns: [x, y, (t.x + t.y)(hidden), t.z(hidden), t._row_id(hidden)], pk_columns: [t._row_id], order_descs: [(t.x + t.y), t.z, t._row_id] }
       StreamProject { exprs: [t.x, t.y, (t.x + t.y), t.z, t._row_id] }
-        StreamTableScan { table: t, columns: [x, y, z, _row_id] }
+        StreamTableScan { table: t, columns: [t.x, t.y, t.z, t._row_id], pk: [t._row_id], distribution: HashShard(t._row_id) }
 - sql: |
     /* order by the number of an output column */
     create table t (x int, y int);
     select x, y from t order by 2;
   optimized_logical_plan: |
-    LogicalScan { table: t, columns: [x, y] }
+    LogicalScan { table: t, columns: [t.x, t.y] }
   batch_plan: |
     BatchExchange { order: [t.y ASC], dist: Single }
       BatchSort { order: [t.y ASC] }
-        BatchScan { table: t, columns: [x, y] }
+        BatchScan { table: t, columns: [t.x, t.y], distribution: SomeShard }
 - sql: |
     /* index exceeds the number of select items */
     create table t (x int, y int);

--- a/src/frontend/test_runner/tests/testdata/pg_catalog.yaml
+++ b/src/frontend/test_runner/tests/testdata/pg_catalog.yaml
@@ -3,20 +3,20 @@
     select * from pg_catalog.pg_type
   logical_plan: |
     LogicalProject { exprs: [pg_type.oid, pg_type.typname] }
-      LogicalScan { table: pg_type, columns: [oid, typname] }
+      LogicalScan { table: pg_type, columns: [pg_type.oid, pg_type.typname] }
   batch_plan: |
-    BatchScan { table: pg_type, columns: [oid, typname] }
+    BatchScan { table: pg_type, columns: [pg_type.oid, pg_type.typname], distribution: Single }
 - sql: |
     select * from pg_catalog.pg_namespace
   logical_plan: |
     LogicalProject { exprs: [pg_namespace.oid, pg_namespace.nspname, pg_namespace.nspowner] }
-      LogicalScan { table: pg_namespace, columns: [oid, nspname, nspowner] }
+      LogicalScan { table: pg_namespace, columns: [pg_namespace.oid, pg_namespace.nspname, pg_namespace.nspowner] }
   batch_plan: |
-    BatchScan { table: pg_namespace, columns: [oid, nspname, nspowner] }
+    BatchScan { table: pg_namespace, columns: [pg_namespace.oid, pg_namespace.nspname, pg_namespace.nspowner], distribution: Single }
 - sql: |
     select * from pg_catalog.pg_cast
   logical_plan: |
     LogicalProject { exprs: [pg_cast.oid, pg_cast.castsource, pg_cast.casttarget, pg_cast.castcontext] }
-      LogicalScan { table: pg_cast, columns: [oid, castsource, casttarget, castcontext] }
+      LogicalScan { table: pg_cast, columns: [pg_cast.oid, pg_cast.castsource, pg_cast.casttarget, pg_cast.castcontext] }
   batch_plan: |
-    BatchScan { table: pg_cast, columns: [oid, castsource, casttarget, castcontext] }
+    BatchScan { table: pg_cast, columns: [pg_cast.oid, pg_cast.castsource, pg_cast.casttarget, pg_cast.castcontext], distribution: Single }

--- a/src/frontend/test_runner/tests/testdata/pg_catalog.yaml
+++ b/src/frontend/test_runner/tests/testdata/pg_catalog.yaml
@@ -9,10 +9,10 @@
 - sql: |
     select * from pg_catalog.pg_namespace
   logical_plan: |
-    LogicalProject { exprs: [pg_namespace.oid, pg_namespace.nspname, pg_namespace.nspowner] }
-      LogicalScan { table: pg_namespace, columns: [pg_namespace.oid, pg_namespace.nspname, pg_namespace.nspowner] }
+    LogicalProject { exprs: [pg_namespace.oid, pg_namespace.nspname, pg_namespace.nspowner, pg_namespace.nspacl] }
+      LogicalScan { table: pg_namespace, columns: [pg_namespace.oid, pg_namespace.nspname, pg_namespace.nspowner, pg_namespace.nspacl] }
   batch_plan: |
-    BatchScan { table: pg_namespace, columns: [pg_namespace.oid, pg_namespace.nspname, pg_namespace.nspowner], distribution: Single }
+    BatchScan { table: pg_namespace, columns: [pg_namespace.oid, pg_namespace.nspname, pg_namespace.nspowner, pg_namespace.nspacl], distribution: Single }
 - sql: |
     select * from pg_catalog.pg_cast
   logical_plan: |

--- a/src/frontend/test_runner/tests/testdata/pk_derive.yaml
+++ b/src/frontend/test_runner/tests/testdata/pk_derive.yaml
@@ -21,15 +21,15 @@
         Tone.id = Ttwo.id;
   stream_plan: |
     StreamMaterialize { columns: [max_v1, max_v2, t1.id(hidden), t2.id(hidden)], pk_columns: [t1.id, t2.id] }
-      StreamHashJoin { type: Inner, predicate: t1.id = t2.id }
+      StreamHashJoin { type: Inner, predicate: t1.id = t2.id, output: [max(t1.v1), max(t2.v2), t1.id, t2.id] }
         StreamProject { exprs: [max(t1.v1), t1.id] }
           StreamHashAgg { group_key: [t1.id], aggs: [count, max(t1.v1)] }
             StreamExchange { dist: HashShard(t1.id) }
-              StreamTableScan { table: t1, columns: [id, v1, _row_id] }
+              StreamTableScan { table: t1, columns: [t1.id, t1.v1, t1._row_id], pk: [t1._row_id], distribution: HashShard(t1._row_id) }
         StreamProject { exprs: [max(t2.v2), t2.id] }
           StreamHashAgg { group_key: [t2.id], aggs: [count, max(t2.v2)] }
             StreamExchange { dist: HashShard(t2.id) }
-              StreamTableScan { table: t2, columns: [id, v2, _row_id] }
+              StreamTableScan { table: t2, columns: [t2.id, t2.v2, t2._row_id], pk: [t2._row_id], distribution: HashShard(t2._row_id) }
 - sql: |
     create table t (id int, v int);
     SELECT Tone.max_v, Ttwo.min_v
@@ -51,15 +51,15 @@
         Tone.id = Ttwo.id;
   stream_plan: |
     StreamMaterialize { columns: [max_v, min_v, t.id(hidden), t.id#1(hidden)], pk_columns: [t.id, t.id#1] }
-      StreamHashJoin { type: Inner, predicate: t.id = t.id }
+      StreamHashJoin { type: Inner, predicate: t.id = t.id, output: [max(t.v), min(t.v), t.id, t.id] }
         StreamProject { exprs: [max(t.v), t.id] }
           StreamHashAgg { group_key: [t.id], aggs: [count, max(t.v)] }
             StreamExchange { dist: HashShard(t.id) }
-              StreamTableScan { table: t, columns: [id, v, _row_id] }
+              StreamTableScan { table: t, columns: [t.id, t.v, t._row_id], pk: [t._row_id], distribution: HashShard(t._row_id) }
         StreamProject { exprs: [min(t.v), t.id] }
           StreamHashAgg { group_key: [t.id], aggs: [count, min(t.v)] }
             StreamExchange { dist: HashShard(t.id) }
-              StreamTableScan { table: t, columns: [id, v, _row_id] }
+              StreamTableScan { table: t, columns: [t.id, t.v, t._row_id], pk: [t._row_id], distribution: HashShard(t._row_id) }
 - sql: |
     create table t (v1 varchar, v2 varchar, v3 varchar);
     select
@@ -72,12 +72,12 @@
         v3;
   optimized_logical_plan: |
     LogicalAgg { group_key: [t.v1, t.v2, t.v3], aggs: [] }
-      LogicalScan { table: t, columns: [v1, v2, v3] }
+      LogicalScan { table: t, columns: [t.v1, t.v2, t.v3] }
   stream_plan: |
     StreamMaterialize { columns: [v1, v2, v3, count(hidden)], pk_columns: [v1, v2, v3] }
       StreamHashAgg { group_key: [t.v1, t.v2, t.v3], aggs: [count] }
         StreamExchange { dist: HashShard(t.v1, t.v2, t.v3) }
-          StreamTableScan { table: t, columns: [v1, v2, v3, _row_id] }
+          StreamTableScan { table: t, columns: [t.v1, t.v2, t.v3, t._row_id], pk: [t._row_id], distribution: HashShard(t._row_id) }
 - sql: |
     create table t (v1 varchar, v2 varchar, v3 varchar);
     create materialized view mv as
@@ -96,8 +96,8 @@
     where
         v3 = 'world' or v3 = 'hello';
   optimized_logical_plan: |
-    LogicalScan { table: mv, output_columns: [v1], required_columns: [v1, v3], predicate: ((mv.v3 = 'world':Varchar) OR (mv.v3 = 'hello':Varchar)) }
+    LogicalScan { table: mv, output_columns: [mv.v1], required_columns: [v1, v3], predicate: ((mv.v3 = 'world':Varchar) OR (mv.v3 = 'hello':Varchar)) }
   stream_plan: |
     StreamMaterialize { columns: [v1, mv.v2(hidden), mv.v3(hidden)], pk_columns: [v1, mv.v2, mv.v3] }
       StreamFilter { predicate: ((mv.v3 = 'world':Varchar) OR (mv.v3 = 'hello':Varchar)) }
-        StreamTableScan { table: mv, columns: [v1, v2, v3] }
+        StreamTableScan { table: mv, columns: [mv.v1, mv.v2, mv.v3], pk: [mv.v1, mv.v2, mv.v3], distribution: HashShard(mv.v1, mv.v2, mv.v3) }

--- a/src/frontend/test_runner/tests/testdata/predicate_pushdown.yaml
+++ b/src/frontend/test_runner/tests/testdata/predicate_pushdown.yaml
@@ -6,13 +6,13 @@
   logical_plan: |
     LogicalProject { exprs: [t1.v1, t1.v2, t1.v3, t2.v1, t2.v2, t2.v3] }
       LogicalFilter { predicate: (t2.v2 > 2:Int32) }
-        LogicalJoin { type: Inner, on: (t1.v1 = t2.v2) AND (t1.v1 > 1:Int32) }
-          LogicalScan { table: t1, columns: [_row_id, v1, v2, v3] }
-          LogicalScan { table: t2, columns: [_row_id, v1, v2, v3] }
+        LogicalJoin { type: Inner, on: (t1.v1 = t2.v2) AND (t1.v1 > 1:Int32), output: all }
+          LogicalScan { table: t1, columns: [t1._row_id, t1.v1, t1.v2, t1.v3] }
+          LogicalScan { table: t2, columns: [t2._row_id, t2.v1, t2.v2, t2.v3] }
   optimized_logical_plan: |
-    LogicalJoin { type: Inner, on: (t1.v1 = t2.v2) }
-      LogicalScan { table: t1, output_columns: [v1, v2, v3], required_columns: [v1, v2, v3], predicate: (t1.v1 > 1:Int32) }
-      LogicalScan { table: t2, output_columns: [v1, v2, v3], required_columns: [v1, v2, v3], predicate: (t2.v2 > 2:Int32) }
+    LogicalJoin { type: Inner, on: (t1.v1 = t2.v2), output: all }
+      LogicalScan { table: t1, output_columns: [t1.v1, t1.v2, t1.v3], required_columns: [v1, v2, v3], predicate: (t1.v1 > 1:Int32) }
+      LogicalScan { table: t2, output_columns: [t2.v1, t2.v2, t2.v3], required_columns: [v1, v2, v3], predicate: (t2.v2 > 2:Int32) }
 - sql: |
     create table t (v1 bigint, v2 double precision);
     select * from (select * from t) where v2 > 1;
@@ -20,9 +20,9 @@
     LogicalProject { exprs: [t.v1, t.v2] }
       LogicalFilter { predicate: (t.v2 > 1:Int32) }
         LogicalProject { exprs: [t.v1, t.v2] }
-          LogicalScan { table: t, columns: [_row_id, v1, v2] }
+          LogicalScan { table: t, columns: [t._row_id, t.v1, t.v2] }
   optimized_logical_plan: |
-    LogicalScan { table: t, output_columns: [v1, v2], required_columns: [v1, v2], predicate: (t.v2 > 1:Int32) }
+    LogicalScan { table: t, output_columns: [t.v1, t.v2], required_columns: [v1, v2], predicate: (t.v2 > 1:Int32) }
 - sql: |
     create table t (v1 bigint, v2 double precision);
     select v1 from (select v2, v1 from t) where v2 > 1;
@@ -30,9 +30,9 @@
     LogicalProject { exprs: [t.v1] }
       LogicalFilter { predicate: (t.v2 > 1:Int32) }
         LogicalProject { exprs: [t.v2, t.v1] }
-          LogicalScan { table: t, columns: [_row_id, v1, v2] }
+          LogicalScan { table: t, columns: [t._row_id, t.v1, t.v2] }
   optimized_logical_plan: |
-    LogicalScan { table: t, output_columns: [v1], required_columns: [v1, v2], predicate: (t.v2 > 1:Int32) }
+    LogicalScan { table: t, output_columns: [t.v1], required_columns: [v1, v2], predicate: (t.v2 > 1:Int32) }
 - sql: |
     create table t (v1 bigint, v2 double precision);
     select v1 from (select v2 as a2, v1 from t where v1 > 2) where a2 > 1;
@@ -41,9 +41,9 @@
       LogicalFilter { predicate: (t.v2 > 1:Int32) }
         LogicalProject { exprs: [t.v2, t.v1] }
           LogicalFilter { predicate: (t.v1 > 2:Int32) }
-            LogicalScan { table: t, columns: [_row_id, v1, v2] }
+            LogicalScan { table: t, columns: [t._row_id, t.v1, t.v2] }
   optimized_logical_plan: |
-    LogicalScan { table: t, output_columns: [v1], required_columns: [v1, v2], predicate: (t.v2 > 1:Int32) AND (t.v1 > 2:Int32) }
+    LogicalScan { table: t, output_columns: [t.v1], required_columns: [v1, v2], predicate: (t.v2 > 1:Int32) AND (t.v1 > 2:Int32) }
 - sql: |
     create table t(v1 int, v2 int, v3 int, v4 int);
     select * from (select v1, min(v2) as min from t group by v1) where v1 > 1 and min > 1 and 1 > 0 and v1 > min;
@@ -53,11 +53,11 @@
         LogicalProject { exprs: [t.v1, min(t.v2)] }
           LogicalAgg { group_key: [t.v1], aggs: [min(t.v2)] }
             LogicalProject { exprs: [t.v1, t.v2] }
-              LogicalScan { table: t, columns: [_row_id, v1, v2, v3, v4] }
+              LogicalScan { table: t, columns: [t._row_id, t.v1, t.v2, t.v3, t.v4] }
   optimized_logical_plan: |
     LogicalFilter { predicate: (min(t.v2) > 1:Int32) AND (t.v1 > min(t.v2)) }
       LogicalAgg { group_key: [t.v1], aggs: [min(t.v2)] }
-        LogicalScan { table: t, output_columns: [v1, v2], required_columns: [v1, v2], predicate: (t.v1 > 1:Int32) AND (1:Int32 > 0:Int32) }
+        LogicalScan { table: t, output_columns: [t.v1, t.v2], required_columns: [v1, v2], predicate: (t.v1 > 1:Int32) AND (1:Int32 > 0:Int32) }
 - sql: |
     /* Always false should not be pushed below SimpleAgg */
     create table t(v1 int, v2 int, v3 int, v4 int);
@@ -65,4 +65,4 @@
   optimized_logical_plan: |
     LogicalFilter { predicate: false:Boolean }
       LogicalAgg { aggs: [min(t.v1)] }
-        LogicalScan { table: t, columns: [v1] }
+        LogicalScan { table: t, columns: [t.v1] }

--- a/src/frontend/test_runner/tests/testdata/project_set.yaml
+++ b/src/frontend/test_runner/tests/testdata/project_set.yaml
@@ -24,11 +24,11 @@
     BatchProject { exprs: [Unnest($1)] }
       BatchExchange { order: [], dist: Single }
         BatchProjectSet { select_list: [Unnest($1)] }
-          BatchScan { table: t, columns: [_row_id, x] }
+          BatchScan { table: t, columns: [t._row_id, t.x], distribution: HashShard(t._row_id) }
   stream_plan: |
     StreamMaterialize { columns: [projected_row_id(hidden), unnest, t._row_id(hidden)], pk_columns: [t._row_id, projected_row_id] }
       StreamProjectSet { select_list: [Unnest($1), $0] }
-        StreamTableScan { table: t, columns: [_row_id, x] }
+        StreamTableScan { table: t, columns: [t._row_id, t.x], pk: [t._row_id], distribution: HashShard(t._row_id) }
 - sql: |
     /* table functions used with usual expressions */
     create table t(x int[]);
@@ -37,7 +37,7 @@
     BatchProject { exprs: [Unnest($1), 1:Int32] }
       BatchExchange { order: [], dist: Single }
         BatchProjectSet { select_list: [Unnest($1), 1:Int32] }
-          BatchScan { table: t, columns: [_row_id, x] }
+          BatchScan { table: t, columns: [t._row_id, t.x], distribution: HashShard(t._row_id) }
 - sql: |
     /* multiple table functions */
     create table t(x int[]);
@@ -46,7 +46,7 @@
     BatchProject { exprs: [Unnest($1), Unnest(Array(1:Int32, 2:Int32))] }
       BatchExchange { order: [], dist: Single }
         BatchProjectSet { select_list: [Unnest($1), Unnest(Array(1:Int32, 2:Int32))] }
-          BatchScan { table: t, columns: [_row_id, x] }
+          BatchScan { table: t, columns: [t._row_id, t.x], distribution: HashShard(t._row_id) }
 - sql: |
     /* table functions as parameters of usual functions */
     create table t(x int);
@@ -55,7 +55,7 @@
     BatchExchange { order: [], dist: Single }
       BatchProject { exprs: [Neg(Generate($1, $1, $1))] }
         BatchProjectSet { select_list: [$0, $1, Generate($1, $1, $1)] }
-          BatchScan { table: t, columns: [_row_id, x] }
+          BatchScan { table: t, columns: [t._row_id, t.x], distribution: HashShard(t._row_id) }
 - sql: |
     /* table functions as parameters of usual functions */
     create table t(x int[]);
@@ -65,12 +65,12 @@
       BatchExchange { order: [], dist: Single }
         BatchProjectSet { select_list: [($3 * $4), Unnest($2)] }
           BatchProjectSet { select_list: [$0, $1, Unnest($1), Unnest($1)] }
-            BatchScan { table: t, columns: [_row_id, x] }
+            BatchScan { table: t, columns: [t._row_id, t.x], distribution: HashShard(t._row_id) }
   stream_plan: |
     StreamMaterialize { columns: [projected_row_id(hidden), a, b, t._row_id(hidden), projected_row_id#1(hidden)], pk_columns: [t._row_id, projected_row_id#1, projected_row_id] }
       StreamProjectSet { select_list: [($3 * $4), Unnest($2), $1, $0] }
         StreamProjectSet { select_list: [$0, $1, Unnest($1), Unnest($1)] }
-          StreamTableScan { table: t, columns: [_row_id, x] }
+          StreamTableScan { table: t, columns: [t._row_id, t.x], pk: [t._row_id], distribution: HashShard(t._row_id) }
 - sql: |
     /* table functions as parameters of table functions */
     create table t(x int[]);
@@ -80,4 +80,4 @@
       BatchExchange { order: [], dist: Single }
         BatchProjectSet { select_list: [Generate($3, 100:Int32, 1:Int32)] }
           BatchProjectSet { select_list: [$0, $1, Unnest($1)] }
-            BatchScan { table: t, columns: [_row_id, x] }
+            BatchScan { table: t, columns: [t._row_id, t.x], distribution: HashShard(t._row_id) }

--- a/src/frontend/test_runner/tests/testdata/range_scan.yaml
+++ b/src/frontend/test_runner/tests/testdata/range_scan.yaml
@@ -13,21 +13,21 @@
     SELECT * FROM orders_count_by_user WHERE user_id = 42
   batch_plan: |
     BatchExchange { order: [], dist: Single }
-      BatchScan { table: orders_count_by_user, columns: [user_id, date, orders_count], scan_ranges: [user_id = Int64(42)] }
+      BatchScan { table: orders_count_by_user, columns: [orders_count_by_user.user_id, orders_count_by_user.date, orders_count_by_user.orders_count], scan_ranges: [orders_count_by_user.user_id = Int64(42)], distribution: HashShard(orders_count_by_user.user_id, orders_count_by_user.date) }
 - before:
   - create_table_and_mv
   sql: |
     SELECT * FROM orders_count_by_user WHERE user_id < 43
   batch_plan: |
     BatchExchange { order: [], dist: Single }
-      BatchScan { table: orders_count_by_user, columns: [user_id, date, orders_count], scan_ranges: [user_id < Int64(43)] }
+      BatchScan { table: orders_count_by_user, columns: [orders_count_by_user.user_id, orders_count_by_user.date, orders_count_by_user.orders_count], scan_ranges: [orders_count_by_user.user_id < Int64(43)], distribution: HashShard(orders_count_by_user.user_id, orders_count_by_user.date) }
 - before:
   - create_table_and_mv
   sql: |
     SELECT * FROM orders_count_by_user WHERE user_id = 42 + 1
   batch_plan: |
     BatchExchange { order: [], dist: Single }
-      BatchScan { table: orders_count_by_user, columns: [user_id, date, orders_count], scan_ranges: [user_id = Int64(43)] }
+      BatchScan { table: orders_count_by_user, columns: [orders_count_by_user.user_id, orders_count_by_user.date, orders_count_by_user.orders_count], scan_ranges: [orders_count_by_user.user_id = Int64(43)], distribution: HashShard(orders_count_by_user.user_id, orders_count_by_user.date) }
 - before:
   - create_table_and_mv
   sql: |
@@ -54,7 +54,7 @@
     SELECT * FROM orders_count_by_user WHERE user_id = '42'
   batch_plan: |
     BatchExchange { order: [], dist: Single }
-      BatchScan { table: orders_count_by_user, columns: [user_id, date, orders_count], scan_ranges: [user_id = Int64(42)] }
+      BatchScan { table: orders_count_by_user, columns: [orders_count_by_user.user_id, orders_count_by_user.date, orders_count_by_user.orders_count], scan_ranges: [orders_count_by_user.user_id = Int64(42)], distribution: HashShard(orders_count_by_user.user_id, orders_count_by_user.date) }
 - before:
   - create_table_and_mv
   sql: |
@@ -68,7 +68,7 @@
   batch_plan: |
     BatchExchange { order: [], dist: Single }
       BatchFilter { predicate: IsNull(orders_count_by_user.user_id) }
-        BatchScan { table: orders_count_by_user, columns: [user_id, date, orders_count] }
+        BatchScan { table: orders_count_by_user, columns: [orders_count_by_user.user_id, orders_count_by_user.date, orders_count_by_user.orders_count], distribution: HashShard(orders_count_by_user.user_id, orders_count_by_user.date) }
 - before:
   - create_table_and_mv
   sql: |
@@ -81,7 +81,7 @@
     SELECT * FROM orders_count_by_user WHERE user_id = 42 AND date = 1111
   batch_plan: |
     BatchExchange { order: [], dist: Single }
-      BatchScan { table: orders_count_by_user, columns: [user_id, date, orders_count], scan_ranges: [user_id = Int64(42), date = Int32(1111)] }
+      BatchScan { table: orders_count_by_user, columns: [orders_count_by_user.user_id, orders_count_by_user.date, orders_count_by_user.orders_count], scan_ranges: [orders_count_by_user.user_id = Int64(42), orders_count_by_user.date = Int32(1111)], distribution: HashShard(orders_count_by_user.user_id, orders_count_by_user.date) }
 - before:
   - create_table_and_mv
   sql: |
@@ -89,7 +89,7 @@
   batch_plan: |
     BatchExchange { order: [], dist: Single }
       BatchFilter { predicate: (2:Int32 > 1:Int32) AND (orders_count_by_user.date = 1111:Int32) }
-        BatchScan { table: orders_count_by_user, columns: [user_id, date, orders_count], scan_ranges: [user_id > Int64(42)] }
+        BatchScan { table: orders_count_by_user, columns: [orders_count_by_user.user_id, orders_count_by_user.date, orders_count_by_user.orders_count], scan_ranges: [orders_count_by_user.user_id > Int64(42)], distribution: HashShard(orders_count_by_user.user_id, orders_count_by_user.date) }
 - before:
   - create_table_and_mv
   sql: |
@@ -97,21 +97,21 @@
   batch_plan: |
     BatchExchange { order: [], dist: Single }
       BatchFilter { predicate: (5:Int32 < 6:Int32) }
-        BatchScan { table: orders_count_by_user, columns: [user_id, date, orders_count], scan_ranges: [user_id = Int64(42), date > Int32(1111) AND date <= Int32(6666)] }
+        BatchScan { table: orders_count_by_user, columns: [orders_count_by_user.user_id, orders_count_by_user.date, orders_count_by_user.orders_count], scan_ranges: [orders_count_by_user.user_id = Int64(42), orders_count_by_user.date > Int32(1111) AND orders_count_by_user.date <= Int32(6666)], distribution: HashShard(orders_count_by_user.user_id, orders_count_by_user.date) }
 - before:
   - create_table_and_mv
   sql: |
     SELECT * FROM orders_count_by_user WHERE user_id in (42, 43)
   batch_plan: |
     BatchExchange { order: [], dist: Single }
-      BatchScan { table: orders_count_by_user, columns: [user_id, date, orders_count], scan_ranges: [user_id = Int64(42) OR user_id = Int64(43)] }
+      BatchScan { table: orders_count_by_user, columns: [orders_count_by_user.user_id, orders_count_by_user.date, orders_count_by_user.orders_count], scan_ranges: [orders_count_by_user.user_id = Int64(42) OR orders_count_by_user.user_id = Int64(43)], distribution: HashShard(orders_count_by_user.user_id, orders_count_by_user.date) }
 - before:
   - create_table_and_mv
   sql: |
     SELECT * FROM orders_count_by_user WHERE user_id in (42+1, 44-1)
   batch_plan: |
     BatchExchange { order: [], dist: Single }
-      BatchScan { table: orders_count_by_user, columns: [user_id, date, orders_count], scan_ranges: [user_id = Int64(43)] }
+      BatchScan { table: orders_count_by_user, columns: [orders_count_by_user.user_id, orders_count_by_user.date, orders_count_by_user.orders_count], scan_ranges: [orders_count_by_user.user_id = Int64(43)], distribution: HashShard(orders_count_by_user.user_id, orders_count_by_user.date) }
 - before:
   - create_table_and_mv
   sql: |
@@ -120,14 +120,14 @@
   batch_plan: |
     BatchExchange { order: [], dist: Single }
       BatchFilter { predicate: In(orders_count_by_user.user_id::Decimal, 42.0:Decimal, 43.0:Decimal) }
-        BatchScan { table: orders_count_by_user, columns: [user_id, date, orders_count] }
+        BatchScan { table: orders_count_by_user, columns: [orders_count_by_user.user_id, orders_count_by_user.date, orders_count_by_user.orders_count], distribution: HashShard(orders_count_by_user.user_id, orders_count_by_user.date) }
 - before:
   - create_table_and_mv
   sql: |
     SELECT * FROM orders_count_by_user WHERE user_id in ('42', '43')
   batch_plan: |
     BatchExchange { order: [], dist: Single }
-      BatchScan { table: orders_count_by_user, columns: [user_id, date, orders_count], scan_ranges: [user_id = Int64(42) OR user_id = Int64(43)] }
+      BatchScan { table: orders_count_by_user, columns: [orders_count_by_user.user_id, orders_count_by_user.date, orders_count_by_user.orders_count], scan_ranges: [orders_count_by_user.user_id = Int64(42) OR orders_count_by_user.user_id = Int64(43)], distribution: HashShard(orders_count_by_user.user_id, orders_count_by_user.date) }
 - before:
   - create_table_and_mv
   sql: |
@@ -140,14 +140,14 @@
   batch_plan: |
     BatchExchange { order: [], dist: Single }
       BatchFilter { predicate: (orders_count_by_user.date = 6666:Int32) }
-        BatchScan { table: orders_count_by_user, columns: [user_id, date, orders_count], scan_ranges: [user_id = Int64(2147483648) OR user_id = Int64(2147483649)] }
+        BatchScan { table: orders_count_by_user, columns: [orders_count_by_user.user_id, orders_count_by_user.date, orders_count_by_user.orders_count], scan_ranges: [orders_count_by_user.user_id = Int64(2147483648) OR orders_count_by_user.user_id = Int64(2147483649)], distribution: HashShard(orders_count_by_user.user_id, orders_count_by_user.date) }
 - before:
   - create_table_and_mv
   sql: |
     SELECT * FROM orders_count_by_user WHERE user_id = 42 AND date in (2222, 3333)
   batch_plan: |
     BatchExchange { order: [], dist: Single }
-      BatchScan { table: orders_count_by_user, columns: [user_id, date, orders_count], scan_ranges: [user_id = Int64(42), date = Int32(2222) OR user_id = Int64(42), date = Int32(3333)] }
+      BatchScan { table: orders_count_by_user, columns: [orders_count_by_user.user_id, orders_count_by_user.date, orders_count_by_user.orders_count], scan_ranges: [orders_count_by_user.user_id = Int64(42), orders_count_by_user.date = Int32(2222) OR orders_count_by_user.user_id = Int64(42), orders_count_by_user.date = Int32(3333)], distribution: HashShard(orders_count_by_user.user_id, orders_count_by_user.date) }
 - before:
   - create_table_and_mv
   sql: |
@@ -155,7 +155,7 @@
     SELECT * FROM orders_count_by_user WHERE user_id = 42 AND date in (2222, 2222)
   batch_plan: |
     BatchExchange { order: [], dist: Single }
-      BatchScan { table: orders_count_by_user, columns: [user_id, date, orders_count], scan_ranges: [user_id = Int64(42), date = Int32(2222)] }
+      BatchScan { table: orders_count_by_user, columns: [orders_count_by_user.user_id, orders_count_by_user.date, orders_count_by_user.orders_count], scan_ranges: [orders_count_by_user.user_id = Int64(42), orders_count_by_user.date = Int32(2222)], distribution: HashShard(orders_count_by_user.user_id, orders_count_by_user.date) }
 - before:
   - create_table_and_mv
   sql: |
@@ -163,7 +163,7 @@
     SELECT * FROM orders_count_by_user WHERE user_id = 42 AND date in (2222, NULL)
   batch_plan: |
     BatchExchange { order: [], dist: Single }
-      BatchScan { table: orders_count_by_user, columns: [user_id, date, orders_count], scan_ranges: [user_id = Int64(42), date = Int32(2222)] }
+      BatchScan { table: orders_count_by_user, columns: [orders_count_by_user.user_id, orders_count_by_user.date, orders_count_by_user.orders_count], scan_ranges: [orders_count_by_user.user_id = Int64(42), orders_count_by_user.date = Int32(2222)], distribution: HashShard(orders_count_by_user.user_id, orders_count_by_user.date) }
 - before:
   - create_table_and_mv
   sql: |
@@ -178,7 +178,7 @@
     SELECT * FROM orders_count_by_user WHERE user_id = 42 AND date in (2222, 3333) AND date in (4444, 3333)
   batch_plan: |
     BatchExchange { order: [], dist: Single }
-      BatchScan { table: orders_count_by_user, columns: [user_id, date, orders_count], scan_ranges: [user_id = Int64(42), date = Int32(3333)] }
+      BatchScan { table: orders_count_by_user, columns: [orders_count_by_user.user_id, orders_count_by_user.date, orders_count_by_user.orders_count], scan_ranges: [orders_count_by_user.user_id = Int64(42), orders_count_by_user.date = Int32(3333)], distribution: HashShard(orders_count_by_user.user_id, orders_count_by_user.date) }
 - before:
   - create_table_and_mv
   sql: |
@@ -186,7 +186,7 @@
     SELECT * FROM orders_count_by_user WHERE user_id = 42 AND date in (2222, 3333) AND date = 3333
   batch_plan: |
     BatchExchange { order: [], dist: Single }
-      BatchScan { table: orders_count_by_user, columns: [user_id, date, orders_count], scan_ranges: [user_id = Int64(42), date = Int32(3333)] }
+      BatchScan { table: orders_count_by_user, columns: [orders_count_by_user.user_id, orders_count_by_user.date, orders_count_by_user.orders_count], scan_ranges: [orders_count_by_user.user_id = Int64(42), orders_count_by_user.date = Int32(3333)], distribution: HashShard(orders_count_by_user.user_id, orders_count_by_user.date) }
 - before:
   - create_table_and_mv
   sql: |
@@ -201,7 +201,7 @@
   batch_plan: |
     BatchExchange { order: [], dist: Single }
       BatchFilter { predicate: In(orders_count_by_user.date, 2222:Int32, 3333:Int32) }
-        BatchScan { table: orders_count_by_user, columns: [user_id, date, orders_count], scan_ranges: [user_id = Int64(2147483648) OR user_id = Int64(2147483649)] }
+        BatchScan { table: orders_count_by_user, columns: [orders_count_by_user.user_id, orders_count_by_user.date, orders_count_by_user.orders_count], scan_ranges: [orders_count_by_user.user_id = Int64(2147483648) OR orders_count_by_user.user_id = Int64(2147483649)], distribution: HashShard(orders_count_by_user.user_id, orders_count_by_user.date) }
 - id: create_table_and_mv_ordered
   sql: |
     CREATE TABLE orders (
@@ -219,21 +219,21 @@
   batch_plan: |
     BatchExchange { order: [], dist: Single }
       BatchFilter { predicate: (orders_count_by_user_ordered.user_id = 42:Int32) }
-        BatchScan { table: orders_count_by_user_ordered, columns: [user_id, date, orders_count] }
+        BatchScan { table: orders_count_by_user_ordered, columns: [orders_count_by_user_ordered.user_id, orders_count_by_user_ordered.date, orders_count_by_user_ordered.orders_count], distribution: HashShard(orders_count_by_user_ordered.user_id, orders_count_by_user_ordered.date) }
 - before:
   - create_table_and_mv_ordered
   sql: |
     SELECT * FROM orders_count_by_user_ordered WHERE user_id > 42 AND orders_count = 10
   batch_plan: |
     BatchExchange { order: [], dist: Single }
-      BatchScan { table: orders_count_by_user_ordered, columns: [user_id, date, orders_count], scan_ranges: [orders_count = Int64(10), user_id > Int32(42)] }
+      BatchScan { table: orders_count_by_user_ordered, columns: [orders_count_by_user_ordered.user_id, orders_count_by_user_ordered.date, orders_count_by_user_ordered.orders_count], scan_ranges: [orders_count_by_user_ordered.orders_count = Int64(10), orders_count_by_user_ordered.user_id > Int32(42)], distribution: HashShard(orders_count_by_user_ordered.user_id, orders_count_by_user_ordered.date) }
 - before:
   - create_table_and_mv_ordered
   sql: |
     SELECT * FROM orders_count_by_user_ordered WHERE orders_count = 10
   batch_plan: |
     BatchExchange { order: [], dist: Single }
-      BatchScan { table: orders_count_by_user_ordered, columns: [user_id, date, orders_count], scan_ranges: [orders_count = Int64(10)] }
+      BatchScan { table: orders_count_by_user_ordered, columns: [orders_count_by_user_ordered.user_id, orders_count_by_user_ordered.date, orders_count_by_user_ordered.orders_count], scan_ranges: [orders_count_by_user_ordered.orders_count = Int64(10)], distribution: HashShard(orders_count_by_user_ordered.user_id, orders_count_by_user_ordered.date) }
 - id: create_small
   sql: |
     CREATE TABLE t(x smallint);
@@ -247,7 +247,7 @@
   batch_plan: |
     BatchExchange { order: [], dist: Single }
       BatchFilter { predicate: (mv.x = 60000:Int32) }
-        BatchScan { table: mv, columns: [x] }
+        BatchScan { table: mv, columns: [mv.x], distribution: HashShard(mv.x) }
 - before:
   - create_small
   sql: |
@@ -256,4 +256,4 @@
   batch_plan: |
     BatchExchange { order: [], dist: Single }
       BatchFilter { predicate: (mv.x < 60000:Int32) }
-        BatchScan { table: mv, columns: [x] }
+        BatchScan { table: mv, columns: [mv.x], distribution: HashShard(mv.x) }

--- a/src/frontend/test_runner/tests/testdata/struct_query.yaml
+++ b/src/frontend/test_runner/tests/testdata/struct_query.yaml
@@ -4,10 +4,10 @@
     select * from t;
   batch_plan: |
     BatchExchange { order: [], dist: Single }
-      BatchScan { table: t, columns: [country] }
+      BatchScan { table: t, columns: [t.country], distribution: SomeShard }
   stream_plan: |
     StreamMaterialize { columns: [country, t._row_id(hidden)], pk_columns: [t._row_id] }
-      StreamTableScan { table: t, columns: [country, _row_id] }
+      StreamTableScan { table: t, columns: [t.country, t._row_id], pk: [t._row_id], distribution: HashShard(t._row_id) }
   create_source:
     row_format: protobuf
     name: s
@@ -34,7 +34,7 @@
     select (t).country.city,(t).country,(country).city.address from t;
   logical_plan: |
     LogicalProject { exprs: [Field(t.country, 1:Int32), t.country, Field(Field(t.country, 1:Int32), 0:Int32)] }
-      LogicalScan { table: t, columns: [id, country, zipcode, rate, _row_id] }
+      LogicalScan { table: t, columns: [t.id, t.country, t.zipcode, t.rate, t._row_id] }
   create_source:
     row_format: protobuf
     name: s
@@ -61,7 +61,7 @@
     select (t).country1.city.*,(t.country2).*,(country3).city.* from t;
   logical_plan: |
     LogicalProject { exprs: [Field(Field(t.country1, 1:Int32), 0:Int32), Field(Field(t.country1, 1:Int32), 1:Int32), Field(t.country2, 0:Int32), Field(t.country2, 1:Int32), Field(t.country2, 2:Int32), Field(Field(t.country3, 1:Int32), 0:Int32), Field(Field(t.country3, 1:Int32), 1:Int32)] }
-      LogicalScan { table: t, columns: [id, country1, country2, country3, zipcode, rate, _row_id] }
+      LogicalScan { table: t, columns: [t.id, t.country1, t.country2, t.country3, t.zipcode, t.rate, t._row_id] }
   create_source:
     row_format: protobuf
     name: s
@@ -91,7 +91,7 @@
   logical_plan: |
     LogicalProject { exprs: [Field(Field(t.country, 1:Int32), 1:Int32)] }
       LogicalProject { exprs: [Field(t.country, 1:Int32)] }
-        LogicalScan { table: t, columns: [id, country, zipcode, rate, _row_id] }
+        LogicalScan { table: t, columns: [t.id, t.country, t.zipcode, t.rate, t._row_id] }
   create_source:
     row_format: protobuf
     name: s
@@ -121,7 +121,7 @@
       LogicalProject { exprs: [min(Field(t.country, 1:Int32))] }
         LogicalAgg { aggs: [min(Field(t.country, 1:Int32))] }
           LogicalProject { exprs: [Field(t.country, 1:Int32)] }
-            LogicalScan { table: t, columns: [id, country, zipcode, rate, _row_id] }
+            LogicalScan { table: t, columns: [t.id, t.country, t.zipcode, t.rate, t._row_id] }
   create_source:
     row_format: protobuf
     name: s
@@ -148,10 +148,10 @@
     select * from (select (country).city as c from t) as vv join t on (c).zipcode=(t.country).zipcode;
   logical_plan: |
     LogicalProject { exprs: [Field(t.country, 1:Int32), t.id, t.country, t.zipcode, t.rate] }
-      LogicalJoin { type: Inner, on: (Field(Field(t.country, 1:Int32), 1:Int32) = Field(t.country, 2:Int32)) }
+      LogicalJoin { type: Inner, on: (Field(Field(t.country, 1:Int32), 1:Int32) = Field(t.country, 2:Int32)), output: all }
         LogicalProject { exprs: [Field(t.country, 1:Int32)] }
-          LogicalScan { table: t, columns: [id, country, zipcode, rate, _row_id] }
-        LogicalScan { table: t, columns: [id, country, zipcode, rate, _row_id] }
+          LogicalScan { table: t, columns: [t.id, t.country, t.zipcode, t.rate, t._row_id] }
+        LogicalScan { table: t, columns: [t.id, t.country, t.zipcode, t.rate, t._row_id] }
   create_source:
     row_format: protobuf
     name: s
@@ -180,7 +180,7 @@
     LogicalProject { exprs: [(min(Field(Field(t.country, 1:Int32), 0:Int32)) + (max(Field(Field(t.country, 1:Int32), 0:Int32)) * count(t.zipcode)))] }
       LogicalAgg { aggs: [min(Field(Field(t.country, 1:Int32), 0:Int32)), max(Field(Field(t.country, 1:Int32), 0:Int32)), count(t.zipcode)] }
         LogicalProject { exprs: [Field(Field(t.country, 1:Int32), 0:Int32), t.zipcode] }
-          LogicalScan { table: t, columns: [id, country, zipcode, rate, _row_id] }
+          LogicalScan { table: t, columns: [t.id, t.country, t.zipcode, t.rate, t._row_id] }
   create_source:
     row_format: protobuf
     name: s
@@ -210,7 +210,7 @@
       LogicalAgg { aggs: [count(1:Int32), count(Field(Field(t.country, 1:Int32), 1:Int32))] }
         LogicalProject { exprs: [1:Int32, Field(Field(t.country, 1:Int32), 1:Int32)] }
           LogicalFilter { predicate: (Field(Field(t.country, 1:Int32), 0:Int32) > 1:Int32) }
-            LogicalScan { table: t, columns: [id, country, zipcode, rate, _row_id] }
+            LogicalScan { table: t, columns: [t.id, t.country, t.zipcode, t.rate, t._row_id] }
   create_source:
     row_format: protobuf
     name: s
@@ -350,7 +350,7 @@
   logical_plan: |
     LogicalProject { exprs: [s.v1, s.v2, s.v3] }
       LogicalFilter { predicate: (s.v3 = Row(1:Int32, 2:Int32, Row(1:Int32, 2:Int32, 3:Int32))) }
-        LogicalScan { table: s, columns: [_row_id, v1, v2, v3] }
+        LogicalScan { table: s, columns: [s._row_id, s.v1, s.v2, s.v3] }
   create_source:
     row_format: protobuf
     name: s

--- a/src/frontend/test_runner/tests/testdata/subquery.yaml
+++ b/src/frontend/test_runner/tests/testdata/subquery.yaml
@@ -6,7 +6,7 @@
     LogicalProject { exprs: [t.v1] }
       LogicalFilter { predicate: (t.v2 > 1:Int32) }
         LogicalProject { exprs: [t.v1, t.v2] }
-          LogicalScan { table: t, columns: [_row_id, v1, v2] }
+          LogicalScan { table: t, columns: [t._row_id, t.v1, t.v2] }
 - sql: |
     /* merge and then eliminate */
     create table t (v1 bigint, v2 double precision);
@@ -14,9 +14,9 @@
   logical_plan: |
     LogicalProject { exprs: [t.v1, t.v2] }
       LogicalProject { exprs: [t.v1, t.v2] }
-        LogicalScan { table: t, columns: [_row_id, v1, v2] }
+        LogicalScan { table: t, columns: [t._row_id, t.v1, t.v2] }
   optimized_logical_plan: |
-    LogicalScan { table: t, columns: [v1, v2] }
+    LogicalScan { table: t, columns: [t.v1, t.v2] }
 - sql: |
     create table t (v1 bigint, v2 double precision);
     select v1 from (select v2, v1 as v3 from t) where v2 > 1;
@@ -28,7 +28,7 @@
     LogicalProject { exprs: [t.v1] }
       LogicalFilter { predicate: (t.v2 > 1:Int32) }
         LogicalProject { exprs: [t.v2, t.v1] }
-          LogicalScan { table: t, columns: [_row_id, v1, v2] }
+          LogicalScan { table: t, columns: [t._row_id, t.v1, t.v2] }
 - sql: |
     /* consecutive projects are merged */
     create table t (v1 bigint, v2 double precision);
@@ -36,49 +36,49 @@
   logical_plan: |
     LogicalProject { exprs: [t.v1, 2:Int32] }
       LogicalProject { exprs: [t.v1, t.v2, 1:Int32] }
-        LogicalScan { table: t, columns: [_row_id, v1, v2] }
+        LogicalScan { table: t, columns: [t._row_id, t.v1, t.v2] }
   optimized_logical_plan: |
     LogicalProject { exprs: [t.v1, 2:Int32] }
-      LogicalScan { table: t, columns: [v1] }
+      LogicalScan { table: t, columns: [t.v1] }
 - sql: |
     create table t (v1 bigint, v2 double precision);
     select * from (select * from t);
   logical_plan: |
     LogicalProject { exprs: [t.v1, t.v2] }
       LogicalProject { exprs: [t.v1, t.v2] }
-        LogicalScan { table: t, columns: [_row_id, v1, v2] }
+        LogicalScan { table: t, columns: [t._row_id, t.v1, t.v2] }
   optimized_logical_plan: |
-    LogicalScan { table: t, columns: [v1, v2] }
+    LogicalScan { table: t, columns: [t.v1, t.v2] }
 - sql: |
     /* joins */
     create table t (v1 bigint, v2 double precision);
     select * from (select * from t), t;
   logical_plan: |
     LogicalProject { exprs: [t.v1, t.v2, t.v1, t.v2] }
-      LogicalJoin { type: Inner, on: true }
+      LogicalJoin { type: Inner, on: true, output: all }
         LogicalProject { exprs: [t.v1, t.v2] }
-          LogicalScan { table: t, columns: [_row_id, v1, v2] }
-        LogicalScan { table: t, columns: [_row_id, v1, v2] }
+          LogicalScan { table: t, columns: [t._row_id, t.v1, t.v2] }
+        LogicalScan { table: t, columns: [t._row_id, t.v1, t.v2] }
 - sql: |
     /* table alias */
     create table t (v1 bigint, v2 double precision);
     select * from (select * from t) as tt join t on tt.v1=t.v1;
   logical_plan: |
     LogicalProject { exprs: [t.v1, t.v2, t.v1, t.v2] }
-      LogicalJoin { type: Inner, on: (t.v1 = t.v1) }
+      LogicalJoin { type: Inner, on: (t.v1 = t.v1), output: all }
         LogicalProject { exprs: [t.v1, t.v2] }
-          LogicalScan { table: t, columns: [_row_id, v1, v2] }
-        LogicalScan { table: t, columns: [_row_id, v1, v2] }
+          LogicalScan { table: t, columns: [t._row_id, t.v1, t.v2] }
+        LogicalScan { table: t, columns: [t._row_id, t.v1, t.v2] }
 - sql: |
     /* alias less columns than available */
     create table t (v1 bigint, v2 double precision);
     select * from (select * from t) as tt(a) join t on a=v1;
   logical_plan: |
     LogicalProject { exprs: [t.v1, t.v2, t.v1, t.v2] }
-      LogicalJoin { type: Inner, on: (t.v1 = t.v1) }
+      LogicalJoin { type: Inner, on: (t.v1 = t.v1), output: all }
         LogicalProject { exprs: [t.v1, t.v2] }
-          LogicalScan { table: t, columns: [_row_id, v1, v2] }
-        LogicalScan { table: t, columns: [_row_id, v1, v2] }
+          LogicalScan { table: t, columns: [t._row_id, t.v1, t.v2] }
+        LogicalScan { table: t, columns: [t._row_id, t.v1, t.v2] }
 - sql: |
     /* alias more columns than available */
     create table t (v1 bigint, v2 double precision);
@@ -109,14 +109,14 @@
     );
   logical_plan: |
     LogicalProject { exprs: [ab.a, ab.b] }
-      LogicalJoin { type: LeftSemi, on: true }
-        LogicalScan { table: ab, columns: [_row_id, a, b] }
+      LogicalJoin { type: LeftSemi, on: true, output: all }
+        LogicalScan { table: ab, columns: [ab._row_id, ab.a, ab.b] }
         LogicalProject { exprs: [bc.b, bc.c, t.v1, t.v2] }
-          LogicalJoin { type: Inner, on: true }
-            LogicalScan { table: bc, columns: [_row_id, b, c] }
+          LogicalJoin { type: Inner, on: true, output: all }
+            LogicalScan { table: bc, columns: [bc._row_id, bc.b, bc.c] }
             LogicalProject { exprs: [t.v1, t.v2] }
               LogicalFilter { predicate: (t.v1 = CorrelatedInputRef { index: 1, correlated_id: 0 }) }
-                LogicalScan { table: t, columns: [_row_id, v1, v2] }
+                LogicalScan { table: t, columns: [t._row_id, t.v1, t.v2] }
 - sql: |
     /* We cannot reference columns in left table if not lateral */
     create table ab (a int, b int);

--- a/src/frontend/test_runner/tests/testdata/subquery_expr.yaml
+++ b/src/frontend/test_runner/tests/testdata/subquery_expr.yaml
@@ -3,7 +3,7 @@
     select (select 1);
   logical_plan: |
     LogicalProject { exprs: [1:Int32] }
-      LogicalJoin { type: LeftOuter, on: true }
+      LogicalJoin { type: LeftOuter, on: true, output: all }
         LogicalValues { rows: [[]], schema: Schema { fields: [] } }
         LogicalProject { exprs: [1:Int32] }
           LogicalValues { rows: [[]], schema: Schema { fields: [] } }
@@ -12,29 +12,29 @@
     select (select x from t), 1 from t;
   logical_plan: |
     LogicalProject { exprs: [t.x, 1:Int32] }
-      LogicalJoin { type: LeftOuter, on: true }
-        LogicalScan { table: t, columns: [_row_id, x] }
+      LogicalJoin { type: LeftOuter, on: true, output: all }
+        LogicalScan { table: t, columns: [t._row_id, t.x] }
         LogicalProject { exprs: [t.x] }
-          LogicalScan { table: t, columns: [_row_id, x] }
+          LogicalScan { table: t, columns: [t._row_id, t.x] }
 - sql: |
     create table t(x int);
     select (select x from t) + 1 from t;
   logical_plan: |
     LogicalProject { exprs: [(t.x + 1:Int32)] }
-      LogicalJoin { type: LeftOuter, on: true }
-        LogicalScan { table: t, columns: [_row_id, x] }
+      LogicalJoin { type: LeftOuter, on: true, output: all }
+        LogicalScan { table: t, columns: [t._row_id, t.x] }
         LogicalProject { exprs: [t.x] }
-          LogicalScan { table: t, columns: [_row_id, x] }
+          LogicalScan { table: t, columns: [t._row_id, t.x] }
 - sql: |
     create table t(x int);
     select (select x from t), (select 1);
   logical_plan: |
     LogicalProject { exprs: [t.x, 1:Int32] }
-      LogicalJoin { type: LeftOuter, on: true }
-        LogicalJoin { type: LeftOuter, on: true }
+      LogicalJoin { type: LeftOuter, on: true, output: all }
+        LogicalJoin { type: LeftOuter, on: true, output: all }
           LogicalValues { rows: [[]], schema: Schema { fields: [] } }
           LogicalProject { exprs: [t.x] }
-            LogicalScan { table: t, columns: [_row_id, x] }
+            LogicalScan { table: t, columns: [t._row_id, t.x] }
         LogicalProject { exprs: [1:Int32] }
           LogicalValues { rows: [[]], schema: Schema { fields: [] } }
 - sql: |
@@ -42,13 +42,13 @@
     select x + (select x + (select x as v1 from t) as v2 from t) as v3 from t;
   logical_plan: |
     LogicalProject { exprs: [(t.x + (t.x + t.x))] }
-      LogicalJoin { type: LeftOuter, on: true }
-        LogicalScan { table: t, columns: [_row_id, x] }
+      LogicalJoin { type: LeftOuter, on: true, output: all }
+        LogicalScan { table: t, columns: [t._row_id, t.x] }
         LogicalProject { exprs: [(t.x + t.x)] }
-          LogicalJoin { type: LeftOuter, on: true }
-            LogicalScan { table: t, columns: [_row_id, x] }
+          LogicalJoin { type: LeftOuter, on: true, output: all }
+            LogicalScan { table: t, columns: [t._row_id, t.x] }
             LogicalProject { exprs: [t.x] }
-              LogicalScan { table: t, columns: [_row_id, x] }
+              LogicalScan { table: t, columns: [t._row_id, t.x] }
 - sql: |
     select (select 1, 2);
   binder_error: 'Bind error: Subquery must return only one column'
@@ -57,13 +57,13 @@
     select 1 where exists (select * from t);
   logical_plan: |
     LogicalProject { exprs: [1:Int32] }
-      LogicalJoin { type: LeftSemi, on: true }
+      LogicalJoin { type: LeftSemi, on: true, output: all }
         LogicalValues { rows: [[]], schema: Schema { fields: [] } }
         LogicalProject { exprs: [t.x] }
-          LogicalScan { table: t, columns: [_row_id, x] }
+          LogicalScan { table: t, columns: [t._row_id, t.x] }
   optimized_logical_plan: |
     LogicalProject { exprs: [1:Int32] }
-      LogicalJoin { type: LeftSemi, on: true }
+      LogicalJoin { type: LeftSemi, on: true, output: all }
         LogicalValues { rows: [[]], schema: Schema { fields: [] } }
         LogicalScan { table: t, columns: [] }
 - sql: |
@@ -71,13 +71,13 @@
     select 1 where not exists (select * from t);
   logical_plan: |
     LogicalProject { exprs: [1:Int32] }
-      LogicalJoin { type: LeftAnti, on: true }
+      LogicalJoin { type: LeftAnti, on: true, output: all }
         LogicalValues { rows: [[]], schema: Schema { fields: [] } }
         LogicalProject { exprs: [t.x] }
-          LogicalScan { table: t, columns: [_row_id, x] }
+          LogicalScan { table: t, columns: [t._row_id, t.x] }
   optimized_logical_plan: |
     LogicalProject { exprs: [1:Int32] }
-      LogicalJoin { type: LeftAnti, on: true }
+      LogicalJoin { type: LeftAnti, on: true, output: all }
         LogicalValues { rows: [[]], schema: Schema { fields: [] } }
         LogicalScan { table: t, columns: [] }
 - sql: |
@@ -86,19 +86,19 @@
     select x from t1 where exists (select x from t2);
   logical_plan: |
     LogicalProject { exprs: [t1.x] }
-      LogicalJoin { type: LeftSemi, on: true }
-        LogicalScan { table: t1, columns: [_row_id, x] }
+      LogicalJoin { type: LeftSemi, on: true, output: all }
+        LogicalScan { table: t1, columns: [t1._row_id, t1.x] }
         LogicalProject { exprs: [t2.x] }
-          LogicalScan { table: t2, columns: [_row_id, x] }
+          LogicalScan { table: t2, columns: [t2._row_id, t2.x] }
 - sql: |
     create table t(x int);
     select x from t where exists (select * from t);
   logical_plan: |
     LogicalProject { exprs: [t.x] }
-      LogicalJoin { type: LeftSemi, on: true }
-        LogicalScan { table: t, columns: [_row_id, x] }
+      LogicalJoin { type: LeftSemi, on: true, output: all }
+        LogicalScan { table: t, columns: [t._row_id, t.x] }
         LogicalProject { exprs: [t.x] }
-          LogicalScan { table: t, columns: [_row_id, x] }
+          LogicalScan { table: t, columns: [t._row_id, t.x] }
 - sql: |
     create table t1(x int);
     create table t2(x int);
@@ -106,16 +106,16 @@
   logical_plan: |
     LogicalProject { exprs: [t1.x] }
       LogicalFilter { predicate: (t1.x > t2.x) }
-        LogicalJoin { type: LeftOuter, on: true }
-          LogicalScan { table: t1, columns: [_row_id, x] }
+        LogicalJoin { type: LeftOuter, on: true, output: all }
+          LogicalScan { table: t1, columns: [t1._row_id, t1.x] }
           LogicalProject { exprs: [t2.x] }
-            LogicalScan { table: t2, columns: [_row_id, x] }
+            LogicalScan { table: t2, columns: [t2._row_id, t2.x] }
 - sql: |
     select 1 where 1>0 and exists (values (1))
   logical_plan: |
     LogicalProject { exprs: [1:Int32] }
       LogicalFilter { predicate: (1:Int32 > 0:Int32) }
-        LogicalJoin { type: LeftSemi, on: true }
+        LogicalJoin { type: LeftSemi, on: true, output: all }
           LogicalValues { rows: [[]], schema: Schema { fields: [] } }
           LogicalValues { rows: [[1:Int32]], schema: Schema { fields: [:Int32] } }
 - sql: |
@@ -123,8 +123,8 @@
   logical_plan: |
     LogicalProject { exprs: [1:Int32] }
       LogicalFilter { predicate: ((1:Int32 > 0:Int32) OR (count >= 1:Int32)) }
-        LogicalJoin { type: LeftOuter, on: true }
-          LogicalJoin { type: LeftAnti, on: true }
+        LogicalJoin { type: LeftOuter, on: true, output: all }
+          LogicalJoin { type: LeftAnti, on: true, output: all }
             LogicalValues { rows: [[]], schema: Schema { fields: [] } }
             LogicalValues { rows: [[1:Int32]], schema: Schema { fields: [:Int32] } }
           LogicalProject { exprs: [(count >= 1:Int32)] }
@@ -139,17 +139,17 @@
     select x from t1 where y in (select y from t2);
   logical_plan: |
     LogicalProject { exprs: [t1.x] }
-      LogicalJoin { type: LeftSemi, on: (t1.y = t2.y) }
-        LogicalScan { table: t1, columns: [_row_id, x, y] }
+      LogicalJoin { type: LeftSemi, on: (t1.y = t2.y), output: all }
+        LogicalScan { table: t1, columns: [t1._row_id, t1.x, t1.y] }
         LogicalProject { exprs: [t2.y] }
-          LogicalScan { table: t2, columns: [_row_id, x, y] }
+          LogicalScan { table: t2, columns: [t2._row_id, t2.x, t2.y] }
 - sql: |
     create table t1(x int, y int);
     create table t2(x int, y int);
     select x from t1 where y not in (select y from t2);
   logical_plan: |
     LogicalProject { exprs: [t1.x] }
-      LogicalJoin { type: LeftAnti, on: (t1.y = t2.y) }
-        LogicalScan { table: t1, columns: [_row_id, x, y] }
+      LogicalJoin { type: LeftAnti, on: (t1.y = t2.y), output: all }
+        LogicalScan { table: t1, columns: [t1._row_id, t1.x, t1.y] }
         LogicalProject { exprs: [t2.y] }
-          LogicalScan { table: t2, columns: [_row_id, x, y] }
+          LogicalScan { table: t2, columns: [t2._row_id, t2.x, t2.y] }

--- a/src/frontend/test_runner/tests/testdata/subquery_expr_correlated.yaml
+++ b/src/frontend/test_runner/tests/testdata/subquery_expr_correlated.yaml
@@ -7,19 +7,19 @@
     LogicalProject { exprs: [t1.x, t1.y] }
       LogicalFilter { predicate: (t1.x > (1.5:Decimal * min(t2.x))) }
         LogicalApply { type: LeftOuter, on: true, correlated_id: 1 }
-          LogicalScan { table: t1, columns: [_row_id, x, y] }
+          LogicalScan { table: t1, columns: [t1._row_id, t1.x, t1.y] }
           LogicalProject { exprs: [(1.5:Decimal * min(t2.x))] }
             LogicalAgg { aggs: [min(t2.x)] }
               LogicalProject { exprs: [t2.x] }
                 LogicalFilter { predicate: (CorrelatedInputRef { index: 2, correlated_id: 1 } = t2.y) AND (t2.y = 1000:Int32) }
-                  LogicalScan { table: t2, columns: [_row_id, x, y] }
+                  LogicalScan { table: t2, columns: [t2._row_id, t2.x, t2.y] }
   optimized_logical_plan: |
-    LogicalJoin { type: Inner, on: (t1.y = t2.y) AND (t1.x > (1.5:Decimal * min(t2.x))) }
-      LogicalScan { table: t1, columns: [x, y] }
+    LogicalJoin { type: Inner, on: (t1.y = t2.y) AND (t1.x > (1.5:Decimal * min(t2.x))), output: [t1.x, t1.y] }
+      LogicalScan { table: t1, columns: [t1.x, t1.y] }
       LogicalProject { exprs: [t2.y, (1.5:Decimal * min(t2.x))] }
         LogicalAgg { group_key: [t2.y], aggs: [min(t2.x)] }
           LogicalProject { exprs: [t2.y, t2.x] }
-            LogicalScan { table: t2, output_columns: [x, y], required_columns: [x, y], predicate: (t2.y = 1000:Int32) }
+            LogicalScan { table: t2, output_columns: [t2.x, t2.y], required_columns: [x, y], predicate: (t2.y = 1000:Int32) }
 - sql: |
     create table t1(x int, y int);
     create table t2(x int, y int);
@@ -28,13 +28,13 @@
     LogicalProject { exprs: [t1.x, t1.y] }
       LogicalFilter { predicate: (t1.x > min(t2.x)) }
         LogicalApply { type: LeftOuter, on: true, correlated_id: 1 }
-          LogicalScan { table: t1, columns: [_row_id, x, y] }
+          LogicalScan { table: t1, columns: [t1._row_id, t1.x, t1.y] }
           LogicalProject { exprs: [min(t2.x)] }
             LogicalAgg { aggs: [min(t2.x)] }
               LogicalProject { exprs: [t2.x] }
                 LogicalFilter { predicate: (t2.y = CorrelatedInputRef { index: 2, correlated_id: 1 }) }
-                  LogicalJoin { type: LeftOuter, on: true }
-                    LogicalScan { table: t2, columns: [_row_id, x, y] }
+                  LogicalJoin { type: LeftOuter, on: true, output: all }
+                    LogicalScan { table: t2, columns: [t2._row_id, t2.x, t2.y] }
                     LogicalProject { exprs: [CorrelatedInputRef { index: 2, correlated_id: 1 }] }
                       LogicalValues { rows: [[]], schema: Schema { fields: [] } }
 - sql: |
@@ -46,19 +46,19 @@
     LogicalProject { exprs: [t1.x, t1.y] }
       LogicalFilter { predicate: (t1.x > min(t2.x)) }
         LogicalApply { type: LeftOuter, on: true, correlated_id: 1 }
-          LogicalScan { table: t1, columns: [_row_id, x, y] }
+          LogicalScan { table: t1, columns: [t1._row_id, t1.x, t1.y] }
           LogicalProject { exprs: [min(t2.x)] }
             LogicalAgg { aggs: [min(t2.x)] }
               LogicalProject { exprs: [t2.x] }
                 LogicalFilter { predicate: (CorrelatedInputRef { index: 2, correlated_id: 1 } = t2.y) AND (CorrelatedInputRef { index: 1, correlated_id: 1 } = max(t3.x)) }
-                  LogicalJoin { type: LeftOuter, on: true }
-                    LogicalScan { table: t2, columns: [_row_id, x, y] }
+                  LogicalJoin { type: LeftOuter, on: true, output: all }
+                    LogicalScan { table: t2, columns: [t2._row_id, t2.x, t2.y] }
                     LogicalProject { exprs: [max(t3.x)] }
                       LogicalAgg { aggs: [max(t3.x)] }
                         LogicalProject { exprs: [t3.x] }
                           LogicalFilter { predicate: (t3.y = CorrelatedInputRef { index: 2, correlated_id: 1 }) }
-                            LogicalJoin { type: Inner, on: true }
-                              LogicalScan { table: t3, columns: [_row_id, x, y] }
+                            LogicalJoin { type: Inner, on: true, output: all }
+                              LogicalScan { table: t3, columns: [t3._row_id, t3.x, t3.y] }
                               LogicalProject { exprs: [1:Int32] }
                                 LogicalValues { rows: [[]], schema: Schema { fields: [] } }
 - sql: |
@@ -68,14 +68,14 @@
   logical_plan: |
     LogicalProject { exprs: [t1.x, t1.y] }
       LogicalApply { type: LeftSemi, on: true, correlated_id: 1 }
-        LogicalScan { table: t1, columns: [_row_id, x, y] }
+        LogicalScan { table: t1, columns: [t1._row_id, t1.x, t1.y] }
         LogicalProject { exprs: [t2.x, t2.y] }
           LogicalFilter { predicate: (t2.y = 100:Int32) AND (CorrelatedInputRef { index: 1, correlated_id: 1 } = t2.x) AND (t2.x = 1000:Int32) AND (CorrelatedInputRef { index: 2, correlated_id: 1 } = t2.y) }
-            LogicalScan { table: t2, columns: [_row_id, x, y] }
+            LogicalScan { table: t2, columns: [t2._row_id, t2.x, t2.y] }
   optimized_logical_plan: |
-    LogicalJoin { type: LeftSemi, on: (t1.x = t2.x) AND (t1.y = t2.y) }
-      LogicalScan { table: t1, columns: [x, y] }
-      LogicalScan { table: t2, output_columns: [x, y], required_columns: [x, y], predicate: (t2.y = 100:Int32) AND (t2.x = 1000:Int32) }
+    LogicalJoin { type: LeftSemi, on: (t1.x = t2.x) AND (t1.y = t2.y), output: all }
+      LogicalScan { table: t1, columns: [t1.x, t1.y] }
+      LogicalScan { table: t2, output_columns: [t2.x, t2.y], required_columns: [x, y], predicate: (t2.y = 100:Int32) AND (t2.x = 1000:Int32) }
 - sql: |
     create table t1(x int, y int);
     create table t2(x int, y int);
@@ -84,19 +84,19 @@
     LogicalProject { exprs: [t1.x, t1.y] }
       LogicalFilter { predicate: (t1.x > (1.5:Decimal * min(t2.x))) }
         LogicalApply { type: LeftOuter, on: true, correlated_id: 1 }
-          LogicalScan { table: t1, columns: [_row_id, x, y] }
+          LogicalScan { table: t1, columns: [t1._row_id, t1.x, t1.y] }
           LogicalProject { exprs: [(1.5:Decimal * min(t2.x))] }
             LogicalAgg { aggs: [min(t2.x)] }
               LogicalProject { exprs: [t2.x] }
                 LogicalFilter { predicate: (CorrelatedInputRef { index: 2, correlated_id: 1 } = t2.y) }
-                  LogicalScan { table: t2, columns: [_row_id, x, y] }
+                  LogicalScan { table: t2, columns: [t2._row_id, t2.x, t2.y] }
   optimized_logical_plan: |
-    LogicalJoin { type: Inner, on: (t1.y = t2.y) AND (t1.x > (1.5:Decimal * min(t2.x))) }
-      LogicalScan { table: t1, columns: [x, y] }
+    LogicalJoin { type: Inner, on: (t1.y = t2.y) AND (t1.x > (1.5:Decimal * min(t2.x))), output: [t1.x, t1.y] }
+      LogicalScan { table: t1, columns: [t1.x, t1.y] }
       LogicalProject { exprs: [t2.y, (1.5:Decimal * min(t2.x))] }
         LogicalAgg { group_key: [t2.y], aggs: [min(t2.x)] }
           LogicalProject { exprs: [t2.y, t2.x] }
-            LogicalScan { table: t2, columns: [x, y] }
+            LogicalScan { table: t2, columns: [t2.x, t2.y] }
 - sql: |
     create table t1(x int, y int);
     create table t2(x int, y int);
@@ -105,17 +105,17 @@
     LogicalProject { exprs: [t1.x, t1.y] }
       LogicalFilter { predicate: (t1.x > count) }
         LogicalApply { type: LeftOuter, on: true, correlated_id: 1 }
-          LogicalScan { table: t1, columns: [_row_id, x, y] }
+          LogicalScan { table: t1, columns: [t1._row_id, t1.x, t1.y] }
           LogicalProject { exprs: [count] }
             LogicalAgg { aggs: [count] }
               LogicalProject { exprs: [] }
                 LogicalFilter { predicate: (CorrelatedInputRef { index: 2, correlated_id: 1 } = t2.y) }
-                  LogicalScan { table: t2, columns: [_row_id, x, y] }
+                  LogicalScan { table: t2, columns: [t2._row_id, t2.x, t2.y] }
   optimized_logical_plan: |
-    LogicalJoin { type: Inner, on: (t1.y = t2.y) AND (t1.x > count) }
-      LogicalScan { table: t1, columns: [x, y] }
+    LogicalJoin { type: Inner, on: (t1.y = t2.y) AND (t1.x > count), output: [t1.x, t1.y] }
+      LogicalScan { table: t1, columns: [t1.x, t1.y] }
       LogicalAgg { group_key: [t2.y], aggs: [count] }
-        LogicalScan { table: t2, columns: [y] }
+        LogicalScan { table: t2, columns: [t2.y] }
 - sql: |
     create table t1(x int, y int);
     create table t2(x int, y int);
@@ -124,18 +124,18 @@
     LogicalProject { exprs: [t1.x, t1.y] }
       LogicalFilter { predicate: (t1.x > (count + count)) }
         LogicalApply { type: LeftOuter, on: true, correlated_id: 1 }
-          LogicalScan { table: t1, columns: [_row_id, x, y] }
+          LogicalScan { table: t1, columns: [t1._row_id, t1.x, t1.y] }
           LogicalProject { exprs: [(count + count)] }
             LogicalAgg { aggs: [count, count] }
               LogicalProject { exprs: [] }
                 LogicalFilter { predicate: (CorrelatedInputRef { index: 2, correlated_id: 1 } = t2.y) }
-                  LogicalScan { table: t2, columns: [_row_id, x, y] }
+                  LogicalScan { table: t2, columns: [t2._row_id, t2.x, t2.y] }
   optimized_logical_plan: |
-    LogicalJoin { type: Inner, on: (t1.y = t2.y) AND (t1.x > (count + count)) }
-      LogicalScan { table: t1, columns: [x, y] }
+    LogicalJoin { type: Inner, on: (t1.y = t2.y) AND (t1.x > (count + count)), output: [t1.x, t1.y] }
+      LogicalScan { table: t1, columns: [t1.x, t1.y] }
       LogicalProject { exprs: [t2.y, (count + count)] }
         LogicalAgg { group_key: [t2.y], aggs: [count, count] }
-          LogicalScan { table: t2, columns: [y] }
+          LogicalScan { table: t2, columns: [t2.y] }
 - sql: |
     create table t1(x int, y int);
     create table t2(x int, y int);
@@ -143,15 +143,15 @@
   logical_plan: |
     LogicalProject { exprs: [t1.x] }
       LogicalApply { type: LeftSemi, on: (t1.y = t2.y), correlated_id: 1 }
-        LogicalScan { table: t1, columns: [_row_id, x, y] }
+        LogicalScan { table: t1, columns: [t1._row_id, t1.x, t1.y] }
         LogicalProject { exprs: [t2.y] }
           LogicalFilter { predicate: (CorrelatedInputRef { index: 1, correlated_id: 1 } = t2.x) }
-            LogicalScan { table: t2, columns: [_row_id, x, y] }
+            LogicalScan { table: t2, columns: [t2._row_id, t2.x, t2.y] }
   optimized_logical_plan: |
-    LogicalJoin { type: LeftSemi, on: (t1.y = t2.y) AND (t1.x = t2.x) }
-      LogicalScan { table: t1, columns: [x, y] }
+    LogicalJoin { type: LeftSemi, on: (t1.y = t2.y) AND (t1.x = t2.x), output: [t1.x] }
+      LogicalScan { table: t1, columns: [t1.x, t1.y] }
       LogicalProject { exprs: [t2.y, t2.x] }
-        LogicalScan { table: t2, columns: [x, y] }
+        LogicalScan { table: t2, columns: [t2.x, t2.y] }
 - sql: |
     create table t1(x int, y int);
     create table t2(x int, y int);
@@ -163,15 +163,15 @@
   logical_plan: |
     LogicalProject { exprs: [t1.x] }
       LogicalApply { type: LeftSemi, on: (t1.y = t2.y), correlated_id: 1 }
-        LogicalScan { table: t1, columns: [_row_id, x, y] }
+        LogicalScan { table: t1, columns: [t1._row_id, t1.x, t1.y] }
         LogicalProject { exprs: [t2.y] }
           LogicalFilter { predicate: ((CorrelatedInputRef { index: 1, correlated_id: 1 } + t2.x) = 100:Int32) AND (CorrelatedInputRef { index: 2, correlated_id: 1 } = 1000:Int32) }
-            LogicalScan { table: t2, columns: [_row_id, x, y] }
+            LogicalScan { table: t2, columns: [t2._row_id, t2.x, t2.y] }
   optimized_logical_plan: |
-    LogicalJoin { type: LeftSemi, on: (t1.y = t2.y) AND ((t1.x + t2.x) = 100:Int32) }
-      LogicalScan { table: t1, output_columns: [x, y], required_columns: [x, y], predicate: (t1.y = 1000:Int32) }
+    LogicalJoin { type: LeftSemi, on: (t1.y = t2.y) AND ((t1.x + t2.x) = 100:Int32), output: [t1.x] }
+      LogicalScan { table: t1, output_columns: [t1.x, t1.y], required_columns: [x, y], predicate: (t1.y = 1000:Int32) }
       LogicalProject { exprs: [t2.y, t2.x] }
-        LogicalScan { table: t2, columns: [x, y] }
+        LogicalScan { table: t2, columns: [t2.x, t2.y] }
 - sql: |
     create table t1(x int, y int);
     create table t2(x int, y int);
@@ -179,15 +179,15 @@
   logical_plan: |
     LogicalProject { exprs: [t1.x] }
       LogicalApply { type: LeftSemi, on: (t1.y = t2.y), correlated_id: 1 }
-        LogicalScan { table: t1, columns: [_row_id, x, y] }
+        LogicalScan { table: t1, columns: [t1._row_id, t1.x, t1.y] }
         LogicalProject { exprs: [t2.y] }
           LogicalFilter { predicate: (CorrelatedInputRef { index: 1, correlated_id: 1 } > (t2.x + 1000:Int32)) }
-            LogicalScan { table: t2, columns: [_row_id, x, y] }
+            LogicalScan { table: t2, columns: [t2._row_id, t2.x, t2.y] }
   optimized_logical_plan: |
-    LogicalJoin { type: LeftSemi, on: (t1.y = t2.y) AND (t1.x > (t2.x + 1000:Int32)) }
-      LogicalScan { table: t1, columns: [x, y] }
+    LogicalJoin { type: LeftSemi, on: (t1.y = t2.y) AND (t1.x > (t2.x + 1000:Int32)), output: [t1.x] }
+      LogicalScan { table: t1, columns: [t1.x, t1.y] }
       LogicalProject { exprs: [t2.y, t2.x] }
-        LogicalScan { table: t2, columns: [x, y] }
+        LogicalScan { table: t2, columns: [t2.x, t2.y] }
 - sql: |
     create table t1(x int, y int);
     create table t2(x int, y int);
@@ -202,22 +202,22 @@
   logical_plan: |
     LogicalProject { exprs: [t1.x] }
       LogicalApply { type: LeftSemi, on: (t1.y = t2.x), correlated_id: 1 }
-        LogicalScan { table: t1, columns: [_row_id, x, y] }
+        LogicalScan { table: t1, columns: [t1._row_id, t1.x, t1.y] }
         LogicalProject { exprs: [t2.x] }
           LogicalFilter { predicate: (t2.y = CorrelatedInputRef { index: 2, correlated_id: 1 }) AND (t2.x > min(t3.x)) }
-            LogicalJoin { type: LeftOuter, on: true }
-              LogicalScan { table: t2, columns: [_row_id, x, y] }
+            LogicalJoin { type: LeftOuter, on: true, output: all }
+              LogicalScan { table: t2, columns: [t2._row_id, t2.x, t2.y] }
               LogicalProject { exprs: [min(t3.x)] }
                 LogicalAgg { aggs: [min(t3.x)] }
                   LogicalProject { exprs: [t3.x] }
-                    LogicalScan { table: t3, columns: [_row_id, x, y] }
+                    LogicalScan { table: t3, columns: [t3._row_id, t3.x, t3.y] }
   optimized_logical_plan: |
-    LogicalJoin { type: LeftSemi, on: (t1.y = t2.x) AND (t2.y = t1.y) }
-      LogicalScan { table: t1, columns: [x, y] }
-      LogicalJoin { type: Inner, on: (t2.x > min(t3.x)) }
-        LogicalScan { table: t2, columns: [x, y] }
+    LogicalJoin { type: LeftSemi, on: (t1.y = t2.x) AND (t2.y = t1.y), output: [t1.x] }
+      LogicalScan { table: t1, columns: [t1.x, t1.y] }
+      LogicalJoin { type: Inner, on: (t2.x > min(t3.x)), output: [t2.x, t2.y] }
+        LogicalScan { table: t2, columns: [t2.x, t2.y] }
         LogicalAgg { aggs: [min(t3.x)] }
-          LogicalScan { table: t3, columns: [x] }
+          LogicalScan { table: t3, columns: [t3.x] }
 - sql: |
     /* correlated inner subquery with depth = 2 */
     create table t1(x int, y int);
@@ -227,13 +227,13 @@
   logical_plan: |
     LogicalProject { exprs: [t1.x] }
       LogicalApply { type: LeftSemi, on: (t1.y = t2.x), correlated_id: 1 }
-        LogicalScan { table: t1, columns: [_row_id, x, y] }
+        LogicalScan { table: t1, columns: [t1._row_id, t1.x, t1.y] }
         LogicalProject { exprs: [t2.x] }
-          LogicalJoin { type: LeftSemi, on: (t2.y = t3.y) }
-            LogicalScan { table: t2, columns: [_row_id, x, y] }
+          LogicalJoin { type: LeftSemi, on: (t2.y = t3.y), output: all }
+            LogicalScan { table: t2, columns: [t2._row_id, t2.x, t2.y] }
             LogicalProject { exprs: [t3.y] }
               LogicalFilter { predicate: (CorrelatedInputRef { index: 2, correlated_id: 1 } = t3.y) }
-                LogicalScan { table: t3, columns: [_row_id, x, y] }
+                LogicalScan { table: t3, columns: [t3._row_id, t3.x, t3.y] }
 - sql: |
     /* uncorrelated outer subquery with a correlated inner subquery */
     create table t1(x int, y int);
@@ -242,21 +242,21 @@
     select x from t1 where y in (select x from t2 where y in (select y from t3 where t2.y = t3.y));
   logical_plan: |
     LogicalProject { exprs: [t1.x] }
-      LogicalJoin { type: LeftSemi, on: (t1.y = t2.x) }
-        LogicalScan { table: t1, columns: [_row_id, x, y] }
+      LogicalJoin { type: LeftSemi, on: (t1.y = t2.x), output: all }
+        LogicalScan { table: t1, columns: [t1._row_id, t1.x, t1.y] }
         LogicalProject { exprs: [t2.x] }
           LogicalApply { type: LeftSemi, on: (t2.y = t3.y), correlated_id: 2 }
-            LogicalScan { table: t2, columns: [_row_id, x, y] }
+            LogicalScan { table: t2, columns: [t2._row_id, t2.x, t2.y] }
             LogicalProject { exprs: [t3.y] }
               LogicalFilter { predicate: (CorrelatedInputRef { index: 2, correlated_id: 2 } = t3.y) }
-                LogicalScan { table: t3, columns: [_row_id, x, y] }
+                LogicalScan { table: t3, columns: [t3._row_id, t3.x, t3.y] }
   optimized_logical_plan: |
-    LogicalJoin { type: LeftSemi, on: (t1.y = t2.x) }
-      LogicalScan { table: t1, columns: [x, y] }
-      LogicalJoin { type: LeftSemi, on: (t2.y = t3.y) AND (t2.y = t3.y) }
-        LogicalScan { table: t2, columns: [x, y] }
+    LogicalJoin { type: LeftSemi, on: (t1.y = t2.x), output: [t1.x] }
+      LogicalScan { table: t1, columns: [t1.x, t1.y] }
+      LogicalJoin { type: LeftSemi, on: (t2.y = t3.y) AND (t2.y = t3.y), output: [t2.x] }
+        LogicalScan { table: t2, columns: [t2.x, t2.y] }
         LogicalProject { exprs: [t3.y, t3.y] }
-          LogicalScan { table: t3, columns: [y] }
+          LogicalScan { table: t3, columns: [t3.y] }
 - sql: |
     /* correlated agg column in SELECT */
     create table t (v1 int, v2 int);
@@ -313,46 +313,46 @@
         LogicalProject { exprs: [t2.x, t1.x, t2.x] }
           LogicalApply { type: LeftOuter, on: true, correlated_id: 1 }
             LogicalFilter { predicate: (t2.x > 100:Int32) }
-              LogicalScan { table: t2, columns: [_row_id, x, y] }
+              LogicalScan { table: t2, columns: [t2._row_id, t2.x, t2.y] }
             LogicalProject { exprs: [t1.x] }
               LogicalFilter { predicate: (t1.y = CorrelatedInputRef { index: 2, correlated_id: 1 }) }
-                LogicalScan { table: t1, columns: [_row_id, x, y] }
+                LogicalScan { table: t1, columns: [t1._row_id, t1.x, t1.y] }
   optimized_logical_plan: |
     LogicalTopN { order: "[t2.x ASC]", limit: 100, offset: 0 }
       LogicalProject { exprs: [t2.x, t1.x, t2.x] }
-        LogicalJoin { type: LeftOuter, on: (t1.y = t2.y) }
-          LogicalScan { table: t2, output_columns: [x, y], required_columns: [x, y], predicate: (t2.x > 100:Int32) }
-          LogicalScan { table: t1, columns: [x, y] }
+        LogicalJoin { type: LeftOuter, on: (t1.y = t2.y), output: [t2.x, t1.x] }
+          LogicalScan { table: t2, output_columns: [t2.x, t2.y], required_columns: [x, y], predicate: (t2.x > 100:Int32) }
+          LogicalScan { table: t1, columns: [t1.x, t1.y] }
 - sql: |
     create table t1(x int, y int);
     create table t2(x int, y int);
     select * from t1 where exists(select x from t2 where t1.x = t2.x and t1.y = t2.y)
   optimized_logical_plan: |
-    LogicalJoin { type: LeftSemi, on: (t1.x = t2.x) AND (t1.y = t2.y) }
-      LogicalScan { table: t1, columns: [x, y] }
-      LogicalScan { table: t2, columns: [x, y] }
+    LogicalJoin { type: LeftSemi, on: (t1.x = t2.x) AND (t1.y = t2.y), output: all }
+      LogicalScan { table: t1, columns: [t1.x, t1.y] }
+      LogicalScan { table: t2, columns: [t2.x, t2.y] }
 - sql: |
     create table t1(x int, y int);
     create table t2(x int, y int);
     create table t3(x int, y int);
     select * from t1, t2 where exists(select x from t3 where t3.x = t1.x and t3.y <> t2.y);
   optimized_logical_plan: |
-    LogicalJoin { type: LeftSemi, on: (t3.x = t1.x) AND (t3.y <> t2.y) }
-      LogicalJoin { type: Inner, on: true }
-        LogicalScan { table: t1, columns: [x, y] }
-        LogicalScan { table: t2, columns: [x, y] }
-      LogicalScan { table: t3, columns: [x, y] }
+    LogicalJoin { type: LeftSemi, on: (t3.x = t1.x) AND (t3.y <> t2.y), output: all }
+      LogicalJoin { type: Inner, on: true, output: all }
+        LogicalScan { table: t1, columns: [t1.x, t1.y] }
+        LogicalScan { table: t2, columns: [t2.x, t2.y] }
+      LogicalScan { table: t3, columns: [t3.x, t3.y] }
 - sql: |
     create table t1(x int, y int);
     create table t2(x int, y int);
     create table t3(x int, y int);
     select * from t1, t2 where exists(select x from t3 where t3.x = t2.y and t3.y = t1.x);
   optimized_logical_plan: |
-    LogicalJoin { type: LeftSemi, on: (t3.x = t2.y) AND (t3.y = t1.x) }
-      LogicalJoin { type: Inner, on: true }
-        LogicalScan { table: t1, columns: [x, y] }
-        LogicalScan { table: t2, columns: [x, y] }
-      LogicalScan { table: t3, columns: [x, y] }
+    LogicalJoin { type: LeftSemi, on: (t3.x = t2.y) AND (t3.y = t1.x), output: all }
+      LogicalJoin { type: Inner, on: true, output: all }
+        LogicalScan { table: t1, columns: [t1.x, t1.y] }
+        LogicalScan { table: t2, columns: [t2.x, t2.y] }
+      LogicalScan { table: t3, columns: [t3.x, t3.y] }
 - sql: |
     create table t1(x int, y int);
     create table t2(x int, y int);
@@ -360,13 +360,13 @@
     create table t4(x int, y int, z int);
     select * from t1, t2, t3 where exists(select x from t4 where t4.x = t2.y and t4.y = t1.x and t4.z = t3.x);
   optimized_logical_plan: |
-    LogicalJoin { type: LeftSemi, on: (t4.x = t2.y) AND (t4.y = t1.x) AND (t4.z = t3.x) }
-      LogicalJoin { type: Inner, on: true }
-        LogicalJoin { type: Inner, on: true }
-          LogicalScan { table: t1, columns: [x, y] }
-          LogicalScan { table: t2, columns: [x, y] }
-        LogicalScan { table: t3, columns: [x, y] }
-      LogicalScan { table: t4, columns: [x, y, z] }
+    LogicalJoin { type: LeftSemi, on: (t4.x = t2.y) AND (t4.y = t1.x) AND (t4.z = t3.x), output: all }
+      LogicalJoin { type: Inner, on: true, output: all }
+        LogicalJoin { type: Inner, on: true, output: all }
+          LogicalScan { table: t1, columns: [t1.x, t1.y] }
+          LogicalScan { table: t2, columns: [t2.x, t2.y] }
+        LogicalScan { table: t3, columns: [t3.x, t3.y] }
+      LogicalScan { table: t4, columns: [t4.x, t4.y, t4.z] }
 - sql: |
     create table a(a1 int, a2 int, a3 int);
     create table b(b1 int, b2 int, b3 int);
@@ -374,202 +374,202 @@
     select count(*) from a, b where a3 = b2 and 3 = (select count(*) from c where b2 = c2 and a3 = c3);
   optimized_logical_plan: |
     LogicalAgg { aggs: [count] }
-      LogicalJoin { type: Inner, on: (a.a3 = c.c3) AND (b.b2 = c.c2) }
-        LogicalJoin { type: Inner, on: (a.a3 = b.b2) }
-          LogicalScan { table: a, columns: [a3] }
-          LogicalScan { table: b, columns: [b2] }
+      LogicalJoin { type: Inner, on: (a.a3 = c.c3) AND (b.b2 = c.c2), output: [] }
+        LogicalJoin { type: Inner, on: (a.a3 = b.b2), output: all }
+          LogicalScan { table: a, columns: [a.a3] }
+          LogicalScan { table: b, columns: [b.b2] }
         LogicalProject { exprs: [c.c3, c.c2] }
           LogicalFilter { predicate: (3:Int32 = count) }
             LogicalAgg { group_key: [c.c3, c.c2], aggs: [count] }
               LogicalProject { exprs: [c.c3, c.c2] }
-                LogicalScan { table: c, columns: [c2, c3] }
+                LogicalScan { table: c, columns: [c.c2, c.c3] }
 - sql: |
     create table a(x int, y int, z int);
     create table b(x int, y int, z int);
     select count(*) from a where a.x=3 and a.y = (select count(*) from b where b.z = a.z and a.x = 3);
   optimized_logical_plan: |
     LogicalAgg { aggs: [count] }
-      LogicalJoin { type: Inner, on: (a.x = a.x) AND (a.z = a.z) AND (a.y = count) }
-        LogicalScan { table: a, output_columns: [x, y, z], required_columns: [x, y, z], predicate: (a.x = 3:Int32) }
+      LogicalJoin { type: Inner, on: (a.x = a.x) AND (a.z = a.z) AND (a.y = count), output: [] }
+        LogicalScan { table: a, output_columns: [a.x, a.y, a.z], required_columns: [x, y, z], predicate: (a.x = 3:Int32) }
         LogicalAgg { group_key: [a.x, a.z], aggs: [count] }
-          LogicalJoin { type: Inner, on: (b.z = a.z) }
+          LogicalJoin { type: Inner, on: (b.z = a.z), output: [a.x, a.z] }
             LogicalAgg { group_key: [a.x, a.z], aggs: [] }
-              LogicalScan { table: a, output_columns: [x, z], required_columns: [x, z], predicate: (a.x = 3:Int32) }
-            LogicalScan { table: b, columns: [z] }
+              LogicalScan { table: a, output_columns: [a.x, a.z], required_columns: [x, z], predicate: (a.x = 3:Int32) }
+            LogicalScan { table: b, columns: [b.z] }
 - sql: |
     create table a(x int, y int, z int);
     create table b(x int, y int, z int);
     select count(*) from a where a.x=3 and a.y = (select count(*) from b where b.z = a.z);
   optimized_logical_plan: |
     LogicalAgg { aggs: [count] }
-      LogicalJoin { type: Inner, on: (a.z = b.z) AND (a.y = count) }
-        LogicalScan { table: a, output_columns: [y, z], required_columns: [y, z, x], predicate: (a.x = 3:Int32) }
+      LogicalJoin { type: Inner, on: (a.z = b.z) AND (a.y = count), output: [] }
+        LogicalScan { table: a, output_columns: [a.y, a.z], required_columns: [y, z, x], predicate: (a.x = 3:Int32) }
         LogicalAgg { group_key: [b.z], aggs: [count] }
-          LogicalScan { table: b, columns: [z] }
+          LogicalScan { table: b, columns: [b.z] }
 - sql: |
     create table a(x int, y varchar, z int);
     create table b(x varchar, y int, z int);
     select count(*) from a where a.y = (select string_agg(x order by x) from b where b.z = a.z);
   optimized_logical_plan: |
     LogicalAgg { aggs: [count] }
-      LogicalJoin { type: Inner, on: (a.z = b.z) AND (a.y = string_agg(b.x order_by(b.x ASC NULLS LAST))) }
-        LogicalScan { table: a, columns: [y, z] }
+      LogicalJoin { type: Inner, on: (a.z = b.z) AND (a.y = string_agg(b.x order_by(b.x ASC NULLS LAST))), output: [] }
+        LogicalScan { table: a, columns: [a.y, a.z] }
         LogicalAgg { group_key: [b.z], aggs: [string_agg(b.x order_by(b.x ASC NULLS LAST))] }
           LogicalProject { exprs: [b.z, b.x] }
-            LogicalScan { table: b, columns: [x, z] }
+            LogicalScan { table: b, columns: [b.x, b.z] }
 - sql: |
     create table a(x int, y int, z int);
     create table b(x int, y int, z int);
     select count(*) from a where a.y = (select count(distinct x) from b where b.z = a.z);
   optimized_logical_plan: |
     LogicalAgg { aggs: [count] }
-      LogicalJoin { type: Inner, on: (a.z = b.z) AND (a.y = count(b.x) filter((flag = 0:Int64))) }
-        LogicalScan { table: a, columns: [y, z] }
+      LogicalJoin { type: Inner, on: (a.z = b.z) AND (a.y = count(b.x) filter((flag = 0:Int64))), output: [] }
+        LogicalScan { table: a, columns: [a.y, a.z] }
         LogicalAgg { group_key: [b.z], aggs: [count(b.x) filter((flag = 0:Int64))] }
           LogicalAgg { group_key: [b.z, b.x, flag], aggs: [] }
             LogicalExpand { column_subsets: [[b.z, b.x]] }
               LogicalProject { exprs: [b.z, b.x] }
-                LogicalScan { table: b, columns: [x, z] }
+                LogicalScan { table: b, columns: [b.x, b.z] }
 - sql: |
     create table a(x int, y int, z int);
     create table b(x int, y int, z int);
     select count(*) from a where a.y = (select count(x) filter(where x < 100) from b where b.z = a.z);
   optimized_logical_plan: |
     LogicalAgg { aggs: [count] }
-      LogicalJoin { type: Inner, on: (a.z = b.z) AND (a.y = count(b.x) filter((b.x < 100:Int32))) }
-        LogicalScan { table: a, columns: [y, z] }
+      LogicalJoin { type: Inner, on: (a.z = b.z) AND (a.y = count(b.x) filter((b.x < 100:Int32))), output: [] }
+        LogicalScan { table: a, columns: [a.y, a.z] }
         LogicalAgg { group_key: [b.z], aggs: [count(b.x) filter((b.x < 100:Int32))] }
           LogicalProject { exprs: [b.z, b.x] }
-            LogicalScan { table: b, columns: [x, z] }
+            LogicalScan { table: b, columns: [b.x, b.z] }
 - sql: |
     create table t1(x int, y int);
     create table t2(x int, y int);
     create table t3(x int, y int);
     select * from t1 where exists(select x from t2 where t1.x = t2.x and t2.y in (select t3.y from t3 where t1.x = t3.x));
   optimized_logical_plan: |
-    LogicalJoin { type: LeftSemi, on: (t1.x = t2.x) }
-      LogicalScan { table: t1, columns: [x, y] }
-      LogicalJoin { type: LeftSemi, on: (t2.y = t3.y) AND (t2.x = t3.x) }
-        LogicalScan { table: t2, columns: [x, y] }
-        LogicalScan { table: t3, columns: [x, y] }
+    LogicalJoin { type: LeftSemi, on: (t1.x = t2.x), output: all }
+      LogicalScan { table: t1, columns: [t1.x, t1.y] }
+      LogicalJoin { type: LeftSemi, on: (t2.y = t3.y) AND (t2.x = t3.x), output: [t2.x] }
+        LogicalScan { table: t2, columns: [t2.x, t2.y] }
+        LogicalScan { table: t3, columns: [t3.x, t3.y] }
 - sql: |
     create table t1(x int, y int);
     create table t2(x int, y int);
     create table t3(x int, y int);
     select * from t1 where exists(select t2.x from t2 join t3 on t2.x = t3.x and t1.y = t2.y and t1.y = t3.y);
   optimized_logical_plan: |
-    LogicalJoin { type: LeftSemi, on: (t1.y = t1.y) }
-      LogicalScan { table: t1, columns: [x, y] }
-      LogicalJoin { type: Inner, on: (t2.x = t3.x) AND (t1.y = t3.y) }
-        LogicalJoin { type: Inner, on: (t1.y = t1.y) }
-          LogicalJoin { type: Inner, on: (t1.y = t2.y) }
+    LogicalJoin { type: LeftSemi, on: (t1.y = t1.y), output: all }
+      LogicalScan { table: t1, columns: [t1.x, t1.y] }
+      LogicalJoin { type: Inner, on: (t2.x = t3.x) AND (t1.y = t3.y), output: [t1.y] }
+        LogicalJoin { type: Inner, on: (t1.y = t1.y), output: [t1.y, t2.x] }
+          LogicalJoin { type: Inner, on: (t1.y = t2.y), output: [t1.y, t2.x] }
             LogicalAgg { group_key: [t1.y], aggs: [] }
-              LogicalScan { table: t1, columns: [y] }
-            LogicalScan { table: t2, columns: [x, y] }
+              LogicalScan { table: t1, columns: [t1.y] }
+            LogicalScan { table: t2, columns: [t2.x, t2.y] }
           LogicalAgg { group_key: [t1.y], aggs: [] }
-            LogicalScan { table: t1, columns: [y] }
-        LogicalScan { table: t3, columns: [x, y] }
+            LogicalScan { table: t1, columns: [t1.y] }
+        LogicalScan { table: t3, columns: [t3.x, t3.y] }
 - sql: |
     create table t1(x int, y int);
     create table t2(x int, y int);
     select * from t1 where t1.y in (select t1.y from t2 where t1.x = t2.x);
   optimized_logical_plan: |
-    LogicalJoin { type: LeftSemi, on: (t1.y = t1.y) AND (t1.x = t1.x) AND (t1.y = t1.y) }
-      LogicalScan { table: t1, columns: [x, y] }
+    LogicalJoin { type: LeftSemi, on: (t1.y = t1.y) AND (t1.x = t1.x) AND (t1.y = t1.y), output: all }
+      LogicalScan { table: t1, columns: [t1.x, t1.y] }
       LogicalProject { exprs: [t1.x, t1.y, t1.y] }
-        LogicalJoin { type: Inner, on: (t1.x = t2.x) }
+        LogicalJoin { type: Inner, on: (t1.x = t2.x), output: [t1.x, t1.y] }
           LogicalAgg { group_key: [t1.x, t1.y], aggs: [] }
-            LogicalScan { table: t1, columns: [x, y] }
-          LogicalScan { table: t2, columns: [x] }
+            LogicalScan { table: t1, columns: [t1.x, t1.y] }
+          LogicalScan { table: t2, columns: [t2.x] }
 - sql: |
     create table t1(x int, y int);
     create table t2(x int, y int);
     create table t3(x int, y int);
     select * from t1 where not exists(select x from t2 where t1.x = t2.x and t2.y not in (select t3.y from t3 where t1.x = t3.x));
   optimized_logical_plan: |
-    LogicalJoin { type: LeftAnti, on: (t1.x = t2.x) }
-      LogicalScan { table: t1, columns: [x, y] }
-      LogicalJoin { type: LeftAnti, on: (t2.y = t3.y) AND (t2.x = t3.x) }
-        LogicalScan { table: t2, columns: [x, y] }
-        LogicalScan { table: t3, columns: [x, y] }
+    LogicalJoin { type: LeftAnti, on: (t1.x = t2.x), output: all }
+      LogicalScan { table: t1, columns: [t1.x, t1.y] }
+      LogicalJoin { type: LeftAnti, on: (t2.y = t3.y) AND (t2.x = t3.x), output: [t2.x] }
+        LogicalScan { table: t2, columns: [t2.x, t2.y] }
+        LogicalScan { table: t3, columns: [t3.x, t3.y] }
 - sql: |
     create table t1(x int, y int);
     create table t2(x int, y int);
     create table t3(x int, y int);
     select * from t1 where exists(select t2.x from t2 left join t3 on t2.x = t3.x and t1.y = t2.y and t1.y = t3.y);
   optimized_logical_plan: |
-    LogicalJoin { type: LeftSemi, on: (t1.y = t1.y) }
-      LogicalScan { table: t1, columns: [x, y] }
-      LogicalJoin { type: LeftOuter, on: (t1.y = t2.y) AND (t2.x = t3.x) AND (t1.y = t3.y) AND (t1.y = t1.y) }
-        LogicalJoin { type: Inner, on: true }
+    LogicalJoin { type: LeftSemi, on: (t1.y = t1.y), output: all }
+      LogicalScan { table: t1, columns: [t1.x, t1.y] }
+      LogicalJoin { type: LeftOuter, on: (t1.y = t2.y) AND (t2.x = t3.x) AND (t1.y = t3.y) AND (t1.y = t1.y), output: [t1.y] }
+        LogicalJoin { type: Inner, on: true, output: all }
           LogicalAgg { group_key: [t1.y], aggs: [] }
-            LogicalScan { table: t1, columns: [y] }
-          LogicalScan { table: t2, columns: [x, y] }
-        LogicalJoin { type: Inner, on: true }
+            LogicalScan { table: t1, columns: [t1.y] }
+          LogicalScan { table: t2, columns: [t2.x, t2.y] }
+        LogicalJoin { type: Inner, on: true, output: all }
           LogicalAgg { group_key: [t1.y], aggs: [] }
-            LogicalScan { table: t1, columns: [y] }
-          LogicalScan { table: t3, columns: [x, y] }
+            LogicalScan { table: t1, columns: [t1.y] }
+          LogicalScan { table: t3, columns: [t3.x, t3.y] }
 - sql: |
     create table t1(x int, y int);
     create table t2(x int, y int);
     create table t3(x int, y int);
     select * from t1 where exists(select t2.x from t2 right join t3 on t2.x = t3.x and t1.y = t2.y and t1.y = t3.y);
   optimized_logical_plan: |
-    LogicalJoin { type: LeftSemi, on: (t1.y = t1.y) }
-      LogicalScan { table: t1, columns: [x, y] }
-      LogicalJoin { type: RightOuter, on: (t2.x = t3.x) AND (t1.y = t3.y) AND (t1.y = t1.y) }
-        LogicalJoin { type: Inner, on: (t1.y = t2.y) }
+    LogicalJoin { type: LeftSemi, on: (t1.y = t1.y), output: all }
+      LogicalScan { table: t1, columns: [t1.x, t1.y] }
+      LogicalJoin { type: RightOuter, on: (t2.x = t3.x) AND (t1.y = t3.y) AND (t1.y = t1.y), output: [t1.y] }
+        LogicalJoin { type: Inner, on: (t1.y = t2.y), output: [t1.y, t2.x] }
           LogicalAgg { group_key: [t1.y], aggs: [] }
-            LogicalScan { table: t1, columns: [y] }
-          LogicalScan { table: t2, columns: [x, y] }
-        LogicalJoin { type: Inner, on: true }
+            LogicalScan { table: t1, columns: [t1.y] }
+          LogicalScan { table: t2, columns: [t2.x, t2.y] }
+        LogicalJoin { type: Inner, on: true, output: all }
           LogicalAgg { group_key: [t1.y], aggs: [] }
-            LogicalScan { table: t1, columns: [y] }
-          LogicalScan { table: t3, columns: [x, y] }
+            LogicalScan { table: t1, columns: [t1.y] }
+          LogicalScan { table: t3, columns: [t3.x, t3.y] }
 - sql: |
     create table t1(x int, y int);
     create table t2(x int, y int);
     create table t3(x int, y int);
     select * from t1 where exists(select t2.x from t2 full join t3 on t2.x = t3.x and t1.y = t2.y and t1.y = t3.y);
   optimized_logical_plan: |
-    LogicalJoin { type: LeftSemi, on: (t1.y = t1.y) }
-      LogicalScan { table: t1, columns: [x, y] }
-      LogicalJoin { type: FullOuter, on: (t1.y = t2.y) AND (t2.x = t3.x) AND (t1.y = t3.y) AND (t1.y = t1.y) }
-        LogicalJoin { type: Inner, on: true }
+    LogicalJoin { type: LeftSemi, on: (t1.y = t1.y), output: all }
+      LogicalScan { table: t1, columns: [t1.x, t1.y] }
+      LogicalJoin { type: FullOuter, on: (t1.y = t2.y) AND (t2.x = t3.x) AND (t1.y = t3.y) AND (t1.y = t1.y), output: [t1.y] }
+        LogicalJoin { type: Inner, on: true, output: all }
           LogicalAgg { group_key: [t1.y], aggs: [] }
-            LogicalScan { table: t1, columns: [y] }
-          LogicalScan { table: t2, columns: [x, y] }
-        LogicalJoin { type: Inner, on: true }
+            LogicalScan { table: t1, columns: [t1.y] }
+          LogicalScan { table: t2, columns: [t2.x, t2.y] }
+        LogicalJoin { type: Inner, on: true, output: all }
           LogicalAgg { group_key: [t1.y], aggs: [] }
-            LogicalScan { table: t1, columns: [y] }
-          LogicalScan { table: t3, columns: [x, y] }
+            LogicalScan { table: t1, columns: [t1.y] }
+          LogicalScan { table: t3, columns: [t3.x, t3.y] }
 - sql: |
     create table t1(x int, y int);
     create table t2(x int, y int);
     create table t3(x int, y int);
     select * from t1 where exists(select x from t2 where t1.x = t2.x and t2.y in (select t3.y + t2.y from t3 where t1.x = t3.x));
   optimized_logical_plan: |
-    LogicalJoin { type: LeftSemi, on: (t1.x = t2.x) }
-      LogicalScan { table: t1, columns: [x, y] }
-      LogicalJoin { type: LeftSemi, on: (t2.y = (t3.y + t2.y)) AND (t2.y = t2.y) AND (t2.x = t3.x) }
-        LogicalScan { table: t2, columns: [x, y] }
+    LogicalJoin { type: LeftSemi, on: (t1.x = t2.x), output: all }
+      LogicalScan { table: t1, columns: [t1.x, t1.y] }
+      LogicalJoin { type: LeftSemi, on: (t2.y = (t3.y + t2.y)) AND (t2.y = t2.y) AND (t2.x = t3.x), output: [t2.x] }
+        LogicalScan { table: t2, columns: [t2.x, t2.y] }
         LogicalProject { exprs: [t3.x, t2.y, (t3.y + t2.y)] }
-          LogicalJoin { type: Inner, on: true }
+          LogicalJoin { type: Inner, on: true, output: all }
             LogicalAgg { group_key: [t2.y], aggs: [] }
-              LogicalScan { table: t2, columns: [y] }
-            LogicalScan { table: t3, columns: [x, y] }
+              LogicalScan { table: t2, columns: [t2.y] }
+            LogicalScan { table: t3, columns: [t3.x, t3.y] }
 - sql: |
     create table t1 (a int, b int);
     create table t2 (b int, c int);
     select a, (select t1.a), c from t1, t2 where t1.b = t2.b order by c;
   optimized_logical_plan: |
     LogicalProject { exprs: [t1.a, t1.a, t2.c] }
-      LogicalJoin { type: LeftOuter, on: (t1.a = t1.a) }
-        LogicalJoin { type: Inner, on: (t1.b = t2.b) }
-          LogicalScan { table: t1, columns: [a, b] }
-          LogicalScan { table: t2, columns: [b, c] }
+      LogicalJoin { type: LeftOuter, on: (t1.a = t1.a), output: [t1.a, t2.c, t1.a] }
+        LogicalJoin { type: Inner, on: (t1.b = t2.b), output: [t1.a, t2.c] }
+          LogicalScan { table: t1, columns: [t1.a, t1.b] }
+          LogicalScan { table: t2, columns: [t2.b, t2.c] }
         LogicalProject { exprs: [t1.a, t1.a] }
-          LogicalJoin { type: Inner, on: true }
+          LogicalJoin { type: Inner, on: true, output: all }
             LogicalAgg { group_key: [t1.a], aggs: [] }
-              LogicalScan { table: t1, columns: [a] }
+              LogicalScan { table: t1, columns: [t1.a] }
             LogicalValues { rows: [[]], schema: Schema { fields: [] } }

--- a/src/frontend/test_runner/tests/testdata/time_window.yaml
+++ b/src/frontend/test_runner/tests/testdata/time_window.yaml
@@ -5,11 +5,11 @@
   logical_plan: |
     LogicalProject { exprs: [t1.id, t1.created_at, TumbleStart(t1.created_at, '3 days 00:00:00':Interval), (TumbleStart(t1.created_at, '3 days 00:00:00':Interval) + '3 days 00:00:00':Interval)] }
       LogicalProject { exprs: [t1._row_id, t1.id, t1.created_at, TumbleStart(t1.created_at, '3 days 00:00:00':Interval), (TumbleStart(t1.created_at, '3 days 00:00:00':Interval) + '3 days 00:00:00':Interval)] }
-        LogicalScan { table: t1, columns: [_row_id, id, created_at] }
+        LogicalScan { table: t1, columns: [t1._row_id, t1.id, t1.created_at] }
   batch_plan: |
     BatchExchange { order: [], dist: Single }
       BatchProject { exprs: [t1.id, t1.created_at, TumbleStart(t1.created_at, '3 days 00:00:00':Interval), (TumbleStart(t1.created_at, '3 days 00:00:00':Interval) + '3 days 00:00:00':Interval)] }
-        BatchScan { table: t1, columns: [id, created_at] }
+        BatchScan { table: t1, columns: [t1.id, t1.created_at], distribution: SomeShard }
 - sql: |
     create materialized view t as select * from s;
     select * from tumble(t, (country).created_at, interval '3' day);
@@ -47,63 +47,63 @@
   logical_plan: |
     LogicalProject { exprs: [t1.id, t1.created_at, window_start, window_end] }
       LogicalHopWindow { time_col: t1.created_at, slide: 1 day 00:00:00, size: 3 days 00:00:00, output: all }
-        LogicalScan { table: t1, columns: [_row_id, id, created_at] }
+        LogicalScan { table: t1, columns: [t1._row_id, t1.id, t1.created_at] }
   stream_plan: |
     StreamMaterialize { columns: [id, created_at, window_start, window_end, t1._row_id(hidden)], pk_columns: [t1._row_id, window_start] }
       StreamHopWindow { time_col: t1.created_at, slide: 1 day 00:00:00, size: 3 days 00:00:00, output: [t1.id, t1.created_at, window_start, window_end, t1._row_id] }
-        StreamTableScan { table: t1, columns: [id, created_at, _row_id] }
+        StreamTableScan { table: t1, columns: [t1.id, t1.created_at, t1._row_id], pk: [t1._row_id], distribution: HashShard(t1._row_id) }
 - sql: |
     create table t1 (id int, created_at date);
     select id, created_at, window_start from hop(t1, created_at, interval '1' day, interval '3' day);
   logical_plan: |
     LogicalProject { exprs: [t1.id, t1.created_at, window_start] }
       LogicalHopWindow { time_col: t1.created_at, slide: 1 day 00:00:00, size: 3 days 00:00:00, output: all }
-        LogicalScan { table: t1, columns: [_row_id, id, created_at] }
+        LogicalScan { table: t1, columns: [t1._row_id, t1.id, t1.created_at] }
   stream_plan: |
     StreamMaterialize { columns: [id, created_at, window_start, t1._row_id(hidden)], pk_columns: [t1._row_id, window_start] }
       StreamHopWindow { time_col: t1.created_at, slide: 1 day 00:00:00, size: 3 days 00:00:00, output: [t1.id, t1.created_at, window_start, t1._row_id] }
-        StreamTableScan { table: t1, columns: [id, created_at, _row_id] }
+        StreamTableScan { table: t1, columns: [t1.id, t1.created_at, t1._row_id], pk: [t1._row_id], distribution: HashShard(t1._row_id) }
 - sql: |
     create table t1 (id int, created_at date);
     select id, created_at, window_end from hop(t1, created_at, interval '1' day, interval '3' day);
   logical_plan: |
     LogicalProject { exprs: [t1.id, t1.created_at, window_end] }
       LogicalHopWindow { time_col: t1.created_at, slide: 1 day 00:00:00, size: 3 days 00:00:00, output: all }
-        LogicalScan { table: t1, columns: [_row_id, id, created_at] }
+        LogicalScan { table: t1, columns: [t1._row_id, t1.id, t1.created_at] }
   stream_plan: |
     StreamMaterialize { columns: [id, created_at, window_end, t1._row_id(hidden)], pk_columns: [t1._row_id, window_end] }
       StreamHopWindow { time_col: t1.created_at, slide: 1 day 00:00:00, size: 3 days 00:00:00, output: [t1.id, t1.created_at, window_end, t1._row_id] }
-        StreamTableScan { table: t1, columns: [id, created_at, _row_id] }
+        StreamTableScan { table: t1, columns: [t1.id, t1.created_at, t1._row_id], pk: [t1._row_id], distribution: HashShard(t1._row_id) }
 - sql: |
     create table t1 (id int, created_at date);
     select id, created_at from hop(t1, created_at, interval '1' day, interval '3' day);
   logical_plan: |
     LogicalProject { exprs: [t1.id, t1.created_at] }
       LogicalHopWindow { time_col: t1.created_at, slide: 1 day 00:00:00, size: 3 days 00:00:00, output: all }
-        LogicalScan { table: t1, columns: [_row_id, id, created_at] }
+        LogicalScan { table: t1, columns: [t1._row_id, t1.id, t1.created_at] }
   batch_plan: |
     BatchHopWindow { time_col: t1.created_at, slide: 1 day 00:00:00, size: 3 days 00:00:00, output: [t1.id, t1.created_at] }
       BatchExchange { order: [], dist: Single }
-        BatchScan { table: t1, columns: [id, created_at] }
+        BatchScan { table: t1, columns: [t1.id, t1.created_at], distribution: SomeShard }
   stream_plan: |
     StreamMaterialize { columns: [id, created_at, window_start(hidden), t1._row_id(hidden)], pk_columns: [t1._row_id, window_start] }
       StreamHopWindow { time_col: t1.created_at, slide: 1 day 00:00:00, size: 3 days 00:00:00, output: [t1.id, t1.created_at, window_start, t1._row_id] }
-        StreamTableScan { table: t1, columns: [id, created_at, _row_id] }
+        StreamTableScan { table: t1, columns: [t1.id, t1.created_at, t1._row_id], pk: [t1._row_id], distribution: HashShard(t1._row_id) }
 - sql: |
     create table t1 (id int, created_at date);
     select t_hop.id, t_hop.created_at from hop(t1, created_at, interval '1' day, interval '3' day) as t_hop;
   logical_plan: |
     LogicalProject { exprs: [t1.id, t1.created_at] }
       LogicalHopWindow { time_col: t1.created_at, slide: 1 day 00:00:00, size: 3 days 00:00:00, output: all }
-        LogicalScan { table: t1, columns: [_row_id, id, created_at] }
+        LogicalScan { table: t1, columns: [t1._row_id, t1.id, t1.created_at] }
   batch_plan: |
     BatchHopWindow { time_col: t1.created_at, slide: 1 day 00:00:00, size: 3 days 00:00:00, output: [t1.id, t1.created_at] }
       BatchExchange { order: [], dist: Single }
-        BatchScan { table: t1, columns: [id, created_at] }
+        BatchScan { table: t1, columns: [t1.id, t1.created_at], distribution: SomeShard }
   stream_plan: |
     StreamMaterialize { columns: [id, created_at, window_start(hidden), t1._row_id(hidden)], pk_columns: [t1._row_id, window_start] }
       StreamHopWindow { time_col: t1.created_at, slide: 1 day 00:00:00, size: 3 days 00:00:00, output: [t1.id, t1.created_at, window_start, t1._row_id] }
-        StreamTableScan { table: t1, columns: [id, created_at, _row_id] }
+        StreamTableScan { table: t1, columns: [t1.id, t1.created_at, t1._row_id], pk: [t1._row_id], distribution: HashShard(t1._row_id) }
 - sql: |
     create table t (v1 varchar, v2 timestamp, v3 float);
     select v1, window_end, avg(v3) as avg from hop( t, v2, interval '1' minute, interval '10' minute) group by v1, window_end;
@@ -112,7 +112,7 @@
       LogicalAgg { group_key: [t.v1, window_end], aggs: [sum(t.v3), count(t.v3)] }
         LogicalProject { exprs: [t.v1, window_end, t.v3] }
           LogicalHopWindow { time_col: t.v2, slide: 00:01:00, size: 00:10:00, output: all }
-            LogicalScan { table: t, columns: [_row_id, v1, v2, v3] }
+            LogicalScan { table: t, columns: [t._row_id, t.v1, t.v2, t.v3] }
   batch_plan: |
     BatchExchange { order: [], dist: Single }
       BatchProject { exprs: [t.v1, window_end, (sum(t.v3) / count(t.v3))] }
@@ -120,7 +120,7 @@
           BatchExchange { order: [], dist: HashShard(t.v1, window_end) }
             BatchProject { exprs: [t.v1, window_end, t.v3] }
               BatchHopWindow { time_col: t.v2, slide: 00:01:00, size: 00:10:00, output: [t.v1, t.v3, window_end] }
-                BatchScan { table: t, columns: [v1, v2, v3] }
+                BatchScan { table: t, columns: [t.v1, t.v2, t.v3], distribution: SomeShard }
   stream_plan: |
     StreamMaterialize { columns: [v1, window_end, avg], pk_columns: [v1, window_end] }
       StreamProject { exprs: [t.v1, window_end, (sum(t.v3) / count(t.v3))] }
@@ -128,7 +128,7 @@
           StreamExchange { dist: HashShard(t.v1, window_end) }
             StreamProject { exprs: [t.v1, window_end, t.v3, t._row_id] }
               StreamHopWindow { time_col: t.v2, slide: 00:01:00, size: 00:10:00, output: [t.v1, t.v3, window_end, t._row_id] }
-                StreamTableScan { table: t, columns: [v1, v2, v3, _row_id] }
+                StreamTableScan { table: t, columns: [t.v1, t.v2, t.v3, t._row_id], pk: [t._row_id], distribution: HashShard(t._row_id) }
 - sql: |
     create table t1 (id int, v1 int, created_at date);
     with t2 as (select * from t1 where v1 >= 10)
@@ -136,15 +136,15 @@
   logical_plan: |
     LogicalProject { exprs: [t1.id, t1.v1, t1.created_at, TumbleStart(t1.created_at, '3 days 00:00:00':Interval), (TumbleStart(t1.created_at, '3 days 00:00:00':Interval) + '3 days 00:00:00':Interval)] }
       LogicalProject { exprs: [t1._row_id, t1.id, t1.v1, t1.created_at, TumbleStart(t1.created_at, '3 days 00:00:00':Interval), (TumbleStart(t1.created_at, '3 days 00:00:00':Interval) + '3 days 00:00:00':Interval)] }
-        LogicalScan { table: t1, columns: [_row_id, id, v1, created_at] }
+        LogicalScan { table: t1, columns: [t1._row_id, t1.id, t1.v1, t1.created_at] }
   batch_plan: |
     BatchExchange { order: [], dist: Single }
       BatchProject { exprs: [t1.id, t1.v1, t1.created_at, TumbleStart(t1.created_at, '3 days 00:00:00':Interval), (TumbleStart(t1.created_at, '3 days 00:00:00':Interval) + '3 days 00:00:00':Interval)] }
-        BatchScan { table: t1, columns: [id, v1, created_at] }
+        BatchScan { table: t1, columns: [t1.id, t1.v1, t1.created_at], distribution: SomeShard }
   stream_plan: |
     StreamMaterialize { columns: [id, v1, created_at, window_start, window_end, t1._row_id(hidden)], pk_columns: [t1._row_id] }
       StreamProject { exprs: [t1.id, t1.v1, t1.created_at, TumbleStart(t1.created_at, '3 days 00:00:00':Interval), (TumbleStart(t1.created_at, '3 days 00:00:00':Interval) + '3 days 00:00:00':Interval), t1._row_id] }
-        StreamTableScan { table: t1, columns: [id, v1, created_at, _row_id] }
+        StreamTableScan { table: t1, columns: [t1.id, t1.v1, t1.created_at, t1._row_id], pk: [t1._row_id], distribution: HashShard(t1._row_id) }
 - sql: |
     create table t1 (id int, v1 int, created_at date);
     with t2 as (select * from t1 where v1 >= 10)
@@ -154,14 +154,14 @@
       LogicalHopWindow { time_col: t1.created_at, slide: 1 day 00:00:00, size: 3 days 00:00:00, output: all }
         LogicalProject { exprs: [t1.id, t1.v1, t1.created_at] }
           LogicalFilter { predicate: (t1.v1 >= 10:Int32) }
-            LogicalScan { table: t1, columns: [_row_id, id, v1, created_at] }
+            LogicalScan { table: t1, columns: [t1._row_id, t1.id, t1.v1, t1.created_at] }
   batch_plan: |
     BatchHopWindow { time_col: t1.created_at, slide: 1 day 00:00:00, size: 3 days 00:00:00, output: all }
       BatchExchange { order: [], dist: Single }
         BatchFilter { predicate: (t1.v1 >= 10:Int32) }
-          BatchScan { table: t1, columns: [id, v1, created_at] }
+          BatchScan { table: t1, columns: [t1.id, t1.v1, t1.created_at], distribution: SomeShard }
   stream_plan: |
     StreamMaterialize { columns: [id, v1, created_at, window_start, window_end, t1._row_id(hidden)], pk_columns: [t1._row_id, window_start] }
       StreamHopWindow { time_col: t1.created_at, slide: 1 day 00:00:00, size: 3 days 00:00:00, output: [t1.id, t1.v1, t1.created_at, window_start, window_end, t1._row_id] }
         StreamFilter { predicate: (t1.v1 >= 10:Int32) }
-          StreamTableScan { table: t1, columns: [id, v1, created_at, _row_id] }
+          StreamTableScan { table: t1, columns: [t1.id, t1.v1, t1.created_at, t1._row_id], pk: [t1._row_id], distribution: HashShard(t1._row_id) }

--- a/src/frontend/test_runner/tests/testdata/tpch.yaml
+++ b/src/frontend/test_runner/tests/testdata/tpch.yaml
@@ -107,12 +107,12 @@
       LogicalAgg { group_key: [lineitem.l_returnflag, lineitem.l_linestatus], aggs: [sum(lineitem.l_quantity), sum(lineitem.l_extendedprice), sum((lineitem.l_extendedprice * (1:Int32 - lineitem.l_discount))), sum(((lineitem.l_extendedprice * (1:Int32 - lineitem.l_discount)) * (1:Int32 + lineitem.l_tax))), sum(lineitem.l_quantity), count(lineitem.l_quantity), sum(lineitem.l_extendedprice), count(lineitem.l_extendedprice), sum(lineitem.l_discount), count(lineitem.l_discount), count] }
         LogicalProject { exprs: [lineitem.l_returnflag, lineitem.l_linestatus, lineitem.l_quantity, lineitem.l_extendedprice, (lineitem.l_extendedprice * (1:Int32 - lineitem.l_discount)), ((lineitem.l_extendedprice * (1:Int32 - lineitem.l_discount)) * (1:Int32 + lineitem.l_tax)), lineitem.l_discount] }
           LogicalFilter { predicate: (lineitem.l_shipdate <= ('1998-12-01':Varchar::Date - '71 days 00:00:00':Interval)) }
-            LogicalScan { table: lineitem, columns: [_row_id, l_orderkey, l_partkey, l_suppkey, l_linenumber, l_quantity, l_extendedprice, l_discount, l_tax, l_returnflag, l_linestatus, l_shipdate, l_commitdate, l_receiptdate, l_shipinstruct, l_shipmode, l_comment] }
+            LogicalScan { table: lineitem, columns: [lineitem._row_id, lineitem.l_orderkey, lineitem.l_partkey, lineitem.l_suppkey, lineitem.l_linenumber, lineitem.l_quantity, lineitem.l_extendedprice, lineitem.l_discount, lineitem.l_tax, lineitem.l_returnflag, lineitem.l_linestatus, lineitem.l_shipdate, lineitem.l_commitdate, lineitem.l_receiptdate, lineitem.l_shipinstruct, lineitem.l_shipmode, lineitem.l_comment] }
   optimized_logical_plan: |
     LogicalProject { exprs: [lineitem.l_returnflag, lineitem.l_linestatus, sum(lineitem.l_quantity), sum(lineitem.l_extendedprice), sum((lineitem.l_extendedprice * (1:Int32 - lineitem.l_discount))), sum(((lineitem.l_extendedprice * (1:Int32 - lineitem.l_discount)) * (1:Int32 + lineitem.l_tax))), RoundDigit((sum(lineitem.l_quantity) / count(lineitem.l_quantity)), 4:Int32), RoundDigit((sum(lineitem.l_extendedprice) / count(lineitem.l_extendedprice)), 4:Int32), RoundDigit((sum(lineitem.l_discount) / count(lineitem.l_discount)), 4:Int32), count] }
       LogicalAgg { group_key: [lineitem.l_returnflag, lineitem.l_linestatus], aggs: [sum(lineitem.l_quantity), sum(lineitem.l_extendedprice), sum((lineitem.l_extendedprice * (1:Int32 - lineitem.l_discount))), sum(((lineitem.l_extendedprice * (1:Int32 - lineitem.l_discount)) * (1:Int32 + lineitem.l_tax))), sum(lineitem.l_quantity), count(lineitem.l_quantity), sum(lineitem.l_extendedprice), count(lineitem.l_extendedprice), sum(lineitem.l_discount), count(lineitem.l_discount), count] }
         LogicalProject { exprs: [lineitem.l_returnflag, lineitem.l_linestatus, lineitem.l_quantity, lineitem.l_extendedprice, (lineitem.l_extendedprice * (1:Int32 - lineitem.l_discount)), ((lineitem.l_extendedprice * (1:Int32 - lineitem.l_discount)) * (1:Int32 + lineitem.l_tax)), lineitem.l_discount] }
-          LogicalScan { table: lineitem, output_columns: [l_quantity, l_extendedprice, l_discount, l_tax, l_returnflag, l_linestatus], required_columns: [l_quantity, l_extendedprice, l_discount, l_tax, l_returnflag, l_linestatus, l_shipdate], predicate: (lineitem.l_shipdate <= ('1998-12-01':Varchar::Date - '71 days 00:00:00':Interval)) }
+          LogicalScan { table: lineitem, output_columns: [lineitem.l_quantity, lineitem.l_extendedprice, lineitem.l_discount, lineitem.l_tax, lineitem.l_returnflag, lineitem.l_linestatus], required_columns: [l_quantity, l_extendedprice, l_discount, l_tax, l_returnflag, l_linestatus, l_shipdate], predicate: (lineitem.l_shipdate <= ('1998-12-01':Varchar::Date - '71 days 00:00:00':Interval)) }
   batch_plan: |
     BatchExchange { order: [lineitem.l_returnflag ASC, lineitem.l_linestatus ASC], dist: Single }
       BatchSort { order: [lineitem.l_returnflag ASC, lineitem.l_linestatus ASC] }
@@ -121,7 +121,7 @@
             BatchExchange { order: [], dist: HashShard(lineitem.l_returnflag, lineitem.l_linestatus) }
               BatchProject { exprs: [lineitem.l_returnflag, lineitem.l_linestatus, lineitem.l_quantity, lineitem.l_extendedprice, (lineitem.l_extendedprice * (1:Int32 - lineitem.l_discount)), ((lineitem.l_extendedprice * (1:Int32 - lineitem.l_discount)) * (1:Int32 + lineitem.l_tax)), lineitem.l_discount] }
                 BatchFilter { predicate: (lineitem.l_shipdate <= ('1998-12-01':Varchar::Date - '71 days 00:00:00':Interval)) }
-                  BatchScan { table: lineitem, columns: [l_quantity, l_extendedprice, l_discount, l_tax, l_returnflag, l_linestatus, l_shipdate] }
+                  BatchScan { table: lineitem, columns: [lineitem.l_quantity, lineitem.l_extendedprice, lineitem.l_discount, lineitem.l_tax, lineitem.l_returnflag, lineitem.l_linestatus, lineitem.l_shipdate], distribution: SomeShard }
   stream_plan: |
     StreamMaterialize { columns: [l_returnflag, l_linestatus, sum_qty, sum_base_price, sum_disc_price, sum_charge, avg_qty, avg_price, avg_disc, count_order], pk_columns: [l_returnflag, l_linestatus] }
       StreamProject { exprs: [lineitem.l_returnflag, lineitem.l_linestatus, sum(lineitem.l_quantity), sum(lineitem.l_extendedprice), sum((lineitem.l_extendedprice * (1:Int32 - lineitem.l_discount))), sum(((lineitem.l_extendedprice * (1:Int32 - lineitem.l_discount)) * (1:Int32 + lineitem.l_tax))), RoundDigit((sum(lineitem.l_quantity) / count(lineitem.l_quantity)), 4:Int32), RoundDigit((sum(lineitem.l_extendedprice) / count(lineitem.l_extendedprice)), 4:Int32), RoundDigit((sum(lineitem.l_discount) / count(lineitem.l_discount)), 4:Int32), count] }
@@ -129,7 +129,7 @@
           StreamExchange { dist: HashShard(lineitem.l_returnflag, lineitem.l_linestatus) }
             StreamProject { exprs: [lineitem.l_returnflag, lineitem.l_linestatus, lineitem.l_quantity, lineitem.l_extendedprice, (lineitem.l_extendedprice * (1:Int32 - lineitem.l_discount)), ((lineitem.l_extendedprice * (1:Int32 - lineitem.l_discount)) * (1:Int32 + lineitem.l_tax)), lineitem.l_discount, lineitem._row_id] }
               StreamFilter { predicate: (lineitem.l_shipdate <= ('1998-12-01':Varchar::Date - '71 days 00:00:00':Interval)) }
-                StreamTableScan { table: lineitem, columns: [l_quantity, l_extendedprice, l_discount, l_tax, l_returnflag, l_linestatus, _row_id, l_shipdate] }
+                StreamTableScan { table: lineitem, columns: [lineitem.l_quantity, lineitem.l_extendedprice, lineitem.l_discount, lineitem.l_tax, lineitem.l_returnflag, lineitem.l_linestatus, lineitem._row_id, lineitem.l_shipdate], pk: [lineitem._row_id], distribution: HashShard(lineitem._row_id) }
 - id: tpch_q2
   before:
   - create_tables
@@ -185,137 +185,137 @@
       LogicalProject { exprs: [supplier.s_acctbal, supplier.s_name, nation.n_name, part.p_partkey, part.p_mfgr, supplier.s_address, supplier.s_phone, supplier.s_comment] }
         LogicalFilter { predicate: (part.p_partkey = partsupp.ps_partkey) AND (supplier.s_suppkey = partsupp.ps_suppkey) AND (part.p_size = 4:Int32) AND Like(part.p_type, '%TIN':Varchar) AND (supplier.s_nationkey = nation.n_nationkey) AND (nation.n_regionkey = region.r_regionkey) AND (region.r_name = 'AFRICA':Varchar) AND (partsupp.ps_supplycost = min(partsupp.ps_supplycost)) }
           LogicalApply { type: LeftOuter, on: true, correlated_id: 1 }
-            LogicalJoin { type: Inner, on: true }
-              LogicalJoin { type: Inner, on: true }
-                LogicalJoin { type: Inner, on: true }
-                  LogicalJoin { type: Inner, on: true }
-                    LogicalScan { table: partsupp, columns: [_row_id, ps_partkey, ps_suppkey, ps_availqty, ps_supplycost, ps_comment] }
-                    LogicalScan { table: part, columns: [_row_id, p_partkey, p_name, p_mfgr, p_brand, p_type, p_size, p_container, p_retailprice, p_comment] }
-                  LogicalScan { table: supplier, columns: [_row_id, s_suppkey, s_name, s_address, s_nationkey, s_phone, s_acctbal, s_comment] }
-                LogicalScan { table: nation, columns: [_row_id, n_nationkey, n_name, n_regionkey, n_comment] }
-              LogicalScan { table: region, columns: [_row_id, r_regionkey, r_name, r_comment] }
+            LogicalJoin { type: Inner, on: true, output: all }
+              LogicalJoin { type: Inner, on: true, output: all }
+                LogicalJoin { type: Inner, on: true, output: all }
+                  LogicalJoin { type: Inner, on: true, output: all }
+                    LogicalScan { table: partsupp, columns: [partsupp._row_id, partsupp.ps_partkey, partsupp.ps_suppkey, partsupp.ps_availqty, partsupp.ps_supplycost, partsupp.ps_comment] }
+                    LogicalScan { table: part, columns: [part._row_id, part.p_partkey, part.p_name, part.p_mfgr, part.p_brand, part.p_type, part.p_size, part.p_container, part.p_retailprice, part.p_comment] }
+                  LogicalScan { table: supplier, columns: [supplier._row_id, supplier.s_suppkey, supplier.s_name, supplier.s_address, supplier.s_nationkey, supplier.s_phone, supplier.s_acctbal, supplier.s_comment] }
+                LogicalScan { table: nation, columns: [nation._row_id, nation.n_nationkey, nation.n_name, nation.n_regionkey, nation.n_comment] }
+              LogicalScan { table: region, columns: [region._row_id, region.r_regionkey, region.r_name, region.r_comment] }
             LogicalProject { exprs: [min(partsupp.ps_supplycost)] }
               LogicalAgg { aggs: [min(partsupp.ps_supplycost)] }
                 LogicalProject { exprs: [partsupp.ps_supplycost] }
                   LogicalFilter { predicate: (CorrelatedInputRef { index: 7, correlated_id: 1 } = partsupp.ps_partkey) AND (supplier.s_suppkey = partsupp.ps_suppkey) AND (supplier.s_nationkey = nation.n_nationkey) AND (nation.n_regionkey = region.r_regionkey) AND (region.r_name = 'AFRICA':Varchar) }
-                    LogicalJoin { type: Inner, on: true }
-                      LogicalJoin { type: Inner, on: true }
-                        LogicalJoin { type: Inner, on: true }
-                          LogicalScan { table: partsupp, columns: [_row_id, ps_partkey, ps_suppkey, ps_availqty, ps_supplycost, ps_comment] }
-                          LogicalScan { table: supplier, columns: [_row_id, s_suppkey, s_name, s_address, s_nationkey, s_phone, s_acctbal, s_comment] }
-                        LogicalScan { table: nation, columns: [_row_id, n_nationkey, n_name, n_regionkey, n_comment] }
-                      LogicalScan { table: region, columns: [_row_id, r_regionkey, r_name, r_comment] }
+                    LogicalJoin { type: Inner, on: true, output: all }
+                      LogicalJoin { type: Inner, on: true, output: all }
+                        LogicalJoin { type: Inner, on: true, output: all }
+                          LogicalScan { table: partsupp, columns: [partsupp._row_id, partsupp.ps_partkey, partsupp.ps_suppkey, partsupp.ps_availqty, partsupp.ps_supplycost, partsupp.ps_comment] }
+                          LogicalScan { table: supplier, columns: [supplier._row_id, supplier.s_suppkey, supplier.s_name, supplier.s_address, supplier.s_nationkey, supplier.s_phone, supplier.s_acctbal, supplier.s_comment] }
+                        LogicalScan { table: nation, columns: [nation._row_id, nation.n_nationkey, nation.n_name, nation.n_regionkey, nation.n_comment] }
+                      LogicalScan { table: region, columns: [region._row_id, region.r_regionkey, region.r_name, region.r_comment] }
   optimized_logical_plan: |
     LogicalTopN { order: "[supplier.s_acctbal DESC, nation.n_name ASC, supplier.s_name ASC, part.p_partkey ASC]", limit: 100, offset: 0 }
       LogicalProject { exprs: [supplier.s_acctbal, supplier.s_name, nation.n_name, part.p_partkey, part.p_mfgr, supplier.s_address, supplier.s_phone, supplier.s_comment] }
-        LogicalJoin { type: Inner, on: (nation.n_regionkey = region.r_regionkey) }
-          LogicalJoin { type: Inner, on: (supplier.s_nationkey = nation.n_nationkey) }
-            LogicalJoin { type: Inner, on: (part.p_partkey = partsupp.ps_partkey) AND (partsupp.ps_supplycost = min(partsupp.ps_supplycost)) }
-              LogicalJoin { type: Inner, on: (supplier.s_suppkey = partsupp.ps_suppkey) }
-                LogicalJoin { type: Inner, on: (part.p_partkey = partsupp.ps_partkey) }
-                  LogicalScan { table: partsupp, columns: [ps_partkey, ps_suppkey, ps_supplycost] }
-                  LogicalScan { table: part, output_columns: [p_partkey, p_mfgr], required_columns: [p_partkey, p_mfgr, p_type, p_size], predicate: (part.p_size = 4:Int32) AND Like(part.p_type, '%TIN':Varchar) }
-                LogicalScan { table: supplier, columns: [s_suppkey, s_name, s_address, s_nationkey, s_phone, s_acctbal, s_comment] }
+        LogicalJoin { type: Inner, on: (nation.n_regionkey = region.r_regionkey), output: [part.p_partkey, part.p_mfgr, supplier.s_name, supplier.s_address, supplier.s_phone, supplier.s_acctbal, supplier.s_comment, nation.n_name] }
+          LogicalJoin { type: Inner, on: (supplier.s_nationkey = nation.n_nationkey), output: [part.p_partkey, part.p_mfgr, supplier.s_name, supplier.s_address, supplier.s_phone, supplier.s_acctbal, supplier.s_comment, nation.n_name, nation.n_regionkey] }
+            LogicalJoin { type: Inner, on: (part.p_partkey = partsupp.ps_partkey) AND (partsupp.ps_supplycost = min(partsupp.ps_supplycost)), output: [part.p_partkey, part.p_mfgr, supplier.s_name, supplier.s_address, supplier.s_nationkey, supplier.s_phone, supplier.s_acctbal, supplier.s_comment] }
+              LogicalJoin { type: Inner, on: (supplier.s_suppkey = partsupp.ps_suppkey), output: [partsupp.ps_supplycost, part.p_partkey, part.p_mfgr, supplier.s_name, supplier.s_address, supplier.s_nationkey, supplier.s_phone, supplier.s_acctbal, supplier.s_comment] }
+                LogicalJoin { type: Inner, on: (part.p_partkey = partsupp.ps_partkey), output: [partsupp.ps_suppkey, partsupp.ps_supplycost, part.p_partkey, part.p_mfgr] }
+                  LogicalScan { table: partsupp, columns: [partsupp.ps_partkey, partsupp.ps_suppkey, partsupp.ps_supplycost] }
+                  LogicalScan { table: part, output_columns: [part.p_partkey, part.p_mfgr], required_columns: [p_partkey, p_mfgr, p_type, p_size], predicate: (part.p_size = 4:Int32) AND Like(part.p_type, '%TIN':Varchar) }
+                LogicalScan { table: supplier, columns: [supplier.s_suppkey, supplier.s_name, supplier.s_address, supplier.s_nationkey, supplier.s_phone, supplier.s_acctbal, supplier.s_comment] }
               LogicalAgg { group_key: [partsupp.ps_partkey], aggs: [min(partsupp.ps_supplycost)] }
-                LogicalJoin { type: Inner, on: (nation.n_regionkey = region.r_regionkey) }
-                  LogicalJoin { type: Inner, on: (supplier.s_nationkey = nation.n_nationkey) }
-                    LogicalJoin { type: Inner, on: (supplier.s_suppkey = partsupp.ps_suppkey) }
-                      LogicalScan { table: partsupp, columns: [ps_partkey, ps_suppkey, ps_supplycost] }
-                      LogicalScan { table: supplier, columns: [s_suppkey, s_nationkey] }
-                    LogicalScan { table: nation, columns: [n_nationkey, n_regionkey] }
-                  LogicalScan { table: region, output_columns: [r_regionkey], required_columns: [r_regionkey, r_name], predicate: (region.r_name = 'AFRICA':Varchar) }
-            LogicalScan { table: nation, columns: [n_nationkey, n_name, n_regionkey] }
-          LogicalScan { table: region, output_columns: [r_regionkey], required_columns: [r_regionkey, r_name], predicate: (region.r_name = 'AFRICA':Varchar) }
+                LogicalJoin { type: Inner, on: (nation.n_regionkey = region.r_regionkey), output: [partsupp.ps_partkey, partsupp.ps_supplycost] }
+                  LogicalJoin { type: Inner, on: (supplier.s_nationkey = nation.n_nationkey), output: [partsupp.ps_partkey, partsupp.ps_supplycost, nation.n_regionkey] }
+                    LogicalJoin { type: Inner, on: (supplier.s_suppkey = partsupp.ps_suppkey), output: [partsupp.ps_partkey, partsupp.ps_supplycost, supplier.s_nationkey] }
+                      LogicalScan { table: partsupp, columns: [partsupp.ps_partkey, partsupp.ps_suppkey, partsupp.ps_supplycost] }
+                      LogicalScan { table: supplier, columns: [supplier.s_suppkey, supplier.s_nationkey] }
+                    LogicalScan { table: nation, columns: [nation.n_nationkey, nation.n_regionkey] }
+                  LogicalScan { table: region, output_columns: [region.r_regionkey], required_columns: [r_regionkey, r_name], predicate: (region.r_name = 'AFRICA':Varchar) }
+            LogicalScan { table: nation, columns: [nation.n_nationkey, nation.n_name, nation.n_regionkey] }
+          LogicalScan { table: region, output_columns: [region.r_regionkey], required_columns: [r_regionkey, r_name], predicate: (region.r_name = 'AFRICA':Varchar) }
   batch_plan: |
     BatchTopN { order: "[supplier.s_acctbal DESC, nation.n_name ASC, supplier.s_name ASC, part.p_partkey ASC]", limit: 100, offset: 0 }
       BatchExchange { order: [], dist: Single }
         BatchTopN { order: "[supplier.s_acctbal DESC, nation.n_name ASC, supplier.s_name ASC, part.p_partkey ASC]", limit: 100, offset: 0 }
           BatchProject { exprs: [supplier.s_acctbal, supplier.s_name, nation.n_name, part.p_partkey, part.p_mfgr, supplier.s_address, supplier.s_phone, supplier.s_comment] }
-            BatchHashJoin { type: Inner, predicate: nation.n_regionkey = region.r_regionkey }
+            BatchHashJoin { type: Inner, predicate: nation.n_regionkey = region.r_regionkey, output: [part.p_partkey, part.p_mfgr, supplier.s_name, supplier.s_address, supplier.s_phone, supplier.s_acctbal, supplier.s_comment, nation.n_name] }
               BatchExchange { order: [], dist: HashShard(nation.n_regionkey) }
-                BatchHashJoin { type: Inner, predicate: supplier.s_nationkey = nation.n_nationkey }
+                BatchHashJoin { type: Inner, predicate: supplier.s_nationkey = nation.n_nationkey, output: [part.p_partkey, part.p_mfgr, supplier.s_name, supplier.s_address, supplier.s_phone, supplier.s_acctbal, supplier.s_comment, nation.n_name, nation.n_regionkey] }
                   BatchExchange { order: [], dist: HashShard(supplier.s_nationkey) }
-                    BatchHashJoin { type: Inner, predicate: part.p_partkey = partsupp.ps_partkey AND partsupp.ps_supplycost = min(partsupp.ps_supplycost) }
+                    BatchHashJoin { type: Inner, predicate: part.p_partkey = partsupp.ps_partkey AND partsupp.ps_supplycost = min(partsupp.ps_supplycost), output: [part.p_partkey, part.p_mfgr, supplier.s_name, supplier.s_address, supplier.s_nationkey, supplier.s_phone, supplier.s_acctbal, supplier.s_comment] }
                       BatchExchange { order: [], dist: HashShard(part.p_partkey) }
-                        BatchHashJoin { type: Inner, predicate: partsupp.ps_suppkey = supplier.s_suppkey }
+                        BatchHashJoin { type: Inner, predicate: partsupp.ps_suppkey = supplier.s_suppkey, output: [partsupp.ps_supplycost, part.p_partkey, part.p_mfgr, supplier.s_name, supplier.s_address, supplier.s_nationkey, supplier.s_phone, supplier.s_acctbal, supplier.s_comment] }
                           BatchExchange { order: [], dist: HashShard(partsupp.ps_suppkey) }
-                            BatchHashJoin { type: Inner, predicate: partsupp.ps_partkey = part.p_partkey }
+                            BatchHashJoin { type: Inner, predicate: partsupp.ps_partkey = part.p_partkey, output: [partsupp.ps_suppkey, partsupp.ps_supplycost, part.p_partkey, part.p_mfgr] }
                               BatchExchange { order: [], dist: HashShard(partsupp.ps_partkey) }
-                                BatchScan { table: partsupp, columns: [ps_partkey, ps_suppkey, ps_supplycost] }
+                                BatchScan { table: partsupp, columns: [partsupp.ps_partkey, partsupp.ps_suppkey, partsupp.ps_supplycost], distribution: SomeShard }
                               BatchExchange { order: [], dist: HashShard(part.p_partkey) }
                                 BatchProject { exprs: [part.p_partkey, part.p_mfgr] }
                                   BatchFilter { predicate: (part.p_size = 4:Int32) AND Like(part.p_type, '%TIN':Varchar) }
-                                    BatchScan { table: part, columns: [p_partkey, p_mfgr, p_type, p_size] }
+                                    BatchScan { table: part, columns: [part.p_partkey, part.p_mfgr, part.p_type, part.p_size], distribution: SomeShard }
                           BatchExchange { order: [], dist: HashShard(supplier.s_suppkey) }
-                            BatchScan { table: supplier, columns: [s_suppkey, s_name, s_address, s_nationkey, s_phone, s_acctbal, s_comment] }
+                            BatchScan { table: supplier, columns: [supplier.s_suppkey, supplier.s_name, supplier.s_address, supplier.s_nationkey, supplier.s_phone, supplier.s_acctbal, supplier.s_comment], distribution: SomeShard }
                       BatchHashAgg { group_key: [partsupp.ps_partkey], aggs: [min(partsupp.ps_supplycost)] }
                         BatchExchange { order: [], dist: HashShard(partsupp.ps_partkey) }
-                          BatchHashJoin { type: Inner, predicate: nation.n_regionkey = region.r_regionkey }
+                          BatchHashJoin { type: Inner, predicate: nation.n_regionkey = region.r_regionkey, output: [partsupp.ps_partkey, partsupp.ps_supplycost] }
                             BatchExchange { order: [], dist: HashShard(nation.n_regionkey) }
-                              BatchHashJoin { type: Inner, predicate: supplier.s_nationkey = nation.n_nationkey }
+                              BatchHashJoin { type: Inner, predicate: supplier.s_nationkey = nation.n_nationkey, output: [partsupp.ps_partkey, partsupp.ps_supplycost, nation.n_regionkey] }
                                 BatchExchange { order: [], dist: HashShard(supplier.s_nationkey) }
-                                  BatchHashJoin { type: Inner, predicate: partsupp.ps_suppkey = supplier.s_suppkey }
+                                  BatchHashJoin { type: Inner, predicate: partsupp.ps_suppkey = supplier.s_suppkey, output: [partsupp.ps_partkey, partsupp.ps_supplycost, supplier.s_nationkey] }
                                     BatchExchange { order: [], dist: HashShard(partsupp.ps_suppkey) }
-                                      BatchScan { table: partsupp, columns: [ps_partkey, ps_suppkey, ps_supplycost] }
+                                      BatchScan { table: partsupp, columns: [partsupp.ps_partkey, partsupp.ps_suppkey, partsupp.ps_supplycost], distribution: SomeShard }
                                     BatchExchange { order: [], dist: HashShard(supplier.s_suppkey) }
-                                      BatchScan { table: supplier, columns: [s_suppkey, s_nationkey] }
+                                      BatchScan { table: supplier, columns: [supplier.s_suppkey, supplier.s_nationkey], distribution: SomeShard }
                                 BatchExchange { order: [], dist: HashShard(nation.n_nationkey) }
-                                  BatchScan { table: nation, columns: [n_nationkey, n_regionkey] }
+                                  BatchScan { table: nation, columns: [nation.n_nationkey, nation.n_regionkey], distribution: SomeShard }
                             BatchExchange { order: [], dist: HashShard(region.r_regionkey) }
                               BatchProject { exprs: [region.r_regionkey] }
                                 BatchFilter { predicate: (region.r_name = 'AFRICA':Varchar) }
-                                  BatchScan { table: region, columns: [r_regionkey, r_name] }
+                                  BatchScan { table: region, columns: [region.r_regionkey, region.r_name], distribution: SomeShard }
                   BatchExchange { order: [], dist: HashShard(nation.n_nationkey) }
-                    BatchScan { table: nation, columns: [n_nationkey, n_name, n_regionkey] }
+                    BatchScan { table: nation, columns: [nation.n_nationkey, nation.n_name, nation.n_regionkey], distribution: SomeShard }
               BatchExchange { order: [], dist: HashShard(region.r_regionkey) }
                 BatchProject { exprs: [region.r_regionkey] }
                   BatchFilter { predicate: (region.r_name = 'AFRICA':Varchar) }
-                    BatchScan { table: region, columns: [r_regionkey, r_name] }
+                    BatchScan { table: region, columns: [region.r_regionkey, region.r_name], distribution: SomeShard }
   stream_plan: |
     StreamMaterialize { columns: [s_acctbal, s_name, n_name, p_partkey, p_mfgr, s_address, s_phone, s_comment, partsupp._row_id(hidden), part._row_id(hidden), supplier._row_id(hidden), partsupp.ps_partkey(hidden), nation._row_id(hidden), region._row_id(hidden)], pk_columns: [partsupp._row_id, part._row_id, supplier._row_id, partsupp.ps_partkey, nation._row_id, region._row_id], order_descs: [s_acctbal, n_name, s_name, p_partkey, partsupp._row_id, part._row_id, supplier._row_id, partsupp.ps_partkey, nation._row_id, region._row_id] }
       StreamTopN { order: "[supplier.s_acctbal DESC, nation.n_name ASC, supplier.s_name ASC, part.p_partkey ASC]", limit: 100, offset: 0 }
         StreamExchange { dist: Single }
           StreamProject { exprs: [supplier.s_acctbal, supplier.s_name, nation.n_name, part.p_partkey, part.p_mfgr, supplier.s_address, supplier.s_phone, supplier.s_comment, partsupp._row_id, part._row_id, supplier._row_id, partsupp.ps_partkey, nation._row_id, region._row_id] }
-            StreamHashJoin { type: Inner, predicate: nation.n_regionkey = region.r_regionkey }
+            StreamHashJoin { type: Inner, predicate: nation.n_regionkey = region.r_regionkey, output: [part.p_partkey, part.p_mfgr, supplier.s_name, supplier.s_address, supplier.s_phone, supplier.s_acctbal, supplier.s_comment, nation.n_name, partsupp._row_id, part._row_id, supplier._row_id, partsupp.ps_partkey, nation._row_id, region._row_id] }
               StreamExchange { dist: HashShard(nation.n_regionkey) }
-                StreamHashJoin { type: Inner, predicate: supplier.s_nationkey = nation.n_nationkey }
+                StreamHashJoin { type: Inner, predicate: supplier.s_nationkey = nation.n_nationkey, output: [part.p_partkey, part.p_mfgr, supplier.s_name, supplier.s_address, supplier.s_phone, supplier.s_acctbal, supplier.s_comment, nation.n_name, nation.n_regionkey, partsupp._row_id, part._row_id, supplier._row_id, partsupp.ps_partkey, nation._row_id] }
                   StreamExchange { dist: HashShard(supplier.s_nationkey) }
-                    StreamHashJoin { type: Inner, predicate: part.p_partkey = partsupp.ps_partkey AND partsupp.ps_supplycost = min(partsupp.ps_supplycost) }
+                    StreamHashJoin { type: Inner, predicate: part.p_partkey = partsupp.ps_partkey AND partsupp.ps_supplycost = min(partsupp.ps_supplycost), output: [part.p_partkey, part.p_mfgr, supplier.s_name, supplier.s_address, supplier.s_nationkey, supplier.s_phone, supplier.s_acctbal, supplier.s_comment, partsupp._row_id, part._row_id, supplier._row_id, partsupp.ps_partkey] }
                       StreamExchange { dist: HashShard(part.p_partkey) }
-                        StreamHashJoin { type: Inner, predicate: partsupp.ps_suppkey = supplier.s_suppkey }
+                        StreamHashJoin { type: Inner, predicate: partsupp.ps_suppkey = supplier.s_suppkey, output: [partsupp.ps_supplycost, part.p_partkey, part.p_mfgr, supplier.s_name, supplier.s_address, supplier.s_nationkey, supplier.s_phone, supplier.s_acctbal, supplier.s_comment, partsupp._row_id, part._row_id, supplier._row_id] }
                           StreamExchange { dist: HashShard(partsupp.ps_suppkey) }
-                            StreamHashJoin { type: Inner, predicate: partsupp.ps_partkey = part.p_partkey }
+                            StreamHashJoin { type: Inner, predicate: partsupp.ps_partkey = part.p_partkey, output: [partsupp.ps_suppkey, partsupp.ps_supplycost, part.p_partkey, part.p_mfgr, partsupp._row_id, part._row_id] }
                               StreamExchange { dist: HashShard(partsupp.ps_partkey) }
-                                StreamTableScan { table: partsupp, columns: [ps_partkey, ps_suppkey, ps_supplycost, _row_id] }
+                                StreamTableScan { table: partsupp, columns: [partsupp.ps_partkey, partsupp.ps_suppkey, partsupp.ps_supplycost, partsupp._row_id], pk: [partsupp._row_id], distribution: HashShard(partsupp._row_id) }
                               StreamExchange { dist: HashShard(part.p_partkey) }
                                 StreamProject { exprs: [part.p_partkey, part.p_mfgr, part._row_id] }
                                   StreamFilter { predicate: (part.p_size = 4:Int32) AND Like(part.p_type, '%TIN':Varchar) }
-                                    StreamTableScan { table: part, columns: [p_partkey, p_mfgr, _row_id, p_type, p_size] }
+                                    StreamTableScan { table: part, columns: [part.p_partkey, part.p_mfgr, part._row_id, part.p_type, part.p_size], pk: [part._row_id], distribution: HashShard(part._row_id) }
                           StreamExchange { dist: HashShard(supplier.s_suppkey) }
-                            StreamTableScan { table: supplier, columns: [s_suppkey, s_name, s_address, s_nationkey, s_phone, s_acctbal, s_comment, _row_id] }
+                            StreamTableScan { table: supplier, columns: [supplier.s_suppkey, supplier.s_name, supplier.s_address, supplier.s_nationkey, supplier.s_phone, supplier.s_acctbal, supplier.s_comment, supplier._row_id], pk: [supplier._row_id], distribution: HashShard(supplier._row_id) }
                       StreamHashAgg { group_key: [partsupp.ps_partkey], aggs: [count, min(partsupp.ps_supplycost)] }
                         StreamExchange { dist: HashShard(partsupp.ps_partkey) }
-                          StreamHashJoin { type: Inner, predicate: nation.n_regionkey = region.r_regionkey }
+                          StreamHashJoin { type: Inner, predicate: nation.n_regionkey = region.r_regionkey, output: [partsupp.ps_partkey, partsupp.ps_supplycost, partsupp._row_id, supplier._row_id, nation._row_id, region._row_id] }
                             StreamExchange { dist: HashShard(nation.n_regionkey) }
-                              StreamHashJoin { type: Inner, predicate: supplier.s_nationkey = nation.n_nationkey }
+                              StreamHashJoin { type: Inner, predicate: supplier.s_nationkey = nation.n_nationkey, output: [partsupp.ps_partkey, partsupp.ps_supplycost, nation.n_regionkey, partsupp._row_id, supplier._row_id, nation._row_id] }
                                 StreamExchange { dist: HashShard(supplier.s_nationkey) }
-                                  StreamHashJoin { type: Inner, predicate: partsupp.ps_suppkey = supplier.s_suppkey }
+                                  StreamHashJoin { type: Inner, predicate: partsupp.ps_suppkey = supplier.s_suppkey, output: [partsupp.ps_partkey, partsupp.ps_supplycost, supplier.s_nationkey, partsupp._row_id, supplier._row_id] }
                                     StreamExchange { dist: HashShard(partsupp.ps_suppkey) }
-                                      StreamTableScan { table: partsupp, columns: [ps_partkey, ps_suppkey, ps_supplycost, _row_id] }
+                                      StreamTableScan { table: partsupp, columns: [partsupp.ps_partkey, partsupp.ps_suppkey, partsupp.ps_supplycost, partsupp._row_id], pk: [partsupp._row_id], distribution: HashShard(partsupp._row_id) }
                                     StreamExchange { dist: HashShard(supplier.s_suppkey) }
-                                      StreamTableScan { table: supplier, columns: [s_suppkey, s_nationkey, _row_id] }
+                                      StreamTableScan { table: supplier, columns: [supplier.s_suppkey, supplier.s_nationkey, supplier._row_id], pk: [supplier._row_id], distribution: HashShard(supplier._row_id) }
                                 StreamExchange { dist: HashShard(nation.n_nationkey) }
-                                  StreamTableScan { table: nation, columns: [n_nationkey, n_regionkey, _row_id] }
+                                  StreamTableScan { table: nation, columns: [nation.n_nationkey, nation.n_regionkey, nation._row_id], pk: [nation._row_id], distribution: HashShard(nation._row_id) }
                             StreamExchange { dist: HashShard(region.r_regionkey) }
                               StreamProject { exprs: [region.r_regionkey, region._row_id] }
                                 StreamFilter { predicate: (region.r_name = 'AFRICA':Varchar) }
-                                  StreamTableScan { table: region, columns: [r_regionkey, _row_id, r_name] }
+                                  StreamTableScan { table: region, columns: [region.r_regionkey, region._row_id, region.r_name], pk: [region._row_id], distribution: HashShard(region._row_id) }
                   StreamExchange { dist: HashShard(nation.n_nationkey) }
-                    StreamTableScan { table: nation, columns: [n_nationkey, n_name, n_regionkey, _row_id] }
+                    StreamTableScan { table: nation, columns: [nation.n_nationkey, nation.n_name, nation.n_regionkey, nation._row_id], pk: [nation._row_id], distribution: HashShard(nation._row_id) }
               StreamExchange { dist: HashShard(region.r_regionkey) }
                 StreamProject { exprs: [region.r_regionkey, region._row_id] }
                   StreamFilter { predicate: (region.r_name = 'AFRICA':Varchar) }
-                    StreamTableScan { table: region, columns: [r_regionkey, _row_id, r_name] }
+                    StreamTableScan { table: region, columns: [region.r_regionkey, region._row_id, region.r_name], pk: [region._row_id], distribution: HashShard(region._row_id) }
 - id: tpch_q3
   before:
   - create_tables
@@ -349,21 +349,21 @@
         LogicalAgg { group_key: [lineitem.l_orderkey, orders.o_orderdate, orders.o_shippriority], aggs: [sum((lineitem.l_extendedprice * (1:Int32 - lineitem.l_discount)))] }
           LogicalProject { exprs: [lineitem.l_orderkey, orders.o_orderdate, orders.o_shippriority, (lineitem.l_extendedprice * (1:Int32 - lineitem.l_discount))] }
             LogicalFilter { predicate: (customer.c_mktsegment = 'FURNITURE':Varchar) AND (customer.c_custkey = orders.o_custkey) AND (lineitem.l_orderkey = orders.o_orderkey) AND (orders.o_orderdate < '1995-03-29':Varchar::Date) AND (lineitem.l_shipdate > '1995-03-29':Varchar::Date) }
-              LogicalJoin { type: Inner, on: true }
-                LogicalJoin { type: Inner, on: true }
-                  LogicalScan { table: customer, columns: [_row_id, c_custkey, c_name, c_address, c_nationkey, c_phone, c_acctbal, c_mktsegment, c_comment] }
-                  LogicalScan { table: orders, columns: [_row_id, o_orderkey, o_custkey, o_orderstatus, o_totalprice, o_orderdate, o_orderpriority, o_clerk, o_shippriority, o_comment] }
-                LogicalScan { table: lineitem, columns: [_row_id, l_orderkey, l_partkey, l_suppkey, l_linenumber, l_quantity, l_extendedprice, l_discount, l_tax, l_returnflag, l_linestatus, l_shipdate, l_commitdate, l_receiptdate, l_shipinstruct, l_shipmode, l_comment] }
+              LogicalJoin { type: Inner, on: true, output: all }
+                LogicalJoin { type: Inner, on: true, output: all }
+                  LogicalScan { table: customer, columns: [customer._row_id, customer.c_custkey, customer.c_name, customer.c_address, customer.c_nationkey, customer.c_phone, customer.c_acctbal, customer.c_mktsegment, customer.c_comment] }
+                  LogicalScan { table: orders, columns: [orders._row_id, orders.o_orderkey, orders.o_custkey, orders.o_orderstatus, orders.o_totalprice, orders.o_orderdate, orders.o_orderpriority, orders.o_clerk, orders.o_shippriority, orders.o_comment] }
+                LogicalScan { table: lineitem, columns: [lineitem._row_id, lineitem.l_orderkey, lineitem.l_partkey, lineitem.l_suppkey, lineitem.l_linenumber, lineitem.l_quantity, lineitem.l_extendedprice, lineitem.l_discount, lineitem.l_tax, lineitem.l_returnflag, lineitem.l_linestatus, lineitem.l_shipdate, lineitem.l_commitdate, lineitem.l_receiptdate, lineitem.l_shipinstruct, lineitem.l_shipmode, lineitem.l_comment] }
   optimized_logical_plan: |
     LogicalTopN { order: "[sum((lineitem.l_extendedprice * (1:Int32 - lineitem.l_discount))) DESC, orders.o_orderdate ASC]", limit: 10, offset: 0 }
       LogicalProject { exprs: [lineitem.l_orderkey, sum((lineitem.l_extendedprice * (1:Int32 - lineitem.l_discount))), orders.o_orderdate, orders.o_shippriority] }
         LogicalAgg { group_key: [lineitem.l_orderkey, orders.o_orderdate, orders.o_shippriority], aggs: [sum((lineitem.l_extendedprice * (1:Int32 - lineitem.l_discount)))] }
           LogicalProject { exprs: [lineitem.l_orderkey, orders.o_orderdate, orders.o_shippriority, (lineitem.l_extendedprice * (1:Int32 - lineitem.l_discount))] }
-            LogicalJoin { type: Inner, on: (lineitem.l_orderkey = orders.o_orderkey) }
-              LogicalJoin { type: Inner, on: (customer.c_custkey = orders.o_custkey) }
-                LogicalScan { table: customer, output_columns: [c_custkey], required_columns: [c_custkey, c_mktsegment], predicate: (customer.c_mktsegment = 'FURNITURE':Varchar) }
-                LogicalScan { table: orders, output_columns: [o_orderkey, o_custkey, o_orderdate, o_shippriority], required_columns: [o_orderkey, o_custkey, o_orderdate, o_shippriority], predicate: (orders.o_orderdate < '1995-03-29':Varchar::Date) }
-              LogicalScan { table: lineitem, output_columns: [l_orderkey, l_extendedprice, l_discount], required_columns: [l_orderkey, l_extendedprice, l_discount, l_shipdate], predicate: (lineitem.l_shipdate > '1995-03-29':Varchar::Date) }
+            LogicalJoin { type: Inner, on: (lineitem.l_orderkey = orders.o_orderkey), output: [orders.o_orderdate, orders.o_shippriority, lineitem.l_orderkey, lineitem.l_extendedprice, lineitem.l_discount] }
+              LogicalJoin { type: Inner, on: (customer.c_custkey = orders.o_custkey), output: [orders.o_orderkey, orders.o_orderdate, orders.o_shippriority] }
+                LogicalScan { table: customer, output_columns: [customer.c_custkey], required_columns: [c_custkey, c_mktsegment], predicate: (customer.c_mktsegment = 'FURNITURE':Varchar) }
+                LogicalScan { table: orders, output_columns: [orders.o_orderkey, orders.o_custkey, orders.o_orderdate, orders.o_shippriority], required_columns: [o_orderkey, o_custkey, o_orderdate, o_shippriority], predicate: (orders.o_orderdate < '1995-03-29':Varchar::Date) }
+              LogicalScan { table: lineitem, output_columns: [lineitem.l_orderkey, lineitem.l_extendedprice, lineitem.l_discount], required_columns: [l_orderkey, l_extendedprice, l_discount, l_shipdate], predicate: (lineitem.l_shipdate > '1995-03-29':Varchar::Date) }
   batch_plan: |
     BatchTopN { order: "[sum((lineitem.l_extendedprice * (1:Int32 - lineitem.l_discount))) DESC, orders.o_orderdate ASC]", limit: 10, offset: 0 }
       BatchExchange { order: [], dist: Single }
@@ -372,20 +372,20 @@
             BatchHashAgg { group_key: [lineitem.l_orderkey, orders.o_orderdate, orders.o_shippriority], aggs: [sum((lineitem.l_extendedprice * (1:Int32 - lineitem.l_discount)))] }
               BatchExchange { order: [], dist: HashShard(lineitem.l_orderkey, orders.o_orderdate, orders.o_shippriority) }
                 BatchProject { exprs: [lineitem.l_orderkey, orders.o_orderdate, orders.o_shippriority, (lineitem.l_extendedprice * (1:Int32 - lineitem.l_discount))] }
-                  BatchHashJoin { type: Inner, predicate: orders.o_orderkey = lineitem.l_orderkey }
+                  BatchHashJoin { type: Inner, predicate: orders.o_orderkey = lineitem.l_orderkey, output: [orders.o_orderdate, orders.o_shippriority, lineitem.l_orderkey, lineitem.l_extendedprice, lineitem.l_discount] }
                     BatchExchange { order: [], dist: HashShard(orders.o_orderkey) }
-                      BatchHashJoin { type: Inner, predicate: customer.c_custkey = orders.o_custkey }
+                      BatchHashJoin { type: Inner, predicate: customer.c_custkey = orders.o_custkey, output: [orders.o_orderkey, orders.o_orderdate, orders.o_shippriority] }
                         BatchExchange { order: [], dist: HashShard(customer.c_custkey) }
                           BatchProject { exprs: [customer.c_custkey] }
                             BatchFilter { predicate: (customer.c_mktsegment = 'FURNITURE':Varchar) }
-                              BatchScan { table: customer, columns: [c_custkey, c_mktsegment] }
+                              BatchScan { table: customer, columns: [customer.c_custkey, customer.c_mktsegment], distribution: SomeShard }
                         BatchExchange { order: [], dist: HashShard(orders.o_custkey) }
                           BatchFilter { predicate: (orders.o_orderdate < '1995-03-29':Varchar::Date) }
-                            BatchScan { table: orders, columns: [o_orderkey, o_custkey, o_orderdate, o_shippriority] }
+                            BatchScan { table: orders, columns: [orders.o_orderkey, orders.o_custkey, orders.o_orderdate, orders.o_shippriority], distribution: SomeShard }
                     BatchExchange { order: [], dist: HashShard(lineitem.l_orderkey) }
                       BatchProject { exprs: [lineitem.l_orderkey, lineitem.l_extendedprice, lineitem.l_discount] }
                         BatchFilter { predicate: (lineitem.l_shipdate > '1995-03-29':Varchar::Date) }
-                          BatchScan { table: lineitem, columns: [l_orderkey, l_extendedprice, l_discount, l_shipdate] }
+                          BatchScan { table: lineitem, columns: [lineitem.l_orderkey, lineitem.l_extendedprice, lineitem.l_discount, lineitem.l_shipdate], distribution: SomeShard }
   stream_plan: |
     StreamMaterialize { columns: [l_orderkey, revenue, o_orderdate, o_shippriority], pk_columns: [l_orderkey, o_orderdate, o_shippriority], order_descs: [revenue, o_orderdate, l_orderkey, o_shippriority] }
       StreamTopN { order: "[sum((lineitem.l_extendedprice * (1:Int32 - lineitem.l_discount))) DESC, orders.o_orderdate ASC]", limit: 10, offset: 0 }
@@ -394,20 +394,20 @@
             StreamHashAgg { group_key: [lineitem.l_orderkey, orders.o_orderdate, orders.o_shippriority], aggs: [count, sum((lineitem.l_extendedprice * (1:Int32 - lineitem.l_discount)))] }
               StreamExchange { dist: HashShard(lineitem.l_orderkey, orders.o_orderdate, orders.o_shippriority) }
                 StreamProject { exprs: [lineitem.l_orderkey, orders.o_orderdate, orders.o_shippriority, (lineitem.l_extendedprice * (1:Int32 - lineitem.l_discount)), customer._row_id, orders._row_id, lineitem._row_id] }
-                  StreamHashJoin { type: Inner, predicate: orders.o_orderkey = lineitem.l_orderkey }
+                  StreamHashJoin { type: Inner, predicate: orders.o_orderkey = lineitem.l_orderkey, output: [orders.o_orderdate, orders.o_shippriority, lineitem.l_orderkey, lineitem.l_extendedprice, lineitem.l_discount, customer._row_id, orders._row_id, lineitem._row_id] }
                     StreamExchange { dist: HashShard(orders.o_orderkey) }
-                      StreamHashJoin { type: Inner, predicate: customer.c_custkey = orders.o_custkey }
+                      StreamHashJoin { type: Inner, predicate: customer.c_custkey = orders.o_custkey, output: [orders.o_orderkey, orders.o_orderdate, orders.o_shippriority, customer._row_id, orders._row_id] }
                         StreamExchange { dist: HashShard(customer.c_custkey) }
                           StreamProject { exprs: [customer.c_custkey, customer._row_id] }
                             StreamFilter { predicate: (customer.c_mktsegment = 'FURNITURE':Varchar) }
-                              StreamTableScan { table: customer, columns: [c_custkey, _row_id, c_mktsegment] }
+                              StreamTableScan { table: customer, columns: [customer.c_custkey, customer._row_id, customer.c_mktsegment], pk: [customer._row_id], distribution: HashShard(customer._row_id) }
                         StreamExchange { dist: HashShard(orders.o_custkey) }
                           StreamFilter { predicate: (orders.o_orderdate < '1995-03-29':Varchar::Date) }
-                            StreamTableScan { table: orders, columns: [o_orderkey, o_custkey, o_orderdate, o_shippriority, _row_id] }
+                            StreamTableScan { table: orders, columns: [orders.o_orderkey, orders.o_custkey, orders.o_orderdate, orders.o_shippriority, orders._row_id], pk: [orders._row_id], distribution: HashShard(orders._row_id) }
                     StreamExchange { dist: HashShard(lineitem.l_orderkey) }
                       StreamProject { exprs: [lineitem.l_orderkey, lineitem.l_extendedprice, lineitem.l_discount, lineitem._row_id] }
                         StreamFilter { predicate: (lineitem.l_shipdate > '1995-03-29':Varchar::Date) }
-                          StreamTableScan { table: lineitem, columns: [l_orderkey, l_extendedprice, l_discount, _row_id, l_shipdate] }
+                          StreamTableScan { table: lineitem, columns: [lineitem.l_orderkey, lineitem.l_extendedprice, lineitem.l_discount, lineitem._row_id, lineitem.l_shipdate], pk: [lineitem._row_id], distribution: HashShard(lineitem._row_id) }
 - id: tpch_q4
   before:
   - create_tables
@@ -439,42 +439,42 @@
         LogicalProject { exprs: [orders.o_orderpriority] }
           LogicalFilter { predicate: (orders.o_orderdate >= '1997-07-01':Varchar::Date) AND (orders.o_orderdate < ('1997-07-01':Varchar::Date + '3 mons 00:00:00':Interval)) }
             LogicalApply { type: LeftSemi, on: true, correlated_id: 1 }
-              LogicalScan { table: orders, columns: [_row_id, o_orderkey, o_custkey, o_orderstatus, o_totalprice, o_orderdate, o_orderpriority, o_clerk, o_shippriority, o_comment] }
+              LogicalScan { table: orders, columns: [orders._row_id, orders.o_orderkey, orders.o_custkey, orders.o_orderstatus, orders.o_totalprice, orders.o_orderdate, orders.o_orderpriority, orders.o_clerk, orders.o_shippriority, orders.o_comment] }
               LogicalProject { exprs: [lineitem.l_orderkey, lineitem.l_partkey, lineitem.l_suppkey, lineitem.l_linenumber, lineitem.l_quantity, lineitem.l_extendedprice, lineitem.l_discount, lineitem.l_tax, lineitem.l_returnflag, lineitem.l_linestatus, lineitem.l_shipdate, lineitem.l_commitdate, lineitem.l_receiptdate, lineitem.l_shipinstruct, lineitem.l_shipmode, lineitem.l_comment] }
                 LogicalFilter { predicate: (lineitem.l_orderkey = CorrelatedInputRef { index: 1, correlated_id: 1 }) AND (lineitem.l_commitdate < lineitem.l_receiptdate) }
-                  LogicalScan { table: lineitem, columns: [_row_id, l_orderkey, l_partkey, l_suppkey, l_linenumber, l_quantity, l_extendedprice, l_discount, l_tax, l_returnflag, l_linestatus, l_shipdate, l_commitdate, l_receiptdate, l_shipinstruct, l_shipmode, l_comment] }
+                  LogicalScan { table: lineitem, columns: [lineitem._row_id, lineitem.l_orderkey, lineitem.l_partkey, lineitem.l_suppkey, lineitem.l_linenumber, lineitem.l_quantity, lineitem.l_extendedprice, lineitem.l_discount, lineitem.l_tax, lineitem.l_returnflag, lineitem.l_linestatus, lineitem.l_shipdate, lineitem.l_commitdate, lineitem.l_receiptdate, lineitem.l_shipinstruct, lineitem.l_shipmode, lineitem.l_comment] }
   optimized_logical_plan: |
     LogicalAgg { group_key: [orders.o_orderpriority], aggs: [count] }
-      LogicalJoin { type: LeftSemi, on: (lineitem.l_orderkey = orders.o_orderkey) }
-        LogicalScan { table: orders, output_columns: [o_orderkey, o_orderpriority], required_columns: [o_orderkey, o_orderpriority, o_orderdate], predicate: (orders.o_orderdate >= '1997-07-01':Varchar::Date) AND (orders.o_orderdate < ('1997-07-01':Varchar::Date + '3 mons 00:00:00':Interval)) }
-        LogicalScan { table: lineitem, output_columns: [l_orderkey], required_columns: [l_orderkey, l_commitdate, l_receiptdate], predicate: (lineitem.l_commitdate < lineitem.l_receiptdate) }
+      LogicalJoin { type: LeftSemi, on: (lineitem.l_orderkey = orders.o_orderkey), output: [orders.o_orderpriority] }
+        LogicalScan { table: orders, output_columns: [orders.o_orderkey, orders.o_orderpriority], required_columns: [o_orderkey, o_orderpriority, o_orderdate], predicate: (orders.o_orderdate >= '1997-07-01':Varchar::Date) AND (orders.o_orderdate < ('1997-07-01':Varchar::Date + '3 mons 00:00:00':Interval)) }
+        LogicalScan { table: lineitem, output_columns: [lineitem.l_orderkey], required_columns: [l_orderkey, l_commitdate, l_receiptdate], predicate: (lineitem.l_commitdate < lineitem.l_receiptdate) }
   batch_plan: |
     BatchExchange { order: [orders.o_orderpriority ASC], dist: Single }
       BatchSort { order: [orders.o_orderpriority ASC] }
         BatchHashAgg { group_key: [orders.o_orderpriority], aggs: [count] }
           BatchExchange { order: [], dist: HashShard(orders.o_orderpriority) }
-            BatchHashJoin { type: LeftSemi, predicate: orders.o_orderkey = lineitem.l_orderkey }
+            BatchHashJoin { type: LeftSemi, predicate: orders.o_orderkey = lineitem.l_orderkey, output: [orders.o_orderpriority] }
               BatchExchange { order: [], dist: HashShard(orders.o_orderkey) }
                 BatchProject { exprs: [orders.o_orderkey, orders.o_orderpriority] }
                   BatchFilter { predicate: (orders.o_orderdate >= '1997-07-01':Varchar::Date) AND (orders.o_orderdate < ('1997-07-01':Varchar::Date + '3 mons 00:00:00':Interval)) }
-                    BatchScan { table: orders, columns: [o_orderkey, o_orderpriority, o_orderdate] }
+                    BatchScan { table: orders, columns: [orders.o_orderkey, orders.o_orderpriority, orders.o_orderdate], distribution: SomeShard }
               BatchExchange { order: [], dist: HashShard(lineitem.l_orderkey) }
                 BatchProject { exprs: [lineitem.l_orderkey] }
                   BatchFilter { predicate: (lineitem.l_commitdate < lineitem.l_receiptdate) }
-                    BatchScan { table: lineitem, columns: [l_orderkey, l_commitdate, l_receiptdate] }
+                    BatchScan { table: lineitem, columns: [lineitem.l_orderkey, lineitem.l_commitdate, lineitem.l_receiptdate], distribution: SomeShard }
   stream_plan: |
     StreamMaterialize { columns: [o_orderpriority, count(hidden), order_count], pk_columns: [o_orderpriority] }
       StreamHashAgg { group_key: [orders.o_orderpriority], aggs: [count, count] }
         StreamExchange { dist: HashShard(orders.o_orderpriority) }
-          StreamHashJoin { type: LeftSemi, predicate: orders.o_orderkey = lineitem.l_orderkey }
+          StreamHashJoin { type: LeftSemi, predicate: orders.o_orderkey = lineitem.l_orderkey, output: [orders.o_orderpriority, orders._row_id] }
             StreamExchange { dist: HashShard(orders.o_orderkey) }
               StreamProject { exprs: [orders.o_orderkey, orders.o_orderpriority, orders._row_id] }
                 StreamFilter { predicate: (orders.o_orderdate >= '1997-07-01':Varchar::Date) AND (orders.o_orderdate < ('1997-07-01':Varchar::Date + '3 mons 00:00:00':Interval)) }
-                  StreamTableScan { table: orders, columns: [o_orderkey, o_orderpriority, _row_id, o_orderdate] }
+                  StreamTableScan { table: orders, columns: [orders.o_orderkey, orders.o_orderpriority, orders._row_id, orders.o_orderdate], pk: [orders._row_id], distribution: HashShard(orders._row_id) }
             StreamExchange { dist: HashShard(lineitem.l_orderkey) }
               StreamProject { exprs: [lineitem.l_orderkey, lineitem._row_id] }
                 StreamFilter { predicate: (lineitem.l_commitdate < lineitem.l_receiptdate) }
-                  StreamTableScan { table: lineitem, columns: [l_orderkey, _row_id, l_commitdate, l_receiptdate] }
+                  StreamTableScan { table: lineitem, columns: [lineitem.l_orderkey, lineitem._row_id, lineitem.l_commitdate, lineitem.l_receiptdate], pk: [lineitem._row_id], distribution: HashShard(lineitem._row_id) }
 - id: tpch_q5
   before:
   - create_tables
@@ -508,92 +508,92 @@
       LogicalAgg { group_key: [nation.n_name], aggs: [sum((lineitem.l_extendedprice * (1:Int32 - lineitem.l_discount)))] }
         LogicalProject { exprs: [nation.n_name, (lineitem.l_extendedprice * (1:Int32 - lineitem.l_discount))] }
           LogicalFilter { predicate: (customer.c_custkey = orders.o_custkey) AND (lineitem.l_orderkey = orders.o_orderkey) AND (lineitem.l_suppkey = supplier.s_suppkey) AND (customer.c_nationkey = supplier.s_nationkey) AND (supplier.s_nationkey = nation.n_nationkey) AND (nation.n_regionkey = region.r_regionkey) AND (region.r_name = 'MIDDLE EAST':Varchar) AND (orders.o_orderdate >= '1994-01-01':Varchar::Date) AND (orders.o_orderdate < ('1994-01-01':Varchar::Date + '1 year 00:00:00':Interval)) }
-            LogicalJoin { type: Inner, on: true }
-              LogicalJoin { type: Inner, on: true }
-                LogicalJoin { type: Inner, on: true }
-                  LogicalJoin { type: Inner, on: true }
-                    LogicalJoin { type: Inner, on: true }
-                      LogicalScan { table: customer, columns: [_row_id, c_custkey, c_name, c_address, c_nationkey, c_phone, c_acctbal, c_mktsegment, c_comment] }
-                      LogicalScan { table: orders, columns: [_row_id, o_orderkey, o_custkey, o_orderstatus, o_totalprice, o_orderdate, o_orderpriority, o_clerk, o_shippriority, o_comment] }
-                    LogicalScan { table: lineitem, columns: [_row_id, l_orderkey, l_partkey, l_suppkey, l_linenumber, l_quantity, l_extendedprice, l_discount, l_tax, l_returnflag, l_linestatus, l_shipdate, l_commitdate, l_receiptdate, l_shipinstruct, l_shipmode, l_comment] }
-                  LogicalScan { table: supplier, columns: [_row_id, s_suppkey, s_name, s_address, s_nationkey, s_phone, s_acctbal, s_comment] }
-                LogicalScan { table: nation, columns: [_row_id, n_nationkey, n_name, n_regionkey, n_comment] }
-              LogicalScan { table: region, columns: [_row_id, r_regionkey, r_name, r_comment] }
+            LogicalJoin { type: Inner, on: true, output: all }
+              LogicalJoin { type: Inner, on: true, output: all }
+                LogicalJoin { type: Inner, on: true, output: all }
+                  LogicalJoin { type: Inner, on: true, output: all }
+                    LogicalJoin { type: Inner, on: true, output: all }
+                      LogicalScan { table: customer, columns: [customer._row_id, customer.c_custkey, customer.c_name, customer.c_address, customer.c_nationkey, customer.c_phone, customer.c_acctbal, customer.c_mktsegment, customer.c_comment] }
+                      LogicalScan { table: orders, columns: [orders._row_id, orders.o_orderkey, orders.o_custkey, orders.o_orderstatus, orders.o_totalprice, orders.o_orderdate, orders.o_orderpriority, orders.o_clerk, orders.o_shippriority, orders.o_comment] }
+                    LogicalScan { table: lineitem, columns: [lineitem._row_id, lineitem.l_orderkey, lineitem.l_partkey, lineitem.l_suppkey, lineitem.l_linenumber, lineitem.l_quantity, lineitem.l_extendedprice, lineitem.l_discount, lineitem.l_tax, lineitem.l_returnflag, lineitem.l_linestatus, lineitem.l_shipdate, lineitem.l_commitdate, lineitem.l_receiptdate, lineitem.l_shipinstruct, lineitem.l_shipmode, lineitem.l_comment] }
+                  LogicalScan { table: supplier, columns: [supplier._row_id, supplier.s_suppkey, supplier.s_name, supplier.s_address, supplier.s_nationkey, supplier.s_phone, supplier.s_acctbal, supplier.s_comment] }
+                LogicalScan { table: nation, columns: [nation._row_id, nation.n_nationkey, nation.n_name, nation.n_regionkey, nation.n_comment] }
+              LogicalScan { table: region, columns: [region._row_id, region.r_regionkey, region.r_name, region.r_comment] }
   optimized_logical_plan: |
     LogicalAgg { group_key: [nation.n_name], aggs: [sum((lineitem.l_extendedprice * (1:Int32 - lineitem.l_discount)))] }
       LogicalProject { exprs: [nation.n_name, (lineitem.l_extendedprice * (1:Int32 - lineitem.l_discount))] }
-        LogicalJoin { type: Inner, on: (nation.n_regionkey = region.r_regionkey) }
-          LogicalJoin { type: Inner, on: (supplier.s_nationkey = nation.n_nationkey) }
-            LogicalJoin { type: Inner, on: (lineitem.l_orderkey = orders.o_orderkey) AND (lineitem.l_suppkey = supplier.s_suppkey) }
-              LogicalJoin { type: Inner, on: (customer.c_nationkey = supplier.s_nationkey) }
-                LogicalJoin { type: Inner, on: (customer.c_custkey = orders.o_custkey) }
-                  LogicalScan { table: customer, columns: [c_custkey, c_nationkey] }
-                  LogicalScan { table: orders, output_columns: [o_orderkey, o_custkey], required_columns: [o_orderkey, o_custkey, o_orderdate], predicate: (orders.o_orderdate >= '1994-01-01':Varchar::Date) AND (orders.o_orderdate < ('1994-01-01':Varchar::Date + '1 year 00:00:00':Interval)) }
-                LogicalScan { table: supplier, columns: [s_suppkey, s_nationkey] }
-              LogicalScan { table: lineitem, columns: [l_orderkey, l_suppkey, l_extendedprice, l_discount] }
-            LogicalScan { table: nation, columns: [n_nationkey, n_name, n_regionkey] }
-          LogicalScan { table: region, output_columns: [r_regionkey], required_columns: [r_regionkey, r_name], predicate: (region.r_name = 'MIDDLE EAST':Varchar) }
+        LogicalJoin { type: Inner, on: (nation.n_regionkey = region.r_regionkey), output: [lineitem.l_extendedprice, lineitem.l_discount, nation.n_name] }
+          LogicalJoin { type: Inner, on: (supplier.s_nationkey = nation.n_nationkey), output: [lineitem.l_extendedprice, lineitem.l_discount, nation.n_name, nation.n_regionkey] }
+            LogicalJoin { type: Inner, on: (lineitem.l_orderkey = orders.o_orderkey) AND (lineitem.l_suppkey = supplier.s_suppkey), output: [supplier.s_nationkey, lineitem.l_extendedprice, lineitem.l_discount] }
+              LogicalJoin { type: Inner, on: (customer.c_nationkey = supplier.s_nationkey), output: [orders.o_orderkey, supplier.s_suppkey, supplier.s_nationkey] }
+                LogicalJoin { type: Inner, on: (customer.c_custkey = orders.o_custkey), output: [customer.c_nationkey, orders.o_orderkey] }
+                  LogicalScan { table: customer, columns: [customer.c_custkey, customer.c_nationkey] }
+                  LogicalScan { table: orders, output_columns: [orders.o_orderkey, orders.o_custkey], required_columns: [o_orderkey, o_custkey, o_orderdate], predicate: (orders.o_orderdate >= '1994-01-01':Varchar::Date) AND (orders.o_orderdate < ('1994-01-01':Varchar::Date + '1 year 00:00:00':Interval)) }
+                LogicalScan { table: supplier, columns: [supplier.s_suppkey, supplier.s_nationkey] }
+              LogicalScan { table: lineitem, columns: [lineitem.l_orderkey, lineitem.l_suppkey, lineitem.l_extendedprice, lineitem.l_discount] }
+            LogicalScan { table: nation, columns: [nation.n_nationkey, nation.n_name, nation.n_regionkey] }
+          LogicalScan { table: region, output_columns: [region.r_regionkey], required_columns: [r_regionkey, r_name], predicate: (region.r_name = 'MIDDLE EAST':Varchar) }
   batch_plan: |
     BatchExchange { order: [sum((lineitem.l_extendedprice * (1:Int32 - lineitem.l_discount))) DESC], dist: Single }
       BatchSort { order: [sum((lineitem.l_extendedprice * (1:Int32 - lineitem.l_discount))) DESC] }
         BatchHashAgg { group_key: [nation.n_name], aggs: [sum((lineitem.l_extendedprice * (1:Int32 - lineitem.l_discount)))] }
           BatchExchange { order: [], dist: HashShard(nation.n_name) }
             BatchProject { exprs: [nation.n_name, (lineitem.l_extendedprice * (1:Int32 - lineitem.l_discount))] }
-              BatchHashJoin { type: Inner, predicate: nation.n_regionkey = region.r_regionkey }
+              BatchHashJoin { type: Inner, predicate: nation.n_regionkey = region.r_regionkey, output: [lineitem.l_extendedprice, lineitem.l_discount, nation.n_name] }
                 BatchExchange { order: [], dist: HashShard(nation.n_regionkey) }
-                  BatchHashJoin { type: Inner, predicate: supplier.s_nationkey = nation.n_nationkey }
+                  BatchHashJoin { type: Inner, predicate: supplier.s_nationkey = nation.n_nationkey, output: [lineitem.l_extendedprice, lineitem.l_discount, nation.n_name, nation.n_regionkey] }
                     BatchExchange { order: [], dist: HashShard(supplier.s_nationkey) }
-                      BatchHashJoin { type: Inner, predicate: orders.o_orderkey = lineitem.l_orderkey AND supplier.s_suppkey = lineitem.l_suppkey }
+                      BatchHashJoin { type: Inner, predicate: orders.o_orderkey = lineitem.l_orderkey AND supplier.s_suppkey = lineitem.l_suppkey, output: [supplier.s_nationkey, lineitem.l_extendedprice, lineitem.l_discount] }
                         BatchExchange { order: [], dist: HashShard(orders.o_orderkey, supplier.s_suppkey) }
-                          BatchHashJoin { type: Inner, predicate: customer.c_nationkey = supplier.s_nationkey }
+                          BatchHashJoin { type: Inner, predicate: customer.c_nationkey = supplier.s_nationkey, output: [orders.o_orderkey, supplier.s_suppkey, supplier.s_nationkey] }
                             BatchExchange { order: [], dist: HashShard(customer.c_nationkey) }
-                              BatchHashJoin { type: Inner, predicate: customer.c_custkey = orders.o_custkey }
+                              BatchHashJoin { type: Inner, predicate: customer.c_custkey = orders.o_custkey, output: [customer.c_nationkey, orders.o_orderkey] }
                                 BatchExchange { order: [], dist: HashShard(customer.c_custkey) }
-                                  BatchScan { table: customer, columns: [c_custkey, c_nationkey] }
+                                  BatchScan { table: customer, columns: [customer.c_custkey, customer.c_nationkey], distribution: SomeShard }
                                 BatchExchange { order: [], dist: HashShard(orders.o_custkey) }
                                   BatchProject { exprs: [orders.o_orderkey, orders.o_custkey] }
                                     BatchFilter { predicate: (orders.o_orderdate >= '1994-01-01':Varchar::Date) AND (orders.o_orderdate < ('1994-01-01':Varchar::Date + '1 year 00:00:00':Interval)) }
-                                      BatchScan { table: orders, columns: [o_orderkey, o_custkey, o_orderdate] }
+                                      BatchScan { table: orders, columns: [orders.o_orderkey, orders.o_custkey, orders.o_orderdate], distribution: SomeShard }
                             BatchExchange { order: [], dist: HashShard(supplier.s_nationkey) }
-                              BatchScan { table: supplier, columns: [s_suppkey, s_nationkey] }
+                              BatchScan { table: supplier, columns: [supplier.s_suppkey, supplier.s_nationkey], distribution: SomeShard }
                         BatchExchange { order: [], dist: HashShard(lineitem.l_orderkey, lineitem.l_suppkey) }
-                          BatchScan { table: lineitem, columns: [l_orderkey, l_suppkey, l_extendedprice, l_discount] }
+                          BatchScan { table: lineitem, columns: [lineitem.l_orderkey, lineitem.l_suppkey, lineitem.l_extendedprice, lineitem.l_discount], distribution: SomeShard }
                     BatchExchange { order: [], dist: HashShard(nation.n_nationkey) }
-                      BatchScan { table: nation, columns: [n_nationkey, n_name, n_regionkey] }
+                      BatchScan { table: nation, columns: [nation.n_nationkey, nation.n_name, nation.n_regionkey], distribution: SomeShard }
                 BatchExchange { order: [], dist: HashShard(region.r_regionkey) }
                   BatchProject { exprs: [region.r_regionkey] }
                     BatchFilter { predicate: (region.r_name = 'MIDDLE EAST':Varchar) }
-                      BatchScan { table: region, columns: [r_regionkey, r_name] }
+                      BatchScan { table: region, columns: [region.r_regionkey, region.r_name], distribution: SomeShard }
   stream_plan: |
     StreamMaterialize { columns: [n_name, count(hidden), revenue], pk_columns: [n_name], order_descs: [revenue, n_name] }
       StreamHashAgg { group_key: [nation.n_name], aggs: [count, sum((lineitem.l_extendedprice * (1:Int32 - lineitem.l_discount)))] }
         StreamExchange { dist: HashShard(nation.n_name) }
           StreamProject { exprs: [nation.n_name, (lineitem.l_extendedprice * (1:Int32 - lineitem.l_discount)), customer._row_id, orders._row_id, supplier._row_id, lineitem._row_id, nation._row_id, region._row_id] }
-            StreamHashJoin { type: Inner, predicate: nation.n_regionkey = region.r_regionkey }
+            StreamHashJoin { type: Inner, predicate: nation.n_regionkey = region.r_regionkey, output: [lineitem.l_extendedprice, lineitem.l_discount, nation.n_name, customer._row_id, orders._row_id, supplier._row_id, lineitem._row_id, nation._row_id, region._row_id] }
               StreamExchange { dist: HashShard(nation.n_regionkey) }
-                StreamHashJoin { type: Inner, predicate: supplier.s_nationkey = nation.n_nationkey }
+                StreamHashJoin { type: Inner, predicate: supplier.s_nationkey = nation.n_nationkey, output: [lineitem.l_extendedprice, lineitem.l_discount, nation.n_name, nation.n_regionkey, customer._row_id, orders._row_id, supplier._row_id, lineitem._row_id, nation._row_id] }
                   StreamExchange { dist: HashShard(supplier.s_nationkey) }
-                    StreamHashJoin { type: Inner, predicate: orders.o_orderkey = lineitem.l_orderkey AND supplier.s_suppkey = lineitem.l_suppkey }
+                    StreamHashJoin { type: Inner, predicate: orders.o_orderkey = lineitem.l_orderkey AND supplier.s_suppkey = lineitem.l_suppkey, output: [supplier.s_nationkey, lineitem.l_extendedprice, lineitem.l_discount, customer._row_id, orders._row_id, supplier._row_id, lineitem._row_id] }
                       StreamExchange { dist: HashShard(orders.o_orderkey, supplier.s_suppkey) }
-                        StreamHashJoin { type: Inner, predicate: customer.c_nationkey = supplier.s_nationkey }
+                        StreamHashJoin { type: Inner, predicate: customer.c_nationkey = supplier.s_nationkey, output: [orders.o_orderkey, supplier.s_suppkey, supplier.s_nationkey, customer._row_id, orders._row_id, supplier._row_id] }
                           StreamExchange { dist: HashShard(customer.c_nationkey) }
-                            StreamHashJoin { type: Inner, predicate: customer.c_custkey = orders.o_custkey }
+                            StreamHashJoin { type: Inner, predicate: customer.c_custkey = orders.o_custkey, output: [customer.c_nationkey, orders.o_orderkey, customer._row_id, orders._row_id] }
                               StreamExchange { dist: HashShard(customer.c_custkey) }
-                                StreamTableScan { table: customer, columns: [c_custkey, c_nationkey, _row_id] }
+                                StreamTableScan { table: customer, columns: [customer.c_custkey, customer.c_nationkey, customer._row_id], pk: [customer._row_id], distribution: HashShard(customer._row_id) }
                               StreamExchange { dist: HashShard(orders.o_custkey) }
                                 StreamProject { exprs: [orders.o_orderkey, orders.o_custkey, orders._row_id] }
                                   StreamFilter { predicate: (orders.o_orderdate >= '1994-01-01':Varchar::Date) AND (orders.o_orderdate < ('1994-01-01':Varchar::Date + '1 year 00:00:00':Interval)) }
-                                    StreamTableScan { table: orders, columns: [o_orderkey, o_custkey, _row_id, o_orderdate] }
+                                    StreamTableScan { table: orders, columns: [orders.o_orderkey, orders.o_custkey, orders._row_id, orders.o_orderdate], pk: [orders._row_id], distribution: HashShard(orders._row_id) }
                           StreamExchange { dist: HashShard(supplier.s_nationkey) }
-                            StreamTableScan { table: supplier, columns: [s_suppkey, s_nationkey, _row_id] }
+                            StreamTableScan { table: supplier, columns: [supplier.s_suppkey, supplier.s_nationkey, supplier._row_id], pk: [supplier._row_id], distribution: HashShard(supplier._row_id) }
                       StreamExchange { dist: HashShard(lineitem.l_orderkey, lineitem.l_suppkey) }
-                        StreamTableScan { table: lineitem, columns: [l_orderkey, l_suppkey, l_extendedprice, l_discount, _row_id] }
+                        StreamTableScan { table: lineitem, columns: [lineitem.l_orderkey, lineitem.l_suppkey, lineitem.l_extendedprice, lineitem.l_discount, lineitem._row_id], pk: [lineitem._row_id], distribution: HashShard(lineitem._row_id) }
                   StreamExchange { dist: HashShard(nation.n_nationkey) }
-                    StreamTableScan { table: nation, columns: [n_nationkey, n_name, n_regionkey, _row_id] }
+                    StreamTableScan { table: nation, columns: [nation.n_nationkey, nation.n_name, nation.n_regionkey, nation._row_id], pk: [nation._row_id], distribution: HashShard(nation._row_id) }
               StreamExchange { dist: HashShard(region.r_regionkey) }
                 StreamProject { exprs: [region.r_regionkey, region._row_id] }
                   StreamFilter { predicate: (region.r_name = 'MIDDLE EAST':Varchar) }
-                    StreamTableScan { table: region, columns: [r_regionkey, _row_id, r_name] }
+                    StreamTableScan { table: region, columns: [region.r_regionkey, region._row_id, region.r_name], pk: [region._row_id], distribution: HashShard(region._row_id) }
 - id: tpch_q6
   before:
   - create_tables
@@ -612,18 +612,18 @@
       LogicalAgg { aggs: [sum((lineitem.l_extendedprice * lineitem.l_discount))] }
         LogicalProject { exprs: [(lineitem.l_extendedprice * lineitem.l_discount)] }
           LogicalFilter { predicate: (lineitem.l_shipdate >= '1994-01-01':Varchar::Date) AND (lineitem.l_shipdate < ('1994-01-01':Varchar::Date + '1 year 00:00:00':Interval)) AND (lineitem.l_discount >= (0.08:Decimal - 0.01:Decimal)) AND (lineitem.l_discount <= (0.08:Decimal + 0.01:Decimal)) AND (lineitem.l_quantity < 24:Int32) }
-            LogicalScan { table: lineitem, columns: [_row_id, l_orderkey, l_partkey, l_suppkey, l_linenumber, l_quantity, l_extendedprice, l_discount, l_tax, l_returnflag, l_linestatus, l_shipdate, l_commitdate, l_receiptdate, l_shipinstruct, l_shipmode, l_comment] }
+            LogicalScan { table: lineitem, columns: [lineitem._row_id, lineitem.l_orderkey, lineitem.l_partkey, lineitem.l_suppkey, lineitem.l_linenumber, lineitem.l_quantity, lineitem.l_extendedprice, lineitem.l_discount, lineitem.l_tax, lineitem.l_returnflag, lineitem.l_linestatus, lineitem.l_shipdate, lineitem.l_commitdate, lineitem.l_receiptdate, lineitem.l_shipinstruct, lineitem.l_shipmode, lineitem.l_comment] }
   optimized_logical_plan: |
     LogicalAgg { aggs: [sum((lineitem.l_extendedprice * lineitem.l_discount))] }
       LogicalProject { exprs: [(lineitem.l_extendedprice * lineitem.l_discount)] }
-        LogicalScan { table: lineitem, output_columns: [l_extendedprice, l_discount], required_columns: [l_extendedprice, l_discount, l_quantity, l_shipdate], predicate: (lineitem.l_shipdate >= '1994-01-01':Varchar::Date) AND (lineitem.l_shipdate < ('1994-01-01':Varchar::Date + '1 year 00:00:00':Interval)) AND (lineitem.l_discount >= (0.08:Decimal - 0.01:Decimal)) AND (lineitem.l_discount <= (0.08:Decimal + 0.01:Decimal)) AND (lineitem.l_quantity < 24:Int32) }
+        LogicalScan { table: lineitem, output_columns: [lineitem.l_extendedprice, lineitem.l_discount], required_columns: [l_extendedprice, l_discount, l_quantity, l_shipdate], predicate: (lineitem.l_shipdate >= '1994-01-01':Varchar::Date) AND (lineitem.l_shipdate < ('1994-01-01':Varchar::Date + '1 year 00:00:00':Interval)) AND (lineitem.l_discount >= (0.08:Decimal - 0.01:Decimal)) AND (lineitem.l_discount <= (0.08:Decimal + 0.01:Decimal)) AND (lineitem.l_quantity < 24:Int32) }
   batch_plan: |
     BatchSimpleAgg { aggs: [sum(sum((lineitem.l_extendedprice * lineitem.l_discount)))] }
       BatchExchange { order: [], dist: Single }
         BatchSimpleAgg { aggs: [sum((lineitem.l_extendedprice * lineitem.l_discount))] }
           BatchProject { exprs: [(lineitem.l_extendedprice * lineitem.l_discount)] }
             BatchFilter { predicate: (lineitem.l_shipdate >= '1994-01-01':Varchar::Date) AND (lineitem.l_shipdate < ('1994-01-01':Varchar::Date + '1 year 00:00:00':Interval)) AND (lineitem.l_discount >= (0.08:Decimal - 0.01:Decimal)) AND (lineitem.l_discount <= (0.08:Decimal + 0.01:Decimal)) AND (lineitem.l_quantity < 24:Int32) }
-              BatchScan { table: lineitem, columns: [l_extendedprice, l_discount, l_quantity, l_shipdate] }
+              BatchScan { table: lineitem, columns: [lineitem.l_extendedprice, lineitem.l_discount, lineitem.l_quantity, lineitem.l_shipdate], distribution: SomeShard }
   stream_plan: |
     StreamMaterialize { columns: [sum(count)(hidden), revenue], pk_columns: [] }
       StreamGlobalSimpleAgg { aggs: [sum(count), sum(sum((lineitem.l_extendedprice * lineitem.l_discount)))] }
@@ -631,7 +631,7 @@
           StreamLocalSimpleAgg { aggs: [count, sum((lineitem.l_extendedprice * lineitem.l_discount))] }
             StreamProject { exprs: [(lineitem.l_extendedprice * lineitem.l_discount), lineitem._row_id] }
               StreamFilter { predicate: (lineitem.l_shipdate >= '1994-01-01':Varchar::Date) AND (lineitem.l_shipdate < ('1994-01-01':Varchar::Date + '1 year 00:00:00':Interval)) AND (lineitem.l_discount >= (0.08:Decimal - 0.01:Decimal)) AND (lineitem.l_discount <= (0.08:Decimal + 0.01:Decimal)) AND (lineitem.l_quantity < 24:Int32) }
-                StreamTableScan { table: lineitem, columns: [l_extendedprice, l_discount, _row_id, l_quantity, l_shipdate] }
+                StreamTableScan { table: lineitem, columns: [lineitem.l_extendedprice, lineitem.l_discount, lineitem._row_id, lineitem.l_quantity, lineitem.l_shipdate], pk: [lineitem._row_id], distribution: HashShard(lineitem._row_id) }
 - id: tpch_q7
   before:
   - create_tables
@@ -681,31 +681,31 @@
         LogicalProject { exprs: [nation.n_name, nation.n_name, Extract('YEAR':Varchar, lineitem.l_shipdate), (lineitem.l_extendedprice * (1:Int32 - lineitem.l_discount))] }
           LogicalProject { exprs: [nation.n_name, nation.n_name, Extract('YEAR':Varchar, lineitem.l_shipdate), (lineitem.l_extendedprice * (1:Int32 - lineitem.l_discount))] }
             LogicalFilter { predicate: (supplier.s_suppkey = lineitem.l_suppkey) AND (orders.o_orderkey = lineitem.l_orderkey) AND (customer.c_custkey = orders.o_custkey) AND (supplier.s_nationkey = nation.n_nationkey) AND (customer.c_nationkey = nation.n_nationkey) AND (((nation.n_name = 'ROMANIA':Varchar) AND (nation.n_name = 'IRAN':Varchar)) OR ((nation.n_name = 'IRAN':Varchar) AND (nation.n_name = 'ROMANIA':Varchar))) AND (lineitem.l_shipdate >= '1983-01-01':Varchar::Date) AND (lineitem.l_shipdate <= '2000-12-31':Varchar::Date) }
-              LogicalJoin { type: Inner, on: true }
-                LogicalJoin { type: Inner, on: true }
-                  LogicalJoin { type: Inner, on: true }
-                    LogicalJoin { type: Inner, on: true }
-                      LogicalJoin { type: Inner, on: true }
-                        LogicalScan { table: supplier, columns: [_row_id, s_suppkey, s_name, s_address, s_nationkey, s_phone, s_acctbal, s_comment] }
-                        LogicalScan { table: lineitem, columns: [_row_id, l_orderkey, l_partkey, l_suppkey, l_linenumber, l_quantity, l_extendedprice, l_discount, l_tax, l_returnflag, l_linestatus, l_shipdate, l_commitdate, l_receiptdate, l_shipinstruct, l_shipmode, l_comment] }
-                      LogicalScan { table: orders, columns: [_row_id, o_orderkey, o_custkey, o_orderstatus, o_totalprice, o_orderdate, o_orderpriority, o_clerk, o_shippriority, o_comment] }
-                    LogicalScan { table: customer, columns: [_row_id, c_custkey, c_name, c_address, c_nationkey, c_phone, c_acctbal, c_mktsegment, c_comment] }
-                  LogicalScan { table: nation, columns: [_row_id, n_nationkey, n_name, n_regionkey, n_comment] }
-                LogicalScan { table: nation, columns: [_row_id, n_nationkey, n_name, n_regionkey, n_comment] }
+              LogicalJoin { type: Inner, on: true, output: all }
+                LogicalJoin { type: Inner, on: true, output: all }
+                  LogicalJoin { type: Inner, on: true, output: all }
+                    LogicalJoin { type: Inner, on: true, output: all }
+                      LogicalJoin { type: Inner, on: true, output: all }
+                        LogicalScan { table: supplier, columns: [supplier._row_id, supplier.s_suppkey, supplier.s_name, supplier.s_address, supplier.s_nationkey, supplier.s_phone, supplier.s_acctbal, supplier.s_comment] }
+                        LogicalScan { table: lineitem, columns: [lineitem._row_id, lineitem.l_orderkey, lineitem.l_partkey, lineitem.l_suppkey, lineitem.l_linenumber, lineitem.l_quantity, lineitem.l_extendedprice, lineitem.l_discount, lineitem.l_tax, lineitem.l_returnflag, lineitem.l_linestatus, lineitem.l_shipdate, lineitem.l_commitdate, lineitem.l_receiptdate, lineitem.l_shipinstruct, lineitem.l_shipmode, lineitem.l_comment] }
+                      LogicalScan { table: orders, columns: [orders._row_id, orders.o_orderkey, orders.o_custkey, orders.o_orderstatus, orders.o_totalprice, orders.o_orderdate, orders.o_orderpriority, orders.o_clerk, orders.o_shippriority, orders.o_comment] }
+                    LogicalScan { table: customer, columns: [customer._row_id, customer.c_custkey, customer.c_name, customer.c_address, customer.c_nationkey, customer.c_phone, customer.c_acctbal, customer.c_mktsegment, customer.c_comment] }
+                  LogicalScan { table: nation, columns: [nation._row_id, nation.n_nationkey, nation.n_name, nation.n_regionkey, nation.n_comment] }
+                LogicalScan { table: nation, columns: [nation._row_id, nation.n_nationkey, nation.n_name, nation.n_regionkey, nation.n_comment] }
   optimized_logical_plan: |
     LogicalAgg { group_key: [nation.n_name, nation.n_name, Extract('YEAR':Varchar, lineitem.l_shipdate)], aggs: [sum((lineitem.l_extendedprice * (1:Int32 - lineitem.l_discount)))] }
       LogicalProject { exprs: [nation.n_name, nation.n_name, Extract('YEAR':Varchar, lineitem.l_shipdate), (lineitem.l_extendedprice * (1:Int32 - lineitem.l_discount))] }
-        LogicalJoin { type: Inner, on: (customer.c_nationkey = nation.n_nationkey) AND (((nation.n_name = 'ROMANIA':Varchar) AND (nation.n_name = 'IRAN':Varchar)) OR ((nation.n_name = 'IRAN':Varchar) AND (nation.n_name = 'ROMANIA':Varchar))) }
-          LogicalJoin { type: Inner, on: (customer.c_custkey = orders.o_custkey) }
-            LogicalJoin { type: Inner, on: (orders.o_orderkey = lineitem.l_orderkey) }
-              LogicalJoin { type: Inner, on: (supplier.s_nationkey = nation.n_nationkey) }
-                LogicalJoin { type: Inner, on: (supplier.s_suppkey = lineitem.l_suppkey) }
-                  LogicalScan { table: supplier, columns: [s_suppkey, s_nationkey] }
-                  LogicalScan { table: lineitem, output_columns: [l_orderkey, l_suppkey, l_extendedprice, l_discount, l_shipdate], required_columns: [l_orderkey, l_suppkey, l_extendedprice, l_discount, l_shipdate], predicate: (lineitem.l_shipdate >= '1983-01-01':Varchar::Date) AND (lineitem.l_shipdate <= '2000-12-31':Varchar::Date) }
-                LogicalScan { table: nation, columns: [n_nationkey, n_name] }
-              LogicalScan { table: orders, columns: [o_orderkey, o_custkey] }
-            LogicalScan { table: customer, columns: [c_custkey, c_nationkey] }
-          LogicalScan { table: nation, columns: [n_nationkey, n_name] }
+        LogicalJoin { type: Inner, on: (customer.c_nationkey = nation.n_nationkey) AND (((nation.n_name = 'ROMANIA':Varchar) AND (nation.n_name = 'IRAN':Varchar)) OR ((nation.n_name = 'IRAN':Varchar) AND (nation.n_name = 'ROMANIA':Varchar))), output: [lineitem.l_extendedprice, lineitem.l_discount, lineitem.l_shipdate, nation.n_name, nation.n_name] }
+          LogicalJoin { type: Inner, on: (customer.c_custkey = orders.o_custkey), output: [lineitem.l_extendedprice, lineitem.l_discount, lineitem.l_shipdate, nation.n_name, customer.c_nationkey] }
+            LogicalJoin { type: Inner, on: (orders.o_orderkey = lineitem.l_orderkey), output: [lineitem.l_extendedprice, lineitem.l_discount, lineitem.l_shipdate, nation.n_name, orders.o_custkey] }
+              LogicalJoin { type: Inner, on: (supplier.s_nationkey = nation.n_nationkey), output: [lineitem.l_orderkey, lineitem.l_extendedprice, lineitem.l_discount, lineitem.l_shipdate, nation.n_name] }
+                LogicalJoin { type: Inner, on: (supplier.s_suppkey = lineitem.l_suppkey), output: [supplier.s_nationkey, lineitem.l_orderkey, lineitem.l_extendedprice, lineitem.l_discount, lineitem.l_shipdate] }
+                  LogicalScan { table: supplier, columns: [supplier.s_suppkey, supplier.s_nationkey] }
+                  LogicalScan { table: lineitem, output_columns: [lineitem.l_orderkey, lineitem.l_suppkey, lineitem.l_extendedprice, lineitem.l_discount, lineitem.l_shipdate], required_columns: [l_orderkey, l_suppkey, l_extendedprice, l_discount, l_shipdate], predicate: (lineitem.l_shipdate >= '1983-01-01':Varchar::Date) AND (lineitem.l_shipdate <= '2000-12-31':Varchar::Date) }
+                LogicalScan { table: nation, columns: [nation.n_nationkey, nation.n_name] }
+              LogicalScan { table: orders, columns: [orders.o_orderkey, orders.o_custkey] }
+            LogicalScan { table: customer, columns: [customer.c_custkey, customer.c_nationkey] }
+          LogicalScan { table: nation, columns: [nation.n_nationkey, nation.n_name] }
   batch_plan: |
     BatchExchange { order: [nation.n_name ASC, nation.n_name ASC, Extract('YEAR':Varchar, lineitem.l_shipdate) ASC], dist: Single }
       BatchSort { order: [nation.n_name ASC, nation.n_name ASC, Extract('YEAR':Varchar, lineitem.l_shipdate) ASC] }
@@ -713,56 +713,56 @@
           BatchExchange { order: [], dist: HashShard(nation.n_name, nation.n_name, Extract('YEAR':Varchar, lineitem.l_shipdate)) }
             BatchProject { exprs: [nation.n_name, nation.n_name, Extract('YEAR':Varchar, lineitem.l_shipdate), (lineitem.l_extendedprice * (1:Int32 - lineitem.l_discount))] }
               BatchFilter { predicate: (((nation.n_name = 'ROMANIA':Varchar) AND (nation.n_name = 'IRAN':Varchar)) OR ((nation.n_name = 'IRAN':Varchar) AND (nation.n_name = 'ROMANIA':Varchar))) }
-                BatchHashJoin { type: Inner, predicate: customer.c_nationkey = nation.n_nationkey }
+                BatchHashJoin { type: Inner, predicate: customer.c_nationkey = nation.n_nationkey, output: all }
                   BatchExchange { order: [], dist: HashShard(customer.c_nationkey) }
-                    BatchHashJoin { type: Inner, predicate: orders.o_custkey = customer.c_custkey }
+                    BatchHashJoin { type: Inner, predicate: orders.o_custkey = customer.c_custkey, output: [lineitem.l_extendedprice, lineitem.l_discount, lineitem.l_shipdate, nation.n_name, customer.c_nationkey] }
                       BatchExchange { order: [], dist: HashShard(orders.o_custkey) }
-                        BatchHashJoin { type: Inner, predicate: lineitem.l_orderkey = orders.o_orderkey }
+                        BatchHashJoin { type: Inner, predicate: lineitem.l_orderkey = orders.o_orderkey, output: [lineitem.l_extendedprice, lineitem.l_discount, lineitem.l_shipdate, nation.n_name, orders.o_custkey] }
                           BatchExchange { order: [], dist: HashShard(lineitem.l_orderkey) }
-                            BatchHashJoin { type: Inner, predicate: supplier.s_nationkey = nation.n_nationkey }
+                            BatchHashJoin { type: Inner, predicate: supplier.s_nationkey = nation.n_nationkey, output: [lineitem.l_orderkey, lineitem.l_extendedprice, lineitem.l_discount, lineitem.l_shipdate, nation.n_name] }
                               BatchExchange { order: [], dist: HashShard(supplier.s_nationkey) }
-                                BatchHashJoin { type: Inner, predicate: supplier.s_suppkey = lineitem.l_suppkey }
+                                BatchHashJoin { type: Inner, predicate: supplier.s_suppkey = lineitem.l_suppkey, output: [supplier.s_nationkey, lineitem.l_orderkey, lineitem.l_extendedprice, lineitem.l_discount, lineitem.l_shipdate] }
                                   BatchExchange { order: [], dist: HashShard(supplier.s_suppkey) }
-                                    BatchScan { table: supplier, columns: [s_suppkey, s_nationkey] }
+                                    BatchScan { table: supplier, columns: [supplier.s_suppkey, supplier.s_nationkey], distribution: SomeShard }
                                   BatchExchange { order: [], dist: HashShard(lineitem.l_suppkey) }
                                     BatchFilter { predicate: (lineitem.l_shipdate >= '1983-01-01':Varchar::Date) AND (lineitem.l_shipdate <= '2000-12-31':Varchar::Date) }
-                                      BatchScan { table: lineitem, columns: [l_orderkey, l_suppkey, l_extendedprice, l_discount, l_shipdate] }
+                                      BatchScan { table: lineitem, columns: [lineitem.l_orderkey, lineitem.l_suppkey, lineitem.l_extendedprice, lineitem.l_discount, lineitem.l_shipdate], distribution: SomeShard }
                               BatchExchange { order: [], dist: HashShard(nation.n_nationkey) }
-                                BatchScan { table: nation, columns: [n_nationkey, n_name] }
+                                BatchScan { table: nation, columns: [nation.n_nationkey, nation.n_name], distribution: SomeShard }
                           BatchExchange { order: [], dist: HashShard(orders.o_orderkey) }
-                            BatchScan { table: orders, columns: [o_orderkey, o_custkey] }
+                            BatchScan { table: orders, columns: [orders.o_orderkey, orders.o_custkey], distribution: SomeShard }
                       BatchExchange { order: [], dist: HashShard(customer.c_custkey) }
-                        BatchScan { table: customer, columns: [c_custkey, c_nationkey] }
+                        BatchScan { table: customer, columns: [customer.c_custkey, customer.c_nationkey], distribution: SomeShard }
                   BatchExchange { order: [], dist: HashShard(nation.n_nationkey) }
-                    BatchScan { table: nation, columns: [n_nationkey, n_name] }
+                    BatchScan { table: nation, columns: [nation.n_nationkey, nation.n_name], distribution: SomeShard }
   stream_plan: |
     StreamMaterialize { columns: [supp_nation, cust_nation, l_year, count(hidden), revenue], pk_columns: [supp_nation, cust_nation, l_year] }
       StreamHashAgg { group_key: [nation.n_name, nation.n_name, Extract('YEAR':Varchar, lineitem.l_shipdate)], aggs: [count, sum((lineitem.l_extendedprice * (1:Int32 - lineitem.l_discount)))] }
         StreamExchange { dist: HashShard(nation.n_name, nation.n_name, Extract('YEAR':Varchar, lineitem.l_shipdate)) }
           StreamProject { exprs: [nation.n_name, nation.n_name, Extract('YEAR':Varchar, lineitem.l_shipdate), (lineitem.l_extendedprice * (1:Int32 - lineitem.l_discount)), supplier._row_id, lineitem._row_id, nation._row_id, orders._row_id, customer._row_id, nation._row_id] }
             StreamFilter { predicate: (((nation.n_name = 'ROMANIA':Varchar) AND (nation.n_name = 'IRAN':Varchar)) OR ((nation.n_name = 'IRAN':Varchar) AND (nation.n_name = 'ROMANIA':Varchar))) }
-              StreamHashJoin { type: Inner, predicate: customer.c_nationkey = nation.n_nationkey }
+              StreamHashJoin { type: Inner, predicate: customer.c_nationkey = nation.n_nationkey, output: all }
                 StreamExchange { dist: HashShard(customer.c_nationkey) }
-                  StreamHashJoin { type: Inner, predicate: orders.o_custkey = customer.c_custkey }
+                  StreamHashJoin { type: Inner, predicate: orders.o_custkey = customer.c_custkey, output: [lineitem.l_extendedprice, lineitem.l_discount, lineitem.l_shipdate, nation.n_name, customer.c_nationkey, supplier._row_id, lineitem._row_id, nation._row_id, orders._row_id, customer._row_id] }
                     StreamExchange { dist: HashShard(orders.o_custkey) }
-                      StreamHashJoin { type: Inner, predicate: lineitem.l_orderkey = orders.o_orderkey }
+                      StreamHashJoin { type: Inner, predicate: lineitem.l_orderkey = orders.o_orderkey, output: [lineitem.l_extendedprice, lineitem.l_discount, lineitem.l_shipdate, nation.n_name, orders.o_custkey, supplier._row_id, lineitem._row_id, nation._row_id, orders._row_id] }
                         StreamExchange { dist: HashShard(lineitem.l_orderkey) }
-                          StreamHashJoin { type: Inner, predicate: supplier.s_nationkey = nation.n_nationkey }
+                          StreamHashJoin { type: Inner, predicate: supplier.s_nationkey = nation.n_nationkey, output: [lineitem.l_orderkey, lineitem.l_extendedprice, lineitem.l_discount, lineitem.l_shipdate, nation.n_name, supplier._row_id, lineitem._row_id, nation._row_id] }
                             StreamExchange { dist: HashShard(supplier.s_nationkey) }
-                              StreamHashJoin { type: Inner, predicate: supplier.s_suppkey = lineitem.l_suppkey }
+                              StreamHashJoin { type: Inner, predicate: supplier.s_suppkey = lineitem.l_suppkey, output: [supplier.s_nationkey, lineitem.l_orderkey, lineitem.l_extendedprice, lineitem.l_discount, lineitem.l_shipdate, supplier._row_id, lineitem._row_id] }
                                 StreamExchange { dist: HashShard(supplier.s_suppkey) }
-                                  StreamTableScan { table: supplier, columns: [s_suppkey, s_nationkey, _row_id] }
+                                  StreamTableScan { table: supplier, columns: [supplier.s_suppkey, supplier.s_nationkey, supplier._row_id], pk: [supplier._row_id], distribution: HashShard(supplier._row_id) }
                                 StreamExchange { dist: HashShard(lineitem.l_suppkey) }
                                   StreamFilter { predicate: (lineitem.l_shipdate >= '1983-01-01':Varchar::Date) AND (lineitem.l_shipdate <= '2000-12-31':Varchar::Date) }
-                                    StreamTableScan { table: lineitem, columns: [l_orderkey, l_suppkey, l_extendedprice, l_discount, l_shipdate, _row_id] }
+                                    StreamTableScan { table: lineitem, columns: [lineitem.l_orderkey, lineitem.l_suppkey, lineitem.l_extendedprice, lineitem.l_discount, lineitem.l_shipdate, lineitem._row_id], pk: [lineitem._row_id], distribution: HashShard(lineitem._row_id) }
                             StreamExchange { dist: HashShard(nation.n_nationkey) }
-                              StreamTableScan { table: nation, columns: [n_nationkey, n_name, _row_id] }
+                              StreamTableScan { table: nation, columns: [nation.n_nationkey, nation.n_name, nation._row_id], pk: [nation._row_id], distribution: HashShard(nation._row_id) }
                         StreamExchange { dist: HashShard(orders.o_orderkey) }
-                          StreamTableScan { table: orders, columns: [o_orderkey, o_custkey, _row_id] }
+                          StreamTableScan { table: orders, columns: [orders.o_orderkey, orders.o_custkey, orders._row_id], pk: [orders._row_id], distribution: HashShard(orders._row_id) }
                     StreamExchange { dist: HashShard(customer.c_custkey) }
-                      StreamTableScan { table: customer, columns: [c_custkey, c_nationkey, _row_id] }
+                      StreamTableScan { table: customer, columns: [customer.c_custkey, customer.c_nationkey, customer._row_id], pk: [customer._row_id], distribution: HashShard(customer._row_id) }
                 StreamExchange { dist: HashShard(nation.n_nationkey) }
-                  StreamTableScan { table: nation, columns: [n_nationkey, n_name, _row_id] }
+                  StreamTableScan { table: nation, columns: [nation.n_nationkey, nation.n_name, nation._row_id], pk: [nation._row_id], distribution: HashShard(nation._row_id) }
 - id: tpch_q8
   before:
   - create_tables
@@ -812,40 +812,40 @@
         LogicalProject { exprs: [Extract('YEAR':Varchar, orders.o_orderdate), Case((nation.n_name = 'IRAN':Varchar), (lineitem.l_extendedprice * (1:Int32 - lineitem.l_discount)), 0:Int32::Decimal), (lineitem.l_extendedprice * (1:Int32 - lineitem.l_discount))] }
           LogicalProject { exprs: [Extract('YEAR':Varchar, orders.o_orderdate), (lineitem.l_extendedprice * (1:Int32 - lineitem.l_discount)), nation.n_name] }
             LogicalFilter { predicate: (part.p_partkey = lineitem.l_partkey) AND (supplier.s_suppkey = lineitem.l_suppkey) AND (lineitem.l_orderkey = orders.o_orderkey) AND (orders.o_custkey = customer.c_custkey) AND (customer.c_nationkey = nation.n_nationkey) AND (nation.n_regionkey = region.r_regionkey) AND (region.r_name = 'ASIA':Varchar) AND (supplier.s_nationkey = nation.n_nationkey) AND (orders.o_orderdate >= '1995-01-01':Varchar::Date) AND (orders.o_orderdate <= '1996-12-31':Varchar::Date) AND (part.p_type = 'PROMO ANODIZED STEEL':Varchar) }
-              LogicalJoin { type: Inner, on: true }
-                LogicalJoin { type: Inner, on: true }
-                  LogicalJoin { type: Inner, on: true }
-                    LogicalJoin { type: Inner, on: true }
-                      LogicalJoin { type: Inner, on: true }
-                        LogicalJoin { type: Inner, on: true }
-                          LogicalJoin { type: Inner, on: true }
-                            LogicalScan { table: lineitem, columns: [_row_id, l_orderkey, l_partkey, l_suppkey, l_linenumber, l_quantity, l_extendedprice, l_discount, l_tax, l_returnflag, l_linestatus, l_shipdate, l_commitdate, l_receiptdate, l_shipinstruct, l_shipmode, l_comment] }
-                            LogicalScan { table: part, columns: [_row_id, p_partkey, p_name, p_mfgr, p_brand, p_type, p_size, p_container, p_retailprice, p_comment] }
-                          LogicalScan { table: supplier, columns: [_row_id, s_suppkey, s_name, s_address, s_nationkey, s_phone, s_acctbal, s_comment] }
-                        LogicalScan { table: orders, columns: [_row_id, o_orderkey, o_custkey, o_orderstatus, o_totalprice, o_orderdate, o_orderpriority, o_clerk, o_shippriority, o_comment] }
-                      LogicalScan { table: customer, columns: [_row_id, c_custkey, c_name, c_address, c_nationkey, c_phone, c_acctbal, c_mktsegment, c_comment] }
-                    LogicalScan { table: nation, columns: [_row_id, n_nationkey, n_name, n_regionkey, n_comment] }
-                  LogicalScan { table: nation, columns: [_row_id, n_nationkey, n_name, n_regionkey, n_comment] }
-                LogicalScan { table: region, columns: [_row_id, r_regionkey, r_name, r_comment] }
+              LogicalJoin { type: Inner, on: true, output: all }
+                LogicalJoin { type: Inner, on: true, output: all }
+                  LogicalJoin { type: Inner, on: true, output: all }
+                    LogicalJoin { type: Inner, on: true, output: all }
+                      LogicalJoin { type: Inner, on: true, output: all }
+                        LogicalJoin { type: Inner, on: true, output: all }
+                          LogicalJoin { type: Inner, on: true, output: all }
+                            LogicalScan { table: lineitem, columns: [lineitem._row_id, lineitem.l_orderkey, lineitem.l_partkey, lineitem.l_suppkey, lineitem.l_linenumber, lineitem.l_quantity, lineitem.l_extendedprice, lineitem.l_discount, lineitem.l_tax, lineitem.l_returnflag, lineitem.l_linestatus, lineitem.l_shipdate, lineitem.l_commitdate, lineitem.l_receiptdate, lineitem.l_shipinstruct, lineitem.l_shipmode, lineitem.l_comment] }
+                            LogicalScan { table: part, columns: [part._row_id, part.p_partkey, part.p_name, part.p_mfgr, part.p_brand, part.p_type, part.p_size, part.p_container, part.p_retailprice, part.p_comment] }
+                          LogicalScan { table: supplier, columns: [supplier._row_id, supplier.s_suppkey, supplier.s_name, supplier.s_address, supplier.s_nationkey, supplier.s_phone, supplier.s_acctbal, supplier.s_comment] }
+                        LogicalScan { table: orders, columns: [orders._row_id, orders.o_orderkey, orders.o_custkey, orders.o_orderstatus, orders.o_totalprice, orders.o_orderdate, orders.o_orderpriority, orders.o_clerk, orders.o_shippriority, orders.o_comment] }
+                      LogicalScan { table: customer, columns: [customer._row_id, customer.c_custkey, customer.c_name, customer.c_address, customer.c_nationkey, customer.c_phone, customer.c_acctbal, customer.c_mktsegment, customer.c_comment] }
+                    LogicalScan { table: nation, columns: [nation._row_id, nation.n_nationkey, nation.n_name, nation.n_regionkey, nation.n_comment] }
+                  LogicalScan { table: nation, columns: [nation._row_id, nation.n_nationkey, nation.n_name, nation.n_regionkey, nation.n_comment] }
+                LogicalScan { table: region, columns: [region._row_id, region.r_regionkey, region.r_name, region.r_comment] }
   optimized_logical_plan: |
     LogicalProject { exprs: [Extract('YEAR':Varchar, orders.o_orderdate), RoundDigit((sum(Case((nation.n_name = 'IRAN':Varchar), (lineitem.l_extendedprice * (1:Int32 - lineitem.l_discount)), 0:Int32::Decimal)) / sum((lineitem.l_extendedprice * (1:Int32 - lineitem.l_discount)))), 6:Int32)] }
       LogicalAgg { group_key: [Extract('YEAR':Varchar, orders.o_orderdate)], aggs: [sum(Case((nation.n_name = 'IRAN':Varchar), (lineitem.l_extendedprice * (1:Int32 - lineitem.l_discount)), 0:Int32::Decimal)), sum((lineitem.l_extendedprice * (1:Int32 - lineitem.l_discount)))] }
         LogicalProject { exprs: [Extract('YEAR':Varchar, orders.o_orderdate), Case((nation.n_name = 'IRAN':Varchar), (lineitem.l_extendedprice * (1:Int32 - lineitem.l_discount)), 0:Int32::Decimal), (lineitem.l_extendedprice * (1:Int32 - lineitem.l_discount))] }
-          LogicalJoin { type: Inner, on: (nation.n_regionkey = region.r_regionkey) }
-            LogicalJoin { type: Inner, on: (customer.c_nationkey = nation.n_nationkey) }
-              LogicalJoin { type: Inner, on: (orders.o_custkey = customer.c_custkey) }
-                LogicalJoin { type: Inner, on: (supplier.s_nationkey = nation.n_nationkey) }
-                  LogicalJoin { type: Inner, on: (lineitem.l_orderkey = orders.o_orderkey) }
-                    LogicalJoin { type: Inner, on: (supplier.s_suppkey = lineitem.l_suppkey) }
-                      LogicalJoin { type: Inner, on: (part.p_partkey = lineitem.l_partkey) }
-                        LogicalScan { table: lineitem, columns: [l_orderkey, l_partkey, l_suppkey, l_extendedprice, l_discount] }
-                        LogicalScan { table: part, output_columns: [p_partkey], required_columns: [p_partkey, p_type], predicate: (part.p_type = 'PROMO ANODIZED STEEL':Varchar) }
-                      LogicalScan { table: supplier, columns: [s_suppkey, s_nationkey] }
-                    LogicalScan { table: orders, output_columns: [o_orderkey, o_custkey, o_orderdate], required_columns: [o_orderkey, o_custkey, o_orderdate], predicate: (orders.o_orderdate >= '1995-01-01':Varchar::Date) AND (orders.o_orderdate <= '1996-12-31':Varchar::Date) }
-                  LogicalScan { table: nation, columns: [n_nationkey, n_name] }
-                LogicalScan { table: customer, columns: [c_custkey, c_nationkey] }
-              LogicalScan { table: nation, columns: [n_nationkey, n_regionkey] }
-            LogicalScan { table: region, output_columns: [r_regionkey], required_columns: [r_regionkey, r_name], predicate: (region.r_name = 'ASIA':Varchar) }
+          LogicalJoin { type: Inner, on: (nation.n_regionkey = region.r_regionkey), output: [lineitem.l_extendedprice, lineitem.l_discount, orders.o_orderdate, nation.n_name] }
+            LogicalJoin { type: Inner, on: (customer.c_nationkey = nation.n_nationkey), output: [lineitem.l_extendedprice, lineitem.l_discount, orders.o_orderdate, nation.n_name, nation.n_regionkey] }
+              LogicalJoin { type: Inner, on: (orders.o_custkey = customer.c_custkey), output: [lineitem.l_extendedprice, lineitem.l_discount, orders.o_orderdate, nation.n_name, customer.c_nationkey] }
+                LogicalJoin { type: Inner, on: (supplier.s_nationkey = nation.n_nationkey), output: [lineitem.l_extendedprice, lineitem.l_discount, orders.o_custkey, orders.o_orderdate, nation.n_name] }
+                  LogicalJoin { type: Inner, on: (lineitem.l_orderkey = orders.o_orderkey), output: [lineitem.l_extendedprice, lineitem.l_discount, supplier.s_nationkey, orders.o_custkey, orders.o_orderdate] }
+                    LogicalJoin { type: Inner, on: (supplier.s_suppkey = lineitem.l_suppkey), output: [lineitem.l_orderkey, lineitem.l_extendedprice, lineitem.l_discount, supplier.s_nationkey] }
+                      LogicalJoin { type: Inner, on: (part.p_partkey = lineitem.l_partkey), output: [lineitem.l_orderkey, lineitem.l_suppkey, lineitem.l_extendedprice, lineitem.l_discount] }
+                        LogicalScan { table: lineitem, columns: [lineitem.l_orderkey, lineitem.l_partkey, lineitem.l_suppkey, lineitem.l_extendedprice, lineitem.l_discount] }
+                        LogicalScan { table: part, output_columns: [part.p_partkey], required_columns: [p_partkey, p_type], predicate: (part.p_type = 'PROMO ANODIZED STEEL':Varchar) }
+                      LogicalScan { table: supplier, columns: [supplier.s_suppkey, supplier.s_nationkey] }
+                    LogicalScan { table: orders, output_columns: [orders.o_orderkey, orders.o_custkey, orders.o_orderdate], required_columns: [o_orderkey, o_custkey, o_orderdate], predicate: (orders.o_orderdate >= '1995-01-01':Varchar::Date) AND (orders.o_orderdate <= '1996-12-31':Varchar::Date) }
+                  LogicalScan { table: nation, columns: [nation.n_nationkey, nation.n_name] }
+                LogicalScan { table: customer, columns: [customer.c_custkey, customer.c_nationkey] }
+              LogicalScan { table: nation, columns: [nation.n_nationkey, nation.n_regionkey] }
+            LogicalScan { table: region, output_columns: [region.r_regionkey], required_columns: [r_regionkey, r_name], predicate: (region.r_name = 'ASIA':Varchar) }
   batch_plan: |
     BatchExchange { order: [Extract('YEAR':Varchar, orders.o_orderdate) ASC], dist: Single }
       BatchSort { order: [Extract('YEAR':Varchar, orders.o_orderdate) ASC] }
@@ -853,80 +853,80 @@
           BatchHashAgg { group_key: [Extract('YEAR':Varchar, orders.o_orderdate)], aggs: [sum(Case((nation.n_name = 'IRAN':Varchar), (lineitem.l_extendedprice * (1:Int32 - lineitem.l_discount)), 0:Int32::Decimal)), sum((lineitem.l_extendedprice * (1:Int32 - lineitem.l_discount)))] }
             BatchExchange { order: [], dist: HashShard(Extract('YEAR':Varchar, orders.o_orderdate)) }
               BatchProject { exprs: [Extract('YEAR':Varchar, orders.o_orderdate), Case((nation.n_name = 'IRAN':Varchar), (lineitem.l_extendedprice * (1:Int32 - lineitem.l_discount)), 0:Int32::Decimal), (lineitem.l_extendedprice * (1:Int32 - lineitem.l_discount))] }
-                BatchHashJoin { type: Inner, predicate: nation.n_regionkey = region.r_regionkey }
+                BatchHashJoin { type: Inner, predicate: nation.n_regionkey = region.r_regionkey, output: [lineitem.l_extendedprice, lineitem.l_discount, orders.o_orderdate, nation.n_name] }
                   BatchExchange { order: [], dist: HashShard(nation.n_regionkey) }
-                    BatchHashJoin { type: Inner, predicate: customer.c_nationkey = nation.n_nationkey }
+                    BatchHashJoin { type: Inner, predicate: customer.c_nationkey = nation.n_nationkey, output: [lineitem.l_extendedprice, lineitem.l_discount, orders.o_orderdate, nation.n_name, nation.n_regionkey] }
                       BatchExchange { order: [], dist: HashShard(customer.c_nationkey) }
-                        BatchHashJoin { type: Inner, predicate: orders.o_custkey = customer.c_custkey }
+                        BatchHashJoin { type: Inner, predicate: orders.o_custkey = customer.c_custkey, output: [lineitem.l_extendedprice, lineitem.l_discount, orders.o_orderdate, nation.n_name, customer.c_nationkey] }
                           BatchExchange { order: [], dist: HashShard(orders.o_custkey) }
-                            BatchHashJoin { type: Inner, predicate: supplier.s_nationkey = nation.n_nationkey }
+                            BatchHashJoin { type: Inner, predicate: supplier.s_nationkey = nation.n_nationkey, output: [lineitem.l_extendedprice, lineitem.l_discount, orders.o_custkey, orders.o_orderdate, nation.n_name] }
                               BatchExchange { order: [], dist: HashShard(supplier.s_nationkey) }
-                                BatchHashJoin { type: Inner, predicate: lineitem.l_orderkey = orders.o_orderkey }
+                                BatchHashJoin { type: Inner, predicate: lineitem.l_orderkey = orders.o_orderkey, output: [lineitem.l_extendedprice, lineitem.l_discount, supplier.s_nationkey, orders.o_custkey, orders.o_orderdate] }
                                   BatchExchange { order: [], dist: HashShard(lineitem.l_orderkey) }
-                                    BatchHashJoin { type: Inner, predicate: lineitem.l_suppkey = supplier.s_suppkey }
+                                    BatchHashJoin { type: Inner, predicate: lineitem.l_suppkey = supplier.s_suppkey, output: [lineitem.l_orderkey, lineitem.l_extendedprice, lineitem.l_discount, supplier.s_nationkey] }
                                       BatchExchange { order: [], dist: HashShard(lineitem.l_suppkey) }
-                                        BatchHashJoin { type: Inner, predicate: lineitem.l_partkey = part.p_partkey }
+                                        BatchHashJoin { type: Inner, predicate: lineitem.l_partkey = part.p_partkey, output: [lineitem.l_orderkey, lineitem.l_suppkey, lineitem.l_extendedprice, lineitem.l_discount] }
                                           BatchExchange { order: [], dist: HashShard(lineitem.l_partkey) }
-                                            BatchScan { table: lineitem, columns: [l_orderkey, l_partkey, l_suppkey, l_extendedprice, l_discount] }
+                                            BatchScan { table: lineitem, columns: [lineitem.l_orderkey, lineitem.l_partkey, lineitem.l_suppkey, lineitem.l_extendedprice, lineitem.l_discount], distribution: SomeShard }
                                           BatchExchange { order: [], dist: HashShard(part.p_partkey) }
                                             BatchProject { exprs: [part.p_partkey] }
                                               BatchFilter { predicate: (part.p_type = 'PROMO ANODIZED STEEL':Varchar) }
-                                                BatchScan { table: part, columns: [p_partkey, p_type] }
+                                                BatchScan { table: part, columns: [part.p_partkey, part.p_type], distribution: SomeShard }
                                       BatchExchange { order: [], dist: HashShard(supplier.s_suppkey) }
-                                        BatchScan { table: supplier, columns: [s_suppkey, s_nationkey] }
+                                        BatchScan { table: supplier, columns: [supplier.s_suppkey, supplier.s_nationkey], distribution: SomeShard }
                                   BatchExchange { order: [], dist: HashShard(orders.o_orderkey) }
                                     BatchFilter { predicate: (orders.o_orderdate >= '1995-01-01':Varchar::Date) AND (orders.o_orderdate <= '1996-12-31':Varchar::Date) }
-                                      BatchScan { table: orders, columns: [o_orderkey, o_custkey, o_orderdate] }
+                                      BatchScan { table: orders, columns: [orders.o_orderkey, orders.o_custkey, orders.o_orderdate], distribution: SomeShard }
                               BatchExchange { order: [], dist: HashShard(nation.n_nationkey) }
-                                BatchScan { table: nation, columns: [n_nationkey, n_name] }
+                                BatchScan { table: nation, columns: [nation.n_nationkey, nation.n_name], distribution: SomeShard }
                           BatchExchange { order: [], dist: HashShard(customer.c_custkey) }
-                            BatchScan { table: customer, columns: [c_custkey, c_nationkey] }
+                            BatchScan { table: customer, columns: [customer.c_custkey, customer.c_nationkey], distribution: SomeShard }
                       BatchExchange { order: [], dist: HashShard(nation.n_nationkey) }
-                        BatchScan { table: nation, columns: [n_nationkey, n_regionkey] }
+                        BatchScan { table: nation, columns: [nation.n_nationkey, nation.n_regionkey], distribution: SomeShard }
                   BatchExchange { order: [], dist: HashShard(region.r_regionkey) }
                     BatchProject { exprs: [region.r_regionkey] }
                       BatchFilter { predicate: (region.r_name = 'ASIA':Varchar) }
-                        BatchScan { table: region, columns: [r_regionkey, r_name] }
+                        BatchScan { table: region, columns: [region.r_regionkey, region.r_name], distribution: SomeShard }
   stream_plan: |
     StreamMaterialize { columns: [o_year, mkt_share], pk_columns: [o_year] }
       StreamProject { exprs: [Extract('YEAR':Varchar, orders.o_orderdate), RoundDigit((sum(Case((nation.n_name = 'IRAN':Varchar), (lineitem.l_extendedprice * (1:Int32 - lineitem.l_discount)), 0:Int32::Decimal)) / sum((lineitem.l_extendedprice * (1:Int32 - lineitem.l_discount)))), 6:Int32)] }
         StreamHashAgg { group_key: [Extract('YEAR':Varchar, orders.o_orderdate)], aggs: [count, sum(Case((nation.n_name = 'IRAN':Varchar), (lineitem.l_extendedprice * (1:Int32 - lineitem.l_discount)), 0:Int32::Decimal)), sum((lineitem.l_extendedprice * (1:Int32 - lineitem.l_discount)))] }
           StreamExchange { dist: HashShard(Extract('YEAR':Varchar, orders.o_orderdate)) }
             StreamProject { exprs: [Extract('YEAR':Varchar, orders.o_orderdate), Case((nation.n_name = 'IRAN':Varchar), (lineitem.l_extendedprice * (1:Int32 - lineitem.l_discount)), 0:Int32::Decimal), (lineitem.l_extendedprice * (1:Int32 - lineitem.l_discount)), lineitem._row_id, part._row_id, supplier._row_id, orders._row_id, nation._row_id, customer._row_id, nation._row_id, region._row_id] }
-              StreamHashJoin { type: Inner, predicate: nation.n_regionkey = region.r_regionkey }
+              StreamHashJoin { type: Inner, predicate: nation.n_regionkey = region.r_regionkey, output: [lineitem.l_extendedprice, lineitem.l_discount, orders.o_orderdate, nation.n_name, lineitem._row_id, part._row_id, supplier._row_id, orders._row_id, nation._row_id, customer._row_id, nation._row_id, region._row_id] }
                 StreamExchange { dist: HashShard(nation.n_regionkey) }
-                  StreamHashJoin { type: Inner, predicate: customer.c_nationkey = nation.n_nationkey }
+                  StreamHashJoin { type: Inner, predicate: customer.c_nationkey = nation.n_nationkey, output: [lineitem.l_extendedprice, lineitem.l_discount, orders.o_orderdate, nation.n_name, nation.n_regionkey, lineitem._row_id, part._row_id, supplier._row_id, orders._row_id, nation._row_id, customer._row_id, nation._row_id] }
                     StreamExchange { dist: HashShard(customer.c_nationkey) }
-                      StreamHashJoin { type: Inner, predicate: orders.o_custkey = customer.c_custkey }
+                      StreamHashJoin { type: Inner, predicate: orders.o_custkey = customer.c_custkey, output: [lineitem.l_extendedprice, lineitem.l_discount, orders.o_orderdate, nation.n_name, customer.c_nationkey, lineitem._row_id, part._row_id, supplier._row_id, orders._row_id, nation._row_id, customer._row_id] }
                         StreamExchange { dist: HashShard(orders.o_custkey) }
-                          StreamHashJoin { type: Inner, predicate: supplier.s_nationkey = nation.n_nationkey }
+                          StreamHashJoin { type: Inner, predicate: supplier.s_nationkey = nation.n_nationkey, output: [lineitem.l_extendedprice, lineitem.l_discount, orders.o_custkey, orders.o_orderdate, nation.n_name, lineitem._row_id, part._row_id, supplier._row_id, orders._row_id, nation._row_id] }
                             StreamExchange { dist: HashShard(supplier.s_nationkey) }
-                              StreamHashJoin { type: Inner, predicate: lineitem.l_orderkey = orders.o_orderkey }
+                              StreamHashJoin { type: Inner, predicate: lineitem.l_orderkey = orders.o_orderkey, output: [lineitem.l_extendedprice, lineitem.l_discount, supplier.s_nationkey, orders.o_custkey, orders.o_orderdate, lineitem._row_id, part._row_id, supplier._row_id, orders._row_id] }
                                 StreamExchange { dist: HashShard(lineitem.l_orderkey) }
-                                  StreamHashJoin { type: Inner, predicate: lineitem.l_suppkey = supplier.s_suppkey }
+                                  StreamHashJoin { type: Inner, predicate: lineitem.l_suppkey = supplier.s_suppkey, output: [lineitem.l_orderkey, lineitem.l_extendedprice, lineitem.l_discount, supplier.s_nationkey, lineitem._row_id, part._row_id, supplier._row_id] }
                                     StreamExchange { dist: HashShard(lineitem.l_suppkey) }
-                                      StreamHashJoin { type: Inner, predicate: lineitem.l_partkey = part.p_partkey }
+                                      StreamHashJoin { type: Inner, predicate: lineitem.l_partkey = part.p_partkey, output: [lineitem.l_orderkey, lineitem.l_suppkey, lineitem.l_extendedprice, lineitem.l_discount, lineitem._row_id, part._row_id] }
                                         StreamExchange { dist: HashShard(lineitem.l_partkey) }
-                                          StreamTableScan { table: lineitem, columns: [l_orderkey, l_partkey, l_suppkey, l_extendedprice, l_discount, _row_id] }
+                                          StreamTableScan { table: lineitem, columns: [lineitem.l_orderkey, lineitem.l_partkey, lineitem.l_suppkey, lineitem.l_extendedprice, lineitem.l_discount, lineitem._row_id], pk: [lineitem._row_id], distribution: HashShard(lineitem._row_id) }
                                         StreamExchange { dist: HashShard(part.p_partkey) }
                                           StreamProject { exprs: [part.p_partkey, part._row_id] }
                                             StreamFilter { predicate: (part.p_type = 'PROMO ANODIZED STEEL':Varchar) }
-                                              StreamTableScan { table: part, columns: [p_partkey, _row_id, p_type] }
+                                              StreamTableScan { table: part, columns: [part.p_partkey, part._row_id, part.p_type], pk: [part._row_id], distribution: HashShard(part._row_id) }
                                     StreamExchange { dist: HashShard(supplier.s_suppkey) }
-                                      StreamTableScan { table: supplier, columns: [s_suppkey, s_nationkey, _row_id] }
+                                      StreamTableScan { table: supplier, columns: [supplier.s_suppkey, supplier.s_nationkey, supplier._row_id], pk: [supplier._row_id], distribution: HashShard(supplier._row_id) }
                                 StreamExchange { dist: HashShard(orders.o_orderkey) }
                                   StreamFilter { predicate: (orders.o_orderdate >= '1995-01-01':Varchar::Date) AND (orders.o_orderdate <= '1996-12-31':Varchar::Date) }
-                                    StreamTableScan { table: orders, columns: [o_orderkey, o_custkey, o_orderdate, _row_id] }
+                                    StreamTableScan { table: orders, columns: [orders.o_orderkey, orders.o_custkey, orders.o_orderdate, orders._row_id], pk: [orders._row_id], distribution: HashShard(orders._row_id) }
                             StreamExchange { dist: HashShard(nation.n_nationkey) }
-                              StreamTableScan { table: nation, columns: [n_nationkey, n_name, _row_id] }
+                              StreamTableScan { table: nation, columns: [nation.n_nationkey, nation.n_name, nation._row_id], pk: [nation._row_id], distribution: HashShard(nation._row_id) }
                         StreamExchange { dist: HashShard(customer.c_custkey) }
-                          StreamTableScan { table: customer, columns: [c_custkey, c_nationkey, _row_id] }
+                          StreamTableScan { table: customer, columns: [customer.c_custkey, customer.c_nationkey, customer._row_id], pk: [customer._row_id], distribution: HashShard(customer._row_id) }
                     StreamExchange { dist: HashShard(nation.n_nationkey) }
-                      StreamTableScan { table: nation, columns: [n_nationkey, n_regionkey, _row_id] }
+                      StreamTableScan { table: nation, columns: [nation.n_nationkey, nation.n_regionkey, nation._row_id], pk: [nation._row_id], distribution: HashShard(nation._row_id) }
                 StreamExchange { dist: HashShard(region.r_regionkey) }
                   StreamProject { exprs: [region.r_regionkey, region._row_id] }
                     StreamFilter { predicate: (region.r_name = 'ASIA':Varchar) }
-                      StreamTableScan { table: region, columns: [r_regionkey, _row_id, r_name] }
+                      StreamTableScan { table: region, columns: [region.r_regionkey, region._row_id, region.r_name], pk: [region._row_id], distribution: HashShard(region._row_id) }
 - id: tpch_q9
   before:
   - create_tables
@@ -971,32 +971,32 @@
         LogicalProject { exprs: [nation.n_name, Extract('YEAR':Varchar, orders.o_orderdate), ((lineitem.l_extendedprice * (1:Int32 - lineitem.l_discount)) - (partsupp.ps_supplycost * lineitem.l_quantity))] }
           LogicalProject { exprs: [nation.n_name, Extract('YEAR':Varchar, orders.o_orderdate), ((lineitem.l_extendedprice * (1:Int32 - lineitem.l_discount)) - (partsupp.ps_supplycost * lineitem.l_quantity))] }
             LogicalFilter { predicate: (supplier.s_suppkey = lineitem.l_suppkey) AND (partsupp.ps_suppkey = lineitem.l_suppkey) AND (partsupp.ps_partkey = lineitem.l_partkey) AND (part.p_partkey = lineitem.l_partkey) AND (orders.o_orderkey = lineitem.l_orderkey) AND (supplier.s_nationkey = nation.n_nationkey) AND Like(part.p_name, '%yellow%':Varchar) }
-              LogicalJoin { type: Inner, on: true }
-                LogicalJoin { type: Inner, on: true }
-                  LogicalJoin { type: Inner, on: true }
-                    LogicalJoin { type: Inner, on: true }
-                      LogicalJoin { type: Inner, on: true }
-                        LogicalScan { table: lineitem, columns: [_row_id, l_orderkey, l_partkey, l_suppkey, l_linenumber, l_quantity, l_extendedprice, l_discount, l_tax, l_returnflag, l_linestatus, l_shipdate, l_commitdate, l_receiptdate, l_shipinstruct, l_shipmode, l_comment] }
-                        LogicalScan { table: part, columns: [_row_id, p_partkey, p_name, p_mfgr, p_brand, p_type, p_size, p_container, p_retailprice, p_comment] }
-                      LogicalScan { table: supplier, columns: [_row_id, s_suppkey, s_name, s_address, s_nationkey, s_phone, s_acctbal, s_comment] }
-                    LogicalScan { table: partsupp, columns: [_row_id, ps_partkey, ps_suppkey, ps_availqty, ps_supplycost, ps_comment] }
-                  LogicalScan { table: orders, columns: [_row_id, o_orderkey, o_custkey, o_orderstatus, o_totalprice, o_orderdate, o_orderpriority, o_clerk, o_shippriority, o_comment] }
-                LogicalScan { table: nation, columns: [_row_id, n_nationkey, n_name, n_regionkey, n_comment] }
+              LogicalJoin { type: Inner, on: true, output: all }
+                LogicalJoin { type: Inner, on: true, output: all }
+                  LogicalJoin { type: Inner, on: true, output: all }
+                    LogicalJoin { type: Inner, on: true, output: all }
+                      LogicalJoin { type: Inner, on: true, output: all }
+                        LogicalScan { table: lineitem, columns: [lineitem._row_id, lineitem.l_orderkey, lineitem.l_partkey, lineitem.l_suppkey, lineitem.l_linenumber, lineitem.l_quantity, lineitem.l_extendedprice, lineitem.l_discount, lineitem.l_tax, lineitem.l_returnflag, lineitem.l_linestatus, lineitem.l_shipdate, lineitem.l_commitdate, lineitem.l_receiptdate, lineitem.l_shipinstruct, lineitem.l_shipmode, lineitem.l_comment] }
+                        LogicalScan { table: part, columns: [part._row_id, part.p_partkey, part.p_name, part.p_mfgr, part.p_brand, part.p_type, part.p_size, part.p_container, part.p_retailprice, part.p_comment] }
+                      LogicalScan { table: supplier, columns: [supplier._row_id, supplier.s_suppkey, supplier.s_name, supplier.s_address, supplier.s_nationkey, supplier.s_phone, supplier.s_acctbal, supplier.s_comment] }
+                    LogicalScan { table: partsupp, columns: [partsupp._row_id, partsupp.ps_partkey, partsupp.ps_suppkey, partsupp.ps_availqty, partsupp.ps_supplycost, partsupp.ps_comment] }
+                  LogicalScan { table: orders, columns: [orders._row_id, orders.o_orderkey, orders.o_custkey, orders.o_orderstatus, orders.o_totalprice, orders.o_orderdate, orders.o_orderpriority, orders.o_clerk, orders.o_shippriority, orders.o_comment] }
+                LogicalScan { table: nation, columns: [nation._row_id, nation.n_nationkey, nation.n_name, nation.n_regionkey, nation.n_comment] }
   optimized_logical_plan: |
     LogicalProject { exprs: [nation.n_name, Extract('YEAR':Varchar, orders.o_orderdate), RoundDigit(sum(((lineitem.l_extendedprice * (1:Int32 - lineitem.l_discount)) - (partsupp.ps_supplycost * lineitem.l_quantity))), 2:Int32)] }
       LogicalAgg { group_key: [nation.n_name, Extract('YEAR':Varchar, orders.o_orderdate)], aggs: [sum(((lineitem.l_extendedprice * (1:Int32 - lineitem.l_discount)) - (partsupp.ps_supplycost * lineitem.l_quantity)))] }
         LogicalProject { exprs: [nation.n_name, Extract('YEAR':Varchar, orders.o_orderdate), ((lineitem.l_extendedprice * (1:Int32 - lineitem.l_discount)) - (partsupp.ps_supplycost * lineitem.l_quantity))] }
-          LogicalJoin { type: Inner, on: (supplier.s_nationkey = nation.n_nationkey) }
-            LogicalJoin { type: Inner, on: (orders.o_orderkey = lineitem.l_orderkey) }
-              LogicalJoin { type: Inner, on: (partsupp.ps_suppkey = lineitem.l_suppkey) AND (partsupp.ps_partkey = lineitem.l_partkey) }
-                LogicalJoin { type: Inner, on: (supplier.s_suppkey = lineitem.l_suppkey) }
-                  LogicalJoin { type: Inner, on: (part.p_partkey = lineitem.l_partkey) }
-                    LogicalScan { table: lineitem, columns: [l_orderkey, l_partkey, l_suppkey, l_quantity, l_extendedprice, l_discount] }
-                    LogicalScan { table: part, output_columns: [p_partkey], required_columns: [p_partkey, p_name], predicate: Like(part.p_name, '%yellow%':Varchar) }
-                  LogicalScan { table: supplier, columns: [s_suppkey, s_nationkey] }
-                LogicalScan { table: partsupp, columns: [ps_partkey, ps_suppkey, ps_supplycost] }
-              LogicalScan { table: orders, columns: [o_orderkey, o_orderdate] }
-            LogicalScan { table: nation, columns: [n_nationkey, n_name] }
+          LogicalJoin { type: Inner, on: (supplier.s_nationkey = nation.n_nationkey), output: [lineitem.l_quantity, lineitem.l_extendedprice, lineitem.l_discount, partsupp.ps_supplycost, orders.o_orderdate, nation.n_name] }
+            LogicalJoin { type: Inner, on: (orders.o_orderkey = lineitem.l_orderkey), output: [lineitem.l_quantity, lineitem.l_extendedprice, lineitem.l_discount, supplier.s_nationkey, partsupp.ps_supplycost, orders.o_orderdate] }
+              LogicalJoin { type: Inner, on: (partsupp.ps_suppkey = lineitem.l_suppkey) AND (partsupp.ps_partkey = lineitem.l_partkey), output: [lineitem.l_orderkey, lineitem.l_quantity, lineitem.l_extendedprice, lineitem.l_discount, supplier.s_nationkey, partsupp.ps_supplycost] }
+                LogicalJoin { type: Inner, on: (supplier.s_suppkey = lineitem.l_suppkey), output: [lineitem.l_orderkey, lineitem.l_partkey, lineitem.l_suppkey, lineitem.l_quantity, lineitem.l_extendedprice, lineitem.l_discount, supplier.s_nationkey] }
+                  LogicalJoin { type: Inner, on: (part.p_partkey = lineitem.l_partkey), output: [lineitem.l_orderkey, lineitem.l_partkey, lineitem.l_suppkey, lineitem.l_quantity, lineitem.l_extendedprice, lineitem.l_discount] }
+                    LogicalScan { table: lineitem, columns: [lineitem.l_orderkey, lineitem.l_partkey, lineitem.l_suppkey, lineitem.l_quantity, lineitem.l_extendedprice, lineitem.l_discount] }
+                    LogicalScan { table: part, output_columns: [part.p_partkey], required_columns: [p_partkey, p_name], predicate: Like(part.p_name, '%yellow%':Varchar) }
+                  LogicalScan { table: supplier, columns: [supplier.s_suppkey, supplier.s_nationkey] }
+                LogicalScan { table: partsupp, columns: [partsupp.ps_partkey, partsupp.ps_suppkey, partsupp.ps_supplycost] }
+              LogicalScan { table: orders, columns: [orders.o_orderkey, orders.o_orderdate] }
+            LogicalScan { table: nation, columns: [nation.n_nationkey, nation.n_name] }
   batch_plan: |
     BatchExchange { order: [nation.n_name ASC, Extract('YEAR':Varchar, orders.o_orderdate) DESC], dist: Single }
       BatchSort { order: [nation.n_name ASC, Extract('YEAR':Varchar, orders.o_orderdate) DESC] }
@@ -1004,58 +1004,58 @@
           BatchHashAgg { group_key: [nation.n_name, Extract('YEAR':Varchar, orders.o_orderdate)], aggs: [sum(((lineitem.l_extendedprice * (1:Int32 - lineitem.l_discount)) - (partsupp.ps_supplycost * lineitem.l_quantity)))] }
             BatchExchange { order: [], dist: HashShard(nation.n_name, Extract('YEAR':Varchar, orders.o_orderdate)) }
               BatchProject { exprs: [nation.n_name, Extract('YEAR':Varchar, orders.o_orderdate), ((lineitem.l_extendedprice * (1:Int32 - lineitem.l_discount)) - (partsupp.ps_supplycost * lineitem.l_quantity))] }
-                BatchHashJoin { type: Inner, predicate: supplier.s_nationkey = nation.n_nationkey }
+                BatchHashJoin { type: Inner, predicate: supplier.s_nationkey = nation.n_nationkey, output: [lineitem.l_quantity, lineitem.l_extendedprice, lineitem.l_discount, partsupp.ps_supplycost, orders.o_orderdate, nation.n_name] }
                   BatchExchange { order: [], dist: HashShard(supplier.s_nationkey) }
-                    BatchHashJoin { type: Inner, predicate: lineitem.l_orderkey = orders.o_orderkey }
+                    BatchHashJoin { type: Inner, predicate: lineitem.l_orderkey = orders.o_orderkey, output: [lineitem.l_quantity, lineitem.l_extendedprice, lineitem.l_discount, supplier.s_nationkey, partsupp.ps_supplycost, orders.o_orderdate] }
                       BatchExchange { order: [], dist: HashShard(lineitem.l_orderkey) }
-                        BatchHashJoin { type: Inner, predicate: lineitem.l_suppkey = partsupp.ps_suppkey AND lineitem.l_partkey = partsupp.ps_partkey }
+                        BatchHashJoin { type: Inner, predicate: lineitem.l_suppkey = partsupp.ps_suppkey AND lineitem.l_partkey = partsupp.ps_partkey, output: [lineitem.l_orderkey, lineitem.l_quantity, lineitem.l_extendedprice, lineitem.l_discount, supplier.s_nationkey, partsupp.ps_supplycost] }
                           BatchExchange { order: [], dist: HashShard(lineitem.l_partkey, lineitem.l_suppkey) }
-                            BatchHashJoin { type: Inner, predicate: lineitem.l_suppkey = supplier.s_suppkey }
+                            BatchHashJoin { type: Inner, predicate: lineitem.l_suppkey = supplier.s_suppkey, output: [lineitem.l_orderkey, lineitem.l_partkey, lineitem.l_suppkey, lineitem.l_quantity, lineitem.l_extendedprice, lineitem.l_discount, supplier.s_nationkey] }
                               BatchExchange { order: [], dist: HashShard(lineitem.l_suppkey) }
-                                BatchHashJoin { type: Inner, predicate: lineitem.l_partkey = part.p_partkey }
+                                BatchHashJoin { type: Inner, predicate: lineitem.l_partkey = part.p_partkey, output: [lineitem.l_orderkey, lineitem.l_partkey, lineitem.l_suppkey, lineitem.l_quantity, lineitem.l_extendedprice, lineitem.l_discount] }
                                   BatchExchange { order: [], dist: HashShard(lineitem.l_partkey) }
-                                    BatchScan { table: lineitem, columns: [l_orderkey, l_partkey, l_suppkey, l_quantity, l_extendedprice, l_discount] }
+                                    BatchScan { table: lineitem, columns: [lineitem.l_orderkey, lineitem.l_partkey, lineitem.l_suppkey, lineitem.l_quantity, lineitem.l_extendedprice, lineitem.l_discount], distribution: SomeShard }
                                   BatchExchange { order: [], dist: HashShard(part.p_partkey) }
                                     BatchProject { exprs: [part.p_partkey] }
                                       BatchFilter { predicate: Like(part.p_name, '%yellow%':Varchar) }
-                                        BatchScan { table: part, columns: [p_partkey, p_name] }
+                                        BatchScan { table: part, columns: [part.p_partkey, part.p_name], distribution: SomeShard }
                               BatchExchange { order: [], dist: HashShard(supplier.s_suppkey) }
-                                BatchScan { table: supplier, columns: [s_suppkey, s_nationkey] }
+                                BatchScan { table: supplier, columns: [supplier.s_suppkey, supplier.s_nationkey], distribution: SomeShard }
                           BatchExchange { order: [], dist: HashShard(partsupp.ps_partkey, partsupp.ps_suppkey) }
-                            BatchScan { table: partsupp, columns: [ps_partkey, ps_suppkey, ps_supplycost] }
+                            BatchScan { table: partsupp, columns: [partsupp.ps_partkey, partsupp.ps_suppkey, partsupp.ps_supplycost], distribution: SomeShard }
                       BatchExchange { order: [], dist: HashShard(orders.o_orderkey) }
-                        BatchScan { table: orders, columns: [o_orderkey, o_orderdate] }
+                        BatchScan { table: orders, columns: [orders.o_orderkey, orders.o_orderdate], distribution: SomeShard }
                   BatchExchange { order: [], dist: HashShard(nation.n_nationkey) }
-                    BatchScan { table: nation, columns: [n_nationkey, n_name] }
+                    BatchScan { table: nation, columns: [nation.n_nationkey, nation.n_name], distribution: SomeShard }
   stream_plan: |
     StreamMaterialize { columns: [nation, o_year, sum_profit], pk_columns: [nation, o_year] }
       StreamProject { exprs: [nation.n_name, Extract('YEAR':Varchar, orders.o_orderdate), RoundDigit(sum(((lineitem.l_extendedprice * (1:Int32 - lineitem.l_discount)) - (partsupp.ps_supplycost * lineitem.l_quantity))), 2:Int32)] }
         StreamHashAgg { group_key: [nation.n_name, Extract('YEAR':Varchar, orders.o_orderdate)], aggs: [count, sum(((lineitem.l_extendedprice * (1:Int32 - lineitem.l_discount)) - (partsupp.ps_supplycost * lineitem.l_quantity)))] }
           StreamExchange { dist: HashShard(nation.n_name, Extract('YEAR':Varchar, orders.o_orderdate)) }
             StreamProject { exprs: [nation.n_name, Extract('YEAR':Varchar, orders.o_orderdate), ((lineitem.l_extendedprice * (1:Int32 - lineitem.l_discount)) - (partsupp.ps_supplycost * lineitem.l_quantity)), lineitem._row_id, part._row_id, supplier._row_id, partsupp._row_id, orders._row_id, nation._row_id] }
-              StreamHashJoin { type: Inner, predicate: supplier.s_nationkey = nation.n_nationkey }
+              StreamHashJoin { type: Inner, predicate: supplier.s_nationkey = nation.n_nationkey, output: [lineitem.l_quantity, lineitem.l_extendedprice, lineitem.l_discount, partsupp.ps_supplycost, orders.o_orderdate, nation.n_name, lineitem._row_id, part._row_id, supplier._row_id, partsupp._row_id, orders._row_id, nation._row_id] }
                 StreamExchange { dist: HashShard(supplier.s_nationkey) }
-                  StreamHashJoin { type: Inner, predicate: lineitem.l_orderkey = orders.o_orderkey }
+                  StreamHashJoin { type: Inner, predicate: lineitem.l_orderkey = orders.o_orderkey, output: [lineitem.l_quantity, lineitem.l_extendedprice, lineitem.l_discount, supplier.s_nationkey, partsupp.ps_supplycost, orders.o_orderdate, lineitem._row_id, part._row_id, supplier._row_id, partsupp._row_id, orders._row_id] }
                     StreamExchange { dist: HashShard(lineitem.l_orderkey) }
-                      StreamHashJoin { type: Inner, predicate: lineitem.l_suppkey = partsupp.ps_suppkey AND lineitem.l_partkey = partsupp.ps_partkey }
+                      StreamHashJoin { type: Inner, predicate: lineitem.l_suppkey = partsupp.ps_suppkey AND lineitem.l_partkey = partsupp.ps_partkey, output: [lineitem.l_orderkey, lineitem.l_quantity, lineitem.l_extendedprice, lineitem.l_discount, supplier.s_nationkey, partsupp.ps_supplycost, lineitem._row_id, part._row_id, supplier._row_id, partsupp._row_id] }
                         StreamExchange { dist: HashShard(lineitem.l_partkey, lineitem.l_suppkey) }
-                          StreamHashJoin { type: Inner, predicate: lineitem.l_suppkey = supplier.s_suppkey }
+                          StreamHashJoin { type: Inner, predicate: lineitem.l_suppkey = supplier.s_suppkey, output: [lineitem.l_orderkey, lineitem.l_partkey, lineitem.l_suppkey, lineitem.l_quantity, lineitem.l_extendedprice, lineitem.l_discount, supplier.s_nationkey, lineitem._row_id, part._row_id, supplier._row_id] }
                             StreamExchange { dist: HashShard(lineitem.l_suppkey) }
-                              StreamHashJoin { type: Inner, predicate: lineitem.l_partkey = part.p_partkey }
+                              StreamHashJoin { type: Inner, predicate: lineitem.l_partkey = part.p_partkey, output: [lineitem.l_orderkey, lineitem.l_partkey, lineitem.l_suppkey, lineitem.l_quantity, lineitem.l_extendedprice, lineitem.l_discount, lineitem._row_id, part._row_id] }
                                 StreamExchange { dist: HashShard(lineitem.l_partkey) }
-                                  StreamTableScan { table: lineitem, columns: [l_orderkey, l_partkey, l_suppkey, l_quantity, l_extendedprice, l_discount, _row_id] }
+                                  StreamTableScan { table: lineitem, columns: [lineitem.l_orderkey, lineitem.l_partkey, lineitem.l_suppkey, lineitem.l_quantity, lineitem.l_extendedprice, lineitem.l_discount, lineitem._row_id], pk: [lineitem._row_id], distribution: HashShard(lineitem._row_id) }
                                 StreamExchange { dist: HashShard(part.p_partkey) }
                                   StreamProject { exprs: [part.p_partkey, part._row_id] }
                                     StreamFilter { predicate: Like(part.p_name, '%yellow%':Varchar) }
-                                      StreamTableScan { table: part, columns: [p_partkey, _row_id, p_name] }
+                                      StreamTableScan { table: part, columns: [part.p_partkey, part._row_id, part.p_name], pk: [part._row_id], distribution: HashShard(part._row_id) }
                             StreamExchange { dist: HashShard(supplier.s_suppkey) }
-                              StreamTableScan { table: supplier, columns: [s_suppkey, s_nationkey, _row_id] }
+                              StreamTableScan { table: supplier, columns: [supplier.s_suppkey, supplier.s_nationkey, supplier._row_id], pk: [supplier._row_id], distribution: HashShard(supplier._row_id) }
                         StreamExchange { dist: HashShard(partsupp.ps_partkey, partsupp.ps_suppkey) }
-                          StreamTableScan { table: partsupp, columns: [ps_partkey, ps_suppkey, ps_supplycost, _row_id] }
+                          StreamTableScan { table: partsupp, columns: [partsupp.ps_partkey, partsupp.ps_suppkey, partsupp.ps_supplycost, partsupp._row_id], pk: [partsupp._row_id], distribution: HashShard(partsupp._row_id) }
                     StreamExchange { dist: HashShard(orders.o_orderkey) }
-                      StreamTableScan { table: orders, columns: [o_orderkey, o_orderdate, _row_id] }
+                      StreamTableScan { table: orders, columns: [orders.o_orderkey, orders.o_orderdate, orders._row_id], pk: [orders._row_id], distribution: HashShard(orders._row_id) }
                 StreamExchange { dist: HashShard(nation.n_nationkey) }
-                  StreamTableScan { table: nation, columns: [n_nationkey, n_name, _row_id] }
+                  StreamTableScan { table: nation, columns: [nation.n_nationkey, nation.n_name, nation._row_id], pk: [nation._row_id], distribution: HashShard(nation._row_id) }
 - id: tpch_q10
   before:
   - create_tables
@@ -1098,25 +1098,25 @@
         LogicalAgg { group_key: [customer.c_custkey, customer.c_name, customer.c_acctbal, customer.c_phone, nation.n_name, customer.c_address, customer.c_comment], aggs: [sum((lineitem.l_extendedprice * (1.00:Decimal - lineitem.l_discount)))] }
           LogicalProject { exprs: [customer.c_custkey, customer.c_name, customer.c_acctbal, customer.c_phone, nation.n_name, customer.c_address, customer.c_comment, (lineitem.l_extendedprice * (1.00:Decimal - lineitem.l_discount))] }
             LogicalFilter { predicate: (customer.c_custkey = orders.o_custkey) AND (lineitem.l_orderkey = orders.o_orderkey) AND (orders.o_orderdate >= '1994-01-01':Varchar::Date) AND (orders.o_orderdate < ('1994-01-01':Varchar::Date + '3 mons 00:00:00':Interval)) AND (lineitem.l_returnflag = 'R':Varchar) AND (customer.c_nationkey = nation.n_nationkey) }
-              LogicalJoin { type: Inner, on: true }
-                LogicalJoin { type: Inner, on: true }
-                  LogicalJoin { type: Inner, on: true }
-                    LogicalScan { table: customer, columns: [_row_id, c_custkey, c_name, c_address, c_nationkey, c_phone, c_acctbal, c_mktsegment, c_comment] }
-                    LogicalScan { table: orders, columns: [_row_id, o_orderkey, o_custkey, o_orderstatus, o_totalprice, o_orderdate, o_orderpriority, o_clerk, o_shippriority, o_comment] }
-                  LogicalScan { table: lineitem, columns: [_row_id, l_orderkey, l_partkey, l_suppkey, l_linenumber, l_quantity, l_extendedprice, l_discount, l_tax, l_returnflag, l_linestatus, l_shipdate, l_commitdate, l_receiptdate, l_shipinstruct, l_shipmode, l_comment] }
-                LogicalScan { table: nation, columns: [_row_id, n_nationkey, n_name, n_regionkey, n_comment] }
+              LogicalJoin { type: Inner, on: true, output: all }
+                LogicalJoin { type: Inner, on: true, output: all }
+                  LogicalJoin { type: Inner, on: true, output: all }
+                    LogicalScan { table: customer, columns: [customer._row_id, customer.c_custkey, customer.c_name, customer.c_address, customer.c_nationkey, customer.c_phone, customer.c_acctbal, customer.c_mktsegment, customer.c_comment] }
+                    LogicalScan { table: orders, columns: [orders._row_id, orders.o_orderkey, orders.o_custkey, orders.o_orderstatus, orders.o_totalprice, orders.o_orderdate, orders.o_orderpriority, orders.o_clerk, orders.o_shippriority, orders.o_comment] }
+                  LogicalScan { table: lineitem, columns: [lineitem._row_id, lineitem.l_orderkey, lineitem.l_partkey, lineitem.l_suppkey, lineitem.l_linenumber, lineitem.l_quantity, lineitem.l_extendedprice, lineitem.l_discount, lineitem.l_tax, lineitem.l_returnflag, lineitem.l_linestatus, lineitem.l_shipdate, lineitem.l_commitdate, lineitem.l_receiptdate, lineitem.l_shipinstruct, lineitem.l_shipmode, lineitem.l_comment] }
+                LogicalScan { table: nation, columns: [nation._row_id, nation.n_nationkey, nation.n_name, nation.n_regionkey, nation.n_comment] }
   optimized_logical_plan: |
     LogicalTopN { order: "[sum((lineitem.l_extendedprice * (1.00:Decimal - lineitem.l_discount))) DESC]", limit: 20, offset: 0 }
       LogicalProject { exprs: [customer.c_custkey, customer.c_name, sum((lineitem.l_extendedprice * (1.00:Decimal - lineitem.l_discount))), customer.c_acctbal, nation.n_name, customer.c_address, customer.c_phone, customer.c_comment] }
         LogicalAgg { group_key: [customer.c_custkey, customer.c_name, customer.c_acctbal, customer.c_phone, nation.n_name, customer.c_address, customer.c_comment], aggs: [sum((lineitem.l_extendedprice * (1.00:Decimal - lineitem.l_discount)))] }
           LogicalProject { exprs: [customer.c_custkey, customer.c_name, customer.c_acctbal, customer.c_phone, nation.n_name, customer.c_address, customer.c_comment, (lineitem.l_extendedprice * (1.00:Decimal - lineitem.l_discount))] }
-            LogicalJoin { type: Inner, on: (lineitem.l_orderkey = orders.o_orderkey) }
-              LogicalJoin { type: Inner, on: (customer.c_nationkey = nation.n_nationkey) }
-                LogicalJoin { type: Inner, on: (customer.c_custkey = orders.o_custkey) }
-                  LogicalScan { table: customer, columns: [c_custkey, c_name, c_address, c_nationkey, c_phone, c_acctbal, c_comment] }
-                  LogicalScan { table: orders, output_columns: [o_orderkey, o_custkey], required_columns: [o_orderkey, o_custkey, o_orderdate], predicate: (orders.o_orderdate >= '1994-01-01':Varchar::Date) AND (orders.o_orderdate < ('1994-01-01':Varchar::Date + '3 mons 00:00:00':Interval)) }
-                LogicalScan { table: nation, columns: [n_nationkey, n_name] }
-              LogicalScan { table: lineitem, output_columns: [l_orderkey, l_extendedprice, l_discount], required_columns: [l_orderkey, l_extendedprice, l_discount, l_returnflag], predicate: (lineitem.l_returnflag = 'R':Varchar) }
+            LogicalJoin { type: Inner, on: (lineitem.l_orderkey = orders.o_orderkey), output: [customer.c_custkey, customer.c_name, customer.c_address, customer.c_phone, customer.c_acctbal, customer.c_comment, nation.n_name, lineitem.l_extendedprice, lineitem.l_discount] }
+              LogicalJoin { type: Inner, on: (customer.c_nationkey = nation.n_nationkey), output: [customer.c_custkey, customer.c_name, customer.c_address, customer.c_phone, customer.c_acctbal, customer.c_comment, orders.o_orderkey, nation.n_name] }
+                LogicalJoin { type: Inner, on: (customer.c_custkey = orders.o_custkey), output: [customer.c_custkey, customer.c_name, customer.c_address, customer.c_nationkey, customer.c_phone, customer.c_acctbal, customer.c_comment, orders.o_orderkey] }
+                  LogicalScan { table: customer, columns: [customer.c_custkey, customer.c_name, customer.c_address, customer.c_nationkey, customer.c_phone, customer.c_acctbal, customer.c_comment] }
+                  LogicalScan { table: orders, output_columns: [orders.o_orderkey, orders.o_custkey], required_columns: [o_orderkey, o_custkey, o_orderdate], predicate: (orders.o_orderdate >= '1994-01-01':Varchar::Date) AND (orders.o_orderdate < ('1994-01-01':Varchar::Date + '3 mons 00:00:00':Interval)) }
+                LogicalScan { table: nation, columns: [nation.n_nationkey, nation.n_name] }
+              LogicalScan { table: lineitem, output_columns: [lineitem.l_orderkey, lineitem.l_extendedprice, lineitem.l_discount], required_columns: [l_orderkey, l_extendedprice, l_discount, l_returnflag], predicate: (lineitem.l_returnflag = 'R':Varchar) }
   batch_plan: |
     BatchTopN { order: "[sum((lineitem.l_extendedprice * (1.00:Decimal - lineitem.l_discount))) DESC]", limit: 20, offset: 0 }
       BatchExchange { order: [], dist: Single }
@@ -1125,23 +1125,23 @@
             BatchHashAgg { group_key: [customer.c_custkey, customer.c_name, customer.c_acctbal, customer.c_phone, nation.n_name, customer.c_address, customer.c_comment], aggs: [sum((lineitem.l_extendedprice * (1.00:Decimal - lineitem.l_discount)))] }
               BatchExchange { order: [], dist: HashShard(customer.c_custkey, customer.c_name, customer.c_acctbal, customer.c_phone, nation.n_name, customer.c_address, customer.c_comment) }
                 BatchProject { exprs: [customer.c_custkey, customer.c_name, customer.c_acctbal, customer.c_phone, nation.n_name, customer.c_address, customer.c_comment, (lineitem.l_extendedprice * (1.00:Decimal - lineitem.l_discount))] }
-                  BatchHashJoin { type: Inner, predicate: orders.o_orderkey = lineitem.l_orderkey }
+                  BatchHashJoin { type: Inner, predicate: orders.o_orderkey = lineitem.l_orderkey, output: [customer.c_custkey, customer.c_name, customer.c_address, customer.c_phone, customer.c_acctbal, customer.c_comment, nation.n_name, lineitem.l_extendedprice, lineitem.l_discount] }
                     BatchExchange { order: [], dist: HashShard(orders.o_orderkey) }
-                      BatchHashJoin { type: Inner, predicate: customer.c_nationkey = nation.n_nationkey }
+                      BatchHashJoin { type: Inner, predicate: customer.c_nationkey = nation.n_nationkey, output: [customer.c_custkey, customer.c_name, customer.c_address, customer.c_phone, customer.c_acctbal, customer.c_comment, orders.o_orderkey, nation.n_name] }
                         BatchExchange { order: [], dist: HashShard(customer.c_nationkey) }
-                          BatchHashJoin { type: Inner, predicate: customer.c_custkey = orders.o_custkey }
+                          BatchHashJoin { type: Inner, predicate: customer.c_custkey = orders.o_custkey, output: [customer.c_custkey, customer.c_name, customer.c_address, customer.c_nationkey, customer.c_phone, customer.c_acctbal, customer.c_comment, orders.o_orderkey] }
                             BatchExchange { order: [], dist: HashShard(customer.c_custkey) }
-                              BatchScan { table: customer, columns: [c_custkey, c_name, c_address, c_nationkey, c_phone, c_acctbal, c_comment] }
+                              BatchScan { table: customer, columns: [customer.c_custkey, customer.c_name, customer.c_address, customer.c_nationkey, customer.c_phone, customer.c_acctbal, customer.c_comment], distribution: SomeShard }
                             BatchExchange { order: [], dist: HashShard(orders.o_custkey) }
                               BatchProject { exprs: [orders.o_orderkey, orders.o_custkey] }
                                 BatchFilter { predicate: (orders.o_orderdate >= '1994-01-01':Varchar::Date) AND (orders.o_orderdate < ('1994-01-01':Varchar::Date + '3 mons 00:00:00':Interval)) }
-                                  BatchScan { table: orders, columns: [o_orderkey, o_custkey, o_orderdate] }
+                                  BatchScan { table: orders, columns: [orders.o_orderkey, orders.o_custkey, orders.o_orderdate], distribution: SomeShard }
                         BatchExchange { order: [], dist: HashShard(nation.n_nationkey) }
-                          BatchScan { table: nation, columns: [n_nationkey, n_name] }
+                          BatchScan { table: nation, columns: [nation.n_nationkey, nation.n_name], distribution: SomeShard }
                     BatchExchange { order: [], dist: HashShard(lineitem.l_orderkey) }
                       BatchProject { exprs: [lineitem.l_orderkey, lineitem.l_extendedprice, lineitem.l_discount] }
                         BatchFilter { predicate: (lineitem.l_returnflag = 'R':Varchar) }
-                          BatchScan { table: lineitem, columns: [l_orderkey, l_extendedprice, l_discount, l_returnflag] }
+                          BatchScan { table: lineitem, columns: [lineitem.l_orderkey, lineitem.l_extendedprice, lineitem.l_discount, lineitem.l_returnflag], distribution: SomeShard }
   stream_plan: |
     StreamMaterialize { columns: [c_custkey, c_name, revenue, c_acctbal, n_name, c_address, c_phone, c_comment], pk_columns: [c_custkey, c_name, c_acctbal, c_phone, n_name, c_address, c_comment], order_descs: [revenue, c_custkey, c_name, c_acctbal, c_phone, n_name, c_address, c_comment] }
       StreamTopN { order: "[sum((lineitem.l_extendedprice * (1.00:Decimal - lineitem.l_discount))) DESC]", limit: 20, offset: 0 }
@@ -1150,23 +1150,23 @@
             StreamHashAgg { group_key: [customer.c_custkey, customer.c_name, customer.c_acctbal, customer.c_phone, nation.n_name, customer.c_address, customer.c_comment], aggs: [count, sum((lineitem.l_extendedprice * (1.00:Decimal - lineitem.l_discount)))] }
               StreamExchange { dist: HashShard(customer.c_custkey, customer.c_name, customer.c_acctbal, customer.c_phone, nation.n_name, customer.c_address, customer.c_comment) }
                 StreamProject { exprs: [customer.c_custkey, customer.c_name, customer.c_acctbal, customer.c_phone, nation.n_name, customer.c_address, customer.c_comment, (lineitem.l_extendedprice * (1.00:Decimal - lineitem.l_discount)), customer._row_id, orders._row_id, nation._row_id, lineitem._row_id] }
-                  StreamHashJoin { type: Inner, predicate: orders.o_orderkey = lineitem.l_orderkey }
+                  StreamHashJoin { type: Inner, predicate: orders.o_orderkey = lineitem.l_orderkey, output: [customer.c_custkey, customer.c_name, customer.c_address, customer.c_phone, customer.c_acctbal, customer.c_comment, nation.n_name, lineitem.l_extendedprice, lineitem.l_discount, customer._row_id, orders._row_id, nation._row_id, lineitem._row_id] }
                     StreamExchange { dist: HashShard(orders.o_orderkey) }
-                      StreamHashJoin { type: Inner, predicate: customer.c_nationkey = nation.n_nationkey }
+                      StreamHashJoin { type: Inner, predicate: customer.c_nationkey = nation.n_nationkey, output: [customer.c_custkey, customer.c_name, customer.c_address, customer.c_phone, customer.c_acctbal, customer.c_comment, orders.o_orderkey, nation.n_name, customer._row_id, orders._row_id, nation._row_id] }
                         StreamExchange { dist: HashShard(customer.c_nationkey) }
-                          StreamHashJoin { type: Inner, predicate: customer.c_custkey = orders.o_custkey }
+                          StreamHashJoin { type: Inner, predicate: customer.c_custkey = orders.o_custkey, output: [customer.c_custkey, customer.c_name, customer.c_address, customer.c_nationkey, customer.c_phone, customer.c_acctbal, customer.c_comment, orders.o_orderkey, customer._row_id, orders._row_id] }
                             StreamExchange { dist: HashShard(customer.c_custkey) }
-                              StreamTableScan { table: customer, columns: [c_custkey, c_name, c_address, c_nationkey, c_phone, c_acctbal, c_comment, _row_id] }
+                              StreamTableScan { table: customer, columns: [customer.c_custkey, customer.c_name, customer.c_address, customer.c_nationkey, customer.c_phone, customer.c_acctbal, customer.c_comment, customer._row_id], pk: [customer._row_id], distribution: HashShard(customer._row_id) }
                             StreamExchange { dist: HashShard(orders.o_custkey) }
                               StreamProject { exprs: [orders.o_orderkey, orders.o_custkey, orders._row_id] }
                                 StreamFilter { predicate: (orders.o_orderdate >= '1994-01-01':Varchar::Date) AND (orders.o_orderdate < ('1994-01-01':Varchar::Date + '3 mons 00:00:00':Interval)) }
-                                  StreamTableScan { table: orders, columns: [o_orderkey, o_custkey, _row_id, o_orderdate] }
+                                  StreamTableScan { table: orders, columns: [orders.o_orderkey, orders.o_custkey, orders._row_id, orders.o_orderdate], pk: [orders._row_id], distribution: HashShard(orders._row_id) }
                         StreamExchange { dist: HashShard(nation.n_nationkey) }
-                          StreamTableScan { table: nation, columns: [n_nationkey, n_name, _row_id] }
+                          StreamTableScan { table: nation, columns: [nation.n_nationkey, nation.n_name, nation._row_id], pk: [nation._row_id], distribution: HashShard(nation._row_id) }
                     StreamExchange { dist: HashShard(lineitem.l_orderkey) }
                       StreamProject { exprs: [lineitem.l_orderkey, lineitem.l_extendedprice, lineitem.l_discount, lineitem._row_id] }
                         StreamFilter { predicate: (lineitem.l_returnflag = 'R':Varchar) }
-                          StreamTableScan { table: lineitem, columns: [l_orderkey, l_extendedprice, l_discount, _row_id, l_returnflag] }
+                          StreamTableScan { table: lineitem, columns: [lineitem.l_orderkey, lineitem.l_extendedprice, lineitem.l_discount, lineitem._row_id, lineitem.l_returnflag], pk: [lineitem._row_id], distribution: HashShard(lineitem._row_id) }
 - id: tpch_q11
   before:
   - create_tables
@@ -1202,75 +1202,75 @@
   logical_plan: |
     LogicalProject { exprs: [partsupp.ps_partkey, sum((partsupp.ps_supplycost * partsupp.ps_availqty))] }
       LogicalFilter { predicate: (sum((partsupp.ps_supplycost * partsupp.ps_availqty)) > (sum((partsupp.ps_supplycost * partsupp.ps_availqty)) * 0.0001000000:Decimal)) }
-        LogicalJoin { type: LeftOuter, on: true }
+        LogicalJoin { type: LeftOuter, on: true, output: all }
           LogicalAgg { group_key: [partsupp.ps_partkey], aggs: [sum((partsupp.ps_supplycost * partsupp.ps_availqty)), sum((partsupp.ps_supplycost * partsupp.ps_availqty))] }
             LogicalProject { exprs: [partsupp.ps_partkey, (partsupp.ps_supplycost * partsupp.ps_availqty)] }
               LogicalFilter { predicate: (partsupp.ps_suppkey = supplier.s_suppkey) AND (supplier.s_nationkey = nation.n_nationkey) AND (nation.n_name = 'ARGENTINA':Varchar) }
-                LogicalJoin { type: Inner, on: true }
-                  LogicalJoin { type: Inner, on: true }
-                    LogicalScan { table: partsupp, columns: [_row_id, ps_partkey, ps_suppkey, ps_availqty, ps_supplycost, ps_comment] }
-                    LogicalScan { table: supplier, columns: [_row_id, s_suppkey, s_name, s_address, s_nationkey, s_phone, s_acctbal, s_comment] }
-                  LogicalScan { table: nation, columns: [_row_id, n_nationkey, n_name, n_regionkey, n_comment] }
+                LogicalJoin { type: Inner, on: true, output: all }
+                  LogicalJoin { type: Inner, on: true, output: all }
+                    LogicalScan { table: partsupp, columns: [partsupp._row_id, partsupp.ps_partkey, partsupp.ps_suppkey, partsupp.ps_availqty, partsupp.ps_supplycost, partsupp.ps_comment] }
+                    LogicalScan { table: supplier, columns: [supplier._row_id, supplier.s_suppkey, supplier.s_name, supplier.s_address, supplier.s_nationkey, supplier.s_phone, supplier.s_acctbal, supplier.s_comment] }
+                  LogicalScan { table: nation, columns: [nation._row_id, nation.n_nationkey, nation.n_name, nation.n_regionkey, nation.n_comment] }
           LogicalProject { exprs: [(sum((partsupp.ps_supplycost * partsupp.ps_availqty)) * 0.0001000000:Decimal)] }
             LogicalAgg { aggs: [sum((partsupp.ps_supplycost * partsupp.ps_availqty))] }
               LogicalProject { exprs: [(partsupp.ps_supplycost * partsupp.ps_availqty)] }
                 LogicalFilter { predicate: (partsupp.ps_suppkey = supplier.s_suppkey) AND (supplier.s_nationkey = nation.n_nationkey) AND (nation.n_name = 'ARGENTINA':Varchar) }
-                  LogicalJoin { type: Inner, on: true }
-                    LogicalJoin { type: Inner, on: true }
-                      LogicalScan { table: partsupp, columns: [_row_id, ps_partkey, ps_suppkey, ps_availqty, ps_supplycost, ps_comment] }
-                      LogicalScan { table: supplier, columns: [_row_id, s_suppkey, s_name, s_address, s_nationkey, s_phone, s_acctbal, s_comment] }
-                    LogicalScan { table: nation, columns: [_row_id, n_nationkey, n_name, n_regionkey, n_comment] }
+                  LogicalJoin { type: Inner, on: true, output: all }
+                    LogicalJoin { type: Inner, on: true, output: all }
+                      LogicalScan { table: partsupp, columns: [partsupp._row_id, partsupp.ps_partkey, partsupp.ps_suppkey, partsupp.ps_availqty, partsupp.ps_supplycost, partsupp.ps_comment] }
+                      LogicalScan { table: supplier, columns: [supplier._row_id, supplier.s_suppkey, supplier.s_name, supplier.s_address, supplier.s_nationkey, supplier.s_phone, supplier.s_acctbal, supplier.s_comment] }
+                    LogicalScan { table: nation, columns: [nation._row_id, nation.n_nationkey, nation.n_name, nation.n_regionkey, nation.n_comment] }
   optimized_logical_plan: |
-    LogicalJoin { type: Inner, on: (sum((partsupp.ps_supplycost * partsupp.ps_availqty)) > (sum((partsupp.ps_supplycost * partsupp.ps_availqty)) * 0.0001000000:Decimal)) }
+    LogicalJoin { type: Inner, on: (sum((partsupp.ps_supplycost * partsupp.ps_availqty)) > (sum((partsupp.ps_supplycost * partsupp.ps_availqty)) * 0.0001000000:Decimal)), output: [partsupp.ps_partkey, sum((partsupp.ps_supplycost * partsupp.ps_availqty))] }
       LogicalAgg { group_key: [partsupp.ps_partkey], aggs: [sum((partsupp.ps_supplycost * partsupp.ps_availqty)), sum((partsupp.ps_supplycost * partsupp.ps_availqty))] }
         LogicalProject { exprs: [partsupp.ps_partkey, (partsupp.ps_supplycost * partsupp.ps_availqty)] }
-          LogicalJoin { type: Inner, on: (supplier.s_nationkey = nation.n_nationkey) }
-            LogicalJoin { type: Inner, on: (partsupp.ps_suppkey = supplier.s_suppkey) }
-              LogicalScan { table: partsupp, columns: [ps_partkey, ps_suppkey, ps_availqty, ps_supplycost] }
-              LogicalScan { table: supplier, columns: [s_suppkey, s_nationkey] }
-            LogicalScan { table: nation, output_columns: [n_nationkey], required_columns: [n_nationkey, n_name], predicate: (nation.n_name = 'ARGENTINA':Varchar) }
+          LogicalJoin { type: Inner, on: (supplier.s_nationkey = nation.n_nationkey), output: [partsupp.ps_partkey, partsupp.ps_availqty, partsupp.ps_supplycost] }
+            LogicalJoin { type: Inner, on: (partsupp.ps_suppkey = supplier.s_suppkey), output: [partsupp.ps_partkey, partsupp.ps_availqty, partsupp.ps_supplycost, supplier.s_nationkey] }
+              LogicalScan { table: partsupp, columns: [partsupp.ps_partkey, partsupp.ps_suppkey, partsupp.ps_availqty, partsupp.ps_supplycost] }
+              LogicalScan { table: supplier, columns: [supplier.s_suppkey, supplier.s_nationkey] }
+            LogicalScan { table: nation, output_columns: [nation.n_nationkey], required_columns: [n_nationkey, n_name], predicate: (nation.n_name = 'ARGENTINA':Varchar) }
       LogicalProject { exprs: [(sum((partsupp.ps_supplycost * partsupp.ps_availqty)) * 0.0001000000:Decimal)] }
         LogicalAgg { aggs: [sum((partsupp.ps_supplycost * partsupp.ps_availqty))] }
           LogicalProject { exprs: [(partsupp.ps_supplycost * partsupp.ps_availqty)] }
-            LogicalJoin { type: Inner, on: (supplier.s_nationkey = nation.n_nationkey) }
-              LogicalJoin { type: Inner, on: (partsupp.ps_suppkey = supplier.s_suppkey) }
-                LogicalScan { table: partsupp, columns: [ps_suppkey, ps_availqty, ps_supplycost] }
-                LogicalScan { table: supplier, columns: [s_suppkey, s_nationkey] }
-              LogicalScan { table: nation, output_columns: [n_nationkey], required_columns: [n_nationkey, n_name], predicate: (nation.n_name = 'ARGENTINA':Varchar) }
+            LogicalJoin { type: Inner, on: (supplier.s_nationkey = nation.n_nationkey), output: [partsupp.ps_availqty, partsupp.ps_supplycost] }
+              LogicalJoin { type: Inner, on: (partsupp.ps_suppkey = supplier.s_suppkey), output: [partsupp.ps_availqty, partsupp.ps_supplycost, supplier.s_nationkey] }
+                LogicalScan { table: partsupp, columns: [partsupp.ps_suppkey, partsupp.ps_availqty, partsupp.ps_supplycost] }
+                LogicalScan { table: supplier, columns: [supplier.s_suppkey, supplier.s_nationkey] }
+              LogicalScan { table: nation, output_columns: [nation.n_nationkey], required_columns: [n_nationkey, n_name], predicate: (nation.n_name = 'ARGENTINA':Varchar) }
   batch_plan: |
     BatchSort { order: [sum((partsupp.ps_supplycost * partsupp.ps_availqty)) DESC] }
-      BatchNestedLoopJoin { type: Inner, predicate: (sum((partsupp.ps_supplycost * partsupp.ps_availqty)) > (sum(sum((partsupp.ps_supplycost * partsupp.ps_availqty))) * 0.0001000000:Decimal)) }
+      BatchNestedLoopJoin { type: Inner, predicate: (sum((partsupp.ps_supplycost * partsupp.ps_availqty)) > (sum(sum((partsupp.ps_supplycost * partsupp.ps_availqty))) * 0.0001000000:Decimal)), output: [partsupp.ps_partkey, sum((partsupp.ps_supplycost * partsupp.ps_availqty))] }
         BatchExchange { order: [], dist: Single }
           BatchHashAgg { group_key: [partsupp.ps_partkey], aggs: [sum((partsupp.ps_supplycost * partsupp.ps_availqty)), sum((partsupp.ps_supplycost * partsupp.ps_availqty))] }
             BatchExchange { order: [], dist: HashShard(partsupp.ps_partkey) }
               BatchProject { exprs: [partsupp.ps_partkey, (partsupp.ps_supplycost * partsupp.ps_availqty)] }
-                BatchHashJoin { type: Inner, predicate: supplier.s_nationkey = nation.n_nationkey }
+                BatchHashJoin { type: Inner, predicate: supplier.s_nationkey = nation.n_nationkey, output: [partsupp.ps_partkey, partsupp.ps_availqty, partsupp.ps_supplycost] }
                   BatchExchange { order: [], dist: HashShard(supplier.s_nationkey) }
-                    BatchHashJoin { type: Inner, predicate: partsupp.ps_suppkey = supplier.s_suppkey }
+                    BatchHashJoin { type: Inner, predicate: partsupp.ps_suppkey = supplier.s_suppkey, output: [partsupp.ps_partkey, partsupp.ps_availqty, partsupp.ps_supplycost, supplier.s_nationkey] }
                       BatchExchange { order: [], dist: HashShard(partsupp.ps_suppkey) }
-                        BatchScan { table: partsupp, columns: [ps_partkey, ps_suppkey, ps_availqty, ps_supplycost] }
+                        BatchScan { table: partsupp, columns: [partsupp.ps_partkey, partsupp.ps_suppkey, partsupp.ps_availqty, partsupp.ps_supplycost], distribution: SomeShard }
                       BatchExchange { order: [], dist: HashShard(supplier.s_suppkey) }
-                        BatchScan { table: supplier, columns: [s_suppkey, s_nationkey] }
+                        BatchScan { table: supplier, columns: [supplier.s_suppkey, supplier.s_nationkey], distribution: SomeShard }
                   BatchExchange { order: [], dist: HashShard(nation.n_nationkey) }
                     BatchProject { exprs: [nation.n_nationkey] }
                       BatchFilter { predicate: (nation.n_name = 'ARGENTINA':Varchar) }
-                        BatchScan { table: nation, columns: [n_nationkey, n_name] }
+                        BatchScan { table: nation, columns: [nation.n_nationkey, nation.n_name], distribution: SomeShard }
         BatchProject { exprs: [(sum(sum((partsupp.ps_supplycost * partsupp.ps_availqty))) * 0.0001000000:Decimal)] }
           BatchSimpleAgg { aggs: [sum(sum((partsupp.ps_supplycost * partsupp.ps_availqty)))] }
             BatchExchange { order: [], dist: Single }
               BatchSimpleAgg { aggs: [sum((partsupp.ps_supplycost * partsupp.ps_availqty))] }
                 BatchProject { exprs: [(partsupp.ps_supplycost * partsupp.ps_availqty)] }
-                  BatchHashJoin { type: Inner, predicate: supplier.s_nationkey = nation.n_nationkey }
+                  BatchHashJoin { type: Inner, predicate: supplier.s_nationkey = nation.n_nationkey, output: [partsupp.ps_availqty, partsupp.ps_supplycost] }
                     BatchExchange { order: [], dist: HashShard(supplier.s_nationkey) }
-                      BatchHashJoin { type: Inner, predicate: partsupp.ps_suppkey = supplier.s_suppkey }
+                      BatchHashJoin { type: Inner, predicate: partsupp.ps_suppkey = supplier.s_suppkey, output: [partsupp.ps_availqty, partsupp.ps_supplycost, supplier.s_nationkey] }
                         BatchExchange { order: [], dist: HashShard(partsupp.ps_suppkey) }
-                          BatchScan { table: partsupp, columns: [ps_suppkey, ps_availqty, ps_supplycost] }
+                          BatchScan { table: partsupp, columns: [partsupp.ps_suppkey, partsupp.ps_availqty, partsupp.ps_supplycost], distribution: SomeShard }
                         BatchExchange { order: [], dist: HashShard(supplier.s_suppkey) }
-                          BatchScan { table: supplier, columns: [s_suppkey, s_nationkey] }
+                          BatchScan { table: supplier, columns: [supplier.s_suppkey, supplier.s_nationkey], distribution: SomeShard }
                     BatchExchange { order: [], dist: HashShard(nation.n_nationkey) }
                       BatchProject { exprs: [nation.n_nationkey] }
                         BatchFilter { predicate: (nation.n_name = 'ARGENTINA':Varchar) }
-                          BatchScan { table: nation, columns: [n_nationkey, n_name] }
+                          BatchScan { table: nation, columns: [nation.n_nationkey, nation.n_name], distribution: SomeShard }
   stream_plan: |
     StreamMaterialize { columns: [ps_partkey, value], pk_columns: [ps_partkey], order_descs: [value, ps_partkey] }
       StreamExchange { dist: HashShard(partsupp.ps_partkey) }
@@ -1280,34 +1280,34 @@
               StreamHashAgg { group_key: [partsupp.ps_partkey], aggs: [count, sum((partsupp.ps_supplycost * partsupp.ps_availqty)), sum((partsupp.ps_supplycost * partsupp.ps_availqty))] }
                 StreamExchange { dist: HashShard(partsupp.ps_partkey) }
                   StreamProject { exprs: [partsupp.ps_partkey, (partsupp.ps_supplycost * partsupp.ps_availqty), partsupp._row_id, supplier._row_id, nation._row_id] }
-                    StreamHashJoin { type: Inner, predicate: supplier.s_nationkey = nation.n_nationkey }
+                    StreamHashJoin { type: Inner, predicate: supplier.s_nationkey = nation.n_nationkey, output: [partsupp.ps_partkey, partsupp.ps_availqty, partsupp.ps_supplycost, partsupp._row_id, supplier._row_id, nation._row_id] }
                       StreamExchange { dist: HashShard(supplier.s_nationkey) }
-                        StreamHashJoin { type: Inner, predicate: partsupp.ps_suppkey = supplier.s_suppkey }
+                        StreamHashJoin { type: Inner, predicate: partsupp.ps_suppkey = supplier.s_suppkey, output: [partsupp.ps_partkey, partsupp.ps_availqty, partsupp.ps_supplycost, supplier.s_nationkey, partsupp._row_id, supplier._row_id] }
                           StreamExchange { dist: HashShard(partsupp.ps_suppkey) }
-                            StreamTableScan { table: partsupp, columns: [ps_partkey, ps_suppkey, ps_availqty, ps_supplycost, _row_id] }
+                            StreamTableScan { table: partsupp, columns: [partsupp.ps_partkey, partsupp.ps_suppkey, partsupp.ps_availqty, partsupp.ps_supplycost, partsupp._row_id], pk: [partsupp._row_id], distribution: HashShard(partsupp._row_id) }
                           StreamExchange { dist: HashShard(supplier.s_suppkey) }
-                            StreamTableScan { table: supplier, columns: [s_suppkey, s_nationkey, _row_id] }
+                            StreamTableScan { table: supplier, columns: [supplier.s_suppkey, supplier.s_nationkey, supplier._row_id], pk: [supplier._row_id], distribution: HashShard(supplier._row_id) }
                       StreamExchange { dist: HashShard(nation.n_nationkey) }
                         StreamProject { exprs: [nation.n_nationkey, nation._row_id] }
                           StreamFilter { predicate: (nation.n_name = 'ARGENTINA':Varchar) }
-                            StreamTableScan { table: nation, columns: [n_nationkey, _row_id, n_name] }
+                            StreamTableScan { table: nation, columns: [nation.n_nationkey, nation._row_id, nation.n_name], pk: [nation._row_id], distribution: HashShard(nation._row_id) }
             StreamExchange { dist: Broadcast }
               StreamProject { exprs: [(sum(sum((partsupp.ps_supplycost * partsupp.ps_availqty))) * 0.0001000000:Decimal)] }
                 StreamGlobalSimpleAgg { aggs: [sum(count), sum(sum((partsupp.ps_supplycost * partsupp.ps_availqty)))] }
                   StreamExchange { dist: Single }
                     StreamLocalSimpleAgg { aggs: [count, sum((partsupp.ps_supplycost * partsupp.ps_availqty))] }
                       StreamProject { exprs: [(partsupp.ps_supplycost * partsupp.ps_availqty), partsupp._row_id, supplier._row_id, nation._row_id] }
-                        StreamHashJoin { type: Inner, predicate: supplier.s_nationkey = nation.n_nationkey }
+                        StreamHashJoin { type: Inner, predicate: supplier.s_nationkey = nation.n_nationkey, output: [partsupp.ps_availqty, partsupp.ps_supplycost, partsupp._row_id, supplier._row_id, nation._row_id] }
                           StreamExchange { dist: HashShard(supplier.s_nationkey) }
-                            StreamHashJoin { type: Inner, predicate: partsupp.ps_suppkey = supplier.s_suppkey }
+                            StreamHashJoin { type: Inner, predicate: partsupp.ps_suppkey = supplier.s_suppkey, output: [partsupp.ps_availqty, partsupp.ps_supplycost, supplier.s_nationkey, partsupp._row_id, supplier._row_id] }
                               StreamExchange { dist: HashShard(partsupp.ps_suppkey) }
-                                StreamTableScan { table: partsupp, columns: [ps_suppkey, ps_availqty, ps_supplycost, _row_id] }
+                                StreamTableScan { table: partsupp, columns: [partsupp.ps_suppkey, partsupp.ps_availqty, partsupp.ps_supplycost, partsupp._row_id], pk: [partsupp._row_id], distribution: HashShard(partsupp._row_id) }
                               StreamExchange { dist: HashShard(supplier.s_suppkey) }
-                                StreamTableScan { table: supplier, columns: [s_suppkey, s_nationkey, _row_id] }
+                                StreamTableScan { table: supplier, columns: [supplier.s_suppkey, supplier.s_nationkey, supplier._row_id], pk: [supplier._row_id], distribution: HashShard(supplier._row_id) }
                           StreamExchange { dist: HashShard(nation.n_nationkey) }
                             StreamProject { exprs: [nation.n_nationkey, nation._row_id] }
                               StreamFilter { predicate: (nation.n_name = 'ARGENTINA':Varchar) }
-                                StreamTableScan { table: nation, columns: [n_nationkey, _row_id, n_name] }
+                                StreamTableScan { table: nation, columns: [nation.n_nationkey, nation._row_id, nation.n_name], pk: [nation._row_id], distribution: HashShard(nation._row_id) }
 - id: tpch_q12
   before:
   - create_tables
@@ -1345,40 +1345,40 @@
       LogicalAgg { group_key: [lineitem.l_shipmode], aggs: [sum(Case(((orders.o_orderpriority = '1-URGENT':Varchar) OR (orders.o_orderpriority = '2-HIGH':Varchar)), 1:Int32, 0:Int32)), sum(Case(((orders.o_orderpriority <> '1-URGENT':Varchar) AND (orders.o_orderpriority <> '2-HIGH':Varchar)), 1:Int32, 0:Int32))] }
         LogicalProject { exprs: [lineitem.l_shipmode, Case(((orders.o_orderpriority = '1-URGENT':Varchar) OR (orders.o_orderpriority = '2-HIGH':Varchar)), 1:Int32, 0:Int32), Case(((orders.o_orderpriority <> '1-URGENT':Varchar) AND (orders.o_orderpriority <> '2-HIGH':Varchar)), 1:Int32, 0:Int32)] }
           LogicalFilter { predicate: (orders.o_orderkey = lineitem.l_orderkey) AND In(lineitem.l_shipmode, 'FOB':Varchar, 'SHIP':Varchar) AND (lineitem.l_commitdate < lineitem.l_receiptdate) AND (lineitem.l_shipdate < lineitem.l_commitdate) AND (lineitem.l_receiptdate >= '1994-01-01':Varchar::Date) AND (lineitem.l_receiptdate < ('1994-01-01':Varchar::Date + '1 year 00:00:00':Interval)) }
-            LogicalJoin { type: Inner, on: true }
-              LogicalScan { table: orders, columns: [_row_id, o_orderkey, o_custkey, o_orderstatus, o_totalprice, o_orderdate, o_orderpriority, o_clerk, o_shippriority, o_comment] }
-              LogicalScan { table: lineitem, columns: [_row_id, l_orderkey, l_partkey, l_suppkey, l_linenumber, l_quantity, l_extendedprice, l_discount, l_tax, l_returnflag, l_linestatus, l_shipdate, l_commitdate, l_receiptdate, l_shipinstruct, l_shipmode, l_comment] }
+            LogicalJoin { type: Inner, on: true, output: all }
+              LogicalScan { table: orders, columns: [orders._row_id, orders.o_orderkey, orders.o_custkey, orders.o_orderstatus, orders.o_totalprice, orders.o_orderdate, orders.o_orderpriority, orders.o_clerk, orders.o_shippriority, orders.o_comment] }
+              LogicalScan { table: lineitem, columns: [lineitem._row_id, lineitem.l_orderkey, lineitem.l_partkey, lineitem.l_suppkey, lineitem.l_linenumber, lineitem.l_quantity, lineitem.l_extendedprice, lineitem.l_discount, lineitem.l_tax, lineitem.l_returnflag, lineitem.l_linestatus, lineitem.l_shipdate, lineitem.l_commitdate, lineitem.l_receiptdate, lineitem.l_shipinstruct, lineitem.l_shipmode, lineitem.l_comment] }
   optimized_logical_plan: |
     LogicalAgg { group_key: [lineitem.l_shipmode], aggs: [sum(Case(((orders.o_orderpriority = '1-URGENT':Varchar) OR (orders.o_orderpriority = '2-HIGH':Varchar)), 1:Int32, 0:Int32)), sum(Case(((orders.o_orderpriority <> '1-URGENT':Varchar) AND (orders.o_orderpriority <> '2-HIGH':Varchar)), 1:Int32, 0:Int32))] }
       LogicalProject { exprs: [lineitem.l_shipmode, Case(((orders.o_orderpriority = '1-URGENT':Varchar) OR (orders.o_orderpriority = '2-HIGH':Varchar)), 1:Int32, 0:Int32), Case(((orders.o_orderpriority <> '1-URGENT':Varchar) AND (orders.o_orderpriority <> '2-HIGH':Varchar)), 1:Int32, 0:Int32)] }
-        LogicalJoin { type: Inner, on: (orders.o_orderkey = lineitem.l_orderkey) }
-          LogicalScan { table: orders, columns: [o_orderkey, o_orderpriority] }
-          LogicalScan { table: lineitem, output_columns: [l_orderkey, l_shipmode], required_columns: [l_orderkey, l_shipmode, l_shipdate, l_commitdate, l_receiptdate], predicate: In(lineitem.l_shipmode, 'FOB':Varchar, 'SHIP':Varchar) AND (lineitem.l_commitdate < lineitem.l_receiptdate) AND (lineitem.l_shipdate < lineitem.l_commitdate) AND (lineitem.l_receiptdate >= '1994-01-01':Varchar::Date) AND (lineitem.l_receiptdate < ('1994-01-01':Varchar::Date + '1 year 00:00:00':Interval)) }
+        LogicalJoin { type: Inner, on: (orders.o_orderkey = lineitem.l_orderkey), output: [orders.o_orderpriority, lineitem.l_shipmode] }
+          LogicalScan { table: orders, columns: [orders.o_orderkey, orders.o_orderpriority] }
+          LogicalScan { table: lineitem, output_columns: [lineitem.l_orderkey, lineitem.l_shipmode], required_columns: [l_orderkey, l_shipmode, l_shipdate, l_commitdate, l_receiptdate], predicate: In(lineitem.l_shipmode, 'FOB':Varchar, 'SHIP':Varchar) AND (lineitem.l_commitdate < lineitem.l_receiptdate) AND (lineitem.l_shipdate < lineitem.l_commitdate) AND (lineitem.l_receiptdate >= '1994-01-01':Varchar::Date) AND (lineitem.l_receiptdate < ('1994-01-01':Varchar::Date + '1 year 00:00:00':Interval)) }
   batch_plan: |
     BatchExchange { order: [lineitem.l_shipmode ASC], dist: Single }
       BatchSort { order: [lineitem.l_shipmode ASC] }
         BatchHashAgg { group_key: [lineitem.l_shipmode], aggs: [sum(Case(((orders.o_orderpriority = '1-URGENT':Varchar) OR (orders.o_orderpriority = '2-HIGH':Varchar)), 1:Int32, 0:Int32)), sum(Case(((orders.o_orderpriority <> '1-URGENT':Varchar) AND (orders.o_orderpriority <> '2-HIGH':Varchar)), 1:Int32, 0:Int32))] }
           BatchExchange { order: [], dist: HashShard(lineitem.l_shipmode) }
             BatchProject { exprs: [lineitem.l_shipmode, Case(((orders.o_orderpriority = '1-URGENT':Varchar) OR (orders.o_orderpriority = '2-HIGH':Varchar)), 1:Int32, 0:Int32), Case(((orders.o_orderpriority <> '1-URGENT':Varchar) AND (orders.o_orderpriority <> '2-HIGH':Varchar)), 1:Int32, 0:Int32)] }
-              BatchHashJoin { type: Inner, predicate: orders.o_orderkey = lineitem.l_orderkey }
+              BatchHashJoin { type: Inner, predicate: orders.o_orderkey = lineitem.l_orderkey, output: [orders.o_orderpriority, lineitem.l_shipmode] }
                 BatchExchange { order: [], dist: HashShard(orders.o_orderkey) }
-                  BatchScan { table: orders, columns: [o_orderkey, o_orderpriority] }
+                  BatchScan { table: orders, columns: [orders.o_orderkey, orders.o_orderpriority], distribution: SomeShard }
                 BatchExchange { order: [], dist: HashShard(lineitem.l_orderkey) }
                   BatchProject { exprs: [lineitem.l_orderkey, lineitem.l_shipmode] }
                     BatchFilter { predicate: In(lineitem.l_shipmode, 'FOB':Varchar, 'SHIP':Varchar) AND (lineitem.l_commitdate < lineitem.l_receiptdate) AND (lineitem.l_shipdate < lineitem.l_commitdate) AND (lineitem.l_receiptdate >= '1994-01-01':Varchar::Date) AND (lineitem.l_receiptdate < ('1994-01-01':Varchar::Date + '1 year 00:00:00':Interval)) }
-                      BatchScan { table: lineitem, columns: [l_orderkey, l_shipmode, l_shipdate, l_commitdate, l_receiptdate] }
+                      BatchScan { table: lineitem, columns: [lineitem.l_orderkey, lineitem.l_shipmode, lineitem.l_shipdate, lineitem.l_commitdate, lineitem.l_receiptdate], distribution: SomeShard }
   stream_plan: |
     StreamMaterialize { columns: [l_shipmode, count(hidden), high_line_count, low_line_count], pk_columns: [l_shipmode] }
       StreamHashAgg { group_key: [lineitem.l_shipmode], aggs: [count, sum(Case(((orders.o_orderpriority = '1-URGENT':Varchar) OR (orders.o_orderpriority = '2-HIGH':Varchar)), 1:Int32, 0:Int32)), sum(Case(((orders.o_orderpriority <> '1-URGENT':Varchar) AND (orders.o_orderpriority <> '2-HIGH':Varchar)), 1:Int32, 0:Int32))] }
         StreamExchange { dist: HashShard(lineitem.l_shipmode) }
           StreamProject { exprs: [lineitem.l_shipmode, Case(((orders.o_orderpriority = '1-URGENT':Varchar) OR (orders.o_orderpriority = '2-HIGH':Varchar)), 1:Int32, 0:Int32), Case(((orders.o_orderpriority <> '1-URGENT':Varchar) AND (orders.o_orderpriority <> '2-HIGH':Varchar)), 1:Int32, 0:Int32), orders._row_id, lineitem._row_id] }
-            StreamHashJoin { type: Inner, predicate: orders.o_orderkey = lineitem.l_orderkey }
+            StreamHashJoin { type: Inner, predicate: orders.o_orderkey = lineitem.l_orderkey, output: [orders.o_orderpriority, lineitem.l_shipmode, orders._row_id, lineitem._row_id] }
               StreamExchange { dist: HashShard(orders.o_orderkey) }
-                StreamTableScan { table: orders, columns: [o_orderkey, o_orderpriority, _row_id] }
+                StreamTableScan { table: orders, columns: [orders.o_orderkey, orders.o_orderpriority, orders._row_id], pk: [orders._row_id], distribution: HashShard(orders._row_id) }
               StreamExchange { dist: HashShard(lineitem.l_orderkey) }
                 StreamProject { exprs: [lineitem.l_orderkey, lineitem.l_shipmode, lineitem._row_id] }
                   StreamFilter { predicate: In(lineitem.l_shipmode, 'FOB':Varchar, 'SHIP':Varchar) AND (lineitem.l_commitdate < lineitem.l_receiptdate) AND (lineitem.l_shipdate < lineitem.l_commitdate) AND (lineitem.l_receiptdate >= '1994-01-01':Varchar::Date) AND (lineitem.l_receiptdate < ('1994-01-01':Varchar::Date + '1 year 00:00:00':Interval)) }
-                    StreamTableScan { table: lineitem, columns: [l_orderkey, l_shipmode, _row_id, l_shipdate, l_commitdate, l_receiptdate] }
+                    StreamTableScan { table: lineitem, columns: [lineitem.l_orderkey, lineitem.l_shipmode, lineitem._row_id, lineitem.l_shipdate, lineitem.l_commitdate, lineitem.l_receiptdate], pk: [lineitem._row_id], distribution: HashShard(lineitem._row_id) }
 - id: tpch_q13
   before:
   - create_tables
@@ -1410,16 +1410,16 @@
           LogicalProject { exprs: [customer.c_custkey, count(orders.o_orderkey)] }
             LogicalAgg { group_key: [customer.c_custkey], aggs: [count(orders.o_orderkey)] }
               LogicalProject { exprs: [customer.c_custkey, orders.o_orderkey] }
-                LogicalJoin { type: LeftOuter, on: (customer.c_custkey = orders.o_custkey) AND Not(Like(orders.o_comment, '%:1%:2%':Varchar)) }
-                  LogicalScan { table: customer, columns: [_row_id, c_custkey, c_name, c_address, c_nationkey, c_phone, c_acctbal, c_mktsegment, c_comment] }
-                  LogicalScan { table: orders, columns: [_row_id, o_orderkey, o_custkey, o_orderstatus, o_totalprice, o_orderdate, o_orderpriority, o_clerk, o_shippriority, o_comment] }
+                LogicalJoin { type: LeftOuter, on: (customer.c_custkey = orders.o_custkey) AND Not(Like(orders.o_comment, '%:1%:2%':Varchar)), output: all }
+                  LogicalScan { table: customer, columns: [customer._row_id, customer.c_custkey, customer.c_name, customer.c_address, customer.c_nationkey, customer.c_phone, customer.c_acctbal, customer.c_mktsegment, customer.c_comment] }
+                  LogicalScan { table: orders, columns: [orders._row_id, orders.o_orderkey, orders.o_custkey, orders.o_orderstatus, orders.o_totalprice, orders.o_orderdate, orders.o_orderpriority, orders.o_clerk, orders.o_shippriority, orders.o_comment] }
   optimized_logical_plan: |
     LogicalAgg { group_key: [count(orders.o_orderkey)], aggs: [count] }
       LogicalProject { exprs: [count(orders.o_orderkey)] }
         LogicalAgg { group_key: [customer.c_custkey], aggs: [count(orders.o_orderkey)] }
-          LogicalJoin { type: LeftOuter, on: (customer.c_custkey = orders.o_custkey) }
-            LogicalScan { table: customer, columns: [c_custkey] }
-            LogicalScan { table: orders, output_columns: [o_orderkey, o_custkey], required_columns: [o_orderkey, o_custkey, o_comment], predicate: Not(Like(orders.o_comment, '%:1%:2%':Varchar)) }
+          LogicalJoin { type: LeftOuter, on: (customer.c_custkey = orders.o_custkey), output: [customer.c_custkey, orders.o_orderkey] }
+            LogicalScan { table: customer, columns: [customer.c_custkey] }
+            LogicalScan { table: orders, output_columns: [orders.o_orderkey, orders.o_custkey], required_columns: [o_orderkey, o_custkey, o_comment], predicate: Not(Like(orders.o_comment, '%:1%:2%':Varchar)) }
   batch_plan: |
     BatchExchange { order: [count DESC, count(orders.o_orderkey) DESC], dist: Single }
       BatchSort { order: [count DESC, count(orders.o_orderkey) DESC] }
@@ -1427,26 +1427,26 @@
           BatchExchange { order: [], dist: HashShard(count(orders.o_orderkey)) }
             BatchProject { exprs: [count(orders.o_orderkey)] }
               BatchHashAgg { group_key: [customer.c_custkey], aggs: [count(orders.o_orderkey)] }
-                BatchHashJoin { type: LeftOuter, predicate: customer.c_custkey = orders.o_custkey }
+                BatchHashJoin { type: LeftOuter, predicate: customer.c_custkey = orders.o_custkey, output: [customer.c_custkey, orders.o_orderkey] }
                   BatchExchange { order: [], dist: HashShard(customer.c_custkey) }
-                    BatchScan { table: customer, columns: [c_custkey] }
+                    BatchScan { table: customer, columns: [customer.c_custkey], distribution: SomeShard }
                   BatchExchange { order: [], dist: HashShard(orders.o_custkey) }
                     BatchProject { exprs: [orders.o_orderkey, orders.o_custkey] }
                       BatchFilter { predicate: Not(Like(orders.o_comment, '%:1%:2%':Varchar)) }
-                        BatchScan { table: orders, columns: [o_orderkey, o_custkey, o_comment] }
+                        BatchScan { table: orders, columns: [orders.o_orderkey, orders.o_custkey, orders.o_comment], distribution: SomeShard }
   stream_plan: |
     StreamMaterialize { columns: [c_count, count(hidden), custdist], pk_columns: [c_count], order_descs: [custdist, c_count] }
       StreamHashAgg { group_key: [count(orders.o_orderkey)], aggs: [count, count] }
         StreamExchange { dist: HashShard(count(orders.o_orderkey)) }
           StreamProject { exprs: [count(orders.o_orderkey), customer.c_custkey] }
             StreamHashAgg { group_key: [customer.c_custkey], aggs: [count, count(orders.o_orderkey)] }
-              StreamHashJoin { type: LeftOuter, predicate: customer.c_custkey = orders.o_custkey }
+              StreamHashJoin { type: LeftOuter, predicate: customer.c_custkey = orders.o_custkey, output: [customer.c_custkey, orders.o_orderkey, customer._row_id, orders._row_id] }
                 StreamExchange { dist: HashShard(customer.c_custkey) }
-                  StreamTableScan { table: customer, columns: [c_custkey, _row_id] }
+                  StreamTableScan { table: customer, columns: [customer.c_custkey, customer._row_id], pk: [customer._row_id], distribution: HashShard(customer._row_id) }
                 StreamExchange { dist: HashShard(orders.o_custkey) }
                   StreamProject { exprs: [orders.o_orderkey, orders.o_custkey, orders._row_id] }
                     StreamFilter { predicate: Not(Like(orders.o_comment, '%:1%:2%':Varchar)) }
-                      StreamTableScan { table: orders, columns: [o_orderkey, o_custkey, _row_id, o_comment] }
+                      StreamTableScan { table: orders, columns: [orders.o_orderkey, orders.o_custkey, orders._row_id, orders.o_comment], pk: [orders._row_id], distribution: HashShard(orders._row_id) }
 - id: tpch_q14
   before:
   - create_tables
@@ -1469,29 +1469,29 @@
       LogicalAgg { aggs: [sum(Case(Like(part.p_type, 'PROMO%':Varchar), (lineitem.l_extendedprice * (1:Int32 - lineitem.l_discount)), 0:Int32::Decimal)), sum((lineitem.l_extendedprice * (1:Int32 - lineitem.l_discount)))] }
         LogicalProject { exprs: [Case(Like(part.p_type, 'PROMO%':Varchar), (lineitem.l_extendedprice * (1:Int32 - lineitem.l_discount)), 0:Int32::Decimal), (lineitem.l_extendedprice * (1:Int32 - lineitem.l_discount))] }
           LogicalFilter { predicate: (lineitem.l_partkey = part.p_partkey) AND (lineitem.l_shipdate >= '1995-09-01':Varchar::Date) AND (lineitem.l_shipdate < ('1995-09-01':Varchar::Date + '1 mon 00:00:00':Interval)) }
-            LogicalJoin { type: Inner, on: true }
-              LogicalScan { table: lineitem, columns: [_row_id, l_orderkey, l_partkey, l_suppkey, l_linenumber, l_quantity, l_extendedprice, l_discount, l_tax, l_returnflag, l_linestatus, l_shipdate, l_commitdate, l_receiptdate, l_shipinstruct, l_shipmode, l_comment] }
-              LogicalScan { table: part, columns: [_row_id, p_partkey, p_name, p_mfgr, p_brand, p_type, p_size, p_container, p_retailprice, p_comment] }
+            LogicalJoin { type: Inner, on: true, output: all }
+              LogicalScan { table: lineitem, columns: [lineitem._row_id, lineitem.l_orderkey, lineitem.l_partkey, lineitem.l_suppkey, lineitem.l_linenumber, lineitem.l_quantity, lineitem.l_extendedprice, lineitem.l_discount, lineitem.l_tax, lineitem.l_returnflag, lineitem.l_linestatus, lineitem.l_shipdate, lineitem.l_commitdate, lineitem.l_receiptdate, lineitem.l_shipinstruct, lineitem.l_shipmode, lineitem.l_comment] }
+              LogicalScan { table: part, columns: [part._row_id, part.p_partkey, part.p_name, part.p_mfgr, part.p_brand, part.p_type, part.p_size, part.p_container, part.p_retailprice, part.p_comment] }
   optimized_logical_plan: |
     LogicalProject { exprs: [((100.00:Decimal * sum(Case(Like(part.p_type, 'PROMO%':Varchar), (lineitem.l_extendedprice * (1:Int32 - lineitem.l_discount)), 0:Int32::Decimal))) / sum((lineitem.l_extendedprice * (1:Int32 - lineitem.l_discount))))] }
       LogicalAgg { aggs: [sum(Case(Like(part.p_type, 'PROMO%':Varchar), (lineitem.l_extendedprice * (1:Int32 - lineitem.l_discount)), 0:Int32::Decimal)), sum((lineitem.l_extendedprice * (1:Int32 - lineitem.l_discount)))] }
         LogicalProject { exprs: [Case(Like(part.p_type, 'PROMO%':Varchar), (lineitem.l_extendedprice * (1:Int32 - lineitem.l_discount)), 0:Int32::Decimal), (lineitem.l_extendedprice * (1:Int32 - lineitem.l_discount))] }
-          LogicalJoin { type: Inner, on: (lineitem.l_partkey = part.p_partkey) }
-            LogicalScan { table: lineitem, output_columns: [l_partkey, l_extendedprice, l_discount], required_columns: [l_partkey, l_extendedprice, l_discount, l_shipdate], predicate: (lineitem.l_shipdate >= '1995-09-01':Varchar::Date) AND (lineitem.l_shipdate < ('1995-09-01':Varchar::Date + '1 mon 00:00:00':Interval)) }
-            LogicalScan { table: part, columns: [p_partkey, p_type] }
+          LogicalJoin { type: Inner, on: (lineitem.l_partkey = part.p_partkey), output: [lineitem.l_extendedprice, lineitem.l_discount, part.p_type] }
+            LogicalScan { table: lineitem, output_columns: [lineitem.l_partkey, lineitem.l_extendedprice, lineitem.l_discount], required_columns: [l_partkey, l_extendedprice, l_discount, l_shipdate], predicate: (lineitem.l_shipdate >= '1995-09-01':Varchar::Date) AND (lineitem.l_shipdate < ('1995-09-01':Varchar::Date + '1 mon 00:00:00':Interval)) }
+            LogicalScan { table: part, columns: [part.p_partkey, part.p_type] }
   batch_plan: |
     BatchProject { exprs: [((100.00:Decimal * sum(sum(Case(Like(part.p_type, 'PROMO%':Varchar), (lineitem.l_extendedprice * (1:Int32 - lineitem.l_discount)), 0:Int32::Decimal)))) / sum(sum((lineitem.l_extendedprice * (1:Int32 - lineitem.l_discount)))))] }
       BatchSimpleAgg { aggs: [sum(sum(Case(Like(part.p_type, 'PROMO%':Varchar), (lineitem.l_extendedprice * (1:Int32 - lineitem.l_discount)), 0:Int32::Decimal))), sum(sum((lineitem.l_extendedprice * (1:Int32 - lineitem.l_discount))))] }
         BatchExchange { order: [], dist: Single }
           BatchSimpleAgg { aggs: [sum(Case(Like(part.p_type, 'PROMO%':Varchar), (lineitem.l_extendedprice * (1:Int32 - lineitem.l_discount)), 0:Int32::Decimal)), sum((lineitem.l_extendedprice * (1:Int32 - lineitem.l_discount)))] }
             BatchProject { exprs: [Case(Like(part.p_type, 'PROMO%':Varchar), (lineitem.l_extendedprice * (1:Int32 - lineitem.l_discount)), 0:Int32::Decimal), (lineitem.l_extendedprice * (1:Int32 - lineitem.l_discount))] }
-              BatchHashJoin { type: Inner, predicate: lineitem.l_partkey = part.p_partkey }
+              BatchHashJoin { type: Inner, predicate: lineitem.l_partkey = part.p_partkey, output: [lineitem.l_extendedprice, lineitem.l_discount, part.p_type] }
                 BatchExchange { order: [], dist: HashShard(lineitem.l_partkey) }
                   BatchProject { exprs: [lineitem.l_partkey, lineitem.l_extendedprice, lineitem.l_discount] }
                     BatchFilter { predicate: (lineitem.l_shipdate >= '1995-09-01':Varchar::Date) AND (lineitem.l_shipdate < ('1995-09-01':Varchar::Date + '1 mon 00:00:00':Interval)) }
-                      BatchScan { table: lineitem, columns: [l_partkey, l_extendedprice, l_discount, l_shipdate] }
+                      BatchScan { table: lineitem, columns: [lineitem.l_partkey, lineitem.l_extendedprice, lineitem.l_discount, lineitem.l_shipdate], distribution: SomeShard }
                 BatchExchange { order: [], dist: HashShard(part.p_partkey) }
-                  BatchScan { table: part, columns: [p_partkey, p_type] }
+                  BatchScan { table: part, columns: [part.p_partkey, part.p_type], distribution: SomeShard }
   stream_plan: |
     StreamMaterialize { columns: [promo_revenue], pk_columns: [] }
       StreamProject { exprs: [((100.00:Decimal * sum(sum(Case(Like(part.p_type, 'PROMO%':Varchar), (lineitem.l_extendedprice * (1:Int32 - lineitem.l_discount)), 0:Int32::Decimal)))) / sum(sum((lineitem.l_extendedprice * (1:Int32 - lineitem.l_discount)))))] }
@@ -1499,13 +1499,13 @@
           StreamExchange { dist: Single }
             StreamLocalSimpleAgg { aggs: [count, sum(Case(Like(part.p_type, 'PROMO%':Varchar), (lineitem.l_extendedprice * (1:Int32 - lineitem.l_discount)), 0:Int32::Decimal)), sum((lineitem.l_extendedprice * (1:Int32 - lineitem.l_discount)))] }
               StreamProject { exprs: [Case(Like(part.p_type, 'PROMO%':Varchar), (lineitem.l_extendedprice * (1:Int32 - lineitem.l_discount)), 0:Int32::Decimal), (lineitem.l_extendedprice * (1:Int32 - lineitem.l_discount)), lineitem._row_id, part._row_id] }
-                StreamHashJoin { type: Inner, predicate: lineitem.l_partkey = part.p_partkey }
+                StreamHashJoin { type: Inner, predicate: lineitem.l_partkey = part.p_partkey, output: [lineitem.l_extendedprice, lineitem.l_discount, part.p_type, lineitem._row_id, part._row_id] }
                   StreamExchange { dist: HashShard(lineitem.l_partkey) }
                     StreamProject { exprs: [lineitem.l_partkey, lineitem.l_extendedprice, lineitem.l_discount, lineitem._row_id] }
                       StreamFilter { predicate: (lineitem.l_shipdate >= '1995-09-01':Varchar::Date) AND (lineitem.l_shipdate < ('1995-09-01':Varchar::Date + '1 mon 00:00:00':Interval)) }
-                        StreamTableScan { table: lineitem, columns: [l_partkey, l_extendedprice, l_discount, _row_id, l_shipdate] }
+                        StreamTableScan { table: lineitem, columns: [lineitem.l_partkey, lineitem.l_extendedprice, lineitem.l_discount, lineitem._row_id, lineitem.l_shipdate], pk: [lineitem._row_id], distribution: HashShard(lineitem._row_id) }
                   StreamExchange { dist: HashShard(part.p_partkey) }
-                    StreamTableScan { table: part, columns: [p_partkey, p_type, _row_id] }
+                    StreamTableScan { table: part, columns: [part.p_partkey, part.p_type, part._row_id], pk: [part._row_id], distribution: HashShard(part._row_id) }
 - id: tpch_q15
   before:
   - create_tables
@@ -1544,14 +1544,14 @@
   logical_plan: |
     LogicalProject { exprs: [supplier.s_suppkey, supplier.s_name, supplier.s_address, supplier.s_phone, sum((lineitem.l_extendedprice * (1:Int32 - lineitem.l_discount)))] }
       LogicalFilter { predicate: (supplier.s_suppkey = lineitem.l_suppkey) AND (sum((lineitem.l_extendedprice * (1:Int32 - lineitem.l_discount))) = max(sum((lineitem.l_extendedprice * (1:Int32 - lineitem.l_discount))))) }
-        LogicalJoin { type: LeftOuter, on: true }
-          LogicalJoin { type: Inner, on: true }
-            LogicalScan { table: supplier, columns: [_row_id, s_suppkey, s_name, s_address, s_nationkey, s_phone, s_acctbal, s_comment] }
+        LogicalJoin { type: LeftOuter, on: true, output: all }
+          LogicalJoin { type: Inner, on: true, output: all }
+            LogicalScan { table: supplier, columns: [supplier._row_id, supplier.s_suppkey, supplier.s_name, supplier.s_address, supplier.s_nationkey, supplier.s_phone, supplier.s_acctbal, supplier.s_comment] }
             LogicalProject { exprs: [lineitem.l_suppkey, sum((lineitem.l_extendedprice * (1:Int32 - lineitem.l_discount)))] }
               LogicalAgg { group_key: [lineitem.l_suppkey], aggs: [sum((lineitem.l_extendedprice * (1:Int32 - lineitem.l_discount)))] }
                 LogicalProject { exprs: [lineitem.l_suppkey, (lineitem.l_extendedprice * (1:Int32 - lineitem.l_discount))] }
                   LogicalFilter { predicate: (lineitem.l_shipdate >= '1993-01-01':Varchar::Date) AND (lineitem.l_shipdate < ('1993-01-01':Varchar::Date + '3 mons 00:00:00':Interval)) }
-                    LogicalScan { table: lineitem, columns: [_row_id, l_orderkey, l_partkey, l_suppkey, l_linenumber, l_quantity, l_extendedprice, l_discount, l_tax, l_returnflag, l_linestatus, l_shipdate, l_commitdate, l_receiptdate, l_shipinstruct, l_shipmode, l_comment] }
+                    LogicalScan { table: lineitem, columns: [lineitem._row_id, lineitem.l_orderkey, lineitem.l_partkey, lineitem.l_suppkey, lineitem.l_linenumber, lineitem.l_quantity, lineitem.l_extendedprice, lineitem.l_discount, lineitem.l_tax, lineitem.l_returnflag, lineitem.l_linestatus, lineitem.l_shipdate, lineitem.l_commitdate, lineitem.l_receiptdate, lineitem.l_shipinstruct, lineitem.l_shipmode, lineitem.l_comment] }
           LogicalProject { exprs: [max(sum((lineitem.l_extendedprice * (1:Int32 - lineitem.l_discount))))] }
             LogicalAgg { aggs: [max(sum((lineitem.l_extendedprice * (1:Int32 - lineitem.l_discount))))] }
               LogicalProject { exprs: [sum((lineitem.l_extendedprice * (1:Int32 - lineitem.l_discount)))] }
@@ -1559,32 +1559,32 @@
                   LogicalAgg { group_key: [lineitem.l_suppkey], aggs: [sum((lineitem.l_extendedprice * (1:Int32 - lineitem.l_discount)))] }
                     LogicalProject { exprs: [lineitem.l_suppkey, (lineitem.l_extendedprice * (1:Int32 - lineitem.l_discount))] }
                       LogicalFilter { predicate: (lineitem.l_shipdate >= '1993-01-01':Varchar::Date) AND (lineitem.l_shipdate < ('1993-01-01':Varchar::Date + '3 mons 00:00:00':Interval)) }
-                        LogicalScan { table: lineitem, columns: [_row_id, l_orderkey, l_partkey, l_suppkey, l_linenumber, l_quantity, l_extendedprice, l_discount, l_tax, l_returnflag, l_linestatus, l_shipdate, l_commitdate, l_receiptdate, l_shipinstruct, l_shipmode, l_comment] }
+                        LogicalScan { table: lineitem, columns: [lineitem._row_id, lineitem.l_orderkey, lineitem.l_partkey, lineitem.l_suppkey, lineitem.l_linenumber, lineitem.l_quantity, lineitem.l_extendedprice, lineitem.l_discount, lineitem.l_tax, lineitem.l_returnflag, lineitem.l_linestatus, lineitem.l_shipdate, lineitem.l_commitdate, lineitem.l_receiptdate, lineitem.l_shipinstruct, lineitem.l_shipmode, lineitem.l_comment] }
   optimized_logical_plan: |
-    LogicalJoin { type: Inner, on: (sum((lineitem.l_extendedprice * (1:Int32 - lineitem.l_discount))) = max(sum((lineitem.l_extendedprice * (1:Int32 - lineitem.l_discount))))) }
-      LogicalJoin { type: Inner, on: (supplier.s_suppkey = lineitem.l_suppkey) }
-        LogicalScan { table: supplier, columns: [s_suppkey, s_name, s_address, s_phone] }
+    LogicalJoin { type: Inner, on: (sum((lineitem.l_extendedprice * (1:Int32 - lineitem.l_discount))) = max(sum((lineitem.l_extendedprice * (1:Int32 - lineitem.l_discount))))), output: [supplier.s_suppkey, supplier.s_name, supplier.s_address, supplier.s_phone, sum((lineitem.l_extendedprice * (1:Int32 - lineitem.l_discount)))] }
+      LogicalJoin { type: Inner, on: (supplier.s_suppkey = lineitem.l_suppkey), output: [supplier.s_suppkey, supplier.s_name, supplier.s_address, supplier.s_phone, sum((lineitem.l_extendedprice * (1:Int32 - lineitem.l_discount)))] }
+        LogicalScan { table: supplier, columns: [supplier.s_suppkey, supplier.s_name, supplier.s_address, supplier.s_phone] }
         LogicalAgg { group_key: [lineitem.l_suppkey], aggs: [sum((lineitem.l_extendedprice * (1:Int32 - lineitem.l_discount)))] }
           LogicalProject { exprs: [lineitem.l_suppkey, (lineitem.l_extendedprice * (1:Int32 - lineitem.l_discount))] }
-            LogicalScan { table: lineitem, output_columns: [l_suppkey, l_extendedprice, l_discount], required_columns: [l_suppkey, l_extendedprice, l_discount, l_shipdate], predicate: (lineitem.l_shipdate >= '1993-01-01':Varchar::Date) AND (lineitem.l_shipdate < ('1993-01-01':Varchar::Date + '3 mons 00:00:00':Interval)) }
+            LogicalScan { table: lineitem, output_columns: [lineitem.l_suppkey, lineitem.l_extendedprice, lineitem.l_discount], required_columns: [l_suppkey, l_extendedprice, l_discount, l_shipdate], predicate: (lineitem.l_shipdate >= '1993-01-01':Varchar::Date) AND (lineitem.l_shipdate < ('1993-01-01':Varchar::Date + '3 mons 00:00:00':Interval)) }
       LogicalAgg { aggs: [max(sum((lineitem.l_extendedprice * (1:Int32 - lineitem.l_discount))))] }
         LogicalProject { exprs: [sum((lineitem.l_extendedprice * (1:Int32 - lineitem.l_discount)))] }
           LogicalAgg { group_key: [lineitem.l_suppkey], aggs: [sum((lineitem.l_extendedprice * (1:Int32 - lineitem.l_discount)))] }
             LogicalProject { exprs: [lineitem.l_suppkey, (lineitem.l_extendedprice * (1:Int32 - lineitem.l_discount))] }
-              LogicalScan { table: lineitem, output_columns: [l_suppkey, l_extendedprice, l_discount], required_columns: [l_suppkey, l_extendedprice, l_discount, l_shipdate], predicate: (lineitem.l_shipdate >= '1993-01-01':Varchar::Date) AND (lineitem.l_shipdate < ('1993-01-01':Varchar::Date + '3 mons 00:00:00':Interval)) }
+              LogicalScan { table: lineitem, output_columns: [lineitem.l_suppkey, lineitem.l_extendedprice, lineitem.l_discount], required_columns: [l_suppkey, l_extendedprice, l_discount, l_shipdate], predicate: (lineitem.l_shipdate >= '1993-01-01':Varchar::Date) AND (lineitem.l_shipdate < ('1993-01-01':Varchar::Date + '3 mons 00:00:00':Interval)) }
   batch_plan: |
     BatchExchange { order: [supplier.s_suppkey ASC], dist: Single }
       BatchSort { order: [supplier.s_suppkey ASC] }
-        BatchHashJoin { type: Inner, predicate: sum((lineitem.l_extendedprice * (1:Int32 - lineitem.l_discount))) = max(max(sum((lineitem.l_extendedprice * (1:Int32 - lineitem.l_discount))))) }
+        BatchHashJoin { type: Inner, predicate: sum((lineitem.l_extendedprice * (1:Int32 - lineitem.l_discount))) = max(max(sum((lineitem.l_extendedprice * (1:Int32 - lineitem.l_discount))))), output: [supplier.s_suppkey, supplier.s_name, supplier.s_address, supplier.s_phone, sum((lineitem.l_extendedprice * (1:Int32 - lineitem.l_discount)))] }
           BatchExchange { order: [], dist: HashShard(sum((lineitem.l_extendedprice * (1:Int32 - lineitem.l_discount)))) }
-            BatchHashJoin { type: Inner, predicate: supplier.s_suppkey = lineitem.l_suppkey }
+            BatchHashJoin { type: Inner, predicate: supplier.s_suppkey = lineitem.l_suppkey, output: [supplier.s_suppkey, supplier.s_name, supplier.s_address, supplier.s_phone, sum((lineitem.l_extendedprice * (1:Int32 - lineitem.l_discount)))] }
               BatchExchange { order: [], dist: HashShard(supplier.s_suppkey) }
-                BatchScan { table: supplier, columns: [s_suppkey, s_name, s_address, s_phone] }
+                BatchScan { table: supplier, columns: [supplier.s_suppkey, supplier.s_name, supplier.s_address, supplier.s_phone], distribution: SomeShard }
               BatchHashAgg { group_key: [lineitem.l_suppkey], aggs: [sum((lineitem.l_extendedprice * (1:Int32 - lineitem.l_discount)))] }
                 BatchExchange { order: [], dist: HashShard(lineitem.l_suppkey) }
                   BatchProject { exprs: [lineitem.l_suppkey, (lineitem.l_extendedprice * (1:Int32 - lineitem.l_discount))] }
                     BatchFilter { predicate: (lineitem.l_shipdate >= '1993-01-01':Varchar::Date) AND (lineitem.l_shipdate < ('1993-01-01':Varchar::Date + '3 mons 00:00:00':Interval)) }
-                      BatchScan { table: lineitem, columns: [l_suppkey, l_extendedprice, l_discount, l_shipdate] }
+                      BatchScan { table: lineitem, columns: [lineitem.l_suppkey, lineitem.l_extendedprice, lineitem.l_discount, lineitem.l_shipdate], distribution: SomeShard }
           BatchExchange { order: [], dist: HashShard(max(max(sum((lineitem.l_extendedprice * (1:Int32 - lineitem.l_discount)))))) }
             BatchSimpleAgg { aggs: [max(max(sum((lineitem.l_extendedprice * (1:Int32 - lineitem.l_discount)))))] }
               BatchExchange { order: [], dist: Single }
@@ -1594,20 +1594,20 @@
                       BatchExchange { order: [], dist: HashShard(lineitem.l_suppkey) }
                         BatchProject { exprs: [lineitem.l_suppkey, (lineitem.l_extendedprice * (1:Int32 - lineitem.l_discount))] }
                           BatchFilter { predicate: (lineitem.l_shipdate >= '1993-01-01':Varchar::Date) AND (lineitem.l_shipdate < ('1993-01-01':Varchar::Date + '3 mons 00:00:00':Interval)) }
-                            BatchScan { table: lineitem, columns: [l_suppkey, l_extendedprice, l_discount, l_shipdate] }
+                            BatchScan { table: lineitem, columns: [lineitem.l_suppkey, lineitem.l_extendedprice, lineitem.l_discount, lineitem.l_shipdate], distribution: SomeShard }
   stream_plan: |
     StreamMaterialize { columns: [s_suppkey, s_name, s_address, s_phone, total_revenue, supplier._row_id(hidden), lineitem.l_suppkey(hidden)], pk_columns: [supplier._row_id, lineitem.l_suppkey], order_descs: [s_suppkey, supplier._row_id, lineitem.l_suppkey] }
       StreamExchange { dist: HashShard(supplier._row_id, lineitem.l_suppkey) }
-        StreamHashJoin { type: Inner, predicate: sum((lineitem.l_extendedprice * (1:Int32 - lineitem.l_discount))) = max(sum((lineitem.l_extendedprice * (1:Int32 - lineitem.l_discount)))) }
+        StreamHashJoin { type: Inner, predicate: sum((lineitem.l_extendedprice * (1:Int32 - lineitem.l_discount))) = max(sum((lineitem.l_extendedprice * (1:Int32 - lineitem.l_discount)))), output: [supplier.s_suppkey, supplier.s_name, supplier.s_address, supplier.s_phone, sum((lineitem.l_extendedprice * (1:Int32 - lineitem.l_discount))), supplier._row_id, lineitem.l_suppkey] }
           StreamExchange { dist: HashShard(sum((lineitem.l_extendedprice * (1:Int32 - lineitem.l_discount)))) }
-            StreamHashJoin { type: Inner, predicate: supplier.s_suppkey = lineitem.l_suppkey }
+            StreamHashJoin { type: Inner, predicate: supplier.s_suppkey = lineitem.l_suppkey, output: [supplier.s_suppkey, supplier.s_name, supplier.s_address, supplier.s_phone, sum((lineitem.l_extendedprice * (1:Int32 - lineitem.l_discount))), supplier._row_id, lineitem.l_suppkey] }
               StreamExchange { dist: HashShard(supplier.s_suppkey) }
-                StreamTableScan { table: supplier, columns: [s_suppkey, s_name, s_address, s_phone, _row_id] }
+                StreamTableScan { table: supplier, columns: [supplier.s_suppkey, supplier.s_name, supplier.s_address, supplier.s_phone, supplier._row_id], pk: [supplier._row_id], distribution: HashShard(supplier._row_id) }
               StreamHashAgg { group_key: [lineitem.l_suppkey], aggs: [count, sum((lineitem.l_extendedprice * (1:Int32 - lineitem.l_discount)))] }
                 StreamExchange { dist: HashShard(lineitem.l_suppkey) }
                   StreamProject { exprs: [lineitem.l_suppkey, (lineitem.l_extendedprice * (1:Int32 - lineitem.l_discount)), lineitem._row_id] }
                     StreamFilter { predicate: (lineitem.l_shipdate >= '1993-01-01':Varchar::Date) AND (lineitem.l_shipdate < ('1993-01-01':Varchar::Date + '3 mons 00:00:00':Interval)) }
-                      StreamTableScan { table: lineitem, columns: [l_suppkey, l_extendedprice, l_discount, _row_id, l_shipdate] }
+                      StreamTableScan { table: lineitem, columns: [lineitem.l_suppkey, lineitem.l_extendedprice, lineitem.l_discount, lineitem._row_id, lineitem.l_shipdate], pk: [lineitem._row_id], distribution: HashShard(lineitem._row_id) }
           StreamExchange { dist: HashShard(max(sum((lineitem.l_extendedprice * (1:Int32 - lineitem.l_discount))))) }
             StreamGlobalSimpleAgg { aggs: [count, max(sum((lineitem.l_extendedprice * (1:Int32 - lineitem.l_discount))))] }
               StreamExchange { dist: Single }
@@ -1616,7 +1616,7 @@
                     StreamExchange { dist: HashShard(lineitem.l_suppkey) }
                       StreamProject { exprs: [lineitem.l_suppkey, (lineitem.l_extendedprice * (1:Int32 - lineitem.l_discount)), lineitem._row_id] }
                         StreamFilter { predicate: (lineitem.l_shipdate >= '1993-01-01':Varchar::Date) AND (lineitem.l_shipdate < ('1993-01-01':Varchar::Date + '3 mons 00:00:00':Interval)) }
-                          StreamTableScan { table: lineitem, columns: [l_suppkey, l_extendedprice, l_discount, _row_id, l_shipdate] }
+                          StreamTableScan { table: lineitem, columns: [lineitem.l_suppkey, lineitem.l_extendedprice, lineitem.l_discount, lineitem._row_id, lineitem.l_shipdate], pk: [lineitem._row_id], distribution: HashShard(lineitem._row_id) }
 - id: tpch_q16
   before:
   - create_tables
@@ -1656,23 +1656,23 @@
       LogicalAgg { group_key: [part.p_brand, part.p_type, part.p_size], aggs: [count(distinct partsupp.ps_suppkey)] }
         LogicalProject { exprs: [part.p_brand, part.p_type, part.p_size, partsupp.ps_suppkey] }
           LogicalFilter { predicate: (part.p_partkey = partsupp.ps_partkey) AND (part.p_brand <> 'Brand#45':Varchar) AND Not(Like(part.p_type, 'SMALL PLATED%':Varchar)) AND In(part.p_size, 19:Int32, 17:Int32, 16:Int32, 23:Int32, 10:Int32, 4:Int32, 38:Int32, 11:Int32) }
-            LogicalJoin { type: LeftAnti, on: (partsupp.ps_suppkey = supplier.s_suppkey) }
-              LogicalJoin { type: Inner, on: true }
-                LogicalScan { table: partsupp, columns: [_row_id, ps_partkey, ps_suppkey, ps_availqty, ps_supplycost, ps_comment] }
-                LogicalScan { table: part, columns: [_row_id, p_partkey, p_name, p_mfgr, p_brand, p_type, p_size, p_container, p_retailprice, p_comment] }
+            LogicalJoin { type: LeftAnti, on: (partsupp.ps_suppkey = supplier.s_suppkey), output: all }
+              LogicalJoin { type: Inner, on: true, output: all }
+                LogicalScan { table: partsupp, columns: [partsupp._row_id, partsupp.ps_partkey, partsupp.ps_suppkey, partsupp.ps_availqty, partsupp.ps_supplycost, partsupp.ps_comment] }
+                LogicalScan { table: part, columns: [part._row_id, part.p_partkey, part.p_name, part.p_mfgr, part.p_brand, part.p_type, part.p_size, part.p_container, part.p_retailprice, part.p_comment] }
               LogicalProject { exprs: [supplier.s_suppkey] }
                 LogicalFilter { predicate: Like(supplier.s_comment, '%Customer%Complaints%':Varchar) }
-                  LogicalScan { table: supplier, columns: [_row_id, s_suppkey, s_name, s_address, s_nationkey, s_phone, s_acctbal, s_comment] }
+                  LogicalScan { table: supplier, columns: [supplier._row_id, supplier.s_suppkey, supplier.s_name, supplier.s_address, supplier.s_nationkey, supplier.s_phone, supplier.s_acctbal, supplier.s_comment] }
   optimized_logical_plan: |
     LogicalAgg { group_key: [part.p_brand, part.p_type, part.p_size], aggs: [count(partsupp.ps_suppkey) filter((flag = 0:Int64))] }
       LogicalAgg { group_key: [part.p_brand, part.p_type, part.p_size, partsupp.ps_suppkey, flag], aggs: [] }
         LogicalExpand { column_subsets: [[part.p_brand, part.p_type, part.p_size, partsupp.ps_suppkey]] }
           LogicalProject { exprs: [part.p_brand, part.p_type, part.p_size, partsupp.ps_suppkey] }
-            LogicalJoin { type: LeftAnti, on: (partsupp.ps_suppkey = supplier.s_suppkey) }
-              LogicalJoin { type: Inner, on: (part.p_partkey = partsupp.ps_partkey) }
-                LogicalScan { table: partsupp, columns: [ps_partkey, ps_suppkey] }
-                LogicalScan { table: part, output_columns: [p_partkey, p_brand, p_type, p_size], required_columns: [p_partkey, p_brand, p_type, p_size], predicate: (part.p_brand <> 'Brand#45':Varchar) AND Not(Like(part.p_type, 'SMALL PLATED%':Varchar)) AND In(part.p_size, 19:Int32, 17:Int32, 16:Int32, 23:Int32, 10:Int32, 4:Int32, 38:Int32, 11:Int32) }
-              LogicalScan { table: supplier, output_columns: [s_suppkey], required_columns: [s_suppkey, s_comment], predicate: Like(supplier.s_comment, '%Customer%Complaints%':Varchar) }
+            LogicalJoin { type: LeftAnti, on: (partsupp.ps_suppkey = supplier.s_suppkey), output: all }
+              LogicalJoin { type: Inner, on: (part.p_partkey = partsupp.ps_partkey), output: [partsupp.ps_suppkey, part.p_brand, part.p_type, part.p_size] }
+                LogicalScan { table: partsupp, columns: [partsupp.ps_partkey, partsupp.ps_suppkey] }
+                LogicalScan { table: part, output_columns: [part.p_partkey, part.p_brand, part.p_type, part.p_size], required_columns: [p_partkey, p_brand, p_type, p_size], predicate: (part.p_brand <> 'Brand#45':Varchar) AND Not(Like(part.p_type, 'SMALL PLATED%':Varchar)) AND In(part.p_size, 19:Int32, 17:Int32, 16:Int32, 23:Int32, 10:Int32, 4:Int32, 38:Int32, 11:Int32) }
+              LogicalScan { table: supplier, output_columns: [supplier.s_suppkey], required_columns: [s_suppkey, s_comment], predicate: Like(supplier.s_comment, '%Customer%Complaints%':Varchar) }
   batch_plan: |
     BatchExchange { order: [count(partsupp.ps_suppkey) filter((flag = 0:Int64)) DESC, part.p_brand ASC, part.p_type ASC, part.p_size ASC], dist: Single }
       BatchSort { order: [count(partsupp.ps_suppkey) filter((flag = 0:Int64)) DESC, part.p_brand ASC, part.p_type ASC, part.p_size ASC] }
@@ -1682,18 +1682,18 @@
               BatchExchange { order: [], dist: HashShard(part.p_brand, part.p_type, part.p_size, partsupp.ps_suppkey, flag) }
                 BatchExpand { column_subsets: [[part.p_brand, part.p_type, part.p_size, partsupp.ps_suppkey]] }
                   BatchProject { exprs: [part.p_brand, part.p_type, part.p_size, partsupp.ps_suppkey] }
-                    BatchHashJoin { type: LeftAnti, predicate: partsupp.ps_suppkey = supplier.s_suppkey }
+                    BatchHashJoin { type: LeftAnti, predicate: partsupp.ps_suppkey = supplier.s_suppkey, output: all }
                       BatchExchange { order: [], dist: HashShard(partsupp.ps_suppkey) }
-                        BatchHashJoin { type: Inner, predicate: partsupp.ps_partkey = part.p_partkey }
+                        BatchHashJoin { type: Inner, predicate: partsupp.ps_partkey = part.p_partkey, output: [partsupp.ps_suppkey, part.p_brand, part.p_type, part.p_size] }
                           BatchExchange { order: [], dist: HashShard(partsupp.ps_partkey) }
-                            BatchScan { table: partsupp, columns: [ps_partkey, ps_suppkey] }
+                            BatchScan { table: partsupp, columns: [partsupp.ps_partkey, partsupp.ps_suppkey], distribution: SomeShard }
                           BatchExchange { order: [], dist: HashShard(part.p_partkey) }
                             BatchFilter { predicate: (part.p_brand <> 'Brand#45':Varchar) AND Not(Like(part.p_type, 'SMALL PLATED%':Varchar)) AND In(part.p_size, 19:Int32, 17:Int32, 16:Int32, 23:Int32, 10:Int32, 4:Int32, 38:Int32, 11:Int32) }
-                              BatchScan { table: part, columns: [p_partkey, p_brand, p_type, p_size] }
+                              BatchScan { table: part, columns: [part.p_partkey, part.p_brand, part.p_type, part.p_size], distribution: SomeShard }
                       BatchExchange { order: [], dist: HashShard(supplier.s_suppkey) }
                         BatchProject { exprs: [supplier.s_suppkey] }
                           BatchFilter { predicate: Like(supplier.s_comment, '%Customer%Complaints%':Varchar) }
-                            BatchScan { table: supplier, columns: [s_suppkey, s_comment] }
+                            BatchScan { table: supplier, columns: [supplier.s_suppkey, supplier.s_comment], distribution: SomeShard }
   stream_plan: |
     StreamMaterialize { columns: [p_brand, p_type, p_size, count(hidden), supplier_cnt], pk_columns: [p_brand, p_type, p_size], order_descs: [supplier_cnt, p_brand, p_type, p_size] }
       StreamHashAgg { group_key: [part.p_brand, part.p_type, part.p_size], aggs: [count, count(partsupp.ps_suppkey) filter((flag = 0:Int64))] }
@@ -1702,18 +1702,18 @@
             StreamExchange { dist: HashShard(part.p_brand, part.p_type, part.p_size, partsupp.ps_suppkey, flag) }
               StreamExpand { column_subsets: [[part.p_brand, part.p_type, part.p_size, partsupp.ps_suppkey]] }
                 StreamProject { exprs: [part.p_brand, part.p_type, part.p_size, partsupp.ps_suppkey, partsupp._row_id, part._row_id] }
-                  StreamHashJoin { type: LeftAnti, predicate: partsupp.ps_suppkey = supplier.s_suppkey }
+                  StreamHashJoin { type: LeftAnti, predicate: partsupp.ps_suppkey = supplier.s_suppkey, output: all }
                     StreamExchange { dist: HashShard(partsupp.ps_suppkey) }
-                      StreamHashJoin { type: Inner, predicate: partsupp.ps_partkey = part.p_partkey }
+                      StreamHashJoin { type: Inner, predicate: partsupp.ps_partkey = part.p_partkey, output: [partsupp.ps_suppkey, part.p_brand, part.p_type, part.p_size, partsupp._row_id, part._row_id] }
                         StreamExchange { dist: HashShard(partsupp.ps_partkey) }
-                          StreamTableScan { table: partsupp, columns: [ps_partkey, ps_suppkey, _row_id] }
+                          StreamTableScan { table: partsupp, columns: [partsupp.ps_partkey, partsupp.ps_suppkey, partsupp._row_id], pk: [partsupp._row_id], distribution: HashShard(partsupp._row_id) }
                         StreamExchange { dist: HashShard(part.p_partkey) }
                           StreamFilter { predicate: (part.p_brand <> 'Brand#45':Varchar) AND Not(Like(part.p_type, 'SMALL PLATED%':Varchar)) AND In(part.p_size, 19:Int32, 17:Int32, 16:Int32, 23:Int32, 10:Int32, 4:Int32, 38:Int32, 11:Int32) }
-                            StreamTableScan { table: part, columns: [p_partkey, p_brand, p_type, p_size, _row_id] }
+                            StreamTableScan { table: part, columns: [part.p_partkey, part.p_brand, part.p_type, part.p_size, part._row_id], pk: [part._row_id], distribution: HashShard(part._row_id) }
                     StreamExchange { dist: HashShard(supplier.s_suppkey) }
                       StreamProject { exprs: [supplier.s_suppkey, supplier._row_id] }
                         StreamFilter { predicate: Like(supplier.s_comment, '%Customer%Complaints%':Varchar) }
-                          StreamTableScan { table: supplier, columns: [s_suppkey, _row_id, s_comment] }
+                          StreamTableScan { table: supplier, columns: [supplier.s_suppkey, supplier._row_id, supplier.s_comment], pk: [supplier._row_id], distribution: HashShard(supplier._row_id) }
 - id: tpch_q17
   before:
   - create_tables
@@ -1741,24 +1741,24 @@
         LogicalProject { exprs: [lineitem.l_extendedprice] }
           LogicalFilter { predicate: (part.p_partkey = lineitem.l_partkey) AND (part.p_brand = 'Brand#13':Varchar) AND (part.p_container = 'JUMBO PKG':Varchar) AND (lineitem.l_quantity < (0.2:Decimal * (sum(lineitem.l_quantity) / count(lineitem.l_quantity)))) }
             LogicalApply { type: LeftOuter, on: true, correlated_id: 1 }
-              LogicalJoin { type: Inner, on: true }
-                LogicalScan { table: lineitem, columns: [_row_id, l_orderkey, l_partkey, l_suppkey, l_linenumber, l_quantity, l_extendedprice, l_discount, l_tax, l_returnflag, l_linestatus, l_shipdate, l_commitdate, l_receiptdate, l_shipinstruct, l_shipmode, l_comment] }
-                LogicalScan { table: part, columns: [_row_id, p_partkey, p_name, p_mfgr, p_brand, p_type, p_size, p_container, p_retailprice, p_comment] }
+              LogicalJoin { type: Inner, on: true, output: all }
+                LogicalScan { table: lineitem, columns: [lineitem._row_id, lineitem.l_orderkey, lineitem.l_partkey, lineitem.l_suppkey, lineitem.l_linenumber, lineitem.l_quantity, lineitem.l_extendedprice, lineitem.l_discount, lineitem.l_tax, lineitem.l_returnflag, lineitem.l_linestatus, lineitem.l_shipdate, lineitem.l_commitdate, lineitem.l_receiptdate, lineitem.l_shipinstruct, lineitem.l_shipmode, lineitem.l_comment] }
+                LogicalScan { table: part, columns: [part._row_id, part.p_partkey, part.p_name, part.p_mfgr, part.p_brand, part.p_type, part.p_size, part.p_container, part.p_retailprice, part.p_comment] }
               LogicalProject { exprs: [(0.2:Decimal * (sum(lineitem.l_quantity) / count(lineitem.l_quantity)))] }
                 LogicalAgg { aggs: [sum(lineitem.l_quantity), count(lineitem.l_quantity)] }
                   LogicalProject { exprs: [lineitem.l_quantity] }
                     LogicalFilter { predicate: (lineitem.l_partkey = CorrelatedInputRef { index: 18, correlated_id: 1 }) }
-                      LogicalScan { table: lineitem, columns: [_row_id, l_orderkey, l_partkey, l_suppkey, l_linenumber, l_quantity, l_extendedprice, l_discount, l_tax, l_returnflag, l_linestatus, l_shipdate, l_commitdate, l_receiptdate, l_shipinstruct, l_shipmode, l_comment] }
+                      LogicalScan { table: lineitem, columns: [lineitem._row_id, lineitem.l_orderkey, lineitem.l_partkey, lineitem.l_suppkey, lineitem.l_linenumber, lineitem.l_quantity, lineitem.l_extendedprice, lineitem.l_discount, lineitem.l_tax, lineitem.l_returnflag, lineitem.l_linestatus, lineitem.l_shipdate, lineitem.l_commitdate, lineitem.l_receiptdate, lineitem.l_shipinstruct, lineitem.l_shipmode, lineitem.l_comment] }
   optimized_logical_plan: |
     LogicalProject { exprs: [RoundDigit((sum(lineitem.l_extendedprice) / 7.0:Decimal), 16:Int32)] }
       LogicalAgg { aggs: [sum(lineitem.l_extendedprice)] }
-        LogicalJoin { type: Inner, on: (part.p_partkey = lineitem.l_partkey) AND (lineitem.l_quantity < (0.2:Decimal * (sum(lineitem.l_quantity) / count(lineitem.l_quantity)))) }
-          LogicalJoin { type: Inner, on: (part.p_partkey = lineitem.l_partkey) }
-            LogicalScan { table: lineitem, columns: [l_partkey, l_quantity, l_extendedprice] }
-            LogicalScan { table: part, output_columns: [p_partkey], required_columns: [p_partkey, p_brand, p_container], predicate: (part.p_brand = 'Brand#13':Varchar) AND (part.p_container = 'JUMBO PKG':Varchar) }
+        LogicalJoin { type: Inner, on: (part.p_partkey = lineitem.l_partkey) AND (lineitem.l_quantity < (0.2:Decimal * (sum(lineitem.l_quantity) / count(lineitem.l_quantity)))), output: [lineitem.l_extendedprice] }
+          LogicalJoin { type: Inner, on: (part.p_partkey = lineitem.l_partkey), output: [lineitem.l_quantity, lineitem.l_extendedprice, part.p_partkey] }
+            LogicalScan { table: lineitem, columns: [lineitem.l_partkey, lineitem.l_quantity, lineitem.l_extendedprice] }
+            LogicalScan { table: part, output_columns: [part.p_partkey], required_columns: [p_partkey, p_brand, p_container], predicate: (part.p_brand = 'Brand#13':Varchar) AND (part.p_container = 'JUMBO PKG':Varchar) }
           LogicalProject { exprs: [lineitem.l_partkey, (0.2:Decimal * (sum(lineitem.l_quantity) / count(lineitem.l_quantity)))] }
             LogicalAgg { group_key: [lineitem.l_partkey], aggs: [sum(lineitem.l_quantity), count(lineitem.l_quantity)] }
-              LogicalScan { table: lineitem, columns: [l_partkey, l_quantity] }
+              LogicalScan { table: lineitem, columns: [lineitem.l_partkey, lineitem.l_quantity] }
   batch_plan: |
     BatchProject { exprs: [RoundDigit((sum(sum(lineitem.l_extendedprice)) / 7.0:Decimal), 16:Int32)] }
       BatchSimpleAgg { aggs: [sum(sum(lineitem.l_extendedprice))] }
@@ -1766,19 +1766,19 @@
           BatchSimpleAgg { aggs: [sum(lineitem.l_extendedprice)] }
             BatchProject { exprs: [lineitem.l_extendedprice] }
               BatchFilter { predicate: (lineitem.l_quantity < (0.2:Decimal * (sum(lineitem.l_quantity) / count(lineitem.l_quantity)))) }
-                BatchHashJoin { type: Inner, predicate: part.p_partkey = lineitem.l_partkey }
+                BatchHashJoin { type: Inner, predicate: part.p_partkey = lineitem.l_partkey, output: all }
                   BatchExchange { order: [], dist: HashShard(part.p_partkey) }
-                    BatchHashJoin { type: Inner, predicate: lineitem.l_partkey = part.p_partkey }
+                    BatchHashJoin { type: Inner, predicate: lineitem.l_partkey = part.p_partkey, output: [lineitem.l_quantity, lineitem.l_extendedprice, part.p_partkey] }
                       BatchExchange { order: [], dist: HashShard(lineitem.l_partkey) }
-                        BatchScan { table: lineitem, columns: [l_partkey, l_quantity, l_extendedprice] }
+                        BatchScan { table: lineitem, columns: [lineitem.l_partkey, lineitem.l_quantity, lineitem.l_extendedprice], distribution: SomeShard }
                       BatchExchange { order: [], dist: HashShard(part.p_partkey) }
                         BatchProject { exprs: [part.p_partkey] }
                           BatchFilter { predicate: (part.p_brand = 'Brand#13':Varchar) AND (part.p_container = 'JUMBO PKG':Varchar) }
-                            BatchScan { table: part, columns: [p_partkey, p_brand, p_container] }
+                            BatchScan { table: part, columns: [part.p_partkey, part.p_brand, part.p_container], distribution: SomeShard }
                   BatchProject { exprs: [lineitem.l_partkey, (0.2:Decimal * (sum(lineitem.l_quantity) / count(lineitem.l_quantity)))] }
                     BatchHashAgg { group_key: [lineitem.l_partkey], aggs: [sum(lineitem.l_quantity), count(lineitem.l_quantity)] }
                       BatchExchange { order: [], dist: HashShard(lineitem.l_partkey) }
-                        BatchScan { table: lineitem, columns: [l_partkey, l_quantity] }
+                        BatchScan { table: lineitem, columns: [lineitem.l_partkey, lineitem.l_quantity], distribution: SomeShard }
   stream_plan: |
     StreamMaterialize { columns: [avg_yearly], pk_columns: [] }
       StreamProject { exprs: [RoundDigit((sum(sum(lineitem.l_extendedprice)) / 7.0:Decimal), 16:Int32)] }
@@ -1787,19 +1787,19 @@
             StreamLocalSimpleAgg { aggs: [count, sum(lineitem.l_extendedprice)] }
               StreamProject { exprs: [lineitem.l_extendedprice, lineitem._row_id, part._row_id, lineitem.l_partkey] }
                 StreamFilter { predicate: (lineitem.l_quantity < (0.2:Decimal * (sum(lineitem.l_quantity) / count(lineitem.l_quantity)))) }
-                  StreamHashJoin { type: Inner, predicate: part.p_partkey = lineitem.l_partkey }
+                  StreamHashJoin { type: Inner, predicate: part.p_partkey = lineitem.l_partkey, output: all }
                     StreamExchange { dist: HashShard(part.p_partkey) }
-                      StreamHashJoin { type: Inner, predicate: lineitem.l_partkey = part.p_partkey }
+                      StreamHashJoin { type: Inner, predicate: lineitem.l_partkey = part.p_partkey, output: [lineitem.l_quantity, lineitem.l_extendedprice, part.p_partkey, lineitem._row_id, part._row_id] }
                         StreamExchange { dist: HashShard(lineitem.l_partkey) }
-                          StreamTableScan { table: lineitem, columns: [l_partkey, l_quantity, l_extendedprice, _row_id] }
+                          StreamTableScan { table: lineitem, columns: [lineitem.l_partkey, lineitem.l_quantity, lineitem.l_extendedprice, lineitem._row_id], pk: [lineitem._row_id], distribution: HashShard(lineitem._row_id) }
                         StreamExchange { dist: HashShard(part.p_partkey) }
                           StreamProject { exprs: [part.p_partkey, part._row_id] }
                             StreamFilter { predicate: (part.p_brand = 'Brand#13':Varchar) AND (part.p_container = 'JUMBO PKG':Varchar) }
-                              StreamTableScan { table: part, columns: [p_partkey, _row_id, p_brand, p_container] }
+                              StreamTableScan { table: part, columns: [part.p_partkey, part._row_id, part.p_brand, part.p_container], pk: [part._row_id], distribution: HashShard(part._row_id) }
                     StreamProject { exprs: [lineitem.l_partkey, (0.2:Decimal * (sum(lineitem.l_quantity) / count(lineitem.l_quantity)))] }
                       StreamHashAgg { group_key: [lineitem.l_partkey], aggs: [count, sum(lineitem.l_quantity), count(lineitem.l_quantity)] }
                         StreamExchange { dist: HashShard(lineitem.l_partkey) }
-                          StreamTableScan { table: lineitem, columns: [l_partkey, l_quantity, _row_id] }
+                          StreamTableScan { table: lineitem, columns: [lineitem.l_partkey, lineitem.l_quantity, lineitem._row_id], pk: [lineitem._row_id], distribution: HashShard(lineitem._row_id) }
 - id: tpch_q18
   before:
   - create_tables
@@ -1844,73 +1844,73 @@
         LogicalAgg { group_key: [customer.c_name, customer.c_custkey, orders.o_orderkey, orders.o_orderdate, orders.o_totalprice], aggs: [sum(lineitem.l_quantity)] }
           LogicalProject { exprs: [customer.c_name, customer.c_custkey, orders.o_orderkey, orders.o_orderdate, orders.o_totalprice, lineitem.l_quantity] }
             LogicalFilter { predicate: (customer.c_custkey = orders.o_custkey) AND (orders.o_orderkey = lineitem.l_orderkey) }
-              LogicalJoin { type: LeftSemi, on: (orders.o_orderkey = lineitem.l_orderkey) }
-                LogicalJoin { type: Inner, on: true }
-                  LogicalJoin { type: Inner, on: true }
-                    LogicalScan { table: customer, columns: [_row_id, c_custkey, c_name, c_address, c_nationkey, c_phone, c_acctbal, c_mktsegment, c_comment] }
-                    LogicalScan { table: orders, columns: [_row_id, o_orderkey, o_custkey, o_orderstatus, o_totalprice, o_orderdate, o_orderpriority, o_clerk, o_shippriority, o_comment] }
-                  LogicalScan { table: lineitem, columns: [_row_id, l_orderkey, l_partkey, l_suppkey, l_linenumber, l_quantity, l_extendedprice, l_discount, l_tax, l_returnflag, l_linestatus, l_shipdate, l_commitdate, l_receiptdate, l_shipinstruct, l_shipmode, l_comment] }
+              LogicalJoin { type: LeftSemi, on: (orders.o_orderkey = lineitem.l_orderkey), output: all }
+                LogicalJoin { type: Inner, on: true, output: all }
+                  LogicalJoin { type: Inner, on: true, output: all }
+                    LogicalScan { table: customer, columns: [customer._row_id, customer.c_custkey, customer.c_name, customer.c_address, customer.c_nationkey, customer.c_phone, customer.c_acctbal, customer.c_mktsegment, customer.c_comment] }
+                    LogicalScan { table: orders, columns: [orders._row_id, orders.o_orderkey, orders.o_custkey, orders.o_orderstatus, orders.o_totalprice, orders.o_orderdate, orders.o_orderpriority, orders.o_clerk, orders.o_shippriority, orders.o_comment] }
+                  LogicalScan { table: lineitem, columns: [lineitem._row_id, lineitem.l_orderkey, lineitem.l_partkey, lineitem.l_suppkey, lineitem.l_linenumber, lineitem.l_quantity, lineitem.l_extendedprice, lineitem.l_discount, lineitem.l_tax, lineitem.l_returnflag, lineitem.l_linestatus, lineitem.l_shipdate, lineitem.l_commitdate, lineitem.l_receiptdate, lineitem.l_shipinstruct, lineitem.l_shipmode, lineitem.l_comment] }
                 LogicalProject { exprs: [lineitem.l_orderkey] }
                   LogicalFilter { predicate: (sum(lineitem.l_quantity) > 1:Int32) }
                     LogicalAgg { group_key: [lineitem.l_orderkey], aggs: [sum(lineitem.l_quantity)] }
                       LogicalProject { exprs: [lineitem.l_orderkey, lineitem.l_quantity] }
-                        LogicalScan { table: lineitem, columns: [_row_id, l_orderkey, l_partkey, l_suppkey, l_linenumber, l_quantity, l_extendedprice, l_discount, l_tax, l_returnflag, l_linestatus, l_shipdate, l_commitdate, l_receiptdate, l_shipinstruct, l_shipmode, l_comment] }
+                        LogicalScan { table: lineitem, columns: [lineitem._row_id, lineitem.l_orderkey, lineitem.l_partkey, lineitem.l_suppkey, lineitem.l_linenumber, lineitem.l_quantity, lineitem.l_extendedprice, lineitem.l_discount, lineitem.l_tax, lineitem.l_returnflag, lineitem.l_linestatus, lineitem.l_shipdate, lineitem.l_commitdate, lineitem.l_receiptdate, lineitem.l_shipinstruct, lineitem.l_shipmode, lineitem.l_comment] }
   optimized_logical_plan: |
     LogicalTopN { order: "[orders.o_totalprice DESC, orders.o_orderdate ASC]", limit: 100, offset: 0 }
       LogicalAgg { group_key: [customer.c_name, customer.c_custkey, orders.o_orderkey, orders.o_orderdate, orders.o_totalprice], aggs: [sum(lineitem.l_quantity)] }
         LogicalProject { exprs: [customer.c_name, customer.c_custkey, orders.o_orderkey, orders.o_orderdate, orders.o_totalprice, lineitem.l_quantity] }
-          LogicalJoin { type: LeftSemi, on: (orders.o_orderkey = lineitem.l_orderkey) }
-            LogicalJoin { type: Inner, on: (orders.o_orderkey = lineitem.l_orderkey) }
-              LogicalJoin { type: Inner, on: (customer.c_custkey = orders.o_custkey) }
-                LogicalScan { table: customer, columns: [c_custkey, c_name] }
-                LogicalScan { table: orders, columns: [o_orderkey, o_custkey, o_totalprice, o_orderdate] }
-              LogicalScan { table: lineitem, columns: [l_orderkey, l_quantity] }
+          LogicalJoin { type: LeftSemi, on: (orders.o_orderkey = lineitem.l_orderkey), output: all }
+            LogicalJoin { type: Inner, on: (orders.o_orderkey = lineitem.l_orderkey), output: [customer.c_custkey, customer.c_name, orders.o_orderkey, orders.o_totalprice, orders.o_orderdate, lineitem.l_quantity] }
+              LogicalJoin { type: Inner, on: (customer.c_custkey = orders.o_custkey), output: [customer.c_custkey, customer.c_name, orders.o_orderkey, orders.o_totalprice, orders.o_orderdate] }
+                LogicalScan { table: customer, columns: [customer.c_custkey, customer.c_name] }
+                LogicalScan { table: orders, columns: [orders.o_orderkey, orders.o_custkey, orders.o_totalprice, orders.o_orderdate] }
+              LogicalScan { table: lineitem, columns: [lineitem.l_orderkey, lineitem.l_quantity] }
             LogicalProject { exprs: [lineitem.l_orderkey] }
               LogicalFilter { predicate: (sum(lineitem.l_quantity) > 1:Int32) }
                 LogicalAgg { group_key: [lineitem.l_orderkey], aggs: [sum(lineitem.l_quantity)] }
-                  LogicalScan { table: lineitem, columns: [l_orderkey, l_quantity] }
+                  LogicalScan { table: lineitem, columns: [lineitem.l_orderkey, lineitem.l_quantity] }
   batch_plan: |
     BatchTopN { order: "[orders.o_totalprice DESC, orders.o_orderdate ASC]", limit: 100, offset: 0 }
       BatchExchange { order: [], dist: Single }
         BatchTopN { order: "[orders.o_totalprice DESC, orders.o_orderdate ASC]", limit: 100, offset: 0 }
           BatchHashAgg { group_key: [customer.c_name, customer.c_custkey, orders.o_orderkey, orders.o_orderdate, orders.o_totalprice], aggs: [sum(lineitem.l_quantity)] }
             BatchProject { exprs: [customer.c_name, customer.c_custkey, orders.o_orderkey, orders.o_orderdate, orders.o_totalprice, lineitem.l_quantity] }
-              BatchHashJoin { type: LeftSemi, predicate: orders.o_orderkey = lineitem.l_orderkey }
-                BatchHashJoin { type: Inner, predicate: orders.o_orderkey = lineitem.l_orderkey }
+              BatchHashJoin { type: LeftSemi, predicate: orders.o_orderkey = lineitem.l_orderkey, output: all }
+                BatchHashJoin { type: Inner, predicate: orders.o_orderkey = lineitem.l_orderkey, output: [customer.c_custkey, customer.c_name, orders.o_orderkey, orders.o_totalprice, orders.o_orderdate, lineitem.l_quantity] }
                   BatchExchange { order: [], dist: HashShard(orders.o_orderkey) }
-                    BatchHashJoin { type: Inner, predicate: customer.c_custkey = orders.o_custkey }
+                    BatchHashJoin { type: Inner, predicate: customer.c_custkey = orders.o_custkey, output: [customer.c_custkey, customer.c_name, orders.o_orderkey, orders.o_totalprice, orders.o_orderdate] }
                       BatchExchange { order: [], dist: HashShard(customer.c_custkey) }
-                        BatchScan { table: customer, columns: [c_custkey, c_name] }
+                        BatchScan { table: customer, columns: [customer.c_custkey, customer.c_name], distribution: SomeShard }
                       BatchExchange { order: [], dist: HashShard(orders.o_custkey) }
-                        BatchScan { table: orders, columns: [o_orderkey, o_custkey, o_totalprice, o_orderdate] }
+                        BatchScan { table: orders, columns: [orders.o_orderkey, orders.o_custkey, orders.o_totalprice, orders.o_orderdate], distribution: SomeShard }
                   BatchExchange { order: [], dist: HashShard(lineitem.l_orderkey) }
-                    BatchScan { table: lineitem, columns: [l_orderkey, l_quantity] }
+                    BatchScan { table: lineitem, columns: [lineitem.l_orderkey, lineitem.l_quantity], distribution: SomeShard }
                 BatchProject { exprs: [lineitem.l_orderkey] }
                   BatchFilter { predicate: (sum(lineitem.l_quantity) > 1:Int32) }
                     BatchHashAgg { group_key: [lineitem.l_orderkey], aggs: [sum(lineitem.l_quantity)] }
                       BatchExchange { order: [], dist: HashShard(lineitem.l_orderkey) }
-                        BatchScan { table: lineitem, columns: [l_orderkey, l_quantity] }
+                        BatchScan { table: lineitem, columns: [lineitem.l_orderkey, lineitem.l_quantity], distribution: SomeShard }
   stream_plan: |
     StreamMaterialize { columns: [c_name, c_custkey, o_orderkey, o_orderdate, o_totalprice, count(hidden), quantity], pk_columns: [c_name, c_custkey, o_orderkey, o_orderdate, o_totalprice], order_descs: [o_totalprice, o_orderdate, c_name, c_custkey, o_orderkey] }
       StreamTopN { order: "[orders.o_totalprice DESC, orders.o_orderdate ASC]", limit: 100, offset: 0 }
         StreamExchange { dist: Single }
           StreamHashAgg { group_key: [customer.c_name, customer.c_custkey, orders.o_orderkey, orders.o_orderdate, orders.o_totalprice], aggs: [count, sum(lineitem.l_quantity)] }
             StreamProject { exprs: [customer.c_name, customer.c_custkey, orders.o_orderkey, orders.o_orderdate, orders.o_totalprice, lineitem.l_quantity, customer._row_id, orders._row_id, lineitem._row_id] }
-              StreamHashJoin { type: LeftSemi, predicate: orders.o_orderkey = lineitem.l_orderkey }
-                StreamHashJoin { type: Inner, predicate: orders.o_orderkey = lineitem.l_orderkey }
+              StreamHashJoin { type: LeftSemi, predicate: orders.o_orderkey = lineitem.l_orderkey, output: all }
+                StreamHashJoin { type: Inner, predicate: orders.o_orderkey = lineitem.l_orderkey, output: [customer.c_custkey, customer.c_name, orders.o_orderkey, orders.o_totalprice, orders.o_orderdate, lineitem.l_quantity, customer._row_id, orders._row_id, lineitem._row_id] }
                   StreamExchange { dist: HashShard(orders.o_orderkey) }
-                    StreamHashJoin { type: Inner, predicate: customer.c_custkey = orders.o_custkey }
+                    StreamHashJoin { type: Inner, predicate: customer.c_custkey = orders.o_custkey, output: [customer.c_custkey, customer.c_name, orders.o_orderkey, orders.o_totalprice, orders.o_orderdate, customer._row_id, orders._row_id] }
                       StreamExchange { dist: HashShard(customer.c_custkey) }
-                        StreamTableScan { table: customer, columns: [c_custkey, c_name, _row_id] }
+                        StreamTableScan { table: customer, columns: [customer.c_custkey, customer.c_name, customer._row_id], pk: [customer._row_id], distribution: HashShard(customer._row_id) }
                       StreamExchange { dist: HashShard(orders.o_custkey) }
-                        StreamTableScan { table: orders, columns: [o_orderkey, o_custkey, o_totalprice, o_orderdate, _row_id] }
+                        StreamTableScan { table: orders, columns: [orders.o_orderkey, orders.o_custkey, orders.o_totalprice, orders.o_orderdate, orders._row_id], pk: [orders._row_id], distribution: HashShard(orders._row_id) }
                   StreamExchange { dist: HashShard(lineitem.l_orderkey) }
-                    StreamTableScan { table: lineitem, columns: [l_orderkey, l_quantity, _row_id] }
+                    StreamTableScan { table: lineitem, columns: [lineitem.l_orderkey, lineitem.l_quantity, lineitem._row_id], pk: [lineitem._row_id], distribution: HashShard(lineitem._row_id) }
                 StreamProject { exprs: [lineitem.l_orderkey] }
                   StreamFilter { predicate: (sum(lineitem.l_quantity) > 1:Int32) }
                     StreamHashAgg { group_key: [lineitem.l_orderkey], aggs: [count, sum(lineitem.l_quantity)] }
                       StreamExchange { dist: HashShard(lineitem.l_orderkey) }
-                        StreamTableScan { table: lineitem, columns: [l_orderkey, l_quantity, _row_id] }
+                        StreamTableScan { table: lineitem, columns: [lineitem.l_orderkey, lineitem.l_quantity, lineitem._row_id], pk: [lineitem._row_id], distribution: HashShard(lineitem._row_id) }
 - id: tpch_q19
   before:
   - create_tables
@@ -1955,29 +1955,29 @@
       LogicalAgg { aggs: [sum((lineitem.l_extendedprice * (1:Int32 - lineitem.l_discount)))] }
         LogicalProject { exprs: [(lineitem.l_extendedprice * (1:Int32 - lineitem.l_discount))] }
           LogicalFilter { predicate: (part.p_partkey = lineitem.l_partkey) AND (part.p_size >= 1:Int32) AND In(lineitem.l_shipmode, 'AIR':Varchar, 'AIR REG':Varchar) AND (lineitem.l_shipinstruct = 'DELIVER IN PERSON':Varchar) AND (((((((part.p_brand = 'Brand#52':Varchar) AND In(part.p_container, 'SM CASE':Varchar, 'SM BOX':Varchar, 'SM PACK':Varchar, 'SM PKG':Varchar)) AND (lineitem.l_quantity >= 1:Int32)) AND (lineitem.l_quantity <= 11:Int32)) AND (part.p_size <= 5:Int32)) OR (((((part.p_brand = 'Brand#24':Varchar) AND In(part.p_container, 'MED BAG':Varchar, 'MED BOX':Varchar, 'MED PKG':Varchar, 'MED PACK':Varchar)) AND (lineitem.l_quantity >= 30:Int32)) AND (lineitem.l_quantity <= 40:Int32)) AND (part.p_size <= 10:Int32))) OR (((((part.p_brand = 'Brand#32':Varchar) AND In(part.p_container, 'LG CASE':Varchar, 'LG BOX':Varchar, 'LG PACK':Varchar, 'LG PKG':Varchar)) AND (lineitem.l_quantity >= 10:Int32)) AND (lineitem.l_quantity <= 20:Int32)) AND (part.p_size <= 15:Int32))) }
-            LogicalJoin { type: Inner, on: true }
-              LogicalScan { table: lineitem, columns: [_row_id, l_orderkey, l_partkey, l_suppkey, l_linenumber, l_quantity, l_extendedprice, l_discount, l_tax, l_returnflag, l_linestatus, l_shipdate, l_commitdate, l_receiptdate, l_shipinstruct, l_shipmode, l_comment] }
-              LogicalScan { table: part, columns: [_row_id, p_partkey, p_name, p_mfgr, p_brand, p_type, p_size, p_container, p_retailprice, p_comment] }
+            LogicalJoin { type: Inner, on: true, output: all }
+              LogicalScan { table: lineitem, columns: [lineitem._row_id, lineitem.l_orderkey, lineitem.l_partkey, lineitem.l_suppkey, lineitem.l_linenumber, lineitem.l_quantity, lineitem.l_extendedprice, lineitem.l_discount, lineitem.l_tax, lineitem.l_returnflag, lineitem.l_linestatus, lineitem.l_shipdate, lineitem.l_commitdate, lineitem.l_receiptdate, lineitem.l_shipinstruct, lineitem.l_shipmode, lineitem.l_comment] }
+              LogicalScan { table: part, columns: [part._row_id, part.p_partkey, part.p_name, part.p_mfgr, part.p_brand, part.p_type, part.p_size, part.p_container, part.p_retailprice, part.p_comment] }
   optimized_logical_plan: |
     LogicalAgg { aggs: [sum((lineitem.l_extendedprice * (1:Int32 - lineitem.l_discount)))] }
       LogicalProject { exprs: [(lineitem.l_extendedprice * (1:Int32 - lineitem.l_discount))] }
-        LogicalJoin { type: Inner, on: (part.p_partkey = lineitem.l_partkey) AND (((((((part.p_brand = 'Brand#52':Varchar) AND In(part.p_container, 'SM CASE':Varchar, 'SM BOX':Varchar, 'SM PACK':Varchar, 'SM PKG':Varchar)) AND (lineitem.l_quantity >= 1:Int32)) AND (lineitem.l_quantity <= 11:Int32)) AND (part.p_size <= 5:Int32)) OR (((((part.p_brand = 'Brand#24':Varchar) AND In(part.p_container, 'MED BAG':Varchar, 'MED BOX':Varchar, 'MED PKG':Varchar, 'MED PACK':Varchar)) AND (lineitem.l_quantity >= 30:Int32)) AND (lineitem.l_quantity <= 40:Int32)) AND (part.p_size <= 10:Int32))) OR (((((part.p_brand = 'Brand#32':Varchar) AND In(part.p_container, 'LG CASE':Varchar, 'LG BOX':Varchar, 'LG PACK':Varchar, 'LG PKG':Varchar)) AND (lineitem.l_quantity >= 10:Int32)) AND (lineitem.l_quantity <= 20:Int32)) AND (part.p_size <= 15:Int32))) }
-          LogicalScan { table: lineitem, output_columns: [l_partkey, l_quantity, l_extendedprice, l_discount], required_columns: [l_partkey, l_quantity, l_extendedprice, l_discount, l_shipinstruct, l_shipmode], predicate: In(lineitem.l_shipmode, 'AIR':Varchar, 'AIR REG':Varchar) AND (lineitem.l_shipinstruct = 'DELIVER IN PERSON':Varchar) }
-          LogicalScan { table: part, output_columns: [p_partkey, p_brand, p_size, p_container], required_columns: [p_partkey, p_brand, p_size, p_container], predicate: (part.p_size >= 1:Int32) }
+        LogicalJoin { type: Inner, on: (part.p_partkey = lineitem.l_partkey) AND (((((((part.p_brand = 'Brand#52':Varchar) AND In(part.p_container, 'SM CASE':Varchar, 'SM BOX':Varchar, 'SM PACK':Varchar, 'SM PKG':Varchar)) AND (lineitem.l_quantity >= 1:Int32)) AND (lineitem.l_quantity <= 11:Int32)) AND (part.p_size <= 5:Int32)) OR (((((part.p_brand = 'Brand#24':Varchar) AND In(part.p_container, 'MED BAG':Varchar, 'MED BOX':Varchar, 'MED PKG':Varchar, 'MED PACK':Varchar)) AND (lineitem.l_quantity >= 30:Int32)) AND (lineitem.l_quantity <= 40:Int32)) AND (part.p_size <= 10:Int32))) OR (((((part.p_brand = 'Brand#32':Varchar) AND In(part.p_container, 'LG CASE':Varchar, 'LG BOX':Varchar, 'LG PACK':Varchar, 'LG PKG':Varchar)) AND (lineitem.l_quantity >= 10:Int32)) AND (lineitem.l_quantity <= 20:Int32)) AND (part.p_size <= 15:Int32))), output: [lineitem.l_extendedprice, lineitem.l_discount] }
+          LogicalScan { table: lineitem, output_columns: [lineitem.l_partkey, lineitem.l_quantity, lineitem.l_extendedprice, lineitem.l_discount], required_columns: [l_partkey, l_quantity, l_extendedprice, l_discount, l_shipinstruct, l_shipmode], predicate: In(lineitem.l_shipmode, 'AIR':Varchar, 'AIR REG':Varchar) AND (lineitem.l_shipinstruct = 'DELIVER IN PERSON':Varchar) }
+          LogicalScan { table: part, output_columns: [part.p_partkey, part.p_brand, part.p_size, part.p_container], required_columns: [p_partkey, p_brand, p_size, p_container], predicate: (part.p_size >= 1:Int32) }
   batch_plan: |
     BatchSimpleAgg { aggs: [sum(sum((lineitem.l_extendedprice * (1:Int32 - lineitem.l_discount))))] }
       BatchExchange { order: [], dist: Single }
         BatchSimpleAgg { aggs: [sum((lineitem.l_extendedprice * (1:Int32 - lineitem.l_discount)))] }
           BatchProject { exprs: [(lineitem.l_extendedprice * (1:Int32 - lineitem.l_discount))] }
             BatchFilter { predicate: (((((((part.p_brand = 'Brand#52':Varchar) AND In(part.p_container, 'SM CASE':Varchar, 'SM BOX':Varchar, 'SM PACK':Varchar, 'SM PKG':Varchar)) AND (lineitem.l_quantity >= 1:Int32)) AND (lineitem.l_quantity <= 11:Int32)) AND (part.p_size <= 5:Int32)) OR (((((part.p_brand = 'Brand#24':Varchar) AND In(part.p_container, 'MED BAG':Varchar, 'MED BOX':Varchar, 'MED PKG':Varchar, 'MED PACK':Varchar)) AND (lineitem.l_quantity >= 30:Int32)) AND (lineitem.l_quantity <= 40:Int32)) AND (part.p_size <= 10:Int32))) OR (((((part.p_brand = 'Brand#32':Varchar) AND In(part.p_container, 'LG CASE':Varchar, 'LG BOX':Varchar, 'LG PACK':Varchar, 'LG PKG':Varchar)) AND (lineitem.l_quantity >= 10:Int32)) AND (lineitem.l_quantity <= 20:Int32)) AND (part.p_size <= 15:Int32))) }
-              BatchHashJoin { type: Inner, predicate: lineitem.l_partkey = part.p_partkey }
+              BatchHashJoin { type: Inner, predicate: lineitem.l_partkey = part.p_partkey, output: all }
                 BatchExchange { order: [], dist: HashShard(lineitem.l_partkey) }
                   BatchProject { exprs: [lineitem.l_partkey, lineitem.l_quantity, lineitem.l_extendedprice, lineitem.l_discount] }
                     BatchFilter { predicate: In(lineitem.l_shipmode, 'AIR':Varchar, 'AIR REG':Varchar) AND (lineitem.l_shipinstruct = 'DELIVER IN PERSON':Varchar) }
-                      BatchScan { table: lineitem, columns: [l_partkey, l_quantity, l_extendedprice, l_discount, l_shipinstruct, l_shipmode] }
+                      BatchScan { table: lineitem, columns: [lineitem.l_partkey, lineitem.l_quantity, lineitem.l_extendedprice, lineitem.l_discount, lineitem.l_shipinstruct, lineitem.l_shipmode], distribution: SomeShard }
                 BatchExchange { order: [], dist: HashShard(part.p_partkey) }
                   BatchFilter { predicate: (part.p_size >= 1:Int32) }
-                    BatchScan { table: part, columns: [p_partkey, p_brand, p_size, p_container] }
+                    BatchScan { table: part, columns: [part.p_partkey, part.p_brand, part.p_size, part.p_container], distribution: SomeShard }
   stream_plan: |
     StreamMaterialize { columns: [sum(count)(hidden), revenue], pk_columns: [] }
       StreamGlobalSimpleAgg { aggs: [sum(count), sum(sum((lineitem.l_extendedprice * (1:Int32 - lineitem.l_discount))))] }
@@ -1985,14 +1985,14 @@
           StreamLocalSimpleAgg { aggs: [count, sum((lineitem.l_extendedprice * (1:Int32 - lineitem.l_discount)))] }
             StreamProject { exprs: [(lineitem.l_extendedprice * (1:Int32 - lineitem.l_discount)), lineitem._row_id, part._row_id] }
               StreamFilter { predicate: (((((((part.p_brand = 'Brand#52':Varchar) AND In(part.p_container, 'SM CASE':Varchar, 'SM BOX':Varchar, 'SM PACK':Varchar, 'SM PKG':Varchar)) AND (lineitem.l_quantity >= 1:Int32)) AND (lineitem.l_quantity <= 11:Int32)) AND (part.p_size <= 5:Int32)) OR (((((part.p_brand = 'Brand#24':Varchar) AND In(part.p_container, 'MED BAG':Varchar, 'MED BOX':Varchar, 'MED PKG':Varchar, 'MED PACK':Varchar)) AND (lineitem.l_quantity >= 30:Int32)) AND (lineitem.l_quantity <= 40:Int32)) AND (part.p_size <= 10:Int32))) OR (((((part.p_brand = 'Brand#32':Varchar) AND In(part.p_container, 'LG CASE':Varchar, 'LG BOX':Varchar, 'LG PACK':Varchar, 'LG PKG':Varchar)) AND (lineitem.l_quantity >= 10:Int32)) AND (lineitem.l_quantity <= 20:Int32)) AND (part.p_size <= 15:Int32))) }
-                StreamHashJoin { type: Inner, predicate: lineitem.l_partkey = part.p_partkey }
+                StreamHashJoin { type: Inner, predicate: lineitem.l_partkey = part.p_partkey, output: all }
                   StreamExchange { dist: HashShard(lineitem.l_partkey) }
                     StreamProject { exprs: [lineitem.l_partkey, lineitem.l_quantity, lineitem.l_extendedprice, lineitem.l_discount, lineitem._row_id] }
                       StreamFilter { predicate: In(lineitem.l_shipmode, 'AIR':Varchar, 'AIR REG':Varchar) AND (lineitem.l_shipinstruct = 'DELIVER IN PERSON':Varchar) }
-                        StreamTableScan { table: lineitem, columns: [l_partkey, l_quantity, l_extendedprice, l_discount, _row_id, l_shipinstruct, l_shipmode] }
+                        StreamTableScan { table: lineitem, columns: [lineitem.l_partkey, lineitem.l_quantity, lineitem.l_extendedprice, lineitem.l_discount, lineitem._row_id, lineitem.l_shipinstruct, lineitem.l_shipmode], pk: [lineitem._row_id], distribution: HashShard(lineitem._row_id) }
                   StreamExchange { dist: HashShard(part.p_partkey) }
                     StreamFilter { predicate: (part.p_size >= 1:Int32) }
-                      StreamTableScan { table: part, columns: [p_partkey, p_brand, p_size, p_container, _row_id] }
+                      StreamTableScan { table: part, columns: [part.p_partkey, part.p_brand, part.p_size, part.p_container, part._row_id], pk: [part._row_id], distribution: HashShard(part._row_id) }
 - id: tpch_q20
   before:
   - create_tables
@@ -2037,95 +2037,95 @@
   logical_plan: |
     LogicalProject { exprs: [supplier.s_name, supplier.s_address] }
       LogicalFilter { predicate: (supplier.s_nationkey = nation.n_nationkey) AND (nation.n_name = 'KENYA':Varchar) }
-        LogicalJoin { type: LeftSemi, on: (supplier.s_suppkey = partsupp.ps_suppkey) }
-          LogicalJoin { type: Inner, on: true }
-            LogicalScan { table: supplier, columns: [_row_id, s_suppkey, s_name, s_address, s_nationkey, s_phone, s_acctbal, s_comment] }
-            LogicalScan { table: nation, columns: [_row_id, n_nationkey, n_name, n_regionkey, n_comment] }
+        LogicalJoin { type: LeftSemi, on: (supplier.s_suppkey = partsupp.ps_suppkey), output: all }
+          LogicalJoin { type: Inner, on: true, output: all }
+            LogicalScan { table: supplier, columns: [supplier._row_id, supplier.s_suppkey, supplier.s_name, supplier.s_address, supplier.s_nationkey, supplier.s_phone, supplier.s_acctbal, supplier.s_comment] }
+            LogicalScan { table: nation, columns: [nation._row_id, nation.n_nationkey, nation.n_name, nation.n_regionkey, nation.n_comment] }
           LogicalProject { exprs: [partsupp.ps_suppkey] }
             LogicalFilter { predicate: (partsupp.ps_availqty > (0.5:Decimal * sum(lineitem.l_quantity))) }
               LogicalApply { type: LeftOuter, on: true, correlated_id: 3 }
-                LogicalJoin { type: LeftSemi, on: (partsupp.ps_partkey = part.p_partkey) }
-                  LogicalScan { table: partsupp, columns: [_row_id, ps_partkey, ps_suppkey, ps_availqty, ps_supplycost, ps_comment] }
+                LogicalJoin { type: LeftSemi, on: (partsupp.ps_partkey = part.p_partkey), output: all }
+                  LogicalScan { table: partsupp, columns: [partsupp._row_id, partsupp.ps_partkey, partsupp.ps_suppkey, partsupp.ps_availqty, partsupp.ps_supplycost, partsupp.ps_comment] }
                   LogicalProject { exprs: [part.p_partkey] }
                     LogicalFilter { predicate: Like(part.p_name, 'forest%':Varchar) }
-                      LogicalScan { table: part, columns: [_row_id, p_partkey, p_name, p_mfgr, p_brand, p_type, p_size, p_container, p_retailprice, p_comment] }
+                      LogicalScan { table: part, columns: [part._row_id, part.p_partkey, part.p_name, part.p_mfgr, part.p_brand, part.p_type, part.p_size, part.p_container, part.p_retailprice, part.p_comment] }
                 LogicalProject { exprs: [(0.5:Decimal * sum(lineitem.l_quantity))] }
                   LogicalAgg { aggs: [sum(lineitem.l_quantity)] }
                     LogicalProject { exprs: [lineitem.l_quantity] }
                       LogicalFilter { predicate: (lineitem.l_partkey = CorrelatedInputRef { index: 1, correlated_id: 3 }) AND (lineitem.l_suppkey = CorrelatedInputRef { index: 2, correlated_id: 3 }) AND (lineitem.l_shipdate >= '1994-01-01':Varchar::Date) AND (lineitem.l_shipdate < ('1994-01-01':Varchar::Date + '1 year 00:00:00':Interval)) }
-                        LogicalScan { table: lineitem, columns: [_row_id, l_orderkey, l_partkey, l_suppkey, l_linenumber, l_quantity, l_extendedprice, l_discount, l_tax, l_returnflag, l_linestatus, l_shipdate, l_commitdate, l_receiptdate, l_shipinstruct, l_shipmode, l_comment] }
+                        LogicalScan { table: lineitem, columns: [lineitem._row_id, lineitem.l_orderkey, lineitem.l_partkey, lineitem.l_suppkey, lineitem.l_linenumber, lineitem.l_quantity, lineitem.l_extendedprice, lineitem.l_discount, lineitem.l_tax, lineitem.l_returnflag, lineitem.l_linestatus, lineitem.l_shipdate, lineitem.l_commitdate, lineitem.l_receiptdate, lineitem.l_shipinstruct, lineitem.l_shipmode, lineitem.l_comment] }
   optimized_logical_plan: |
-    LogicalJoin { type: LeftSemi, on: (supplier.s_suppkey = partsupp.ps_suppkey) }
-      LogicalJoin { type: Inner, on: (supplier.s_nationkey = nation.n_nationkey) }
-        LogicalScan { table: supplier, columns: [s_suppkey, s_name, s_address, s_nationkey] }
-        LogicalScan { table: nation, output_columns: [n_nationkey], required_columns: [n_nationkey, n_name], predicate: (nation.n_name = 'KENYA':Varchar) }
-      LogicalJoin { type: Inner, on: (partsupp.ps_partkey = lineitem.l_partkey) AND (partsupp.ps_suppkey = lineitem.l_suppkey) AND (partsupp.ps_availqty > (0.5:Decimal * sum(lineitem.l_quantity))) }
-        LogicalJoin { type: LeftSemi, on: (partsupp.ps_partkey = part.p_partkey) }
-          LogicalScan { table: partsupp, columns: [ps_partkey, ps_suppkey, ps_availqty] }
-          LogicalScan { table: part, output_columns: [p_partkey], required_columns: [p_partkey, p_name], predicate: Like(part.p_name, 'forest%':Varchar) }
+    LogicalJoin { type: LeftSemi, on: (supplier.s_suppkey = partsupp.ps_suppkey), output: [supplier.s_name, supplier.s_address] }
+      LogicalJoin { type: Inner, on: (supplier.s_nationkey = nation.n_nationkey), output: [supplier.s_suppkey, supplier.s_name, supplier.s_address] }
+        LogicalScan { table: supplier, columns: [supplier.s_suppkey, supplier.s_name, supplier.s_address, supplier.s_nationkey] }
+        LogicalScan { table: nation, output_columns: [nation.n_nationkey], required_columns: [n_nationkey, n_name], predicate: (nation.n_name = 'KENYA':Varchar) }
+      LogicalJoin { type: Inner, on: (partsupp.ps_partkey = lineitem.l_partkey) AND (partsupp.ps_suppkey = lineitem.l_suppkey) AND (partsupp.ps_availqty > (0.5:Decimal * sum(lineitem.l_quantity))), output: [partsupp.ps_suppkey] }
+        LogicalJoin { type: LeftSemi, on: (partsupp.ps_partkey = part.p_partkey), output: all }
+          LogicalScan { table: partsupp, columns: [partsupp.ps_partkey, partsupp.ps_suppkey, partsupp.ps_availqty] }
+          LogicalScan { table: part, output_columns: [part.p_partkey], required_columns: [p_partkey, p_name], predicate: Like(part.p_name, 'forest%':Varchar) }
         LogicalProject { exprs: [lineitem.l_partkey, lineitem.l_suppkey, (0.5:Decimal * sum(lineitem.l_quantity))] }
           LogicalAgg { group_key: [lineitem.l_partkey, lineitem.l_suppkey], aggs: [sum(lineitem.l_quantity)] }
-            LogicalScan { table: lineitem, output_columns: [l_partkey, l_suppkey, l_quantity], required_columns: [l_partkey, l_suppkey, l_quantity, l_shipdate], predicate: (lineitem.l_shipdate >= '1994-01-01':Varchar::Date) AND (lineitem.l_shipdate < ('1994-01-01':Varchar::Date + '1 year 00:00:00':Interval)) }
+            LogicalScan { table: lineitem, output_columns: [lineitem.l_partkey, lineitem.l_suppkey, lineitem.l_quantity], required_columns: [l_partkey, l_suppkey, l_quantity, l_shipdate], predicate: (lineitem.l_shipdate >= '1994-01-01':Varchar::Date) AND (lineitem.l_shipdate < ('1994-01-01':Varchar::Date + '1 year 00:00:00':Interval)) }
   batch_plan: |
     BatchExchange { order: [supplier.s_name ASC], dist: Single }
       BatchSort { order: [supplier.s_name ASC] }
-        BatchHashJoin { type: LeftSemi, predicate: supplier.s_suppkey = partsupp.ps_suppkey }
+        BatchHashJoin { type: LeftSemi, predicate: supplier.s_suppkey = partsupp.ps_suppkey, output: [supplier.s_name, supplier.s_address] }
           BatchExchange { order: [], dist: HashShard(supplier.s_suppkey) }
-            BatchHashJoin { type: Inner, predicate: supplier.s_nationkey = nation.n_nationkey }
+            BatchHashJoin { type: Inner, predicate: supplier.s_nationkey = nation.n_nationkey, output: [supplier.s_suppkey, supplier.s_name, supplier.s_address] }
               BatchExchange { order: [], dist: HashShard(supplier.s_nationkey) }
-                BatchScan { table: supplier, columns: [s_suppkey, s_name, s_address, s_nationkey] }
+                BatchScan { table: supplier, columns: [supplier.s_suppkey, supplier.s_name, supplier.s_address, supplier.s_nationkey], distribution: SomeShard }
               BatchExchange { order: [], dist: HashShard(nation.n_nationkey) }
                 BatchProject { exprs: [nation.n_nationkey] }
                   BatchFilter { predicate: (nation.n_name = 'KENYA':Varchar) }
-                    BatchScan { table: nation, columns: [n_nationkey, n_name] }
+                    BatchScan { table: nation, columns: [nation.n_nationkey, nation.n_name], distribution: SomeShard }
           BatchExchange { order: [], dist: HashShard(partsupp.ps_suppkey) }
             BatchProject { exprs: [partsupp.ps_suppkey] }
               BatchFilter { predicate: (partsupp.ps_availqty > (0.5:Decimal * sum(lineitem.l_quantity))) }
-                BatchHashJoin { type: Inner, predicate: partsupp.ps_partkey = lineitem.l_partkey AND partsupp.ps_suppkey = lineitem.l_suppkey }
+                BatchHashJoin { type: Inner, predicate: partsupp.ps_partkey = lineitem.l_partkey AND partsupp.ps_suppkey = lineitem.l_suppkey, output: all }
                   BatchExchange { order: [], dist: HashShard(partsupp.ps_partkey, partsupp.ps_suppkey) }
-                    BatchHashJoin { type: LeftSemi, predicate: partsupp.ps_partkey = part.p_partkey }
+                    BatchHashJoin { type: LeftSemi, predicate: partsupp.ps_partkey = part.p_partkey, output: all }
                       BatchExchange { order: [], dist: HashShard(partsupp.ps_partkey) }
-                        BatchScan { table: partsupp, columns: [ps_partkey, ps_suppkey, ps_availqty] }
+                        BatchScan { table: partsupp, columns: [partsupp.ps_partkey, partsupp.ps_suppkey, partsupp.ps_availqty], distribution: SomeShard }
                       BatchExchange { order: [], dist: HashShard(part.p_partkey) }
                         BatchProject { exprs: [part.p_partkey] }
                           BatchFilter { predicate: Like(part.p_name, 'forest%':Varchar) }
-                            BatchScan { table: part, columns: [p_partkey, p_name] }
+                            BatchScan { table: part, columns: [part.p_partkey, part.p_name], distribution: SomeShard }
                   BatchProject { exprs: [lineitem.l_partkey, lineitem.l_suppkey, (0.5:Decimal * sum(lineitem.l_quantity))] }
                     BatchHashAgg { group_key: [lineitem.l_partkey, lineitem.l_suppkey], aggs: [sum(lineitem.l_quantity)] }
                       BatchExchange { order: [], dist: HashShard(lineitem.l_partkey, lineitem.l_suppkey) }
                         BatchProject { exprs: [lineitem.l_partkey, lineitem.l_suppkey, lineitem.l_quantity] }
                           BatchFilter { predicate: (lineitem.l_shipdate >= '1994-01-01':Varchar::Date) AND (lineitem.l_shipdate < ('1994-01-01':Varchar::Date + '1 year 00:00:00':Interval)) }
-                            BatchScan { table: lineitem, columns: [l_partkey, l_suppkey, l_quantity, l_shipdate] }
+                            BatchScan { table: lineitem, columns: [lineitem.l_partkey, lineitem.l_suppkey, lineitem.l_quantity, lineitem.l_shipdate], distribution: SomeShard }
   stream_plan: |
     StreamMaterialize { columns: [s_name, s_address, supplier._row_id(hidden), nation._row_id(hidden)], pk_columns: [supplier._row_id, nation._row_id], order_descs: [s_name, supplier._row_id, nation._row_id] }
       StreamExchange { dist: HashShard(supplier._row_id, nation._row_id) }
-        StreamHashJoin { type: LeftSemi, predicate: supplier.s_suppkey = partsupp.ps_suppkey }
+        StreamHashJoin { type: LeftSemi, predicate: supplier.s_suppkey = partsupp.ps_suppkey, output: [supplier.s_name, supplier.s_address, supplier._row_id, nation._row_id] }
           StreamExchange { dist: HashShard(supplier.s_suppkey) }
-            StreamHashJoin { type: Inner, predicate: supplier.s_nationkey = nation.n_nationkey }
+            StreamHashJoin { type: Inner, predicate: supplier.s_nationkey = nation.n_nationkey, output: [supplier.s_suppkey, supplier.s_name, supplier.s_address, supplier._row_id, nation._row_id] }
               StreamExchange { dist: HashShard(supplier.s_nationkey) }
-                StreamTableScan { table: supplier, columns: [s_suppkey, s_name, s_address, s_nationkey, _row_id] }
+                StreamTableScan { table: supplier, columns: [supplier.s_suppkey, supplier.s_name, supplier.s_address, supplier.s_nationkey, supplier._row_id], pk: [supplier._row_id], distribution: HashShard(supplier._row_id) }
               StreamExchange { dist: HashShard(nation.n_nationkey) }
                 StreamProject { exprs: [nation.n_nationkey, nation._row_id] }
                   StreamFilter { predicate: (nation.n_name = 'KENYA':Varchar) }
-                    StreamTableScan { table: nation, columns: [n_nationkey, _row_id, n_name] }
+                    StreamTableScan { table: nation, columns: [nation.n_nationkey, nation._row_id, nation.n_name], pk: [nation._row_id], distribution: HashShard(nation._row_id) }
           StreamExchange { dist: HashShard(partsupp.ps_suppkey) }
             StreamProject { exprs: [partsupp.ps_suppkey, partsupp._row_id, lineitem.l_partkey, lineitem.l_suppkey] }
               StreamFilter { predicate: (partsupp.ps_availqty > (0.5:Decimal * sum(lineitem.l_quantity))) }
-                StreamHashJoin { type: Inner, predicate: partsupp.ps_partkey = lineitem.l_partkey AND partsupp.ps_suppkey = lineitem.l_suppkey }
+                StreamHashJoin { type: Inner, predicate: partsupp.ps_partkey = lineitem.l_partkey AND partsupp.ps_suppkey = lineitem.l_suppkey, output: all }
                   StreamExchange { dist: HashShard(partsupp.ps_partkey, partsupp.ps_suppkey) }
-                    StreamHashJoin { type: LeftSemi, predicate: partsupp.ps_partkey = part.p_partkey }
+                    StreamHashJoin { type: LeftSemi, predicate: partsupp.ps_partkey = part.p_partkey, output: all }
                       StreamExchange { dist: HashShard(partsupp.ps_partkey) }
-                        StreamTableScan { table: partsupp, columns: [ps_partkey, ps_suppkey, ps_availqty, _row_id] }
+                        StreamTableScan { table: partsupp, columns: [partsupp.ps_partkey, partsupp.ps_suppkey, partsupp.ps_availqty, partsupp._row_id], pk: [partsupp._row_id], distribution: HashShard(partsupp._row_id) }
                       StreamExchange { dist: HashShard(part.p_partkey) }
                         StreamProject { exprs: [part.p_partkey, part._row_id] }
                           StreamFilter { predicate: Like(part.p_name, 'forest%':Varchar) }
-                            StreamTableScan { table: part, columns: [p_partkey, _row_id, p_name] }
+                            StreamTableScan { table: part, columns: [part.p_partkey, part._row_id, part.p_name], pk: [part._row_id], distribution: HashShard(part._row_id) }
                   StreamProject { exprs: [lineitem.l_partkey, lineitem.l_suppkey, (0.5:Decimal * sum(lineitem.l_quantity))] }
                     StreamHashAgg { group_key: [lineitem.l_partkey, lineitem.l_suppkey], aggs: [count, sum(lineitem.l_quantity)] }
                       StreamExchange { dist: HashShard(lineitem.l_partkey, lineitem.l_suppkey) }
                         StreamProject { exprs: [lineitem.l_partkey, lineitem.l_suppkey, lineitem.l_quantity, lineitem._row_id] }
                           StreamFilter { predicate: (lineitem.l_shipdate >= '1994-01-01':Varchar::Date) AND (lineitem.l_shipdate < ('1994-01-01':Varchar::Date + '1 year 00:00:00':Interval)) }
-                            StreamTableScan { table: lineitem, columns: [l_partkey, l_suppkey, l_quantity, _row_id, l_shipdate] }
+                            StreamTableScan { table: lineitem, columns: [lineitem.l_partkey, lineitem.l_suppkey, lineitem.l_quantity, lineitem._row_id, lineitem.l_shipdate], pk: [lineitem._row_id], distribution: HashShard(lineitem._row_id) }
 - id: tpch_q21
   before:
   - create_tables
@@ -2178,99 +2178,99 @@
             LogicalFilter { predicate: (supplier.s_suppkey = lineitem.l_suppkey) AND (orders.o_orderkey = lineitem.l_orderkey) AND (orders.o_orderstatus = 'F':Varchar) AND (lineitem.l_receiptdate > lineitem.l_commitdate) AND (supplier.s_nationkey = nation.n_nationkey) AND (nation.n_name = 'GERMANY':Varchar) }
               LogicalApply { type: LeftAnti, on: true, correlated_id: 2 }
                 LogicalApply { type: LeftSemi, on: true, correlated_id: 1 }
-                  LogicalJoin { type: Inner, on: true }
-                    LogicalJoin { type: Inner, on: true }
-                      LogicalJoin { type: Inner, on: true }
-                        LogicalScan { table: supplier, columns: [_row_id, s_suppkey, s_name, s_address, s_nationkey, s_phone, s_acctbal, s_comment] }
-                        LogicalScan { table: lineitem, columns: [_row_id, l_orderkey, l_partkey, l_suppkey, l_linenumber, l_quantity, l_extendedprice, l_discount, l_tax, l_returnflag, l_linestatus, l_shipdate, l_commitdate, l_receiptdate, l_shipinstruct, l_shipmode, l_comment] }
-                      LogicalScan { table: orders, columns: [_row_id, o_orderkey, o_custkey, o_orderstatus, o_totalprice, o_orderdate, o_orderpriority, o_clerk, o_shippriority, o_comment] }
-                    LogicalScan { table: nation, columns: [_row_id, n_nationkey, n_name, n_regionkey, n_comment] }
+                  LogicalJoin { type: Inner, on: true, output: all }
+                    LogicalJoin { type: Inner, on: true, output: all }
+                      LogicalJoin { type: Inner, on: true, output: all }
+                        LogicalScan { table: supplier, columns: [supplier._row_id, supplier.s_suppkey, supplier.s_name, supplier.s_address, supplier.s_nationkey, supplier.s_phone, supplier.s_acctbal, supplier.s_comment] }
+                        LogicalScan { table: lineitem, columns: [lineitem._row_id, lineitem.l_orderkey, lineitem.l_partkey, lineitem.l_suppkey, lineitem.l_linenumber, lineitem.l_quantity, lineitem.l_extendedprice, lineitem.l_discount, lineitem.l_tax, lineitem.l_returnflag, lineitem.l_linestatus, lineitem.l_shipdate, lineitem.l_commitdate, lineitem.l_receiptdate, lineitem.l_shipinstruct, lineitem.l_shipmode, lineitem.l_comment] }
+                      LogicalScan { table: orders, columns: [orders._row_id, orders.o_orderkey, orders.o_custkey, orders.o_orderstatus, orders.o_totalprice, orders.o_orderdate, orders.o_orderpriority, orders.o_clerk, orders.o_shippriority, orders.o_comment] }
+                    LogicalScan { table: nation, columns: [nation._row_id, nation.n_nationkey, nation.n_name, nation.n_regionkey, nation.n_comment] }
                   LogicalProject { exprs: [lineitem.l_orderkey, lineitem.l_partkey, lineitem.l_suppkey, lineitem.l_linenumber, lineitem.l_quantity, lineitem.l_extendedprice, lineitem.l_discount, lineitem.l_tax, lineitem.l_returnflag, lineitem.l_linestatus, lineitem.l_shipdate, lineitem.l_commitdate, lineitem.l_receiptdate, lineitem.l_shipinstruct, lineitem.l_shipmode, lineitem.l_comment] }
                     LogicalFilter { predicate: (lineitem.l_orderkey = CorrelatedInputRef { index: 9, correlated_id: 1 }) AND (lineitem.l_suppkey <> CorrelatedInputRef { index: 11, correlated_id: 1 }) }
-                      LogicalScan { table: lineitem, columns: [_row_id, l_orderkey, l_partkey, l_suppkey, l_linenumber, l_quantity, l_extendedprice, l_discount, l_tax, l_returnflag, l_linestatus, l_shipdate, l_commitdate, l_receiptdate, l_shipinstruct, l_shipmode, l_comment] }
+                      LogicalScan { table: lineitem, columns: [lineitem._row_id, lineitem.l_orderkey, lineitem.l_partkey, lineitem.l_suppkey, lineitem.l_linenumber, lineitem.l_quantity, lineitem.l_extendedprice, lineitem.l_discount, lineitem.l_tax, lineitem.l_returnflag, lineitem.l_linestatus, lineitem.l_shipdate, lineitem.l_commitdate, lineitem.l_receiptdate, lineitem.l_shipinstruct, lineitem.l_shipmode, lineitem.l_comment] }
                 LogicalProject { exprs: [lineitem.l_orderkey, lineitem.l_partkey, lineitem.l_suppkey, lineitem.l_linenumber, lineitem.l_quantity, lineitem.l_extendedprice, lineitem.l_discount, lineitem.l_tax, lineitem.l_returnflag, lineitem.l_linestatus, lineitem.l_shipdate, lineitem.l_commitdate, lineitem.l_receiptdate, lineitem.l_shipinstruct, lineitem.l_shipmode, lineitem.l_comment] }
                   LogicalFilter { predicate: (lineitem.l_orderkey = CorrelatedInputRef { index: 9, correlated_id: 2 }) AND (lineitem.l_suppkey <> CorrelatedInputRef { index: 11, correlated_id: 2 }) AND (lineitem.l_receiptdate > lineitem.l_commitdate) }
-                    LogicalScan { table: lineitem, columns: [_row_id, l_orderkey, l_partkey, l_suppkey, l_linenumber, l_quantity, l_extendedprice, l_discount, l_tax, l_returnflag, l_linestatus, l_shipdate, l_commitdate, l_receiptdate, l_shipinstruct, l_shipmode, l_comment] }
+                    LogicalScan { table: lineitem, columns: [lineitem._row_id, lineitem.l_orderkey, lineitem.l_partkey, lineitem.l_suppkey, lineitem.l_linenumber, lineitem.l_quantity, lineitem.l_extendedprice, lineitem.l_discount, lineitem.l_tax, lineitem.l_returnflag, lineitem.l_linestatus, lineitem.l_shipdate, lineitem.l_commitdate, lineitem.l_receiptdate, lineitem.l_shipinstruct, lineitem.l_shipmode, lineitem.l_comment] }
   optimized_logical_plan: |
     LogicalTopN { order: "[count DESC, supplier.s_name ASC]", limit: 100, offset: 0 }
       LogicalAgg { group_key: [supplier.s_name], aggs: [count] }
-        LogicalJoin { type: LeftAnti, on: (lineitem.l_orderkey = lineitem.l_orderkey) AND (lineitem.l_suppkey <> lineitem.l_suppkey) }
-          LogicalJoin { type: LeftSemi, on: (lineitem.l_orderkey = lineitem.l_orderkey) AND (lineitem.l_suppkey <> lineitem.l_suppkey) }
-            LogicalJoin { type: Inner, on: (orders.o_orderkey = lineitem.l_orderkey) }
-              LogicalJoin { type: Inner, on: (supplier.s_nationkey = nation.n_nationkey) }
-                LogicalJoin { type: Inner, on: (supplier.s_suppkey = lineitem.l_suppkey) }
-                  LogicalScan { table: supplier, columns: [s_suppkey, s_name, s_nationkey] }
-                  LogicalScan { table: lineitem, output_columns: [l_orderkey, l_suppkey], required_columns: [l_orderkey, l_suppkey, l_commitdate, l_receiptdate], predicate: (lineitem.l_receiptdate > lineitem.l_commitdate) }
-                LogicalScan { table: nation, output_columns: [n_nationkey], required_columns: [n_nationkey, n_name], predicate: (nation.n_name = 'GERMANY':Varchar) }
-              LogicalScan { table: orders, output_columns: [o_orderkey], required_columns: [o_orderkey, o_orderstatus], predicate: (orders.o_orderstatus = 'F':Varchar) }
-            LogicalScan { table: lineitem, columns: [l_orderkey, l_suppkey] }
-          LogicalScan { table: lineitem, output_columns: [l_orderkey, l_suppkey], required_columns: [l_orderkey, l_suppkey, l_commitdate, l_receiptdate], predicate: (lineitem.l_receiptdate > lineitem.l_commitdate) }
+        LogicalJoin { type: LeftAnti, on: (lineitem.l_orderkey = lineitem.l_orderkey) AND (lineitem.l_suppkey <> lineitem.l_suppkey), output: [supplier.s_name] }
+          LogicalJoin { type: LeftSemi, on: (lineitem.l_orderkey = lineitem.l_orderkey) AND (lineitem.l_suppkey <> lineitem.l_suppkey), output: all }
+            LogicalJoin { type: Inner, on: (orders.o_orderkey = lineitem.l_orderkey), output: [supplier.s_name, lineitem.l_orderkey, lineitem.l_suppkey] }
+              LogicalJoin { type: Inner, on: (supplier.s_nationkey = nation.n_nationkey), output: [supplier.s_name, lineitem.l_orderkey, lineitem.l_suppkey] }
+                LogicalJoin { type: Inner, on: (supplier.s_suppkey = lineitem.l_suppkey), output: [supplier.s_name, supplier.s_nationkey, lineitem.l_orderkey, lineitem.l_suppkey] }
+                  LogicalScan { table: supplier, columns: [supplier.s_suppkey, supplier.s_name, supplier.s_nationkey] }
+                  LogicalScan { table: lineitem, output_columns: [lineitem.l_orderkey, lineitem.l_suppkey], required_columns: [l_orderkey, l_suppkey, l_commitdate, l_receiptdate], predicate: (lineitem.l_receiptdate > lineitem.l_commitdate) }
+                LogicalScan { table: nation, output_columns: [nation.n_nationkey], required_columns: [n_nationkey, n_name], predicate: (nation.n_name = 'GERMANY':Varchar) }
+              LogicalScan { table: orders, output_columns: [orders.o_orderkey], required_columns: [o_orderkey, o_orderstatus], predicate: (orders.o_orderstatus = 'F':Varchar) }
+            LogicalScan { table: lineitem, columns: [lineitem.l_orderkey, lineitem.l_suppkey] }
+          LogicalScan { table: lineitem, output_columns: [lineitem.l_orderkey, lineitem.l_suppkey], required_columns: [l_orderkey, l_suppkey, l_commitdate, l_receiptdate], predicate: (lineitem.l_receiptdate > lineitem.l_commitdate) }
   batch_plan: |
     BatchTopN { order: "[count DESC, supplier.s_name ASC]", limit: 100, offset: 0 }
       BatchExchange { order: [], dist: Single }
         BatchTopN { order: "[count DESC, supplier.s_name ASC]", limit: 100, offset: 0 }
           BatchHashAgg { group_key: [supplier.s_name], aggs: [count] }
             BatchExchange { order: [], dist: HashShard(supplier.s_name) }
-              BatchHashJoin { type: LeftAnti, predicate: lineitem.l_orderkey = lineitem.l_orderkey AND (lineitem.l_suppkey <> lineitem.l_suppkey) }
-                BatchHashJoin { type: LeftSemi, predicate: lineitem.l_orderkey = lineitem.l_orderkey AND (lineitem.l_suppkey <> lineitem.l_suppkey) }
-                  BatchHashJoin { type: Inner, predicate: lineitem.l_orderkey = orders.o_orderkey }
+              BatchHashJoin { type: LeftAnti, predicate: lineitem.l_orderkey = lineitem.l_orderkey AND (lineitem.l_suppkey <> lineitem.l_suppkey), output: [supplier.s_name] }
+                BatchHashJoin { type: LeftSemi, predicate: lineitem.l_orderkey = lineitem.l_orderkey AND (lineitem.l_suppkey <> lineitem.l_suppkey), output: all }
+                  BatchHashJoin { type: Inner, predicate: lineitem.l_orderkey = orders.o_orderkey, output: [supplier.s_name, lineitem.l_orderkey, lineitem.l_suppkey] }
                     BatchExchange { order: [], dist: HashShard(lineitem.l_orderkey) }
-                      BatchHashJoin { type: Inner, predicate: supplier.s_nationkey = nation.n_nationkey }
+                      BatchHashJoin { type: Inner, predicate: supplier.s_nationkey = nation.n_nationkey, output: [supplier.s_name, lineitem.l_orderkey, lineitem.l_suppkey] }
                         BatchExchange { order: [], dist: HashShard(supplier.s_nationkey) }
-                          BatchHashJoin { type: Inner, predicate: supplier.s_suppkey = lineitem.l_suppkey }
+                          BatchHashJoin { type: Inner, predicate: supplier.s_suppkey = lineitem.l_suppkey, output: [supplier.s_name, supplier.s_nationkey, lineitem.l_orderkey, lineitem.l_suppkey] }
                             BatchExchange { order: [], dist: HashShard(supplier.s_suppkey) }
-                              BatchScan { table: supplier, columns: [s_suppkey, s_name, s_nationkey] }
+                              BatchScan { table: supplier, columns: [supplier.s_suppkey, supplier.s_name, supplier.s_nationkey], distribution: SomeShard }
                             BatchExchange { order: [], dist: HashShard(lineitem.l_suppkey) }
                               BatchProject { exprs: [lineitem.l_orderkey, lineitem.l_suppkey] }
                                 BatchFilter { predicate: (lineitem.l_receiptdate > lineitem.l_commitdate) }
-                                  BatchScan { table: lineitem, columns: [l_orderkey, l_suppkey, l_commitdate, l_receiptdate] }
+                                  BatchScan { table: lineitem, columns: [lineitem.l_orderkey, lineitem.l_suppkey, lineitem.l_commitdate, lineitem.l_receiptdate], distribution: SomeShard }
                         BatchExchange { order: [], dist: HashShard(nation.n_nationkey) }
                           BatchProject { exprs: [nation.n_nationkey] }
                             BatchFilter { predicate: (nation.n_name = 'GERMANY':Varchar) }
-                              BatchScan { table: nation, columns: [n_nationkey, n_name] }
+                              BatchScan { table: nation, columns: [nation.n_nationkey, nation.n_name], distribution: SomeShard }
                     BatchExchange { order: [], dist: HashShard(orders.o_orderkey) }
                       BatchProject { exprs: [orders.o_orderkey] }
                         BatchFilter { predicate: (orders.o_orderstatus = 'F':Varchar) }
-                          BatchScan { table: orders, columns: [o_orderkey, o_orderstatus] }
+                          BatchScan { table: orders, columns: [orders.o_orderkey, orders.o_orderstatus], distribution: SomeShard }
                   BatchExchange { order: [], dist: HashShard(lineitem.l_orderkey) }
-                    BatchScan { table: lineitem, columns: [l_orderkey, l_suppkey] }
+                    BatchScan { table: lineitem, columns: [lineitem.l_orderkey, lineitem.l_suppkey], distribution: SomeShard }
                 BatchExchange { order: [], dist: HashShard(lineitem.l_orderkey) }
                   BatchProject { exprs: [lineitem.l_orderkey, lineitem.l_suppkey] }
                     BatchFilter { predicate: (lineitem.l_receiptdate > lineitem.l_commitdate) }
-                      BatchScan { table: lineitem, columns: [l_orderkey, l_suppkey, l_commitdate, l_receiptdate] }
+                      BatchScan { table: lineitem, columns: [lineitem.l_orderkey, lineitem.l_suppkey, lineitem.l_commitdate, lineitem.l_receiptdate], distribution: SomeShard }
   stream_plan: |
     StreamMaterialize { columns: [s_name, count(hidden), numwait], pk_columns: [s_name], order_descs: [numwait, s_name] }
       StreamTopN { order: "[count DESC, supplier.s_name ASC]", limit: 100, offset: 0 }
         StreamExchange { dist: Single }
           StreamHashAgg { group_key: [supplier.s_name], aggs: [count, count] }
             StreamExchange { dist: HashShard(supplier.s_name) }
-              StreamHashJoin { type: LeftAnti, predicate: lineitem.l_orderkey = lineitem.l_orderkey AND (lineitem.l_suppkey <> lineitem.l_suppkey) }
-                StreamHashJoin { type: LeftSemi, predicate: lineitem.l_orderkey = lineitem.l_orderkey AND (lineitem.l_suppkey <> lineitem.l_suppkey) }
-                  StreamHashJoin { type: Inner, predicate: lineitem.l_orderkey = orders.o_orderkey }
+              StreamHashJoin { type: LeftAnti, predicate: lineitem.l_orderkey = lineitem.l_orderkey AND (lineitem.l_suppkey <> lineitem.l_suppkey), output: [supplier.s_name, supplier._row_id, lineitem._row_id, nation._row_id, orders._row_id] }
+                StreamHashJoin { type: LeftSemi, predicate: lineitem.l_orderkey = lineitem.l_orderkey AND (lineitem.l_suppkey <> lineitem.l_suppkey), output: all }
+                  StreamHashJoin { type: Inner, predicate: lineitem.l_orderkey = orders.o_orderkey, output: [supplier.s_name, lineitem.l_orderkey, lineitem.l_suppkey, supplier._row_id, lineitem._row_id, nation._row_id, orders._row_id] }
                     StreamExchange { dist: HashShard(lineitem.l_orderkey) }
-                      StreamHashJoin { type: Inner, predicate: supplier.s_nationkey = nation.n_nationkey }
+                      StreamHashJoin { type: Inner, predicate: supplier.s_nationkey = nation.n_nationkey, output: [supplier.s_name, lineitem.l_orderkey, lineitem.l_suppkey, supplier._row_id, lineitem._row_id, nation._row_id] }
                         StreamExchange { dist: HashShard(supplier.s_nationkey) }
-                          StreamHashJoin { type: Inner, predicate: supplier.s_suppkey = lineitem.l_suppkey }
+                          StreamHashJoin { type: Inner, predicate: supplier.s_suppkey = lineitem.l_suppkey, output: [supplier.s_name, supplier.s_nationkey, lineitem.l_orderkey, lineitem.l_suppkey, supplier._row_id, lineitem._row_id] }
                             StreamExchange { dist: HashShard(supplier.s_suppkey) }
-                              StreamTableScan { table: supplier, columns: [s_suppkey, s_name, s_nationkey, _row_id] }
+                              StreamTableScan { table: supplier, columns: [supplier.s_suppkey, supplier.s_name, supplier.s_nationkey, supplier._row_id], pk: [supplier._row_id], distribution: HashShard(supplier._row_id) }
                             StreamExchange { dist: HashShard(lineitem.l_suppkey) }
                               StreamProject { exprs: [lineitem.l_orderkey, lineitem.l_suppkey, lineitem._row_id] }
                                 StreamFilter { predicate: (lineitem.l_receiptdate > lineitem.l_commitdate) }
-                                  StreamTableScan { table: lineitem, columns: [l_orderkey, l_suppkey, _row_id, l_commitdate, l_receiptdate] }
+                                  StreamTableScan { table: lineitem, columns: [lineitem.l_orderkey, lineitem.l_suppkey, lineitem._row_id, lineitem.l_commitdate, lineitem.l_receiptdate], pk: [lineitem._row_id], distribution: HashShard(lineitem._row_id) }
                         StreamExchange { dist: HashShard(nation.n_nationkey) }
                           StreamProject { exprs: [nation.n_nationkey, nation._row_id] }
                             StreamFilter { predicate: (nation.n_name = 'GERMANY':Varchar) }
-                              StreamTableScan { table: nation, columns: [n_nationkey, _row_id, n_name] }
+                              StreamTableScan { table: nation, columns: [nation.n_nationkey, nation._row_id, nation.n_name], pk: [nation._row_id], distribution: HashShard(nation._row_id) }
                     StreamExchange { dist: HashShard(orders.o_orderkey) }
                       StreamProject { exprs: [orders.o_orderkey, orders._row_id] }
                         StreamFilter { predicate: (orders.o_orderstatus = 'F':Varchar) }
-                          StreamTableScan { table: orders, columns: [o_orderkey, _row_id, o_orderstatus] }
+                          StreamTableScan { table: orders, columns: [orders.o_orderkey, orders._row_id, orders.o_orderstatus], pk: [orders._row_id], distribution: HashShard(orders._row_id) }
                   StreamExchange { dist: HashShard(lineitem.l_orderkey) }
-                    StreamTableScan { table: lineitem, columns: [l_orderkey, l_suppkey, _row_id] }
+                    StreamTableScan { table: lineitem, columns: [lineitem.l_orderkey, lineitem.l_suppkey, lineitem._row_id], pk: [lineitem._row_id], distribution: HashShard(lineitem._row_id) }
                 StreamExchange { dist: HashShard(lineitem.l_orderkey) }
                   StreamProject { exprs: [lineitem.l_orderkey, lineitem.l_suppkey, lineitem._row_id] }
                     StreamFilter { predicate: (lineitem.l_receiptdate > lineitem.l_commitdate) }
-                      StreamTableScan { table: lineitem, columns: [l_orderkey, l_suppkey, _row_id, l_commitdate, l_receiptdate] }
+                      StreamTableScan { table: lineitem, columns: [lineitem.l_orderkey, lineitem.l_suppkey, lineitem._row_id, lineitem.l_commitdate, lineitem.l_receiptdate], pk: [lineitem._row_id], distribution: HashShard(lineitem._row_id) }
 - id: tpch_q22
   before:
   - create_tables
@@ -2318,48 +2318,48 @@
         LogicalProject { exprs: [Substr(customer.c_phone, 1:Int32, 2:Int32), customer.c_acctbal] }
           LogicalProject { exprs: [Substr(customer.c_phone, 1:Int32, 2:Int32), customer.c_acctbal] }
             LogicalFilter { predicate: In(Substr(customer.c_phone, 1:Int32, 2:Int32), '30':Varchar, '24':Varchar, '31':Varchar, '38':Varchar, '25':Varchar, '34':Varchar, '37':Varchar) AND (customer.c_acctbal > (sum(customer.c_acctbal) / count(customer.c_acctbal))) }
-              LogicalJoin { type: LeftOuter, on: true }
+              LogicalJoin { type: LeftOuter, on: true, output: all }
                 LogicalApply { type: LeftAnti, on: true, correlated_id: 1 }
-                  LogicalScan { table: customer, columns: [_row_id, c_custkey, c_name, c_address, c_nationkey, c_phone, c_acctbal, c_mktsegment, c_comment] }
+                  LogicalScan { table: customer, columns: [customer._row_id, customer.c_custkey, customer.c_name, customer.c_address, customer.c_nationkey, customer.c_phone, customer.c_acctbal, customer.c_mktsegment, customer.c_comment] }
                   LogicalProject { exprs: [orders.o_orderkey, orders.o_custkey, orders.o_orderstatus, orders.o_totalprice, orders.o_orderdate, orders.o_orderpriority, orders.o_clerk, orders.o_shippriority, orders.o_comment] }
                     LogicalFilter { predicate: (orders.o_custkey = CorrelatedInputRef { index: 1, correlated_id: 1 }) }
-                      LogicalScan { table: orders, columns: [_row_id, o_orderkey, o_custkey, o_orderstatus, o_totalprice, o_orderdate, o_orderpriority, o_clerk, o_shippriority, o_comment] }
+                      LogicalScan { table: orders, columns: [orders._row_id, orders.o_orderkey, orders.o_custkey, orders.o_orderstatus, orders.o_totalprice, orders.o_orderdate, orders.o_orderpriority, orders.o_clerk, orders.o_shippriority, orders.o_comment] }
                 LogicalProject { exprs: [(sum(customer.c_acctbal) / count(customer.c_acctbal))] }
                   LogicalAgg { aggs: [sum(customer.c_acctbal), count(customer.c_acctbal)] }
                     LogicalProject { exprs: [customer.c_acctbal] }
                       LogicalFilter { predicate: (customer.c_acctbal > 0.00:Decimal) AND In(Substr(customer.c_phone, 1:Int32, 2:Int32), '30':Varchar, '24':Varchar, '31':Varchar, '38':Varchar, '25':Varchar, '34':Varchar, '37':Varchar) }
-                        LogicalScan { table: customer, columns: [_row_id, c_custkey, c_name, c_address, c_nationkey, c_phone, c_acctbal, c_mktsegment, c_comment] }
+                        LogicalScan { table: customer, columns: [customer._row_id, customer.c_custkey, customer.c_name, customer.c_address, customer.c_nationkey, customer.c_phone, customer.c_acctbal, customer.c_mktsegment, customer.c_comment] }
   optimized_logical_plan: |
     LogicalAgg { group_key: [Substr(customer.c_phone, 1:Int32, 2:Int32)], aggs: [count, sum(customer.c_acctbal)] }
       LogicalProject { exprs: [Substr(customer.c_phone, 1:Int32, 2:Int32), customer.c_acctbal] }
-        LogicalJoin { type: Inner, on: (customer.c_acctbal > (sum(customer.c_acctbal) / count(customer.c_acctbal))) }
-          LogicalJoin { type: LeftAnti, on: (orders.o_custkey = customer.c_custkey) }
-            LogicalScan { table: customer, output_columns: [c_custkey, c_phone, c_acctbal], required_columns: [c_custkey, c_phone, c_acctbal], predicate: In(Substr(customer.c_phone, 1:Int32, 2:Int32), '30':Varchar, '24':Varchar, '31':Varchar, '38':Varchar, '25':Varchar, '34':Varchar, '37':Varchar) }
-            LogicalScan { table: orders, columns: [o_custkey] }
+        LogicalJoin { type: Inner, on: (customer.c_acctbal > (sum(customer.c_acctbal) / count(customer.c_acctbal))), output: [customer.c_phone, customer.c_acctbal] }
+          LogicalJoin { type: LeftAnti, on: (orders.o_custkey = customer.c_custkey), output: [customer.c_phone, customer.c_acctbal] }
+            LogicalScan { table: customer, output_columns: [customer.c_custkey, customer.c_phone, customer.c_acctbal], required_columns: [c_custkey, c_phone, c_acctbal], predicate: In(Substr(customer.c_phone, 1:Int32, 2:Int32), '30':Varchar, '24':Varchar, '31':Varchar, '38':Varchar, '25':Varchar, '34':Varchar, '37':Varchar) }
+            LogicalScan { table: orders, columns: [orders.o_custkey] }
           LogicalProject { exprs: [(sum(customer.c_acctbal) / count(customer.c_acctbal))] }
             LogicalAgg { aggs: [sum(customer.c_acctbal), count(customer.c_acctbal)] }
-              LogicalScan { table: customer, output_columns: [c_acctbal], required_columns: [c_acctbal, c_phone], predicate: (customer.c_acctbal > 0.00:Decimal) AND In(Substr(customer.c_phone, 1:Int32, 2:Int32), '30':Varchar, '24':Varchar, '31':Varchar, '38':Varchar, '25':Varchar, '34':Varchar, '37':Varchar) }
+              LogicalScan { table: customer, output_columns: [customer.c_acctbal], required_columns: [c_acctbal, c_phone], predicate: (customer.c_acctbal > 0.00:Decimal) AND In(Substr(customer.c_phone, 1:Int32, 2:Int32), '30':Varchar, '24':Varchar, '31':Varchar, '38':Varchar, '25':Varchar, '34':Varchar, '37':Varchar) }
   batch_plan: |
     BatchExchange { order: [Substr(customer.c_phone, 1:Int32, 2:Int32) ASC], dist: Single }
       BatchSort { order: [Substr(customer.c_phone, 1:Int32, 2:Int32) ASC] }
         BatchHashAgg { group_key: [Substr(customer.c_phone, 1:Int32, 2:Int32)], aggs: [count, sum(customer.c_acctbal)] }
           BatchExchange { order: [], dist: HashShard(Substr(customer.c_phone, 1:Int32, 2:Int32)) }
             BatchProject { exprs: [Substr(customer.c_phone, 1:Int32, 2:Int32), customer.c_acctbal] }
-              BatchNestedLoopJoin { type: Inner, predicate: (customer.c_acctbal > (sum(sum(customer.c_acctbal)) / sum(count(customer.c_acctbal)))) }
+              BatchNestedLoopJoin { type: Inner, predicate: (customer.c_acctbal > (sum(sum(customer.c_acctbal)) / sum(count(customer.c_acctbal)))), output: [customer.c_phone, customer.c_acctbal] }
                 BatchExchange { order: [], dist: Single }
-                  BatchHashJoin { type: LeftAnti, predicate: customer.c_custkey = orders.o_custkey }
+                  BatchHashJoin { type: LeftAnti, predicate: customer.c_custkey = orders.o_custkey, output: [customer.c_phone, customer.c_acctbal] }
                     BatchExchange { order: [], dist: HashShard(customer.c_custkey) }
                       BatchFilter { predicate: In(Substr(customer.c_phone, 1:Int32, 2:Int32), '30':Varchar, '24':Varchar, '31':Varchar, '38':Varchar, '25':Varchar, '34':Varchar, '37':Varchar) }
-                        BatchScan { table: customer, columns: [c_custkey, c_phone, c_acctbal] }
+                        BatchScan { table: customer, columns: [customer.c_custkey, customer.c_phone, customer.c_acctbal], distribution: SomeShard }
                     BatchExchange { order: [], dist: HashShard(orders.o_custkey) }
-                      BatchScan { table: orders, columns: [o_custkey] }
+                      BatchScan { table: orders, columns: [orders.o_custkey], distribution: SomeShard }
                 BatchProject { exprs: [(sum(sum(customer.c_acctbal)) / sum(count(customer.c_acctbal)))] }
                   BatchSimpleAgg { aggs: [sum(sum(customer.c_acctbal)), sum(count(customer.c_acctbal))] }
                     BatchExchange { order: [], dist: Single }
                       BatchSimpleAgg { aggs: [sum(customer.c_acctbal), count(customer.c_acctbal)] }
                         BatchProject { exprs: [customer.c_acctbal] }
                           BatchFilter { predicate: (customer.c_acctbal > 0.00:Decimal) AND In(Substr(customer.c_phone, 1:Int32, 2:Int32), '30':Varchar, '24':Varchar, '31':Varchar, '38':Varchar, '25':Varchar, '34':Varchar, '37':Varchar) }
-                            BatchScan { table: customer, columns: [c_acctbal, c_phone] }
+                            BatchScan { table: customer, columns: [customer.c_acctbal, customer.c_phone], distribution: SomeShard }
   stream_plan: |
     StreamMaterialize { columns: [cntrycode, count(hidden), numcust, totacctbal], pk_columns: [cntrycode] }
       StreamHashAgg { group_key: [Substr(customer.c_phone, 1:Int32, 2:Int32)], aggs: [count, count, sum(customer.c_acctbal)] }
@@ -2367,12 +2367,12 @@
           StreamProject { exprs: [Substr(customer.c_phone, 1:Int32, 2:Int32), customer.c_acctbal, customer._row_id] }
             StreamDynamicFilter { predicate: (customer.c_acctbal > (sum(sum(customer.c_acctbal)) / sum(count(customer.c_acctbal)))) }
               StreamExchange { dist: HashShard(customer.c_acctbal) }
-                StreamHashJoin { type: LeftAnti, predicate: customer.c_custkey = orders.o_custkey }
+                StreamHashJoin { type: LeftAnti, predicate: customer.c_custkey = orders.o_custkey, output: [customer.c_phone, customer.c_acctbal, customer._row_id] }
                   StreamExchange { dist: HashShard(customer.c_custkey) }
                     StreamFilter { predicate: In(Substr(customer.c_phone, 1:Int32, 2:Int32), '30':Varchar, '24':Varchar, '31':Varchar, '38':Varchar, '25':Varchar, '34':Varchar, '37':Varchar) }
-                      StreamTableScan { table: customer, columns: [c_custkey, c_phone, c_acctbal, _row_id] }
+                      StreamTableScan { table: customer, columns: [customer.c_custkey, customer.c_phone, customer.c_acctbal, customer._row_id], pk: [customer._row_id], distribution: HashShard(customer._row_id) }
                   StreamExchange { dist: HashShard(orders.o_custkey) }
-                    StreamTableScan { table: orders, columns: [o_custkey, _row_id] }
+                    StreamTableScan { table: orders, columns: [orders.o_custkey, orders._row_id], pk: [orders._row_id], distribution: HashShard(orders._row_id) }
               StreamExchange { dist: Broadcast }
                 StreamProject { exprs: [(sum(sum(customer.c_acctbal)) / sum(count(customer.c_acctbal)))] }
                   StreamGlobalSimpleAgg { aggs: [sum(count), sum(sum(customer.c_acctbal)), sum(count(customer.c_acctbal))] }
@@ -2380,4 +2380,4 @@
                       StreamLocalSimpleAgg { aggs: [count, sum(customer.c_acctbal), count(customer.c_acctbal)] }
                         StreamProject { exprs: [customer.c_acctbal, customer._row_id] }
                           StreamFilter { predicate: (customer.c_acctbal > 0.00:Decimal) AND In(Substr(customer.c_phone, 1:Int32, 2:Int32), '30':Varchar, '24':Varchar, '31':Varchar, '38':Varchar, '25':Varchar, '34':Varchar, '37':Varchar) }
-                            StreamTableScan { table: customer, columns: [c_acctbal, _row_id, c_phone] }
+                            StreamTableScan { table: customer, columns: [customer.c_acctbal, customer._row_id, customer.c_phone], pk: [customer._row_id], distribution: HashShard(customer._row_id) }

--- a/src/frontend/test_runner/tests/testdata/update.yaml
+++ b/src/frontend/test_runner/tests/testdata/update.yaml
@@ -4,7 +4,7 @@
     update t set v1 = 0;
   batch_plan: |
     BatchUpdate { table: t, exprs: [$0, 0:Int32, $2] }
-      BatchScan { table: t, columns: [_row_id, v1, v2] }
+      BatchScan { table: t, columns: [t._row_id, t.v1, t.v2], distribution: HashShard(t._row_id) }
 - sql: |
     create table t (v1 int, v2 int);
     update t set v1 = true;
@@ -14,24 +14,24 @@
     update t set v1 = v2 + 1;
   batch_plan: |
     BatchUpdate { table: t, exprs: [$0, ($2 + 1:Int32), $2] }
-      BatchScan { table: t, columns: [_row_id, v1, v2] }
+      BatchScan { table: t, columns: [t._row_id, t.v1, t.v2], distribution: HashShard(t._row_id) }
 - sql: |
     create table t (v1 int, v2 real);
     update t set v1 = v2;
   batch_plan: |
     BatchUpdate { table: t, exprs: [$0, $2::Int32, $2] }
-      BatchScan { table: t, columns: [_row_id, v1, v2] }
+      BatchScan { table: t, columns: [t._row_id, t.v1, t.v2], distribution: HashShard(t._row_id) }
 - sql: |
     create table t (v1 int, v2 int);
     update t set v1 = v2 + 1 where v2 > 0;
   batch_plan: |
     BatchUpdate { table: t, exprs: [$0, ($2 + 1:Int32), $2] }
       BatchFilter { predicate: (t.v2 > 0:Int32) }
-        BatchScan { table: t, columns: [_row_id, v1, v2] }
+        BatchScan { table: t, columns: [t._row_id, t.v1, t.v2], distribution: HashShard(t._row_id) }
 - sql: |
     create table t (v1 int, v2 int);
     update t set (v1, v2) = (v2 + 1, v1 - 1) where v1 != v2;
   batch_plan: |
     BatchUpdate { table: t, exprs: [$0, ($2 + 1:Int32), ($1 - 1:Int32)] }
       BatchFilter { predicate: (t.v1 <> t.v2) }
-        BatchScan { table: t, columns: [_row_id, v1, v2] }
+        BatchScan { table: t, columns: [t._row_id, t.v1, t.v2], distribution: HashShard(t._row_id) }


### PR DESCRIPTION
I hereby agree to the terms of the [Singularity Data, Inc. Contributor License Agreement](https://gist.github.com/skyzh/0663682a70b0edde7ae991492f2314cb#file-s9y_cla).

## What's changed and what's your intention?
The current behaviour is not to explain verbose in planner tests, we thereby do not capture: node distributions, fully qualified column names, and output indices in joins.

This PR will use explain verbose in all planner tests.

## Checklist

- [x] I have written necessary rustdoc comments
- [x] I have added necessary unit tests and integration tests
- [x] All checks passed in `./risedev check` (or alias, `./risedev c`)