### PR TITLE
refactor(batch): unify scan type in batch scan

### DIFF
--- a/src/compute/tests/integration_tests.rs
+++ b/src/compute/tests/integration_tests.rs
@@ -210,7 +210,7 @@ async fn test_table_v2_materialize() -> Result<()> {
 
     let scan = Box::new(RowSeqScanExecutor::new(
         table.schema().clone(),
-        vec![ScanType::TableScan(table.batch_iter(u64::MAX).await?)],
+        vec![ScanType::BatchScan(table.batch_iter(u64::MAX).await?)],
         1024,
         "RowSeqExecutor2".to_string(),
         Arc::new(BatchMetrics::unused()),
@@ -268,7 +268,7 @@ async fn test_table_v2_materialize() -> Result<()> {
     // Scan the table again, we are able to get the data now!
     let scan = Box::new(RowSeqScanExecutor::new(
         table.schema().clone(),
-        vec![ScanType::TableScan(table.batch_iter(u64::MAX).await?)],
+        vec![ScanType::BatchScan(table.batch_iter(u64::MAX).await?)],
         1024,
         "RowSeqScanExecutor2".to_string(),
         Arc::new(BatchMetrics::unused()),
@@ -335,7 +335,7 @@ async fn test_table_v2_materialize() -> Result<()> {
     // Scan the table again, we are able to see the deletion now!
     let scan = Box::new(RowSeqScanExecutor::new(
         table.schema().clone(),
-        vec![ScanType::TableScan(table.batch_iter(u64::MAX).await?)],
+        vec![ScanType::BatchScan(table.batch_iter(u64::MAX).await?)],
         1024,
         "RowSeqScanExecutor2".to_string(),
         Arc::new(BatchMetrics::unused()),
@@ -397,7 +397,7 @@ async fn test_row_seq_scan() -> Result<()> {
 
     let executor = Box::new(RowSeqScanExecutor::new(
         table.schema().clone(),
-        vec![ScanType::TableScan(
+        vec![ScanType::BatchScan(
             table.batch_iter(u64::MAX).await.unwrap(),
         )],
         1,


### PR DESCRIPTION
I hereby agree to the terms of the [Singularity Data, Inc. Contributor License Agreement](https://gist.github.com/skyzh/0663682a70b0edde7ae991492f2314cb#file-s9y_cla).

## What's changed and what's your intention?

As there is no difference in TableScan and RangeScan, it's no need to differentiate them.

## Checklist

- [x] I have written necessary rustdoc comments
- [x] I have added necessary unit tests and integration tests
- [x] All checks passed in `./risedev check` (or alias, `./risedev c`)

## Documentation

If your pull request contains user-facing changes, please specify the types of the changes, and create a release note. Otherwise, please feel free to remove this section.

### Types of user-facing changes

Please keep the types that apply to your changes, and remove those that do not apply.

* Installation and deployment 
* Connector (sources & sinks)
* SQL commands, functions, and operators
* RisingWave cluster configuration changes
* Other (please specify in the release note below)

### Release note

Please create a release note for your changes. In the release note, focus on the impact on users, and mention the environment or conditions where the impact may occur.

## Refer to a related PR or issue link (optional)
