### PR TITLE
refactor(meta): eliminate usages of `RwError`

### DIFF
--- a/src/batch/src/executor/row_seq_scan.rs
+++ b/src/batch/src/executor/row_seq_scan.rs
@@ -193,7 +193,7 @@ impl BoxedExecutorBuilder for RowSeqScanExecutorBuilder {
 
         let distribution = match &seq_scan_node.vnode_bitmap {
             Some(vnodes) => Distribution {
-                vnodes: Bitmap::try_from(vnodes).unwrap().into(),
+                vnodes: Bitmap::from(vnodes).into(),
                 dist_key_indices,
             },
             // This is possbile for dml. vnode_bitmap is not filled by scheduler.

--- a/src/common/src/array/column_proto_readers.rs
+++ b/src/common/src/array/column_proto_readers.rs
@@ -49,7 +49,7 @@ pub fn read_numeric_array<T: PrimitiveArrayItemType, R: PrimitiveValueReader<T>>
     );
 
     let mut builder = PrimitiveArrayBuilder::<T>::new(cardinality);
-    let bitmap: Bitmap = array.get_null_bitmap()?.try_into()?;
+    let bitmap: Bitmap = array.get_null_bitmap()?.into();
     let mut cursor = Cursor::new(buf);
     for not_null in bitmap.iter() {
         if not_null {
@@ -69,8 +69,8 @@ pub fn read_bool_array(array: &ProstArray, cardinality: usize) -> ArrayResult<Ar
         "Must have only 1 buffer in a bool array"
     );
 
-    let data = (&array.get_values()[0]).try_into()?;
-    let bitmap: Bitmap = array.get_null_bitmap()?.try_into()?;
+    let data = (&array.get_values()[0]).into();
+    let bitmap: Bitmap = array.get_null_bitmap()?.into();
 
     let arr = BoolArray::new(bitmap, data);
     assert_eq!(arr.len(), cardinality);
@@ -127,7 +127,7 @@ macro_rules! read_one_value_array {
                 let buf = array.get_values()[0].get_body().as_slice();
 
                 let mut builder = $builder::new(cardinality);
-                let bitmap: Bitmap = array.get_null_bitmap()?.try_into()?;
+                let bitmap: Bitmap = array.get_null_bitmap()?.into();
                 let mut cursor = Cursor::new(buf);
                 for not_null in bitmap.iter() {
                     if not_null {
@@ -170,7 +170,7 @@ pub fn read_string_array<B: ArrayBuilder, R: VarSizedValueReader<B>>(
     let data_buf = array.get_values()[1].get_body().as_slice();
 
     let mut builder = B::with_meta(cardinality, ArrayMeta::Simple);
-    let bitmap: Bitmap = array.get_null_bitmap()?.try_into()?;
+    let bitmap: Bitmap = array.get_null_bitmap()?.into();
     let mut offset_cursor = Cursor::new(offset_buff);
     let mut data_cursor = Cursor::new(data_buf);
     let mut prev_offset: i64 = -1;

--- a/src/common/src/array/list_array.rs
+++ b/src/common/src/array/list_array.rs
@@ -228,7 +228,7 @@ impl ListArray {
             array.values.is_empty(),
             "Must have no buffer in a list array"
         );
-        let bitmap: Bitmap = array.get_null_bitmap()?.try_into()?;
+        let bitmap: Bitmap = array.get_null_bitmap()?.into();
         let cardinality = bitmap.len();
         let array_data = array.get_list_array_data()?.to_owned();
         let value = ArrayImpl::from_protobuf(array_data.value.as_ref().unwrap(), cardinality)?;

--- a/src/common/src/array/struct_array.rs
+++ b/src/common/src/array/struct_array.rs
@@ -231,7 +231,7 @@ impl StructArray {
             array.values.is_empty(),
             "Must have no buffer in a struct array"
         );
-        let bitmap: Bitmap = array.get_null_bitmap()?.try_into()?;
+        let bitmap: Bitmap = array.get_null_bitmap()?.into();
         let cardinality = bitmap.len();
         let array_data = array.get_struct_array_data()?;
         let children = array_data

--- a/src/common/src/buffer/bitmap.rs
+++ b/src/common/src/buffer/bitmap.rs
@@ -40,7 +40,6 @@ use itertools::Itertools;
 use risingwave_pb::common::buffer::CompressionType;
 use risingwave_pb::common::Buffer as ProstBuffer;
 
-use crate::array::error::ArrayError;
 use crate::array::ArrayResult;
 use crate::util::bit_util;
 
@@ -330,15 +329,13 @@ impl Bitmap {
     }
 }
 
-impl TryFrom<&ProstBuffer> for Bitmap {
-    type Error = ArrayError;
-
-    fn try_from(buf: &ProstBuffer) -> ArrayResult<Bitmap> {
+impl From<&ProstBuffer> for Bitmap {
+    fn from(buf: &ProstBuffer) -> Self {
         let last_byte_num_bits = u8::from_be_bytes(buf.body[..1].try_into().unwrap());
         let bits = Bytes::copy_from_slice(&buf.body[1..]); // TODO: avoid this allocation
         let num_bits = (bits.len() << 3) - ((8 - last_byte_num_bits) % 8) as usize;
 
-        Ok(Self::from_bytes_with_num_bits(bits, num_bits))
+        Self::from_bytes_with_num_bits(bits, num_bits)
     }
 }
 

--- a/src/common/src/error.rs
+++ b/src/common/src/error.rs
@@ -218,12 +218,6 @@ impl From<JoinError> for RwError {
     }
 }
 
-impl From<prost::DecodeError> for RwError {
-    fn from(prost_error: prost::DecodeError) -> Self {
-        ErrorCode::ProstError(prost_error).into()
-    }
-}
-
 impl From<MemComparableError> for RwError {
     fn from(mem_comparable_error: MemComparableError) -> Self {
         ErrorCode::MemComparableError(mem_comparable_error).into()

--- a/src/meta/src/barrier/command.rs
+++ b/src/meta/src/barrier/command.rs
@@ -17,7 +17,6 @@ use std::sync::Arc;
 
 use futures::future::try_join_all;
 use risingwave_common::catalog::TableId;
-use risingwave_common::error::{Result, RwError};
 use risingwave_common::util::epoch::Epoch;
 use risingwave_connector::source::SplitImpl;
 use risingwave_pb::source::{ConnectorSplit, ConnectorSplits};
@@ -39,6 +38,7 @@ use crate::barrier::CommandChanges;
 use crate::model::{ActorId, DispatcherId, FragmentId, TableFragments};
 use crate::storage::MetaStore;
 use crate::stream::FragmentManagerRef;
+use crate::{MetaError, MetaResult};
 
 /// [`Reschedule`] is for the [`Command::RescheduleFragment`], which is used for rescheduling actors
 /// in some fragment, like scaling or migrating.
@@ -188,7 +188,7 @@ where
     S: MetaStore,
 {
     /// Generate a mutation for the given command.
-    pub async fn to_mutation(&self) -> Result<Option<Mutation>> {
+    pub async fn to_mutation(&self) -> MetaResult<Option<Mutation>> {
         let mutation = match &self.command {
             Command::Plain(mutation) => mutation.clone(),
 
@@ -322,7 +322,7 @@ where
     }
 
     /// Do some stuffs after barriers are collected, for the given command.
-    pub async fn post_collect(&self) -> Result<()> {
+    pub async fn post_collect(&self) -> MetaResult<()> {
         match &self.command {
             Command::Plain(_) => {}
 
@@ -341,7 +341,7 @@ where
                         };
                         client.drop_actors(request).await?;
 
-                        Ok::<_, RwError>(())
+                        Ok::<_, MetaError>(())
                     }
                 });
 

--- a/src/meta/src/barrier/mod.rs
+++ b/src/meta/src/barrier/mod.rs
@@ -18,13 +18,13 @@ use std::mem::take;
 use std::sync::Arc;
 use std::time::{Duration, Instant};
 
+use anyhow::anyhow;
 use fail::fail_point;
 use futures::future::try_join_all;
 use itertools::Itertools;
 use log::debug;
 use prometheus::HistogramTimer;
 use risingwave_common::catalog::TableId;
-use risingwave_common::error::{ErrorCode, Result, RwError};
 use risingwave_common::util::epoch::{Epoch, INVALID_EPOCH};
 use risingwave_hummock_sdk::{HummockSstableId, LocalSstableInfo};
 use risingwave_pb::common::worker_node::State::Running;
@@ -54,6 +54,7 @@ use crate::model::{ActorId, BarrierManagerState};
 use crate::rpc::metrics::MetaMetrics;
 use crate::storage::MetaStore;
 use crate::stream::FragmentManagerRef;
+use crate::{MetaError, MetaResult};
 
 mod command;
 mod info;
@@ -159,9 +160,7 @@ impl ScheduledBarriers {
         let mut buffer = self.buffer.write().await;
         while let Some((_, notifiers)) = buffer.pop_front() {
             notifiers.into_iter().for_each(|notify| {
-                notify.notify_collection_failed(RwError::from(ErrorCode::InternalError(
-                    "Scheduled barrier abort.".to_string(),
-                )))
+                notify.notify_collection_failed(anyhow!("Scheduled barrier abort.").into())
             })
         }
     }
@@ -348,7 +347,7 @@ where
     fn complete(
         &mut self,
         prev_epoch: u64,
-        result: Result<Vec<BarrierCompleteResponse>>,
+        result: MetaResult<Vec<BarrierCompleteResponse>>,
     ) -> Vec<EpochNode<S>> {
         // change state to complete, and wait for nodes with the smaller epoch to commit
         let wait_commit_timer = self.metrics.barrier_wait_commit_latency.start_timer();
@@ -445,13 +444,12 @@ pub struct EpochNode<S: MetaStore> {
 }
 
 /// The state of barrier.
-#[derive(PartialEq)]
 enum BarrierEpochState {
     /// This barrier is current in-flight on the stream graph of compute nodes.
     InFlight,
 
     /// This barrier is completed or failed.
-    Completed(Result<Vec<BarrierCompleteResponse>>),
+    Completed(MetaResult<Vec<BarrierCompleteResponse>>),
 }
 
 impl<S> GlobalBarrierManager<S>
@@ -494,7 +492,7 @@ where
     }
 
     /// Flush means waiting for the next barrier to collect.
-    pub async fn flush(&self) -> Result<()> {
+    pub async fn flush(&self) -> MetaResult<()> {
         let start = Instant::now();
 
         debug!("start barrier flush");
@@ -623,7 +621,7 @@ where
     async fn inject_and_send_err(
         &self,
         command_context: Arc<CommandContext<S>>,
-        barrier_complete_tx: UnboundedSender<(u64, Result<Vec<BarrierCompleteResponse>>)>,
+        barrier_complete_tx: UnboundedSender<(u64, MetaResult<Vec<BarrierCompleteResponse>>)>,
     ) {
         let result = self
             .inject_barrier(command_context.clone(), barrier_complete_tx.clone())
@@ -640,11 +638,11 @@ where
     async fn inject_barrier(
         &self,
         command_context: Arc<CommandContext<S>>,
-        barrier_complete_tx: UnboundedSender<(u64, Result<Vec<BarrierCompleteResponse>>)>,
-    ) -> Result<()> {
-        fail_point!("inject_barrier_err", |_| Err(RwError::from(
-            ErrorCode::InternalError("inject_barrier_err".to_string(),)
-        )));
+        barrier_complete_tx: UnboundedSender<(u64, MetaResult<Vec<BarrierCompleteResponse>>)>,
+    ) -> MetaResult<()> {
+        fail_point!("inject_barrier_err", |_| Err(
+            anyhow!("inject_barrier_err").into()
+        ));
         let mutation = command_context.to_mutation().await?;
         let info = command_context.info.clone();
         let mut node_need_collect = HashMap::new();
@@ -688,7 +686,7 @@ where
                         .inject_barrier(request)
                         .await
                         .map(tonic::Response::<_>::into_inner)
-                        .map_err(RwError::from)
+                        .map_err(MetaError::from)
                 }
                 .into()
             }
@@ -720,14 +718,16 @@ where
                             .barrier_complete(request)
                             .await
                             .map(tonic::Response::<_>::into_inner)
-                            .map_err(RwError::from)
+                            .map_err(MetaError::from)
                     }
                     .into()
                 }
             });
 
             let result = try_join_all(collect_futures).await;
-            barrier_complete_tx.send((prev_epoch, result)).unwrap();
+            barrier_complete_tx
+                .send((prev_epoch, result.map_err(Into::into)))
+                .unwrap();
         });
         Ok(())
     }
@@ -737,7 +737,7 @@ where
     async fn barrier_complete_and_commit(
         &self,
         prev_epoch: u64,
-        result: Result<Vec<BarrierCompleteResponse>>,
+        result: MetaResult<Vec<BarrierCompleteResponse>>,
         state: &mut BarrierManagerState,
         tracker: &mut CreateMviewProgressTracker,
         checkpoint_control: &mut CheckpointControl<S>,
@@ -798,7 +798,7 @@ where
         &self,
         node: &mut EpochNode<S>,
         tracker: &mut CreateMviewProgressTracker,
-    ) -> Result<()> {
+    ) -> MetaResult<()> {
         let prev_epoch = node.command_ctx.prev_epoch.0;
 
         match &node.state {
@@ -889,9 +889,9 @@ where
 
     /// Run multiple commands and return when they're all completely finished. It's ensured that
     /// multiple commands is executed continuously and atomically.
-    pub async fn run_multiple_commands(&self, commands: Vec<Command>) -> Result<()> {
+    pub async fn run_multiple_commands(&self, commands: Vec<Command>) -> MetaResult<()> {
         struct Context {
-            collect_rx: Receiver<Result<()>>,
+            collect_rx: Receiver<MetaResult<()>>,
             finish_rx: Receiver<()>,
             is_create_mv: bool,
         }
@@ -946,13 +946,13 @@ where
     }
 
     /// Run a command and return when it's completely finished.
-    pub async fn run_command(&self, command: Command) -> Result<()> {
+    pub async fn run_command(&self, command: Command) -> MetaResult<()> {
         self.run_multiple_commands(vec![command]).await
     }
 
     /// Wait for the next barrier to collect. Note that the barrier flowing in our stream graph is
     /// ignored, if exists.
-    pub async fn wait_for_next_barrier_to_collect(&self) -> Result<()> {
+    pub async fn wait_for_next_barrier_to_collect(&self) -> MetaResult<()> {
         let (tx, rx) = oneshot::channel();
         let notifier = Notifier {
             collected: Some(tx),

--- a/src/meta/src/barrier/notifier.rs
+++ b/src/meta/src/barrier/notifier.rs
@@ -12,8 +12,9 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use risingwave_common::error::{Result, RwError};
 use tokio::sync::oneshot;
+
+use crate::{MetaError, MetaResult};
 
 /// Used for notifying the status of a scheduled command/barrier.
 #[derive(Debug, Default)]
@@ -22,7 +23,7 @@ pub(super) struct Notifier {
     pub to_send: Option<oneshot::Sender<()>>,
 
     /// Get notified when scheduled barrier is collected or failed.
-    pub collected: Option<oneshot::Sender<Result<()>>>,
+    pub collected: Option<oneshot::Sender<MetaResult<()>>>,
 
     /// Get notified when scheduled barrier is finished.
     pub finished: Option<oneshot::Sender<()>>,
@@ -44,7 +45,7 @@ impl Notifier {
     }
 
     /// Notify when we failed to collect a barrier. This function consumes `self`.
-    pub fn notify_collection_failed(self, err: RwError) {
+    pub fn notify_collection_failed(self, err: MetaError) {
         if let Some(tx) = self.collected {
             tx.send(Err(err)).ok();
         }

--- a/src/meta/src/barrier/recovery.rs
+++ b/src/meta/src/barrier/recovery.rs
@@ -20,7 +20,6 @@ use std::time::Duration;
 use futures::future::try_join_all;
 use itertools::Itertools;
 use log::{debug, error};
-use risingwave_common::error::{ErrorCode, Result, RwError};
 use risingwave_common::types::VIRTUAL_NODE_COUNT;
 use risingwave_common::util::compress::decompress_data;
 use risingwave_common::util::epoch::Epoch;
@@ -41,6 +40,7 @@ use crate::barrier::{CheckpointControl, Command, GlobalBarrierManager};
 use crate::cluster::WorkerId;
 use crate::model::ActorId;
 use crate::storage::MetaStore;
+use crate::{MetaError, MetaResult};
 
 pub type RecoveryResult = (Epoch, HashSet<ActorId>, Vec<CreateMviewProgress>);
 
@@ -200,7 +200,7 @@ where
         (migrate_map, node_map)
     }
 
-    async fn migrate_actors(&self, info: &BarrierActorInfo) -> Result<()> {
+    async fn migrate_actors(&self, info: &BarrierActorInfo) -> MetaResult<()> {
         debug!("start migrate actors.");
         // get expired workers
         let expired_workers = info
@@ -225,8 +225,7 @@ where
         let res = self
             .catalog_manager
             .update_table_mapping(&new_fragments, &migrate_map)
-            .await
-            .map_err(RwError::from);
+            .await;
         // update hash mapping
         for fragments in new_fragments {
             for (fragment_id, fragment) in fragments.fragments {
@@ -244,7 +243,7 @@ where
 
     /// Sync all sources in compute nodes, the local source manager in compute nodes may be dirty
     /// already.
-    async fn sync_sources(&self, info: &BarrierActorInfo) -> Result<()> {
+    async fn sync_sources(&self, info: &BarrierActorInfo) -> MetaResult<()> {
         let catalog_guard = self.catalog_manager.get_catalog_core_guard().await;
         let sources = catalog_guard.list_sources().await?;
 
@@ -256,7 +255,7 @@ where
                 let client = &self.env.stream_client_pool().get(node).await?;
                 client.to_owned().sync_sources(request).await?;
 
-                Ok::<_, RwError>(())
+                Ok::<_, MetaError>(())
             }
         });
 
@@ -266,17 +265,13 @@ where
     }
 
     /// Update all actors in compute nodes.
-    async fn update_actors(&self, info: &BarrierActorInfo) -> Result<()> {
+    async fn update_actors(&self, info: &BarrierActorInfo) -> MetaResult<()> {
         let mut actor_infos = vec![];
         for (node_id, actors) in &info.actor_map {
             let host = info
                 .node_map
                 .get(node_id)
-                .ok_or_else(|| {
-                    RwError::from(ErrorCode::InternalError(
-                        "worker evicted, wait for online.".to_string(),
-                    ))
-                })?
+                .ok_or_else(|| anyhow::anyhow!("worker evicted, wait for online."))?
                 .host
                 .clone();
             actor_infos.extend(actors.iter().map(|&actor_id| ActorInfo {
@@ -313,7 +308,7 @@ where
     }
 
     /// Build all actors in compute nodes.
-    async fn build_actors(&self, info: &BarrierActorInfo) -> Result<()> {
+    async fn build_actors(&self, info: &BarrierActorInfo) -> MetaResult<()> {
         for (node_id, actors) in &info.actor_map {
             let node = info.node_map.get(node_id).unwrap();
             let client = self.env.stream_client_pool().get(node).await?;
@@ -338,7 +333,7 @@ where
         info: &BarrierActorInfo,
         prev_epoch: &Epoch,
         new_epoch: &Epoch,
-    ) -> Result<()> {
+    ) -> MetaResult<()> {
         let futures = info.node_map.iter().map(|(_, worker_node)| async move {
             let client = self.env.stream_client_pool().get(worker_node).await?;
             debug!("force stop actors: {}", worker_node.id);
@@ -352,7 +347,7 @@ where
                     }),
                 })
                 .await
-                .map_err(RwError::from)
+                .map_err(MetaError::from)
         });
 
         try_join_all(futures).await?;

--- a/src/meta/src/cluster/mod.rs
+++ b/src/meta/src/cluster/mod.rs
@@ -21,7 +21,6 @@ use std::sync::Arc;
 use std::time::{Duration, SystemTime};
 
 use itertools::Itertools;
-use risingwave_common::error::{internal_error, ErrorCode, Result};
 use risingwave_common::types::ParallelUnitId;
 use risingwave_pb::common::worker_node::State;
 use risingwave_pb::common::{HostAddress, ParallelUnit, WorkerNode, WorkerType};
@@ -33,6 +32,7 @@ use tokio::task::JoinHandle;
 use crate::manager::{IdCategory, LocalNotification, MetaSrvEnv};
 use crate::model::{MetadataModel, Worker, INVALID_EXPIRE_AT};
 use crate::storage::MetaStore;
+use crate::MetaResult;
 
 pub type WorkerId = u32;
 pub type WorkerLocations = HashMap<WorkerId, WorkerNode>;
@@ -71,7 +71,7 @@ impl<S> ClusterManager<S>
 where
     S: MetaStore,
 {
-    pub async fn new(env: MetaSrvEnv<S>, max_heartbeat_interval: Duration) -> Result<Self> {
+    pub async fn new(env: MetaSrvEnv<S>, max_heartbeat_interval: Duration) -> MetaResult<Self> {
         let meta_store = env.meta_store_ref();
         let core = ClusterManagerCore::new(meta_store.clone()).await?;
 
@@ -97,7 +97,7 @@ where
         r#type: WorkerType,
         host_address: HostAddress,
         worker_node_parallelism: usize,
-    ) -> Result<WorkerNode> {
+    ) -> MetaResult<WorkerNode> {
         let mut core = self.core.write().await;
         match core.get_worker_by_host(host_address.clone()) {
             // TODO(zehua): update parallelism when the worker exists.
@@ -137,7 +137,7 @@ where
         }
     }
 
-    pub async fn activate_worker_node(&self, host_address: HostAddress) -> Result<()> {
+    pub async fn activate_worker_node(&self, host_address: HostAddress) -> MetaResult<()> {
         let mut core = self.core.write().await;
         let mut worker = core.get_worker_by_host_checked(host_address.clone())?;
         if worker.worker_node.state == State::Running as i32 {
@@ -159,7 +159,7 @@ where
         Ok(())
     }
 
-    pub async fn delete_worker_node(&self, host_address: HostAddress) -> Result<()> {
+    pub async fn delete_worker_node(&self, host_address: HostAddress) -> MetaResult<()> {
         let mut core = self.core.write().await;
         let worker = core.get_worker_by_host_checked(host_address.clone())?;
         let worker_type = worker.worker_type();
@@ -189,7 +189,7 @@ where
     }
 
     /// Invoked when it receives a heartbeat from a worker node.
-    pub async fn heartbeat(&self, worker_id: WorkerId) -> Result<()> {
+    pub async fn heartbeat(&self, worker_id: WorkerId) -> MetaResult<()> {
         tracing::trace!(target: "events::meta::server_heartbeat", worker_id = worker_id, "receive heartbeat");
         let mut core = self.core.write().await;
 
@@ -197,7 +197,7 @@ where
             core.update_worker_ttl(worker.key().unwrap(), self.max_heartbeat_interval);
             Ok(())
         } else {
-            Err(ErrorCode::UnknownWorker.into())
+            Err(anyhow::anyhow!("unknown worker_id: {}", worker_id).into())
         }
     }
 
@@ -305,7 +305,7 @@ where
         &self,
         parallel_degree: usize,
         worker_id: WorkerId,
-    ) -> Result<Vec<ParallelUnit>> {
+    ) -> MetaResult<Vec<ParallelUnit>> {
         let start_id = self
             .env
             .id_gen_manager()
@@ -334,7 +334,7 @@ pub struct ClusterManagerCore {
 }
 
 impl ClusterManagerCore {
-    async fn new<S>(meta_store: Arc<S>) -> Result<Self>
+    async fn new<S>(meta_store: Arc<S>) -> MetaResult<Self>
     where
         S: MetaStore,
     {
@@ -354,9 +354,9 @@ impl ClusterManagerCore {
     }
 
     /// If no worker exists, return an error.
-    fn get_worker_by_host_checked(&self, host_address: HostAddress) -> Result<Worker> {
+    fn get_worker_by_host_checked(&self, host_address: HostAddress) -> MetaResult<Worker> {
         self.get_worker_by_host(host_address)
-            .ok_or_else(|| internal_error("Worker node does not exist!"))
+            .ok_or_else(|| anyhow::anyhow!("Worker node does not exist!").into())
     }
 
     fn get_worker_by_host(&self, host_address: HostAddress) -> Option<Worker> {
@@ -442,7 +442,7 @@ mod tests {
     use crate::storage::MemStore;
 
     #[tokio::test]
-    async fn test_cluster_manager() -> Result<()> {
+    async fn test_cluster_manager() -> MetaResult<()> {
         let env = MetaSrvEnv::for_test().await;
 
         let cluster_manager = Arc::new(

--- a/src/meta/src/cluster/mod.rs
+++ b/src/meta/src/cluster/mod.rs
@@ -21,6 +21,7 @@ use std::sync::Arc;
 use std::time::{Duration, SystemTime};
 
 use itertools::Itertools;
+use risingwave_common::bail;
 use risingwave_common::types::ParallelUnitId;
 use risingwave_pb::common::worker_node::State;
 use risingwave_pb::common::{HostAddress, ParallelUnit, WorkerNode, WorkerType};
@@ -197,7 +198,7 @@ where
             core.update_worker_ttl(worker.key().unwrap(), self.max_heartbeat_interval);
             Ok(())
         } else {
-            Err(anyhow::anyhow!("unknown worker_id: {}", worker_id).into())
+            bail!("unknown worker id: {}", worker_id);
         }
     }
 

--- a/src/meta/src/dashboard/mod.rs
+++ b/src/meta/src/dashboard/mod.rs
@@ -21,7 +21,6 @@ use axum::http::{Method, StatusCode};
 use axum::response::{Html, IntoResponse};
 use axum::routing::{get, get_service};
 use axum::Router;
-use risingwave_common::error::ErrorCode;
 use tower::ServiceBuilder;
 use tower_http::add_extension::AddExtensionLayer;
 use tower_http::cors::{self, CorsLayer};
@@ -192,7 +191,7 @@ where
         axum::Server::bind(&srv.dashboard_addr)
             .serve(app.into_make_service())
             .await
-            .map_err(|err| ErrorCode::MetaError(err.to_string()))?;
+            .map_err(|err| anyhow!(err.to_string()))?;
         Ok(())
     }
 }

--- a/src/meta/src/dashboard/mod.rs
+++ b/src/meta/src/dashboard/mod.rs
@@ -191,7 +191,7 @@ where
         axum::Server::bind(&srv.dashboard_addr)
             .serve(app.into_make_service())
             .await
-            .map_err(|err| anyhow!(err.to_string()))?;
+            .map_err(|err| anyhow!(err))?;
         Ok(())
     }
 }

--- a/src/meta/src/error.rs
+++ b/src/meta/src/error.rs
@@ -82,7 +82,7 @@ impl MetaError {
         MetaErrorInner::TransactionError(e).into()
     }
 
-    /// PermissionDenied
+    /// Permission denied error.
     pub fn permission_denied(s: String) -> Self {
         MetaErrorInner::PermissionDenied(s).into()
     }

--- a/src/meta/src/error.rs
+++ b/src/meta/src/error.rs
@@ -38,6 +38,9 @@ enum MetaErrorInner {
     #[error("Rpc error: {0}")]
     RpcError(RpcError),
 
+    #[error("PermissionDenied: {0}")]
+    PermissionDenied(String),
+
     #[error(transparent)]
     Internal(anyhow::Error),
 }
@@ -77,6 +80,11 @@ impl MetaError {
     /// `MetaStore` transaction error.
     pub fn transaction_error(e: MetaStoreError) -> Self {
         MetaErrorInner::TransactionError(e).into()
+    }
+
+    /// PermissionDenied
+    pub fn permission_denied(s: String) -> Self {
+        MetaErrorInner::PermissionDenied(s).into()
     }
 }
 

--- a/src/meta/src/error.rs
+++ b/src/meta/src/error.rs
@@ -1,0 +1,128 @@
+// Copyright 2022 Singularity Data
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::backtrace::Backtrace;
+use std::sync::Arc;
+
+use risingwave_pb::ProstFieldNotFound;
+use risingwave_rpc_client::error::RpcError;
+
+use crate::hummock::error::Error as HummockError;
+use crate::model::MetadataModelError;
+use crate::storage::MetaStoreError;
+
+pub type MetaResult<T> = std::result::Result<T, MetaError>;
+
+#[derive(thiserror::Error, Debug)]
+enum MetaErrorInner {
+    #[error("MetaStore transaction error: {0}")]
+    TransactionError(MetaStoreError),
+
+    #[error("MetadataModel error: {0}")]
+    MetadataModelError(MetadataModelError),
+
+    #[error("Hummock error: {0}")]
+    HummockError(HummockError),
+
+    #[error("Rpc error: {0}")]
+    RpcError(RpcError),
+
+    #[error(transparent)]
+    Internal(anyhow::Error),
+}
+
+impl From<MetaErrorInner> for MetaError {
+    fn from(inner: MetaErrorInner) -> Self {
+        Self {
+            inner: Arc::new(inner),
+            backtrace: Arc::new(Backtrace::capture()),
+        }
+    }
+}
+
+#[derive(thiserror::Error, Clone)]
+#[error("{inner}")]
+pub struct MetaError {
+    inner: Arc<MetaErrorInner>,
+    backtrace: Arc<Backtrace>,
+}
+
+impl std::fmt::Debug for MetaError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        use std::error::Error;
+
+        write!(f, "{}", self.inner)?;
+        writeln!(f)?;
+        if let Some(backtrace) = self.inner.backtrace() {
+            write!(f, "  backtrace of inner error:\n{}", backtrace)?;
+        } else {
+            write!(f, "  backtrace of `MetaError`:\n{}", self.backtrace)?;
+        }
+        Ok(())
+    }
+}
+
+impl MetaError {
+    /// `MetaStore` transaction error.
+    pub fn transaction_error(e: MetaStoreError) -> Self {
+        MetaErrorInner::TransactionError(e).into()
+    }
+}
+
+impl From<MetadataModelError> for MetaError {
+    fn from(e: MetadataModelError) -> Self {
+        MetaErrorInner::MetadataModelError(e).into()
+    }
+}
+
+impl From<HummockError> for MetaError {
+    fn from(e: HummockError) -> Self {
+        MetaErrorInner::HummockError(e).into()
+    }
+}
+
+impl From<RpcError> for MetaError {
+    fn from(e: RpcError) -> Self {
+        MetaErrorInner::RpcError(e).into()
+    }
+}
+
+impl From<anyhow::Error> for MetaError {
+    fn from(a: anyhow::Error) -> Self {
+        MetaErrorInner::Internal(a).into()
+    }
+}
+
+impl From<MetaError> for tonic::Status {
+    fn from(err: MetaError) -> Self {
+        tonic::Status::internal(err.to_string())
+    }
+}
+
+impl From<tonic::Status> for MetaError {
+    fn from(status: tonic::Status) -> Self {
+        RpcError::from(status).into()
+    }
+}
+
+/// Convert `MetaError` into `tonic::Status`. Generally used in `map_err`.
+pub fn meta_error_to_tonic(err: impl Into<MetaError>) -> tonic::Status {
+    err.into().into()
+}
+
+impl From<ProstFieldNotFound> for MetaError {
+    fn from(e: ProstFieldNotFound) -> Self {
+        MetadataModelError::from(e).into()
+    }
+}

--- a/src/meta/src/error.rs
+++ b/src/meta/src/error.rs
@@ -114,7 +114,12 @@ impl From<anyhow::Error> for MetaError {
 
 impl From<MetaError> for tonic::Status {
     fn from(err: MetaError) -> Self {
-        tonic::Status::internal(err.to_string())
+        match &*err.inner {
+            MetaErrorInner::PermissionDenied(_) => {
+                tonic::Status::permission_denied(err.to_string())
+            }
+            _ => tonic::Status::internal(err.to_string()),
+        }
     }
 }
 

--- a/src/meta/src/error.rs
+++ b/src/meta/src/error.rs
@@ -77,11 +77,6 @@ impl std::fmt::Debug for MetaError {
 }
 
 impl MetaError {
-    /// `MetaStore` transaction error.
-    pub fn transaction_error(e: MetaStoreError) -> Self {
-        MetaErrorInner::TransactionError(e).into()
-    }
-
     /// Permission denied error.
     pub fn permission_denied(s: String) -> Self {
         MetaErrorInner::PermissionDenied(s).into()
@@ -137,5 +132,15 @@ pub fn meta_error_to_tonic(err: impl Into<MetaError>) -> tonic::Status {
 impl From<ProstFieldNotFound> for MetaError {
     fn from(e: ProstFieldNotFound) -> Self {
         MetadataModelError::from(e).into()
+    }
+}
+
+impl From<MetaStoreError> for MetaError {
+    fn from(e: MetaStoreError) -> Self {
+        match e {
+            // `MetaStore::txn` method error.
+            MetaStoreError::TransactionAbort() => MetaErrorInner::TransactionError(e).into(),
+            _ => MetadataModelError::from(e).into(),
+        }
     }
 }

--- a/src/meta/src/hummock/error.rs
+++ b/src/meta/src/hummock/error.rs
@@ -12,7 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use risingwave_common::error::{ErrorCode, ToErrorStr};
 use risingwave_hummock_sdk::compaction_group::StateTableId;
 use risingwave_hummock_sdk::{CompactionGroupId, HummockContextId, HummockSstableId};
 use thiserror::Error;
@@ -63,45 +62,6 @@ impl From<MetaStoreError> for Error {
             // to more detail meta_store errors.
             MetaStoreError::Internal(err) => Error::MetaStoreError(err),
         }
-    }
-}
-
-impl From<Error> for ErrorCode {
-    fn from(error: Error) -> Self {
-        match error {
-            Error::InvalidContext(err) => {
-                ErrorCode::InternalError(format!("invalid hummock context {}", err))
-            }
-            Error::MetaStoreError(err) => ErrorCode::MetaError(err.to_error_str()),
-            Error::InternalError(err) => ErrorCode::InternalError(err),
-            Error::CompactorBusy(context_id) => {
-                ErrorCode::InternalError(format!("compactor {} is busy", context_id))
-            }
-            Error::CompactorUnreachable(context_id) => {
-                ErrorCode::InternalError(format!("compactor {} is unreachable", context_id))
-            }
-            Error::CompactionTaskAlreadyAssigned(task_id, context_id) => {
-                ErrorCode::InternalError(format!(
-                    "compaction task {} already assigned to compactor {}",
-                    task_id, context_id
-                ))
-            }
-            Error::InvalidCompactionGroup(group_id) => {
-                ErrorCode::InternalError(format!("invalid compaction group {}", group_id))
-            }
-            Error::InvalidCompactionGroupMember(table_id) => {
-                ErrorCode::InternalError(format!("invalid compaction group member {}", table_id))
-            }
-            Error::InvalidSst(sst_id) => {
-                ErrorCode::InternalError(format!("SST {} is invalid", sst_id))
-            }
-        }
-    }
-}
-
-impl From<Error> for risingwave_common::error::RwError {
-    fn from(error: Error) -> Self {
-        ErrorCode::from(error).into()
     }
 }
 

--- a/src/meta/src/hummock/vacuum.rs
+++ b/src/meta/src/hummock/vacuum.rs
@@ -16,12 +16,12 @@ use std::collections::HashSet;
 use std::sync::Arc;
 
 use itertools::Itertools;
-use risingwave_common::error::Result;
 use risingwave_hummock_sdk::HummockSstableId;
 use risingwave_pb::hummock::VacuumTask;
 
 use crate::hummock::{CompactorManager, HummockManagerRef};
 use crate::storage::MetaStore;
+use crate::MetaResult;
 
 // TODO #4037: GC orphan SSTs in object store
 pub struct VacuumTrigger<S: MetaStore> {
@@ -50,7 +50,7 @@ where
     /// Tries to make checkpoint at the minimum pinned version.
     ///
     /// Returns number of deleted deltas
-    pub async fn vacuum_version_metadata(&self) -> Result<usize> {
+    pub async fn vacuum_version_metadata(&self) -> MetaResult<usize> {
         self.hummock_manager.proceed_version_checkpoint().await?;
         let batch_size = 64usize;
         let mut total_deleted = 0;
@@ -70,7 +70,7 @@ where
     /// Schedules deletion of SSTs from object store
     ///
     /// Returns SSTs scheduled in worker node.
-    pub async fn vacuum_sst_data(&self) -> Result<Vec<HummockSstableId>> {
+    pub async fn vacuum_sst_data(&self) -> MetaResult<Vec<HummockSstableId>> {
         // Select SSTs to delete.
         let ssts_to_delete = {
             // 1. Retry the pending SSTs first.
@@ -148,7 +148,7 @@ where
     }
 
     /// Acknowledges deletion of SSTs and deletes corresponding metadata.
-    pub async fn report_vacuum_task(&self, vacuum_task: VacuumTask) -> Result<()> {
+    pub async fn report_vacuum_task(&self, vacuum_task: VacuumTask) -> MetaResult<()> {
         let deleted_sst_ids = self
             .pending_sst_ids
             .read()

--- a/src/meta/src/lib.rs
+++ b/src/meta/src/lib.rs
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#![feature(backtrace)]
 #![allow(clippy::derive_partial_eq_without_eq)]
 #![warn(clippy::dbg_macro)]
 #![warn(clippy::disallowed_methods)]
@@ -45,6 +46,7 @@ extern crate core;
 mod barrier;
 pub mod cluster;
 mod dashboard;
+mod error;
 pub mod hummock;
 pub mod manager;
 mod model;
@@ -56,6 +58,7 @@ pub mod test_utils;
 use std::time::Duration;
 
 use clap::{ArgEnum, Parser};
+pub use error::{MetaError, MetaResult};
 use risingwave_common::config::ComputeNodeConfig;
 
 use crate::manager::MetaOpts;

--- a/src/meta/src/manager/catalog.rs
+++ b/src/meta/src/manager/catalog.rs
@@ -340,12 +340,10 @@ where
         let table = Table::select(self.env.meta_store(), &table_id).await?;
         if let Some(table) = table {
             match core.get_ref_count(table_id) {
-                Some(ref_count) => Err(anyhow!(
+                Some(ref_count) => Err(MetaError::permission_denied(format!(
                     "Fail to delete table `{}` because {} other relation(s) depend on it",
-                    table.name,
-                    ref_count
-                )
-                .into()),
+                    table.name, ref_count
+                ))),
                 None => {
                     Table::delete(self.env.meta_store(), &table_id).await?;
                     core.drop_table(&table);
@@ -458,12 +456,10 @@ where
         let source = Source::select(self.env.meta_store(), &source_id).await?;
         if let Some(source) = source {
             match core.get_ref_count(source_id) {
-                Some(ref_count) => Err(anyhow!(
+                Some(ref_count) => Err(MetaError::permission_denied(format!(
                     "Fail to delete source `{}` because {} other relation(s) depend on it",
-                    source.name,
-                    ref_count
-                )
-                .into()),
+                    source.name, ref_count
+                ))),
                 None => {
                     Source::delete(self.env.meta_store(), &source_id).await?;
                     core.drop_source(&source);
@@ -598,20 +594,16 @@ where
                 }
                 // check ref count
                 if let Some(ref_count) = core.get_ref_count(mview_id) {
-                    return Err(anyhow!(
+                    return Err(MetaError::permission_denied(format!(
                         "Fail to delete table `{}` because {} other relation(s) depend on it",
-                        mview.name,
-                        ref_count
-                    )
-                    .into());
+                        mview.name, ref_count
+                    )));
                 }
                 if let Some(ref_count) = core.get_ref_count(source_id) {
-                    return Err(anyhow!(
+                    return Err(MetaError::permission_denied(format!(
                         "Fail to delete source `{}` because {} other relation(s) depend on it",
-                        source.name,
-                        ref_count
-                    )
-                    .into());
+                        source.name, ref_count
+                    )));
                 }
 
                 // now is safe to delete both mview and source

--- a/src/meta/src/model/error.rs
+++ b/src/meta/src/model/error.rs
@@ -12,7 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use risingwave_common::error::{ErrorCode, RwError};
 use risingwave_pb::ProstFieldNotFound;
 use thiserror::Error;
 
@@ -38,12 +37,5 @@ impl From<ProstFieldNotFound> for MetadataModelError {
             "Failed to decode prost: field not found `{}`",
             p.0
         ))
-    }
-}
-
-// TODO(zehua): replace `RwError` with meta's own error type.
-impl From<MetadataModelError> for RwError {
-    fn from(err: MetadataModelError) -> Self {
-        RwError::from(ErrorCode::InternalError(err.to_string()))
     }
 }

--- a/src/meta/src/model/mod.rs
+++ b/src/meta/src/model/mod.rs
@@ -87,7 +87,7 @@ pub trait MetadataModel: std::fmt::Debug + Sized {
                     .map(Self::from_protobuf)
                     .map_err(Into::into)
             })
-            .collect::<MetadataModelResult<Vec<_>>>()
+            .collect()
     }
 
     /// `insert` insert a new record in meta store, replaced it if the record already exist.

--- a/src/meta/src/model/mod.rs
+++ b/src/meta/src/model/mod.rs
@@ -80,10 +80,14 @@ pub trait MetadataModel: std::fmt::Debug + Sized {
         S: MetaStore,
     {
         let bytes_vec = store.list_cf(&Self::cf_name()).await?;
-        Ok(bytes_vec
+        bytes_vec
             .iter()
-            .map(|bytes| Self::from_protobuf(Self::ProstType::decode(bytes.as_slice()).unwrap()))
-            .collect::<Vec<_>>())
+            .map(|bytes| {
+                Self::ProstType::decode(bytes.as_slice())
+                    .map(Self::from_protobuf)
+                    .map_err(Into::into)
+            })
+            .collect::<MetadataModelResult<Vec<_>>>()
     }
 
     /// `insert` insert a new record in meta store, replaced it if the record already exist.

--- a/src/meta/src/rpc/server.rs
+++ b/src/meta/src/rpc/server.rs
@@ -19,8 +19,6 @@ use std::time::{Duration, SystemTime, UNIX_EPOCH};
 use etcd_client::{Client as EtcdClient, ConnectOptions};
 use itertools::Itertools;
 use prost::Message;
-use risingwave_common::error::ErrorCode::InternalError;
-use risingwave_common::error::{ErrorCode, Result, RwError};
 use risingwave_common::monitor::process_linux::monitor_process;
 use risingwave_common_service::metrics_manager::MetricsManager;
 use risingwave_pb::ddl_service::ddl_service_server::DdlServiceServer;
@@ -43,7 +41,6 @@ use super::DdlServiceImpl;
 use crate::barrier::GlobalBarrierManager;
 use crate::cluster::ClusterManager;
 use crate::dashboard::DashboardService;
-use crate::hummock;
 use crate::hummock::compaction_group::manager::CompactionGroupManager;
 use crate::hummock::CompactionScheduler;
 use crate::manager::{CatalogManager, IdleManager, MetaOpts, MetaSrvEnv, UserManager};
@@ -56,6 +53,7 @@ use crate::rpc::service::user_service::UserServiceImpl;
 use crate::rpc::{META_CF_NAME, META_LEADER_KEY, META_LEASE_KEY};
 use crate::storage::{EtcdMetaStore, MemStore, MetaStore, MetaStoreError, Transaction};
 use crate::stream::{FragmentManager, GlobalStreamManager, SourceManager};
+use crate::{hummock, MetaResult};
 
 #[derive(Debug)]
 pub enum MetaStoreBackend {
@@ -93,7 +91,7 @@ pub async fn rpc_serve(
     max_heartbeat_interval: Duration,
     lease_interval_secs: u64,
     opts: MetaOpts,
-) -> Result<(JoinHandle<()>, Sender<()>)> {
+) -> MetaResult<(JoinHandle<()>, Sender<()>)> {
     match meta_store_backend {
         MetaStoreBackend::Etcd {
             endpoints,
@@ -106,9 +104,7 @@ pub async fn rpc_serve(
             }
             let client = EtcdClient::connect(endpoints, Some(options))
                 .await
-                .map_err(|e| {
-                    RwError::from(InternalError(format!("failed to connect etcd {}", e)))
-                })?;
+                .map_err(|e| anyhow::anyhow!("failed to connect etcd {}", e))?;
             let meta_store = Arc::new(EtcdMetaStore::new(client));
             rpc_serve_with_store(
                 meta_store,
@@ -137,7 +133,7 @@ pub async fn register_leader_for_meta<S: MetaStore>(
     addr: String,
     meta_store: Arc<S>,
     lease_time: u64,
-) -> Result<(MetaLeaderInfo, JoinHandle<()>, Sender<()>)> {
+) -> MetaResult<(MetaLeaderInfo, JoinHandle<()>, Sender<()>)> {
     let mut tick_interval = tokio::time::interval(Duration::from_secs(lease_time / 2));
     loop {
         tick_interval.tick().await;
@@ -176,7 +172,7 @@ pub async fn register_leader_for_meta<S: MetaStore>(
                     now.as_secs(),
                 );
                 tracing::error!("{}", err_info);
-                return Err(RwError::from(ErrorCode::MetaError(err_info)));
+                return Err(anyhow::anyhow!(err_info).into());
             }
         }
         let lease_id = if !old_leader_info.is_empty() {
@@ -300,7 +296,7 @@ pub async fn rpc_serve_with_store<S: MetaStore>(
     max_heartbeat_interval: Duration,
     lease_interval_secs: u64,
     opts: MetaOpts,
-) -> Result<(JoinHandle<()>, Sender<()>)> {
+) -> MetaResult<(JoinHandle<()>, Sender<()>)> {
     let (info, lease_handle, lease_shutdown) = register_leader_for_meta(
         address_info.addr.clone(),
         meta_store.clone(),

--- a/src/meta/src/rpc/server.rs
+++ b/src/meta/src/rpc/server.rs
@@ -19,6 +19,7 @@ use std::time::{Duration, SystemTime, UNIX_EPOCH};
 use etcd_client::{Client as EtcdClient, ConnectOptions};
 use itertools::Itertools;
 use prost::Message;
+use risingwave_common::bail;
 use risingwave_common::monitor::process_linux::monitor_process;
 use risingwave_common_service::metrics_manager::MetricsManager;
 use risingwave_pb::ddl_service::ddl_service_server::DdlServiceServer;
@@ -172,7 +173,7 @@ pub async fn register_leader_for_meta<S: MetaStore>(
                     now.as_secs(),
                 );
                 tracing::error!("{}", err_info);
-                return Err(anyhow::anyhow!(err_info).into());
+                bail!(err_info);
             }
         }
         let lease_id = if !old_leader_info.is_empty() {

--- a/src/meta/src/rpc/service/cluster_service.rs
+++ b/src/meta/src/rpc/service/cluster_service.rs
@@ -12,7 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use risingwave_common::error::tonic_err;
 use risingwave_pb::meta::cluster_service_server::ClusterService;
 use risingwave_pb::meta::{
     ActivateWorkerNodeRequest, ActivateWorkerNodeResponse, AddWorkerNodeRequest,
@@ -22,6 +21,7 @@ use risingwave_pb::meta::{
 use tonic::{Request, Response, Status};
 
 use crate::cluster::ClusterManagerRef;
+use crate::error::meta_error_to_tonic;
 use crate::storage::MetaStore;
 
 #[derive(Clone)]
@@ -48,8 +48,8 @@ where
         request: Request<AddWorkerNodeRequest>,
     ) -> Result<Response<AddWorkerNodeResponse>, Status> {
         let req = request.into_inner();
-        let worker_type = req.get_worker_type().map_err(tonic_err)?;
-        let host = req.get_host().map_err(tonic_err)?.clone();
+        let worker_type = req.get_worker_type().map_err(meta_error_to_tonic)?;
+        let host = req.get_host().map_err(meta_error_to_tonic)?.clone();
         let worker_node_parallelism = req.worker_node_parallelism as usize;
         let worker_node = self
             .cluster_manager
@@ -66,7 +66,7 @@ where
         request: Request<ActivateWorkerNodeRequest>,
     ) -> Result<Response<ActivateWorkerNodeResponse>, Status> {
         let req = request.into_inner();
-        let host = req.get_host().map_err(tonic_err)?.clone();
+        let host = req.get_host().map_err(meta_error_to_tonic)?.clone();
         self.cluster_manager.activate_worker_node(host).await?;
         Ok(Response::new(ActivateWorkerNodeResponse { status: None }))
     }
@@ -76,7 +76,7 @@ where
         request: Request<DeleteWorkerNodeRequest>,
     ) -> Result<Response<DeleteWorkerNodeResponse>, Status> {
         let req = request.into_inner();
-        let host = req.get_host().map_err(tonic_err)?.clone();
+        let host = req.get_host().map_err(meta_error_to_tonic)?.clone();
         self.cluster_manager.delete_worker_node(host).await?;
         Ok(Response::new(DeleteWorkerNodeResponse { status: None }))
     }
@@ -86,7 +86,7 @@ where
         request: Request<ListAllNodesRequest>,
     ) -> Result<Response<ListAllNodesResponse>, Status> {
         let req = request.into_inner();
-        let worker_type = req.get_worker_type().map_err(tonic_err)?;
+        let worker_type = req.get_worker_type().map_err(meta_error_to_tonic)?;
         let worker_state = if req.include_starting_nodes {
             None
         } else {

--- a/src/meta/src/rpc/service/mod.rs
+++ b/src/meta/src/rpc/service/mod.rs
@@ -27,28 +27,27 @@ use std::task::{Context, Poll};
 use futures::Stream;
 use tokio::sync::mpsc::Receiver;
 
-use crate::error::meta_error_to_tonic;
 use crate::MetaError;
 
-/// `MetaErrorReceiverStream` is a wrapper around `tokio::sync::mpsc::Receiver` that implements
-/// Stream. `MetaErrorReceiverStream` is similar to `tokio_stream::wrappers::ReceiverStream`, but it
+/// `RwReceiverStream` is a wrapper around `tokio::sync::mpsc::Receiver` that implements
+/// Stream. `RwReceiverStream` is similar to `tokio_stream::wrappers::ReceiverStream`, but it
 /// maps Result<S, `MetaError`> to Result<S, `tonic::Status`>.
-pub struct MetaErrorReceiverStream<S> {
+pub struct RwReceiverStream<S> {
     inner: Receiver<Result<S, MetaError>>,
 }
 
-impl<S> MetaErrorReceiverStream<S> {
+impl<S> RwReceiverStream<S> {
     pub fn new(inner: Receiver<Result<S, MetaError>>) -> Self {
         Self { inner }
     }
 }
 
-impl<S> Stream for MetaErrorReceiverStream<S> {
+impl<S> Stream for RwReceiverStream<S> {
     type Item = Result<S, tonic::Status>;
 
     fn poll_next(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
         self.inner
             .poll_recv(cx)
-            .map(|opt| opt.map(|res| res.map_err(meta_error_to_tonic)))
+            .map(|opt| opt.map(|res| res.map_err(Into::into)))
     }
 }

--- a/src/meta/src/rpc/service/user_service.rs
+++ b/src/meta/src/rpc/service/user_service.rs
@@ -13,7 +13,6 @@
 // limitations under the License.
 
 use itertools::Itertools;
-use risingwave_common::error::{tonic_err, Result as RwResult};
 use risingwave_pb::user::grant_privilege::Object;
 use risingwave_pb::user::update_user_request::UpdateField;
 use risingwave_pb::user::user_service_server::UserService;
@@ -24,8 +23,10 @@ use risingwave_pb::user::{
 };
 use tonic::{Request, Response, Status};
 
+use crate::error::meta_error_to_tonic;
 use crate::manager::{CatalogManagerRef, IdCategory, MetaSrvEnv, UserInfoManagerRef};
 use crate::storage::MetaStore;
+use crate::MetaResult;
 
 // TODO: Change user manager as a part of the catalog manager, to ensure that operations on Catalog
 // and User are transactional.
@@ -58,7 +59,7 @@ where
         &self,
         privileges: &[GrantPrivilege],
         with_grant_option: Option<bool>,
-    ) -> RwResult<Vec<GrantPrivilege>> {
+    ) -> MetaResult<Vec<GrantPrivilege>> {
         let mut expanded_privileges = Vec::new();
         for privilege in privileges {
             if let Some(Object::AllTablesSchemaId(schema_id)) = &privilege.object {
@@ -114,14 +115,14 @@ impl<S: MetaStore> UserService for UserServiceImpl<S> {
             .id_gen_manager()
             .generate::<{ IdCategory::User }>()
             .await
-            .map_err(tonic_err)? as u32;
-        let mut user = req.get_user().map_err(tonic_err)?.clone();
+            .map_err(meta_error_to_tonic)? as u32;
+        let mut user = req.get_user().map_err(meta_error_to_tonic)?.clone();
         user.id = id;
         let version = self
             .user_manager
             .create_user(&user)
             .await
-            .map_err(tonic_err)?;
+            .map_err(meta_error_to_tonic)?;
 
         Ok(Response::new(CreateUserResponse {
             status: None,
@@ -139,7 +140,7 @@ impl<S: MetaStore> UserService for UserServiceImpl<S> {
             .user_manager
             .drop_user(req.user_id)
             .await
-            .map_err(tonic_err)?;
+            .map_err(meta_error_to_tonic)?;
 
         Ok(Response::new(DropUserResponse {
             status: None,
@@ -158,12 +159,12 @@ impl<S: MetaStore> UserService for UserServiceImpl<S> {
             .iter()
             .map(|i| UpdateField::from_i32(*i).unwrap())
             .collect_vec();
-        let user = req.get_user().map_err(tonic_err)?.clone();
+        let user = req.get_user().map_err(meta_error_to_tonic)?.clone();
         let version = self
             .user_manager
             .update_user(&user, &update_fields)
             .await
-            .map_err(tonic_err)?;
+            .map_err(meta_error_to_tonic)?;
 
         Ok(Response::new(UpdateUserResponse {
             status: None,
@@ -180,12 +181,12 @@ impl<S: MetaStore> UserService for UserServiceImpl<S> {
         let new_privileges = self
             .expand_privilege(req.get_privileges(), Some(req.with_grant_option))
             .await
-            .map_err(tonic_err)?;
+            .map_err(meta_error_to_tonic)?;
         let version = self
             .user_manager
             .grant_privilege(&req.user_ids, &new_privileges, req.granted_by)
             .await
-            .map_err(tonic_err)?;
+            .map_err(meta_error_to_tonic)?;
 
         Ok(Response::new(GrantPrivilegeResponse {
             status: None,
@@ -202,7 +203,7 @@ impl<S: MetaStore> UserService for UserServiceImpl<S> {
         let privileges = self
             .expand_privilege(req.get_privileges(), None)
             .await
-            .map_err(tonic_err)?;
+            .map_err(meta_error_to_tonic)?;
         let revoke_grant_option = req.revoke_grant_option;
         let version = self
             .user_manager
@@ -215,7 +216,7 @@ impl<S: MetaStore> UserService for UserServiceImpl<S> {
                 req.cascade,
             )
             .await
-            .map_err(tonic_err)?;
+            .map_err(meta_error_to_tonic)?;
 
         Ok(Response::new(RevokePrivilegeResponse {
             status: None,

--- a/src/meta/src/rpc/service/user_service.rs
+++ b/src/meta/src/rpc/service/user_service.rs
@@ -118,11 +118,7 @@ impl<S: MetaStore> UserService for UserServiceImpl<S> {
             .map_err(meta_error_to_tonic)? as u32;
         let mut user = req.get_user().map_err(meta_error_to_tonic)?.clone();
         user.id = id;
-        let version = self
-            .user_manager
-            .create_user(&user)
-            .await
-            .map_err(meta_error_to_tonic)?;
+        let version = self.user_manager.create_user(&user).await?;
 
         Ok(Response::new(CreateUserResponse {
             status: None,
@@ -136,11 +132,7 @@ impl<S: MetaStore> UserService for UserServiceImpl<S> {
         request: Request<DropUserRequest>,
     ) -> Result<Response<DropUserResponse>, Status> {
         let req = request.into_inner();
-        let version = self
-            .user_manager
-            .drop_user(req.user_id)
-            .await
-            .map_err(meta_error_to_tonic)?;
+        let version = self.user_manager.drop_user(req.user_id).await?;
 
         Ok(Response::new(DropUserResponse {
             status: None,
@@ -160,11 +152,7 @@ impl<S: MetaStore> UserService for UserServiceImpl<S> {
             .map(|i| UpdateField::from_i32(*i).unwrap())
             .collect_vec();
         let user = req.get_user().map_err(meta_error_to_tonic)?.clone();
-        let version = self
-            .user_manager
-            .update_user(&user, &update_fields)
-            .await
-            .map_err(meta_error_to_tonic)?;
+        let version = self.user_manager.update_user(&user, &update_fields).await?;
 
         Ok(Response::new(UpdateUserResponse {
             status: None,
@@ -180,13 +168,11 @@ impl<S: MetaStore> UserService for UserServiceImpl<S> {
         let req = request.into_inner();
         let new_privileges = self
             .expand_privilege(req.get_privileges(), Some(req.with_grant_option))
-            .await
-            .map_err(meta_error_to_tonic)?;
+            .await?;
         let version = self
             .user_manager
             .grant_privilege(&req.user_ids, &new_privileges, req.granted_by)
-            .await
-            .map_err(meta_error_to_tonic)?;
+            .await?;
 
         Ok(Response::new(GrantPrivilegeResponse {
             status: None,
@@ -200,10 +186,7 @@ impl<S: MetaStore> UserService for UserServiceImpl<S> {
         request: Request<RevokePrivilegeRequest>,
     ) -> Result<Response<RevokePrivilegeResponse>, Status> {
         let req = request.into_inner();
-        let privileges = self
-            .expand_privilege(req.get_privileges(), None)
-            .await
-            .map_err(meta_error_to_tonic)?;
+        let privileges = self.expand_privilege(req.get_privileges(), None).await?;
         let revoke_grant_option = req.revoke_grant_option;
         let version = self
             .user_manager
@@ -215,8 +198,7 @@ impl<S: MetaStore> UserService for UserServiceImpl<S> {
                 revoke_grant_option,
                 req.cascade,
             )
-            .await
-            .map_err(meta_error_to_tonic)?;
+            .await?;
 
         Ok(Response::new(RevokePrivilegeResponse {
             status: None,

--- a/src/meta/src/storage/meta_store.rs
+++ b/src/meta/src/storage/meta_store.rs
@@ -16,7 +16,6 @@ use std::fmt::{Display, Formatter};
 use std::str;
 
 use async_trait::async_trait;
-use risingwave_common::error::RwError;
 use thiserror::Error;
 
 use crate::storage::transaction::Transaction;
@@ -59,12 +58,6 @@ pub enum MetaStoreError {
 }
 
 pub type MetaStoreResult<T> = std::result::Result<T, MetaStoreError>;
-
-impl From<MetaStoreError> for RwError {
-    fn from(e: MetaStoreError) -> Self {
-        crate::model::MetadataModelError::from(e).into()
-    }
-}
 
 impl Display for MetaStoreError {
     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {

--- a/src/meta/src/storage/tests.rs
+++ b/src/meta/src/storage/tests.rs
@@ -15,7 +15,6 @@
 use assert_matches::assert_matches;
 use async_trait::async_trait;
 use itertools::Itertools;
-use risingwave_common::error::Result;
 
 use crate::storage::{
     Key, MemStore, MetaStore, MetaStoreError, MetaStoreResult, Operation, Snapshot, Transaction,
@@ -116,7 +115,7 @@ async fn test_meta_store_basic<S: MetaStore>(store: &S) -> MetaStoreResult<()> {
     Ok(())
 }
 
-async fn test_meta_store_transaction<S: MetaStore>(meta_store: &S) -> Result<()> {
+async fn test_meta_store_transaction<S: MetaStore>(meta_store: &S) -> MetaStoreResult<()> {
     let cf = "test_trx_cf";
     let mut kvs = vec![];
     for i in 1..=5 {
@@ -181,7 +180,7 @@ async fn test_meta_store_transaction<S: MetaStore>(meta_store: &S) -> Result<()>
     Ok(())
 }
 
-async fn test_meta_store_keys_share_prefix<S: MetaStore>(meta_store: &S) -> Result<()> {
+async fn test_meta_store_keys_share_prefix<S: MetaStore>(meta_store: &S) -> MetaStoreResult<()> {
     let cf = "test_overlapped_key_cf";
     let batch = vec![
         (
@@ -213,7 +212,7 @@ async fn test_meta_store_keys_share_prefix<S: MetaStore>(meta_store: &S) -> Resu
     Ok(())
 }
 
-async fn test_meta_store_overlapped_cf<S: MetaStore>(meta_store: &S) -> Result<()> {
+async fn test_meta_store_overlapped_cf<S: MetaStore>(meta_store: &S) -> MetaStoreResult<()> {
     let cf1 = "test_overlapped_cf1";
     let cf2 = "test_overlapped_cf11";
     let cf3 = "test_overlapped_cf111";
@@ -245,7 +244,7 @@ async fn test_meta_store_overlapped_cf<S: MetaStore>(meta_store: &S) -> Result<(
 }
 
 #[tokio::test]
-async fn test_mem_store() -> Result<()> {
+async fn test_mem_store() -> MetaStoreResult<()> {
     let store = MemStore::default();
     test_meta_store_basic(&store).await.unwrap();
     test_meta_store_keys_share_prefix(&store).await.unwrap();

--- a/src/meta/src/stream/mod.rs
+++ b/src/meta/src/stream/mod.rs
@@ -21,7 +21,6 @@ mod stream_manager;
 mod test_fragmenter;
 
 pub use meta::*;
-use risingwave_common::error::Result;
 use risingwave_pb::stream_plan::stream_node::NodeBody;
 use risingwave_pb::stream_plan::StreamNode;
 pub use scheduler::*;
@@ -31,13 +30,14 @@ pub use stream_manager::*;
 
 use crate::manager::HashMappingManagerRef;
 use crate::model::FragmentId;
+use crate::MetaResult;
 
 /// Record vnode mapping for stateful operators in meta.
 pub fn record_table_vnode_mappings(
     hash_mapping_manager: &HashMappingManagerRef,
     stream_node: &StreamNode,
     fragment_id: FragmentId,
-) -> Result<()> {
+) -> MetaResult<()> {
     // We only consider stateful operators with multiple parallel degrees here. Singleton stateful
     // operators will not have vnode mappings, so that compactors could omit the unnecessary probing
     // on vnode mappings.

--- a/src/meta/src/stream/scheduler.rs
+++ b/src/meta/src/stream/scheduler.rs
@@ -19,7 +19,6 @@ use anyhow::anyhow;
 use rand::prelude::SliceRandom;
 use risingwave_common::bail;
 use risingwave_common::buffer::BitmapBuilder;
-use risingwave_common::error::Result;
 use risingwave_common::types::VIRTUAL_NODE_COUNT;
 use risingwave_common::util::compress::compress_data;
 use risingwave_pb::common::{ActorInfo, ParallelUnit, ParallelUnitMapping, WorkerNode};
@@ -31,6 +30,7 @@ use crate::cluster::{ClusterManagerRef, WorkerId, WorkerLocations};
 use crate::manager::HashMappingManagerRef;
 use crate::model::ActorId;
 use crate::storage::MetaStore;
+use crate::MetaResult;
 
 /// [`Scheduler`] defines schedule logic for mv actors.
 pub struct Scheduler<S: MetaStore> {
@@ -106,7 +106,7 @@ impl ScheduledLocations {
     }
 
     /// Find a placement location that is on the same worker node of given actor ids.
-    pub fn schedule_colocate_with(&self, actor_ids: &[ActorId]) -> Result<ParallelUnit> {
+    pub fn schedule_colocate_with(&self, actor_ids: &[ActorId]) -> MetaResult<ParallelUnit> {
         let mut result_location = None;
         for actor_id in actor_ids {
             let location = self
@@ -152,7 +152,7 @@ where
         &self,
         fragment: &mut Fragment,
         locations: &mut ScheduledLocations,
-    ) -> Result<()> {
+    ) -> MetaResult<()> {
         if fragment.actors.is_empty() {
             bail!("fragment has no actor");
         }
@@ -244,7 +244,7 @@ where
         &self,
         fragment: &mut Fragment,
         parallel_units: &[ParallelUnit],
-    ) -> Result<()> {
+    ) -> MetaResult<()> {
         let vnode_mapping = self
             .hash_mapping_manager
             .build_fragment_hash_mapping(fragment.fragment_id, parallel_units);
@@ -285,7 +285,7 @@ mod test {
     use crate::manager::MetaSrvEnv;
 
     #[tokio::test]
-    async fn test_schedule() -> Result<()> {
+    async fn test_schedule() -> MetaResult<()> {
         let env = MetaSrvEnv::for_test().await;
         let cluster_manager =
             Arc::new(ClusterManager::new(env.clone(), Duration::from_secs(3600)).await?);
@@ -418,7 +418,7 @@ mod test {
             );
             let mut vnode_sum = 0;
             for actor in fragment.actors {
-                vnode_sum += Bitmap::try_from(actor.get_vnode_bitmap()?)?.num_high_bits();
+                vnode_sum += Bitmap::from(actor.get_vnode_bitmap()?).num_high_bits();
             }
             assert_eq!(vnode_sum as usize, VIRTUAL_NODE_COUNT);
         }

--- a/src/meta/src/stream/source_manager.rs
+++ b/src/meta/src/stream/source_manager.rs
@@ -57,7 +57,7 @@ use crate::model::{
 };
 use crate::storage::{MetaStore, Transaction};
 use crate::stream::FragmentManagerRef;
-use crate::{MetaError, MetaResult};
+use crate::MetaResult;
 
 pub type SourceManagerRef<S> = Arc<SourceManager<S>>;
 
@@ -478,11 +478,7 @@ where
             }
         }
 
-        self.env
-            .meta_store()
-            .txn(trx)
-            .await
-            .map_err(MetaError::transaction_error)
+        self.env.meta_store().txn(trx).await.map_err(Into::into)
     }
 
     pub async fn patch_update(
@@ -498,11 +494,7 @@ where
             }
         }
 
-        self.env
-            .meta_store()
-            .txn(trx)
-            .await
-            .map_err(MetaError::transaction_error)?;
+        self.env.meta_store().txn(trx).await?;
 
         let mut core = self.core.lock().await;
         core.patch_diff(source_fragments, actor_splits);

--- a/src/meta/src/stream/source_manager.rs
+++ b/src/meta/src/stream/source_manager.rs
@@ -18,10 +18,10 @@ use std::collections::{BTreeMap, BTreeSet, HashMap, HashSet};
 use std::sync::Arc;
 use std::time::Duration;
 
+use anyhow::anyhow;
 use futures::future::try_join_all;
 use itertools::Itertools;
 use risingwave_common::catalog::TableId;
-use risingwave_common::error::{internal_error, Result, RwError, ToRwResult};
 use risingwave_common::try_match_expand;
 use risingwave_connector::source::{
     ConnectorProperties, SplitEnumeratorImpl, SplitImpl, SplitMetaData,
@@ -57,6 +57,7 @@ use crate::model::{
 };
 use crate::storage::{MetaStore, Transaction};
 use crate::stream::FragmentManagerRef;
+use crate::{MetaError, MetaResult};
 
 pub type SourceManagerRef<S> = Arc<SourceManager<S>>;
 
@@ -128,18 +129,15 @@ impl MetadataModel for SourceActorInfo {
 }
 
 impl ConnectorSourceWorker {
-    pub async fn create(source: &Source, period: Duration) -> Result<Self> {
+    pub async fn create(source: &Source, period: Duration) -> MetaResult<Self> {
         let source_id = source.get_id();
         let info = source
             .info
             .clone()
-            .ok_or_else(|| internal_error("source info is empty"))?;
+            .ok_or_else(|| anyhow!("source info is empty"))?;
         let stream_source_info = try_match_expand!(info, Info::StreamSource)?;
-        let properties =
-            ConnectorProperties::extract(stream_source_info.properties).to_rw_result()?;
-        let enumerator = SplitEnumeratorImpl::create(properties)
-            .await
-            .to_rw_result()?;
+        let properties = ConnectorProperties::extract(stream_source_info.properties)?;
+        let enumerator = SplitEnumeratorImpl::create(properties).await?;
         let current_splits = Arc::new(Mutex::new(SharedSplitMap { splits: None }));
         Ok(Self {
             source_id,
@@ -149,7 +147,10 @@ impl ConnectorSourceWorker {
         })
     }
 
-    pub async fn run(&mut self, mut sync_call_rx: UnboundedReceiver<oneshot::Sender<Result<()>>>) {
+    pub async fn run(
+        &mut self,
+        mut sync_call_rx: UnboundedReceiver<oneshot::Sender<MetaResult<()>>>,
+    ) {
         let mut interval = time::interval(self.period);
         interval.set_missed_tick_behavior(MissedTickBehavior::Skip);
         loop {
@@ -169,8 +170,8 @@ impl ConnectorSourceWorker {
         }
     }
 
-    async fn tick(&mut self) -> Result<()> {
-        let splits = self.enumerator.list_splits().await.to_rw_result()?;
+    async fn tick(&mut self) -> MetaResult<()> {
+        let splits = self.enumerator.list_splits().await?;
         let mut current_splits = self.current_splits.lock().await;
         current_splits.splits.replace(
             splits
@@ -185,7 +186,7 @@ impl ConnectorSourceWorker {
 
 pub struct ConnectorSourceWorkerHandle {
     handle: JoinHandle<()>,
-    sync_call_tx: UnboundedSender<oneshot::Sender<Result<()>>>,
+    sync_call_tx: UnboundedSender<oneshot::Sender<MetaResult<()>>>,
     splits: SharedSplitMapRef,
 }
 
@@ -214,7 +215,7 @@ where
         }
     }
 
-    async fn diff(&mut self) -> Result<HashMap<ActorId, Vec<SplitImpl>>> {
+    async fn diff(&mut self) -> MetaResult<HashMap<ActorId, Vec<SplitImpl>>> {
         // first, list all fragment, so that we can get `FragmentId` -> `Vec<ActorId>` map
         let table_frags = self.fragment_manager.list_table_fragments().await?;
         let mut frag_actors: HashMap<FragmentId, Vec<ActorId>> = HashMap::new();
@@ -415,7 +416,7 @@ where
         catalog_manager: CatalogManagerRef<S>,
         fragment_manager: FragmentManagerRef<S>,
         compaction_group_manager: CompactionGroupManagerRef<S>,
-    ) -> Result<Self> {
+    ) -> MetaResult<Self> {
         let mut managed_sources = HashMap::new();
         {
             let catalog_guard = catalog_manager.get_catalog_core_guard().await;
@@ -460,7 +461,7 @@ where
         &self,
         source_fragments: Option<HashMap<SourceId, BTreeSet<FragmentId>>>,
         actor_splits: Option<HashSet<ActorId>>,
-    ) -> Result<()> {
+    ) -> MetaResult<()> {
         {
             let mut core = self.core.lock().await;
             core.drop_diff(source_fragments, actor_splits.clone());
@@ -481,14 +482,14 @@ where
             .meta_store()
             .txn(trx)
             .await
-            .map_err(|e| internal_error(e.to_string()))
+            .map_err(MetaError::transaction_error)
     }
 
     pub async fn patch_update(
         &self,
         source_fragments: Option<HashMap<SourceId, BTreeSet<FragmentId>>>,
         actor_splits: Option<HashMap<ActorId, Vec<SplitImpl>>>,
-    ) -> Result<()> {
+    ) -> MetaResult<()> {
         let mut trx = Transaction::default();
         if let Some(actor_splits) = actor_splits.clone() {
             for (actor_id, splits) in actor_splits {
@@ -501,7 +502,7 @@ where
             .meta_store()
             .txn(trx)
             .await
-            .map_err(|e| internal_error(e.to_string()))?;
+            .map_err(MetaError::transaction_error)?;
 
         let mut core = self.core.lock().await;
         core.patch_diff(source_fragments, actor_splits);
@@ -513,7 +514,7 @@ where
         &self,
         table_id: &TableId,
         source_fragments: HashMap<SourceId, BTreeSet<FragmentId>>,
-    ) -> Result<HashMap<ActorId, Vec<SplitImpl>>> {
+    ) -> MetaResult<HashMap<ActorId, Vec<SplitImpl>>> {
         let core = self.core.lock().await;
         let table_fragments = core
             .fragment_manager
@@ -526,13 +527,16 @@ where
             let handle = core
                 .managed_sources
                 .get(&source_id)
-                .ok_or_else(|| internal_error(format!("could not found source {}", source_id)))?;
+                .ok_or_else(|| anyhow!("could not found source {}", source_id))?;
 
             if handle.splits.lock().await.splits.is_none() {
                 // force refresh source
                 let (tx, rx) = oneshot::channel();
-                handle.sync_call_tx.send(tx).to_rw_result()?;
-                rx.await.map_err(|e| internal_error(e.to_string()))??;
+                handle
+                    .sync_call_tx
+                    .send(tx)
+                    .map_err(|e| anyhow!(e.to_string()))?;
+                rx.await.map_err(|e| anyhow!(e.to_string()))??;
             }
 
             if let Some(splits) = &handle.splits.lock().await.splits {
@@ -545,9 +549,7 @@ where
                     let empty_actor_splits = table_fragments
                         .fragments
                         .get(&fragment_id)
-                        .ok_or_else(|| {
-                            internal_error(format!("could not found source {}", source_id))
-                        })?
+                        .ok_or_else(|| anyhow!("could not found source {}", source_id))?
                         .actors
                         .iter()
                         .map(|actor| (actor.actor_id, vec![]))
@@ -565,7 +567,7 @@ where
         Ok(assigned)
     }
 
-    async fn all_stream_clients(&self) -> Result<impl Iterator<Item = StreamClient>> {
+    async fn all_stream_clients(&self) -> MetaResult<impl Iterator<Item = StreamClient>> {
         // FIXME: there is gap between the compute node activate itself and source ddl operation,
         // create/drop source(non-stateful source like TableSource) before the compute node
         // activate itself will cause an inconsistent state. This situation will happen when some
@@ -587,7 +589,7 @@ where
     }
 
     /// Broadcast the create source request to all compute nodes.
-    pub async fn create_source(&self, source: &Source) -> Result<()> {
+    pub async fn create_source(&self, source: &Source) -> MetaResult<()> {
         // This scope guard does clean up jobs ASYNCHRONOUSLY before Err returns.
         // It MUST be cleared before Ok returns.
         let mut revert_funcs = scopeguard::guard(
@@ -620,7 +622,7 @@ where
                 let request = ComputeNodeCreateSourceRequest {
                     source: Some(source.clone()),
                 };
-                async move { client.create_source(request).await.map_err(RwError::from) }
+                async move { client.create_source(request).await }
             });
 
         // ignore response body, always none
@@ -644,7 +646,7 @@ where
     async fn create_source_worker(
         source: &Source,
         managed_sources: &mut HashMap<SourceId, ConnectorSourceWorkerHandle>,
-    ) -> Result<()> {
+    ) -> MetaResult<()> {
         let mut worker = ConnectorSourceWorker::create(source, Duration::from_secs(10)).await?;
         let current_splits_ref = worker.current_splits.clone();
         log::info!("spawning new watcher for source {}", source.id);
@@ -664,14 +666,14 @@ where
         Ok(())
     }
 
-    pub async fn drop_source(&self, source_id: SourceId) -> Result<()> {
+    pub async fn drop_source(&self, source_id: SourceId) -> MetaResult<()> {
         let futures = self
             .all_stream_clients()
             .await?
             .into_iter()
             .map(|mut client| {
                 let request = ComputeNodeDropSourceRequest { source_id };
-                async move { client.drop_source(request).await.map_err(RwError::from) }
+                async move { client.drop_source(request).await }
             });
         let _responses: Vec<_> = try_join_all(futures).await?;
 
@@ -705,7 +707,7 @@ where
         Ok(())
     }
 
-    async fn tick(&self) -> Result<()> {
+    async fn tick(&self) -> MetaResult<()> {
         let diff = {
             let mut core_guard = self.core.lock().await;
             core_guard.diff().await?
@@ -742,7 +744,7 @@ where
         Ok(())
     }
 
-    pub async fn run(&self) -> Result<()> {
+    pub async fn run(&self) -> MetaResult<()> {
         let mut ticker = time::interval(Self::SOURCE_TICK_INTERVAL);
         ticker.set_missed_tick_behavior(MissedTickBehavior::Skip);
         loop {

--- a/src/meta/src/stream/stream_graph.rs
+++ b/src/meta/src/stream/stream_graph.rs
@@ -20,7 +20,6 @@ use std::sync::Arc;
 use assert_matches::assert_matches;
 use itertools::Itertools;
 use risingwave_common::catalog::{generate_intertable_name_with_type, TableId};
-use risingwave_common::error::{ErrorCode, Result};
 use risingwave_pb::catalog::Table;
 use risingwave_pb::meta::table_fragments::fragment::FragmentDistributionType;
 use risingwave_pb::meta::table_fragments::Fragment;
@@ -37,6 +36,7 @@ use crate::cluster::WorkerId;
 use crate::manager::{IdCategory, IdGeneratorManagerRef};
 use crate::model::{ActorId, FragmentId};
 use crate::storage::MetaStore;
+use crate::MetaResult;
 
 /// Id of an Actor, maybe local or global
 #[derive(Clone, Copy, Debug, Hash, Eq, PartialEq, PartialOrd, Ord)]
@@ -475,7 +475,7 @@ impl StreamGraphBuilder {
         ctx: &mut CreateMaterializedViewContext,
         actor_id_offset: u32,
         actor_id_len: u32,
-    ) -> Result<HashMap<GlobalFragmentId, Vec<StreamActor>>> {
+    ) -> MetaResult<HashMap<GlobalFragmentId, Vec<StreamActor>>> {
         let mut graph = HashMap::new();
 
         for builder in self.actor_builders.values_mut() {
@@ -525,7 +525,7 @@ impl StreamGraphBuilder {
         actor_id: LocalActorId,
         upstream_actor_id: &mut HashMap<u64, OrderedActorLink>,
         upstream_fragment_id: &mut HashMap<u64, GlobalFragmentId>,
-    ) -> Result<StreamNode> {
+    ) -> MetaResult<StreamNode> {
         let table_id_offset = ctx.table_id_offset;
         let mut check_and_fill_internal_table = |table_id: u32, table: Option<Table>| {
             ctx.internal_table_id_map.entry(table_id).or_insert(table);
@@ -708,7 +708,7 @@ impl StreamGraphBuilder {
     }
 
     /// Resolve the chain node, only rewrite the schema of input `MergeNode`.
-    fn resolve_chain_node(&self, stream_node: &StreamNode) -> Result<StreamNode> {
+    fn resolve_chain_node(&self, stream_node: &StreamNode) -> MetaResult<StreamNode> {
         let NodeBody::Chain(chain_node) = stream_node.get_node_body().unwrap() else {
             unreachable!()
         };
@@ -783,7 +783,7 @@ impl ActorGraphBuilder {
         fragment_graph: &StreamFragmentGraphProto,
         default_parallelism: u32,
         ctx: &mut CreateMaterializedViewContext,
-    ) -> Result<Self>
+    ) -> MetaResult<Self>
     where
         S: MetaStore,
     {
@@ -835,7 +835,7 @@ impl ActorGraphBuilder {
         id_gen_manager: IdGeneratorManagerRef<S>,
         fragment_manager: FragmentManagerRef<S>,
         ctx: &mut CreateMaterializedViewContext,
-    ) -> Result<BTreeMap<FragmentId, Fragment>>
+    ) -> MetaResult<BTreeMap<FragmentId, Fragment>>
     where
         S: MetaStore,
     {
@@ -849,7 +849,7 @@ impl ActorGraphBuilder {
         id_gen_manager: IdGeneratorManagerRef<S>,
         fragment_manager: FragmentManagerRef<S>,
         ctx: &mut CreateMaterializedViewContext,
-    ) -> Result<BTreeMap<FragmentId, Fragment>>
+    ) -> MetaResult<BTreeMap<FragmentId, Fragment>>
     where
         S: MetaStore,
     {
@@ -920,7 +920,7 @@ impl ActorGraphBuilder {
         &self,
         state: &mut BuildActorGraphState,
         fragment_graph: &StreamFragmentGraph,
-    ) -> Result<()> {
+    ) -> MetaResult<()> {
         // Use topological sort to build the graph from downstream to upstream. (The first fragment
         // poped out from the heap will be the top-most node in plan, or the sink in stream graph.)
         let mut actionable_fragment_id = VecDeque::new();
@@ -956,7 +956,7 @@ impl ActorGraphBuilder {
 
         if !downstream_cnts.is_empty() {
             // There are fragments that are not processed yet.
-            return Err(ErrorCode::InternalError("graph is not a DAG".into()).into());
+            return Err(anyhow::anyhow!("graph is not a DAG").into());
         }
 
         Ok(())
@@ -967,7 +967,7 @@ impl ActorGraphBuilder {
         fragment_id: GlobalFragmentId,
         state: &mut BuildActorGraphState,
         fragment_graph: &StreamFragmentGraph,
-    ) -> Result<()> {
+    ) -> MetaResult<()> {
         let current_fragment = fragment_graph.get_fragment(fragment_id).unwrap().clone();
 
         let parallel_degree = self

--- a/src/meta/src/stream/stream_graph.rs
+++ b/src/meta/src/stream/stream_graph.rs
@@ -19,6 +19,7 @@ use std::sync::Arc;
 
 use assert_matches::assert_matches;
 use itertools::Itertools;
+use risingwave_common::bail;
 use risingwave_common::catalog::{generate_intertable_name_with_type, TableId};
 use risingwave_pb::catalog::Table;
 use risingwave_pb::meta::table_fragments::fragment::FragmentDistributionType;
@@ -956,7 +957,7 @@ impl ActorGraphBuilder {
 
         if !downstream_cnts.is_empty() {
             // There are fragments that are not processed yet.
-            return Err(anyhow::anyhow!("graph is not a DAG").into());
+            bail!("graph is not a DAG");
         }
 
         Ok(())

--- a/src/meta/src/stream/stream_manager.rs
+++ b/src/meta/src/stream/stream_manager.rs
@@ -1281,7 +1281,7 @@ mod tests {
         // TODO: check memory and metastore consistent
         assert_eq!(
             select_err_1.to_string(),
-            "internal error: table_fragment not exist: id=0"
+            "table_fragment not exist: id=0"
         );
 
         services.stop().await;

--- a/src/meta/src/stream/stream_manager.rs
+++ b/src/meta/src/stream/stream_manager.rs
@@ -1279,10 +1279,7 @@ mod tests {
             .unwrap_err();
 
         // TODO: check memory and metastore consistent
-        assert_eq!(
-            select_err_1.to_string(),
-            "table_fragment not exist: id=0"
-        );
+        assert_eq!(select_err_1.to_string(), "table_fragment not exist: id=0");
 
         services.stop().await;
     }

--- a/src/meta/src/stream/stream_manager.rs
+++ b/src/meta/src/stream/stream_manager.rs
@@ -18,7 +18,6 @@ use std::sync::Arc;
 use itertools::Itertools;
 use risingwave_common::bail;
 use risingwave_common::catalog::TableId;
-use risingwave_common::error::Result;
 use risingwave_common::types::{ParallelUnitId, VIRTUAL_NODE_COUNT};
 use risingwave_pb::catalog::{Source, Table};
 use risingwave_pb::common::{ActorInfo, ParallelUnitMapping, WorkerType};
@@ -40,6 +39,7 @@ use crate::manager::{DatabaseId, HashMappingManagerRef, MetaSrvEnv, SchemaId};
 use crate::model::{ActorId, TableFragments};
 use crate::storage::MetaStore;
 use crate::stream::{fetch_source_fragments, FragmentManagerRef, Scheduler, SourceManagerRef};
+use crate::MetaResult;
 
 pub type GlobalStreamManagerRef<S> = Arc<GlobalStreamManager<S>>;
 
@@ -106,7 +106,7 @@ where
         cluster_manager: ClusterManagerRef<S>,
         source_manager: SourceManagerRef<S>,
         compaction_group_manager: CompactionGroupManagerRef<S>,
-    ) -> Result<Self> {
+    ) -> MetaResult<Self> {
         Ok(Self {
             scheduler: Scheduler::new(cluster_manager.clone(), env.hash_mapping_manager_ref()),
             fragment_manager,
@@ -126,7 +126,7 @@ where
         dispatchers: &mut HashMap<ActorId, Vec<Dispatcher>>,
         upstream_worker_actors: &mut HashMap<WorkerId, HashSet<ActorId>>,
         locations: &ScheduledLocations,
-    ) -> Result<()> {
+    ) -> MetaResult<()> {
         // The closure environment. Used to simulate recursive closure.
         struct Env<'a> {
             /// Records what's the correspoding actor of each parallel unit of one table.
@@ -148,7 +148,7 @@ where
                 actor_id: ActorId,
                 same_worker_node_as_upstream: bool,
                 is_singleton: bool,
-            ) -> Result<()> {
+            ) -> MetaResult<()> {
                 let Some(NodeBody::Chain(ref mut chain)) = stream_node.node_body else {
                     // If node is not chain node, recursively deal with input nodes
                     for input in &mut stream_node.input {
@@ -311,7 +311,7 @@ where
             table_properties,
             ..
         }: &mut CreateMaterializedViewContext,
-    ) -> Result<()> {
+    ) -> MetaResult<()> {
         // This scope guard does clean up jobs ASYNCHRONOUSLY before Err returns.
         // It MUST be cleared before Ok returns.
         let mut revert_funcs = scopeguard::guard(
@@ -652,7 +652,7 @@ where
 
     /// Dropping materialized view is done by barrier manager. Check
     /// [`Command::DropMaterializedView`] for details.
-    pub async fn drop_materialized_view(&self, table_id: &TableId) -> Result<()> {
+    pub async fn drop_materialized_view(&self, table_id: &TableId) -> MetaResult<()> {
         let table_fragments = self
             .fragment_manager
             .select_table_fragments_by_table_id(table_id)
@@ -708,7 +708,6 @@ mod tests {
     use std::time::Duration;
 
     use risingwave_common::catalog::TableId;
-    use risingwave_common::error::tonic_err;
     use risingwave_pb::common::{HostAddress, WorkerType};
     use risingwave_pb::meta::table_fragments::fragment::FragmentDistributionType;
     use risingwave_pb::meta::table_fragments::Fragment;
@@ -729,6 +728,7 @@ mod tests {
     use super::*;
     use crate::barrier::GlobalBarrierManager;
     use crate::cluster::ClusterManager;
+    use crate::error::meta_error_to_tonic;
     use crate::hummock::compaction_group::manager::CompactionGroupManager;
     use crate::hummock::{CompactorManager, HummockManager};
     use crate::manager::{CatalogManager, MetaSrvEnv};
@@ -788,7 +788,7 @@ mod tests {
             for info in req.get_info() {
                 guard.insert(
                     info.get_actor_id(),
-                    info.get_host().map_err(tonic_err)?.clone(),
+                    info.get_host().map_err(meta_error_to_tonic)?.clone(),
                 );
             }
 
@@ -856,7 +856,7 @@ mod tests {
     }
 
     impl MockServices {
-        async fn start(host: &str, port: u16) -> Result<Self> {
+        async fn start(host: &str, port: u16) -> MetaResult<Self> {
             let addr = SocketAddr::new(host.parse().unwrap(), port);
             let state = Arc::new(FakeFragmentState {
                 actor_streams: Mutex::new(HashMap::new()),
@@ -984,7 +984,7 @@ mod tests {
     }
 
     #[tokio::test(flavor = "multi_thread")]
-    async fn test_create_materialized_view() -> Result<()> {
+    async fn test_create_materialized_view() -> MetaResult<()> {
         let services = MockServices::start("127.0.0.1", 12333).await?;
 
         let table_id = TableId::new(0);
@@ -1060,7 +1060,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn test_drop_materialized_view() -> Result<()> {
+    async fn test_drop_materialized_view() -> MetaResult<()> {
         let services = MockServices::start("127.0.0.1", 12334).await?;
 
         let table_id = TableId::new(0);
@@ -1156,10 +1156,7 @@ mod tests {
             .unwrap_err();
 
         // TODO: check memory and metastore consistent
-        assert_eq!(
-            select_err_1.to_string(),
-            "internal error: table_fragment not exist: id=0"
-        );
+        assert_eq!(select_err_1.to_string(), "table_fragment not exist: id=0");
 
         services.stop().await;
         Ok(())

--- a/src/meta/src/stream/test_fragmenter.rs
+++ b/src/meta/src/stream/test_fragmenter.rs
@@ -17,7 +17,6 @@ use std::sync::Arc;
 use std::vec;
 
 use risingwave_common::catalog::{DatabaseId, SchemaId, TableId};
-use risingwave_common::error::Result;
 use risingwave_pb::catalog::Table as ProstTable;
 use risingwave_pb::data::data_type::TypeName;
 use risingwave_pb::data::DataType;
@@ -38,6 +37,7 @@ use crate::manager::MetaSrvEnv;
 use crate::model::TableFragments;
 use crate::stream::stream_graph::ActorGraphBuilder;
 use crate::stream::{CreateMaterializedViewContext, FragmentManager};
+use crate::MetaResult;
 
 fn make_inputref(idx: i32) -> ExprNode {
     ExprNode {
@@ -347,7 +347,7 @@ fn make_stream_graph() -> StreamFragmentGraph {
 // NOTE: frontend is not yet available with madsim
 #[cfg(not(madsim))]
 #[tokio::test]
-async fn test_fragmenter() -> Result<()> {
+async fn test_fragmenter() -> MetaResult<()> {
     let env = MetaSrvEnv::for_test().await;
     let fragment_manager = Arc::new(FragmentManager::new(env.clone()).await?);
     let parallel_degree = 4;


### PR DESCRIPTION
I hereby agree to the terms of the [Singularity Data, Inc. Contributor License Agreement](https://gist.github.com/skyzh/0663682a70b0edde7ae991492f2314cb#file-s9y_cla).

## What's changed and what's your intention?

1. add `MetaError`.
2. remove `RwError`, `RwResult` and `ErrorCode` in meta's source files.
3. replace `impl TryFrom<&ProstBuffer> for Bitmap` with `impl From<&ProstBuffer> for Bitmap`.

Now the organization of Error type in meta is as follows:
Each arrow without text means `impl From<X> for Y`.
Each arrow with text means there is a function `Y::text(X) -> Y`
![error type](https://user-images.githubusercontent.com/41586196/182547891-a64c7548-2424-44e4-b957-8dbdb053dea1.png)

### TODO

Add a struct `StreamClient` used in `StreamClientPool`. It can convert `tonic::Status` to `RpcError` and help us hide `tonic::Status` from meta's source files.

## Checklist

- [x] I have written necessary rustdoc comments
- [x] I have added necessary unit tests and integration tests
- [x] All checks passed in `./risedev check` (or alias, `./risedev c`)

## Refer to a related PR or issue link (optional)
close #4168 

