### PR TITLE
feat(sqlsmith): test stream queries

### DIFF
--- a/src/tests/sqlsmith/tests/frontend/mod.rs
+++ b/src/tests/sqlsmith/tests/frontend/mod.rs
@@ -106,6 +106,32 @@ async fn create_tables(session: Arc<SessionImpl>, rng: &mut impl Rng) -> (Vec<Ta
     (tables, setup_sql)
 }
 
+async fn test_stream_query(
+    session: Arc<SessionImpl>,
+    tables: Vec<Table>,
+    seed: u64,
+    setup_sql: &str,
+) {
+    let mut rng;
+    if let Ok(x) = env::var("RW_RANDOM_SEED_SQLSMITH") && x == "true" {
+        rng = SmallRng::from_entropy();
+    } else {
+        rng = SmallRng::seed_from_u64(seed);
+    }
+
+    let (sql, table) = mview_sql_gen(&mut rng, tables.clone(), "stream_query");
+    reproduce_failing_queries(setup_sql, &sql);
+    // The generated SQL must be parsable.
+    let statements = parse_sql(&sql);
+    let stmt = statements[0].clone();
+    handle(session.clone(), stmt, &sql).await;
+
+    let drop_sql = format!("DROP MATERIALIZED VIEW {}", table.name);
+    let drop_stmts = parse_sql(&drop_sql);
+    let drop_stmt = drop_stmts[0].clone();
+    handle(session.clone(), drop_stmt, &drop_sql).await;
+}
+
 fn test_batch_query(session: Arc<SessionImpl>, tables: Vec<Table>, seed: u64, setup_sql: &str) {
     let mut rng;
     if let Ok(x) = env::var("RW_RANDOM_SEED_SQLSMITH") && x == "true" {
@@ -194,6 +220,13 @@ pub fn run() {
             setup_sql,
         } = &*SQLSMITH_ENV;
         test_batch_query(session.clone(), tables.clone(), test.data, &setup_sql);
+        let test_stream_query =
+            test_stream_query(session.clone(), tables.clone(), test.data, &setup_sql);
+        tokio::runtime::Builder::new_multi_thread()
+            .enable_all()
+            .build()
+            .unwrap()
+            .block_on(test_stream_query);
         Outcome::Passed
     })
     .exit();


### PR DESCRIPTION
I hereby agree to the terms of the [Singularity Data, Inc. Contributor License Agreement](https://gist.github.com/skyzh/0663682a70b0edde7ae991492f2314cb#file-s9y_cla).

## What's changed and what's your intention?

Add stream queries to workflow.

- Previously #4228 disabled stream generators for frontend.
- e2e tests did not have stream queries tested.

This PR enables both.

## Checklist

- [x] I have written necessary rustdoc comments
- [x] I have added necessary unit tests and integration tests
- [x] All checks passed in `./risedev check` (or alias, `./risedev c`)

## Documentation

If your pull request contains user-facing changes, please specify the types of the changes, and create a release note. Otherwise, please feel free to remove this section.

### Types of user-facing changes

Please keep the types that apply to your changes, and remove those that do not apply.

* Installation and deployment 
* Connector (sources & sinks)
* SQL commands, functions, and operators
* RisingWave cluster configuration changes
* Other (please specify in the release note below)

### Release note

Please create a release note for your changes. In the release note, focus on the impact on users, and mention the environment or conditions where the impact may occur.

## Refer to a related PR or issue link (optional)
