### PR TITLE
refactor(frontend): simplify ConditionDisplay

### DIFF
--- a/src/frontend/src/expr/mod.rs
+++ b/src/frontend/src/expr/mod.rs
@@ -634,6 +634,12 @@ impl std::fmt::Debug for ExprDisplay<'_> {
     }
 }
 
+impl std::fmt::Display for ExprDisplay<'_> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        (self as &dyn std::fmt::Debug).fmt(f)
+    }
+}
+
 #[cfg(test)]
 /// Asserts that the expression is an [`InputRef`] with the given index.
 macro_rules! assert_eq_input_ref {

--- a/src/frontend/src/utils/condition.rs
+++ b/src/frontend/src/utils/condition.rs
@@ -13,7 +13,7 @@
 // limitations under the License.
 
 use std::collections::{HashMap, HashSet};
-use std::fmt;
+use std::fmt::{self, Debug, Display};
 use std::ops::Bound;
 
 use fixedbitset::FixedBitSet;
@@ -526,33 +526,20 @@ pub struct ConditionDisplay<'a> {
 
 impl ConditionDisplay<'_> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        let that = self.condition;
-        let mut conjunctions = that.conjunctions.iter();
-        if let Some(expr) = conjunctions.next() {
-            write!(
-                f,
-                "{:?}",
-                ExprDisplay {
-                    expr,
-                    input_schema: self.input_schema
-                }
-            )?;
-        }
-        if that.always_true() {
-            write!(f, "true")?;
+        if self.condition.always_true() {
+            write!(f, "true")
         } else {
-            for expr in conjunctions {
-                write!(
-                    f,
-                    " AND {:?}",
-                    ExprDisplay {
+            self.condition
+                .conjunctions
+                .iter()
+                .format_with(" AND ", |expr, f| {
+                    f(&ExprDisplay {
                         expr,
-                        input_schema: self.input_schema
-                    }
-                )?;
-            }
+                        input_schema: self.input_schema,
+                    })
+                })
+                .fmt(f)
         }
-        Ok(())
     }
 }
 


### PR DESCRIPTION
I hereby agree to the terms of the [Singularity Data, Inc. Contributor License Agreement](https://gist.github.com/skyzh/0663682a70b0edde7ae991492f2314cb#file-s9y_cla).

## What's changed and what's your intention?
using [`Itertools::format_with`](https://docs.rs/itertools/0.8.0/itertools/trait.Itertools.html#method.format_with), which allows specifying a separator
