### PR TITLE
fix(common): use smaller upperbound for generators to avoid range overflow

### DIFF
--- a/src/common/src/field_generator/numeric.rs
+++ b/src/common/src/field_generator/numeric.rs
@@ -37,17 +37,12 @@ where
         + serde::Serialize
         + SampleUniform,
 {
-    const DEFAULT_MIN: Self;
-    const DEFAULT_MAX: Self;
 }
 
 macro_rules! impl_numeric_type {
     ($({ $random_variant_name:ident, $sequence_variant_name:ident,$field_type:ty }),*) => {
         $(
-            impl NumericType for $field_type {
-                const DEFAULT_MIN: $field_type = <$field_type>::MIN;
-                const DEFAULT_MAX: $field_type = <$field_type>::MAX;
-            }
+            impl NumericType for $field_type {}
         )*
     };
 }
@@ -76,8 +71,8 @@ where
     where
         Self: Sized,
     {
-        let mut min = T::DEFAULT_MIN;
-        let mut max = T::DEFAULT_MAX;
+        let mut min = T::zero();
+        let mut max = T::from(i16::MAX).unwrap();
 
         if let Some(min_option) = min_option {
             min = min_option.parse::<T>()?;
@@ -117,7 +112,7 @@ where
         Self: Sized,
     {
         let mut start = T::zero();
-        let mut end = T::DEFAULT_MAX;
+        let mut end = T::from(i16::MAX).unwrap();
 
         if let Some(star_optiont) = star_option {
             start = star_optiont.parse::<T>()?;
@@ -214,6 +209,15 @@ mod tests {
             let res = res.as_i64().unwrap();
             assert!((5..=10).contains(&res));
         }
+
+        // test overflow
+        let mut i64_field = I64RandomField::new(None, None, 114).unwrap();
+        for i in 0..100 {
+            let res = i64_field.generate(i as u64);
+            assert!(res.is_number());
+            let res = res.as_i64().unwrap();
+            assert!(res >= 0);
+        }
     }
     #[test]
     fn test_sequence_datum_generator() {
@@ -237,6 +241,61 @@ mod tests {
             assert!(res.is_some());
             let res = res.unwrap();
             assert!(lower <= res && res <= upper);
+        }
+    }
+
+    #[test]
+    fn test_sequence_field_generator_float() {
+        let mut f64_field =
+            F64SequenceField::new(Some("0".to_string()), Some("10".to_string()), 0, 1).unwrap();
+        for i in 0..=10 {
+            assert_eq!(f64_field.generate(), json!(i as f64));
+        }
+
+        let mut f32_field =
+            F32SequenceField::new(Some("-5".to_string()), Some("5".to_string()), 0, 1).unwrap();
+        for i in -5..=5 {
+            assert_eq!(f32_field.generate(), json!(i as f32));
+        }
+    }
+
+    #[test]
+    fn test_random_field_generator_float() {
+        let mut f64_field =
+            F64RandomField::new(Some("5".to_string()), Some("10".to_string()), 114).unwrap();
+        for i in 0..100 {
+            let res = f64_field.generate(i as u64);
+            assert!(res.is_number());
+            let res = res.as_f64().unwrap();
+            assert!(res >= 5. && res <= 10.);
+        }
+
+        // test overflow
+        let mut f64_field = F64RandomField::new(None, None, 114).unwrap();
+        for i in 0..100 {
+            let res = f64_field.generate(i as u64);
+            assert!(res.is_number());
+            let res = res.as_f64().unwrap();
+            assert!(res >= 0.);
+        }
+
+        let mut f32_field =
+            F32RandomField::new(Some("5".to_string()), Some("10".to_string()), 114).unwrap();
+        for i in 0..100 {
+            let res = f32_field.generate(i as u64);
+            assert!(res.is_number());
+            // it seems there is no `as_f32`...
+            let res = res.as_f64().unwrap();
+            assert!(res >= 5. && res <= 10.);
+        }
+
+        // test overflow
+        let mut f32_field = F32RandomField::new(None, None, 114).unwrap();
+        for i in 0..100 {
+            let res = f32_field.generate(i as u64);
+            assert!(res.is_number());
+            let res = res.as_f64().unwrap();
+            assert!(res >= 0.);
         }
     }
 }

--- a/src/common/src/field_generator/numeric.rs
+++ b/src/common/src/field_generator/numeric.rs
@@ -267,7 +267,7 @@ mod tests {
             let res = f64_field.generate(i as u64);
             assert!(res.is_number());
             let res = res.as_f64().unwrap();
-            assert!(res >= 5. && res <= 10.);
+            assert!((5. ..10.).contains(&res));
         }
 
         // test overflow
@@ -286,7 +286,7 @@ mod tests {
             assert!(res.is_number());
             // it seems there is no `as_f32`...
             let res = res.as_f64().unwrap();
-            assert!(res >= 5. && res <= 10.);
+            assert!((5. ..10.).contains(&res));
         }
 
         // test overflow

--- a/src/common/src/types/ordered_float.rs
+++ b/src/common/src/types/ordered_float.rs
@@ -106,16 +106,6 @@ impl<T: Float> OrderedFloat<T> {
     }
 }
 
-impl OrderedFloat<f32> {
-    pub const MAX: Self = Self(f32::MAX);
-    pub const MIN: Self = Self(f32::MIN);
-}
-
-impl OrderedFloat<f64> {
-    pub const MAX: Self = Self(f64::MAX);
-    pub const MIN: Self = Self(f64::MIN);
-}
-
 impl<T: Float> AsRef<T> for OrderedFloat<T> {
     #[inline]
     fn as_ref(&self) -> &T {


### PR DESCRIPTION
I hereby agree to the terms of the [Singularity Data, Inc. Contributor License Agreement](https://gist.github.com/skyzh/0663682a70b0edde7ae991492f2314cb#file-s9y_cla).

## What's changed and what's your intention?

Now the default range of all field generators is set to [0, i16::MAX] to avoid range overflow.

## Checklist

- [x] I have written necessary rustdoc comments
- [x] I have added necessary unit tests and integration tests
- [x] All checks passed in `./risedev check` (or alias, `./risedev c`)

## Documentation

## Types of user-facing changes

* Other (please specify in the release note below)

## Release note

When creating a field generator without specific lowerbound and upperbound, the generator will generate data in range [0, i16::MAX] by default, rather than [0, T::MAX].

## Refer to a related PR or issue link (optional)
close #4363 