### PR TITLE
fix(optimizer): push Apply down scalar agg.

### DIFF
--- a/src/frontend/src/optimizer/plan_node/logical_apply.rs
+++ b/src/frontend/src/optimizer/plan_node/logical_apply.rs
@@ -19,10 +19,10 @@ use risingwave_common::error::{ErrorCode, Result, RwError};
 use risingwave_pb::plan_common::JoinType;
 
 use super::{
-    ColPrunable, LogicalJoin, PlanBase, PlanRef, PlanTreeNodeBinary, PredicatePushdown, ToBatch,
-    ToStream,
+    ColPrunable, LogicalJoin, LogicalProject, PlanBase, PlanRef, PlanTreeNodeBinary,
+    PredicatePushdown, ToBatch, ToStream,
 };
-use crate::expr::CorrelatedId;
+use crate::expr::{CorrelatedId, Expr, ExprImpl, ExprRewriter, InputRef};
 use crate::utils::{ColIndexMapping, Condition, ConditionDisplay};
 
 /// `LogicalApply` represents a correlated join, where the right side may refer to columns from the
@@ -146,6 +146,75 @@ impl LogicalApply {
 
     pub fn correlated_id(&self) -> CorrelatedId {
         self.correlated_id
+    }
+
+    pub fn correlated_indices(&self) -> Vec<usize> {
+        self.correlated_indices.to_owned()
+    }
+
+    /// Translate Apply.
+    ///
+    /// Used to convert other kinds of Apply to cross Apply.
+    pub fn translate_apply(self, new_apply_left: PlanRef, eq_predicates: Vec<ExprImpl>) -> PlanRef {
+        let (apply_left, apply_right, on, apply_type, correlated_id, correlated_indices) =
+            self.decompose();
+        let apply_left_len = apply_left.schema().len();
+        let correlated_indices_len = correlated_indices.len();
+
+        let new_apply = LogicalApply::create(
+            new_apply_left,
+            apply_right,
+            JoinType::Inner,
+            Condition::true_cond(),
+            correlated_id,
+            correlated_indices,
+        );
+
+        let on = Self::rewrite_on(on, correlated_indices_len, apply_left_len).and(Condition {
+            conjunctions: eq_predicates,
+        });
+        let new_join = LogicalJoin::new(apply_left, new_apply, apply_type, on);
+
+        if new_join.join_type() != JoinType::LeftSemi {
+            // `new_join`'s schema is different from original apply's schema, so `LogicalProject` is
+            // used to ensure they are the same.
+            let mut exprs: Vec<ExprImpl> = vec![];
+            new_join
+                .schema()
+                .data_types()
+                .into_iter()
+                .enumerate()
+                .for_each(|(index, data_type)| {
+                    if index < apply_left_len || index >= apply_left_len + correlated_indices_len {
+                        exprs.push(InputRef::new(index, data_type).into());
+                    }
+                });
+            LogicalProject::create(new_join.into(), exprs)
+        } else {
+            new_join.into()
+        }
+    }
+
+    fn rewrite_on(on: Condition, offset: usize, apply_left_len: usize) -> Condition {
+        struct Rewriter {
+            offset: usize,
+            apply_left_len: usize,
+        }
+        impl ExprRewriter for Rewriter {
+            fn rewrite_input_ref(&mut self, input_ref: InputRef) -> ExprImpl {
+                let index = input_ref.index();
+                if index >= self.apply_left_len {
+                    InputRef::new(index + self.offset, input_ref.return_type()).into()
+                } else {
+                    input_ref.into()
+                }
+            }
+        }
+        let mut rewriter = Rewriter {
+            offset,
+            apply_left_len,
+        };
+        on.rewrite_expr(&mut rewriter)
     }
 }
 

--- a/src/frontend/src/optimizer/rule/apply_agg.rs
+++ b/src/frontend/src/optimizer/rule/apply_agg.rs
@@ -12,10 +12,13 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use risingwave_common::types::DataType;
+use risingwave_expr::expr::AggKind;
 use risingwave_pb::plan_common::JoinType;
 
 use super::{BoxedRule, Rule};
-use crate::optimizer::plan_node::{LogicalAgg, LogicalApply, LogicalFilter};
+use crate::expr::{ExprImpl, ExprType, FunctionCall, InputRef};
+use crate::optimizer::plan_node::{LogicalAgg, LogicalApply, LogicalFilter, LogicalProject};
 use crate::optimizer::PlanRef;
 use crate::utils::{ColIndexMapping, Condition};
 
@@ -27,42 +30,98 @@ impl Rule for ApplyAggRule {
         let (left, right, on, join_type, correlated_id, correlated_indices) =
             apply.clone().decompose();
         assert_eq!(join_type, JoinType::Inner);
-        let agg = right.as_logical_agg()?;
-
-        // Insert all the columns of `LogicalApply`'s left at the beginning of `LogicalAgg`.
+        let agg: &LogicalAgg = right.as_logical_agg()?;
+        let (mut agg_calls, agg_group_key, agg_input) = agg.clone().decompose();
+        let is_scalar_agg = agg_group_key.is_empty();
+        let agg_input_len = agg_input.schema().len();
         let apply_left_len = left.schema().len();
-        let mut group_key: Vec<usize> = (0..apply_left_len).collect();
-        let (mut agg_calls, agg_group_key, input) = agg.clone().decompose();
-        group_key.extend(agg_group_key.into_iter().map(|key| key + apply_left_len));
 
-        // Shift index of agg_calls' `InputRef` with `apply_left_len`.
-        let offset = apply_left_len as isize;
-        let mut shift_index = ColIndexMapping::with_shift_offset(input.schema().len(), offset);
-        agg_calls.iter_mut().for_each(|agg_call| {
-            agg_call.inputs.iter_mut().for_each(|input_ref| {
-                input_ref.shift_with_offset(offset);
+        let input = if is_scalar_agg {
+            // add a constant column to help convert count(*) to count(c) where c is non-nullable.
+            let mut exprs: Vec<ExprImpl> = agg_input
+                .schema()
+                .data_types()
+                .into_iter()
+                .enumerate()
+                .map(|(i, data_type)| InputRef::new(i, data_type).into())
+                .collect();
+            exprs.push(ExprImpl::literal_int(1));
+            LogicalProject::create(agg_input, exprs)
+        } else {
+            agg_input
+        };
+
+        let node = if is_scalar_agg {
+            // LOJ Apply need to be converted to cross Apply.
+            let left_len = left.schema().len();
+            let eq_predicates = left
+                .schema()
+                .data_types()
+                .into_iter()
+                .enumerate()
+                .map(|(i, data_type)| {
+                    let left = InputRef::new(i, data_type.clone());
+                    let right = InputRef::new(i + left_len, data_type);
+                    // TODO: use is not distinct from instead of equal
+                    FunctionCall::new_unchecked(
+                        ExprType::Equal,
+                        vec![left.into(), right.into()],
+                        DataType::Boolean,
+                    )
+                    .into()
+                })
+                .collect();
+            LogicalApply::new(
+                left.clone(),
+                input,
+                JoinType::LeftOuter,
+                Condition::true_cond(),
+                correlated_id,
+                correlated_indices,
+            )
+            .translate_apply(left, eq_predicates)
+        } else {
+            LogicalApply::new(
+                left,
+                input,
+                JoinType::Inner,
+                Condition::true_cond(),
+                correlated_id,
+                correlated_indices,
+            )
+            .into()
+        };
+
+        let group_agg = {
+            // shift index of agg_calls' `InputRef` with `apply_left_len`.
+            let offset = apply_left_len as isize;
+            let mut shift_index = ColIndexMapping::with_shift_offset(agg_input_len, offset);
+            agg_calls.iter_mut().for_each(|agg_call| {
+                agg_call.inputs.iter_mut().for_each(|input_ref| {
+                    input_ref.shift_with_offset(offset);
+                });
+                agg_call
+                    .order_by_fields
+                    .iter_mut()
+                    .for_each(|o| o.input.shift_with_offset(offset));
+                agg_call.filter = agg_call.filter.clone().rewrite_expr(&mut shift_index);
             });
-            agg_call
-                .order_by_fields
-                .iter_mut()
-                .for_each(|o| o.input.shift_with_offset(offset));
-            agg_call.filter = agg_call.filter.clone().rewrite_expr(&mut shift_index);
-        });
+            if is_scalar_agg {
+                // convert count(*) to count(1).
+                let pos_of_constant_column = node.schema().len() - 1;
+                agg_calls.iter_mut().for_each(|agg_call| {
+                    if agg_call.agg_kind == AggKind::Count && agg_call.inputs.is_empty() {
+                        let input_ref = InputRef::new(pos_of_constant_column, DataType::Int32);
+                        agg_call.inputs.push(input_ref);
+                    }
+                });
+            }
+            let mut group_keys: Vec<usize> = (0..apply_left_len).collect();
+            group_keys.extend(agg_group_key.into_iter().map(|key| key + apply_left_len));
+            LogicalAgg::new(agg_calls, group_keys, node).into()
+        };
 
-        let new_apply = LogicalApply::create(
-            left,
-            input,
-            join_type,
-            Condition {
-                conjunctions: vec![],
-            },
-            correlated_id,
-            correlated_indices,
-        );
-        let new_agg: PlanRef = LogicalAgg::new(agg_calls, group_key, new_apply).into();
-
-        // leave apply's on condition for predicate push to deal with
-        let filter = LogicalFilter::create(new_agg, on);
+        let filter = LogicalFilter::create(group_agg, on);
         Some(filter)
     }
 }

--- a/src/frontend/src/optimizer/rule/apply_proj.rs
+++ b/src/frontend/src/optimizer/rule/apply_proj.rs
@@ -29,7 +29,6 @@ impl Rule for ApplyProjRule {
         let (left, right, on, join_type, correlated_id, correlated_indices) =
             apply.clone().decompose();
         let project = right.as_logical_project()?;
-
         assert_eq!(join_type, JoinType::Inner);
 
         // Insert all the columns of `LogicalApply`'s left at the beginning of the new

--- a/src/frontend/src/optimizer/rule/translate_apply.rs
+++ b/src/frontend/src/optimizer/rule/translate_apply.rs
@@ -16,13 +16,11 @@ use std::collections::HashMap;
 
 use itertools::Itertools;
 use risingwave_common::types::DataType;
-use risingwave_pb::plan_common::JoinType;
 
 use super::{BoxedRule, Rule};
-use crate::expr::{Expr, ExprImpl, ExprRewriter, ExprType, FunctionCall, InputRef};
+use crate::expr::{ExprImpl, ExprType, FunctionCall, InputRef};
 use crate::optimizer::plan_node::{
-    LogicalAgg, LogicalApply, LogicalJoin, LogicalProject, LogicalScan, PlanTreeNodeBinary,
-    PlanTreeNodeUnary,
+    LogicalAgg, LogicalJoin, LogicalProject, LogicalScan, PlanTreeNodeBinary, PlanTreeNodeUnary,
 };
 use crate::optimizer::PlanRef;
 use crate::utils::{ColIndexMapping, Condition};
@@ -33,45 +31,45 @@ pub struct TranslateApplyRule {}
 impl Rule for TranslateApplyRule {
     fn apply(&self, plan: PlanRef) -> Option<PlanRef> {
         let apply = plan.as_logical_apply()?;
-        let (left, right, on, join_type, correlated_id, correlated_indices) =
-            apply.clone().decompose();
+        let left = apply.left();
         let apply_left_len = left.schema().len();
-        let correlated_indices_len = correlated_indices.len();
+        let correlated_indices = apply.correlated_indices();
 
         let mut index_mapping =
             ColIndexMapping::with_target_size(vec![None; apply_left_len], apply_left_len);
         let mut data_types = HashMap::new();
         let mut index = 0;
 
-        let rewritten_left = Self::rewrite(
-            &left,
-            correlated_indices.clone(),
-            0,
-            &mut index_mapping,
-            &mut data_types,
-            &mut index,
-        )?;
-
-        // This `LogicalProject` is used to make sure that after `LogicalApply`'s left was
-        // rewritten, the new index of `correlated_index` is always at its position in
-        // `correlated_indices`.
-        let exprs = correlated_indices
-            .clone()
-            .into_iter()
-            .enumerate()
-            .map(|(i, correlated_index)| {
-                let index = index_mapping.map(correlated_index);
-                let data_type = rewritten_left.schema().fields()[index].data_type.clone();
-                index_mapping.put(correlated_index, Some(i));
-                InputRef::new(index, data_type).into()
-            })
-            .collect();
-        let project = LogicalProject::create(rewritten_left, exprs);
-
-        let distinct = LogicalAgg::new(vec![], (0..project.schema().len()).collect_vec(), project);
+        let new_apply_left = {
+            let rewritten_left = Self::rewrite(
+                &left,
+                correlated_indices.clone(),
+                0,
+                &mut index_mapping,
+                &mut data_types,
+                &mut index,
+            )?;
+            // This `LogicalProject` is used to make sure that after `LogicalApply`'s left was
+            // rewritten, the new index of `correlated_index` is always at its position in
+            // `correlated_indices`.
+            let exprs = correlated_indices
+                .clone()
+                .into_iter()
+                .enumerate()
+                .map(|(i, correlated_index)| {
+                    let index = index_mapping.map(correlated_index);
+                    let data_type = rewritten_left.schema().fields()[index].data_type.clone();
+                    index_mapping.put(correlated_index, Some(i));
+                    InputRef::new(index, data_type).into()
+                })
+                .collect();
+            let project = LogicalProject::create(rewritten_left, exprs);
+            let distinct =
+                LogicalAgg::new(vec![], (0..project.schema().len()).collect_vec(), project);
+            distinct.into()
+        };
 
         let eq_predicates = correlated_indices
-            .clone()
             .into_iter()
             .enumerate()
             .map(|(i, correlated_index)| {
@@ -89,38 +87,8 @@ impl Rule for TranslateApplyRule {
                 .into()
             })
             .collect::<Vec<ExprImpl>>();
-        let on = Self::rewrite_on(on, correlated_indices_len, apply_left_len).and(Condition {
-            conjunctions: eq_predicates,
-        });
 
-        let new_apply = LogicalApply::create(
-            distinct.into(),
-            right,
-            JoinType::Inner,
-            Condition::true_cond(),
-            correlated_id,
-            correlated_indices,
-        );
-        let new_join = LogicalJoin::new(left, new_apply, join_type, on);
-
-        let new_node = if new_join.join_type() != JoinType::LeftSemi {
-            // `new_join`'s shcema is different from original apply's schema, so `LogicalProject` is
-            // used to ensure they are the same.
-            let mut exprs: Vec<ExprImpl> = vec![];
-            new_join
-                .schema()
-                .data_types()
-                .into_iter()
-                .enumerate()
-                .for_each(|(index, data_type)| {
-                    if index < apply_left_len || index >= apply_left_len + correlated_indices_len {
-                        exprs.push(InputRef::new(index, data_type).into());
-                    }
-                });
-            LogicalProject::create(new_join.into(), exprs)
-        } else {
-            new_join.into()
-        };
+        let new_node = apply.clone().translate_apply(new_apply_left, eq_predicates);
         Some(new_node)
     }
 }
@@ -244,32 +212,5 @@ impl TranslateApplyRule {
         }
 
         Some(scan.clone_with_output_indices(required_col_idx).into())
-    }
-
-    fn rewrite_on(on: Condition, offset: usize, apply_left_len: usize) -> Condition {
-        struct Rewriter {
-            offset: usize,
-            apply_left_len: usize,
-        }
-        impl ExprRewriter for Rewriter {
-            fn rewrite_input_ref(&mut self, input_ref: InputRef) -> ExprImpl {
-                let index = input_ref.index();
-                if index >= self.apply_left_len {
-                    InputRef::new(index + self.offset, input_ref.return_type()).into()
-                } else {
-                    input_ref.into()
-                }
-            }
-        }
-        let mut rewriter = Rewriter {
-            offset,
-            apply_left_len,
-        };
-        Condition {
-            conjunctions: on
-                .into_iter()
-                .map(|expr| rewriter.rewrite_expr(expr))
-                .collect_vec(),
-        }
     }
 }

--- a/src/frontend/test_runner/tests/testdata/subquery_expr_correlated.yaml
+++ b/src/frontend/test_runner/tests/testdata/subquery_expr_correlated.yaml
@@ -14,12 +14,15 @@
                 LogicalFilter { predicate: (CorrelatedInputRef { index: 2, correlated_id: 1 } = t2.y) AND (t2.y = 1000:Int32) }
                   LogicalScan { table: t2, columns: [t2._row_id, t2.x, t2.y] }
   optimized_logical_plan: |
-    LogicalJoin { type: Inner, on: (t1.y = t2.y) AND (t1.x > (1.5:Decimal * min(t2.x))), output: [t1.x, t1.y] }
+    LogicalJoin { type: Inner, on: (t1.y = t1.y) AND (t1.x > (1.5:Decimal * min(t2.x))), output: [t1.x, t1.y] }
       LogicalScan { table: t1, columns: [t1.x, t1.y] }
-      LogicalProject { exprs: [t2.y, (1.5:Decimal * min(t2.x))] }
-        LogicalAgg { group_key: [t2.y], aggs: [min(t2.x)] }
-          LogicalProject { exprs: [t2.y, t2.x] }
-            LogicalScan { table: t2, output_columns: [t2.x, t2.y], required_columns: [x, y], predicate: (t2.y = 1000:Int32) }
+      LogicalProject { exprs: [t1.y, (1.5:Decimal * min(t2.x))] }
+        LogicalAgg { group_key: [t1.y], aggs: [min(t2.x)] }
+          LogicalJoin { type: LeftOuter, on: (t1.y = t2.y), output: [t1.y, t2.x] }
+            LogicalAgg { group_key: [t1.y], aggs: [] }
+              LogicalScan { table: t1, columns: [t1.y] }
+            LogicalProject { exprs: [t2.y, t2.x] }
+              LogicalScan { table: t2, output_columns: [t2.x, t2.y], required_columns: [x, y], predicate: (t2.y = 1000:Int32) }
 - sql: |
     create table t1(x int, y int);
     create table t2(x int, y int);
@@ -91,12 +94,15 @@
                 LogicalFilter { predicate: (CorrelatedInputRef { index: 2, correlated_id: 1 } = t2.y) }
                   LogicalScan { table: t2, columns: [t2._row_id, t2.x, t2.y] }
   optimized_logical_plan: |
-    LogicalJoin { type: Inner, on: (t1.y = t2.y) AND (t1.x > (1.5:Decimal * min(t2.x))), output: [t1.x, t1.y] }
+    LogicalJoin { type: Inner, on: (t1.y = t1.y) AND (t1.x > (1.5:Decimal * min(t2.x))), output: [t1.x, t1.y] }
       LogicalScan { table: t1, columns: [t1.x, t1.y] }
-      LogicalProject { exprs: [t2.y, (1.5:Decimal * min(t2.x))] }
-        LogicalAgg { group_key: [t2.y], aggs: [min(t2.x)] }
-          LogicalProject { exprs: [t2.y, t2.x] }
-            LogicalScan { table: t2, columns: [t2.x, t2.y] }
+      LogicalProject { exprs: [t1.y, (1.5:Decimal * min(t2.x))] }
+        LogicalAgg { group_key: [t1.y], aggs: [min(t2.x)] }
+          LogicalJoin { type: LeftOuter, on: (t1.y = t2.y), output: [t1.y, t2.x] }
+            LogicalAgg { group_key: [t1.y], aggs: [] }
+              LogicalScan { table: t1, columns: [t1.y] }
+            LogicalProject { exprs: [t2.y, t2.x] }
+              LogicalScan { table: t2, columns: [t2.x, t2.y] }
 - sql: |
     create table t1(x int, y int);
     create table t2(x int, y int);
@@ -112,10 +118,14 @@
                 LogicalFilter { predicate: (CorrelatedInputRef { index: 2, correlated_id: 1 } = t2.y) }
                   LogicalScan { table: t2, columns: [t2._row_id, t2.x, t2.y] }
   optimized_logical_plan: |
-    LogicalJoin { type: Inner, on: (t1.y = t2.y) AND (t1.x > count), output: [t1.x, t1.y] }
+    LogicalJoin { type: Inner, on: (t1.y = t1.y) AND (t1.x > count(1:Int32)), output: [t1.x, t1.y] }
       LogicalScan { table: t1, columns: [t1.x, t1.y] }
-      LogicalAgg { group_key: [t2.y], aggs: [count] }
-        LogicalScan { table: t2, columns: [t2.y] }
+      LogicalAgg { group_key: [t1.y], aggs: [count(1:Int32)] }
+        LogicalJoin { type: LeftOuter, on: (t1.y = t2.y), output: [t1.y, 1:Int32] }
+          LogicalAgg { group_key: [t1.y], aggs: [] }
+            LogicalScan { table: t1, columns: [t1.y] }
+          LogicalProject { exprs: [t2.y, 1:Int32] }
+            LogicalScan { table: t2, columns: [t2.y] }
 - sql: |
     create table t1(x int, y int);
     create table t2(x int, y int);
@@ -131,11 +141,15 @@
                 LogicalFilter { predicate: (CorrelatedInputRef { index: 2, correlated_id: 1 } = t2.y) }
                   LogicalScan { table: t2, columns: [t2._row_id, t2.x, t2.y] }
   optimized_logical_plan: |
-    LogicalJoin { type: Inner, on: (t1.y = t2.y) AND (t1.x > (count + count)), output: [t1.x, t1.y] }
+    LogicalJoin { type: Inner, on: (t1.y = t1.y) AND (t1.x > (count(1:Int32) + count(1:Int32))), output: [t1.x, t1.y] }
       LogicalScan { table: t1, columns: [t1.x, t1.y] }
-      LogicalProject { exprs: [t2.y, (count + count)] }
-        LogicalAgg { group_key: [t2.y], aggs: [count, count] }
-          LogicalScan { table: t2, columns: [t2.y] }
+      LogicalProject { exprs: [t1.y, (count(1:Int32) + count(1:Int32))] }
+        LogicalAgg { group_key: [t1.y], aggs: [count(1:Int32), count(1:Int32)] }
+          LogicalJoin { type: LeftOuter, on: (t1.y = t2.y), output: [t1.y, 1:Int32] }
+            LogicalAgg { group_key: [t1.y], aggs: [] }
+              LogicalScan { table: t1, columns: [t1.y] }
+            LogicalProject { exprs: [t2.y, 1:Int32] }
+              LogicalScan { table: t2, columns: [t2.y] }
 - sql: |
     create table t1(x int, y int);
     create table t2(x int, y int);
@@ -374,77 +388,99 @@
     select count(*) from a, b where a3 = b2 and 3 = (select count(*) from c where b2 = c2 and a3 = c3);
   optimized_logical_plan: |
     LogicalAgg { aggs: [count] }
-      LogicalJoin { type: Inner, on: (a.a3 = c.c3) AND (b.b2 = c.c2), output: [] }
+      LogicalJoin { type: Inner, on: (a.a3 = a.a3) AND (b.b2 = b.b2), output: [] }
         LogicalJoin { type: Inner, on: (a.a3 = b.b2), output: all }
           LogicalScan { table: a, columns: [a.a3] }
           LogicalScan { table: b, columns: [b.b2] }
-        LogicalProject { exprs: [c.c3, c.c2] }
-          LogicalFilter { predicate: (3:Int32 = count) }
-            LogicalAgg { group_key: [c.c3, c.c2], aggs: [count] }
-              LogicalProject { exprs: [c.c3, c.c2] }
-                LogicalScan { table: c, columns: [c.c2, c.c3] }
+        LogicalProject { exprs: [a.a3, b.b2] }
+          LogicalFilter { predicate: (3:Int32 = count(1:Int32)) }
+            LogicalAgg { group_key: [a.a3, b.b2], aggs: [count(1:Int32)] }
+              LogicalJoin { type: LeftOuter, on: (a.a3 = c.c3) AND (b.b2 = c.c2), output: [a.a3, b.b2, 1:Int32] }
+                LogicalAgg { group_key: [a.a3, b.b2], aggs: [] }
+                  LogicalJoin { type: Inner, on: true, output: all }
+                    LogicalScan { table: a, columns: [a.a3] }
+                    LogicalScan { table: b, columns: [b.b2] }
+                LogicalProject { exprs: [c.c3, c.c2, 1:Int32] }
+                  LogicalScan { table: c, columns: [c.c2, c.c3] }
 - sql: |
     create table a(x int, y int, z int);
     create table b(x int, y int, z int);
     select count(*) from a where a.x=3 and a.y = (select count(*) from b where b.z = a.z and a.x = 3);
   optimized_logical_plan: |
     LogicalAgg { aggs: [count] }
-      LogicalJoin { type: Inner, on: (a.x = a.x) AND (a.z = a.z) AND (a.y::Int64 = count), output: [] }
+      LogicalJoin { type: Inner, on: (a.x = a.x) AND (a.z = a.z) AND (a.y::Int64 = count(1:Int32)), output: [] }
         LogicalProject { exprs: [a.x, a.z, a.y::Int64] }
           LogicalScan { table: a, output_columns: [a.x, a.y, a.z], required_columns: [x, y, z], predicate: (a.x = 3:Int32) }
-        LogicalAgg { group_key: [a.x, a.z], aggs: [count] }
-          LogicalJoin { type: Inner, on: (b.z = a.z), output: [a.x, a.z] }
+        LogicalAgg { group_key: [a.x, a.z], aggs: [count(1:Int32)] }
+          LogicalJoin { type: LeftOuter, on: (a.x = a.x) AND (a.z = a.z), output: [a.x, a.z, 1:Int32] }
             LogicalAgg { group_key: [a.x, a.z], aggs: [] }
-              LogicalScan { table: a, output_columns: [a.x, a.z], required_columns: [x, z], predicate: (a.x = 3:Int32) }
-            LogicalScan { table: b, columns: [b.z] }
+              LogicalScan { table: a, columns: [a.x, a.z] }
+            LogicalProject { exprs: [a.x, a.z, 1:Int32] }
+              LogicalJoin { type: Inner, on: (b.z = a.z), output: [a.x, a.z] }
+                LogicalAgg { group_key: [a.x, a.z], aggs: [] }
+                  LogicalScan { table: a, output_columns: [a.x, a.z], required_columns: [x, z], predicate: (a.x = 3:Int32) }
+                LogicalScan { table: b, columns: [b.z] }
 - sql: |
     create table a(x int, y int, z int);
     create table b(x int, y int, z int);
     select count(*) from a where a.x=3 and a.y = (select count(*) from b where b.z = a.z);
   optimized_logical_plan: |
     LogicalAgg { aggs: [count] }
-      LogicalJoin { type: Inner, on: (a.z = b.z) AND (a.y::Int64 = count), output: [] }
+      LogicalJoin { type: Inner, on: (a.z = a.z) AND (a.y::Int64 = count(1:Int32)), output: [] }
         LogicalProject { exprs: [a.z, a.y::Int64] }
           LogicalScan { table: a, output_columns: [a.y, a.z], required_columns: [y, z, x], predicate: (a.x = 3:Int32) }
-        LogicalAgg { group_key: [b.z], aggs: [count] }
-          LogicalScan { table: b, columns: [b.z] }
+        LogicalAgg { group_key: [a.z], aggs: [count(1:Int32)] }
+          LogicalJoin { type: LeftOuter, on: (a.z = b.z), output: [a.z, 1:Int32] }
+            LogicalAgg { group_key: [a.z], aggs: [] }
+              LogicalScan { table: a, columns: [a.z] }
+            LogicalProject { exprs: [b.z, 1:Int32] }
+              LogicalScan { table: b, columns: [b.z] }
 - sql: |
     create table a(x int, y varchar, z int);
     create table b(x varchar, y int, z int);
     select count(*) from a where a.y = (select string_agg(x order by x) from b where b.z = a.z);
   optimized_logical_plan: |
     LogicalAgg { aggs: [count] }
-      LogicalJoin { type: Inner, on: (a.z = b.z) AND (a.y = string_agg(b.x order_by(b.x ASC NULLS LAST))), output: [] }
+      LogicalJoin { type: Inner, on: (a.z = a.z) AND (a.y = string_agg(b.x order_by(b.x ASC NULLS LAST))), output: [] }
         LogicalScan { table: a, columns: [a.y, a.z] }
-        LogicalAgg { group_key: [b.z], aggs: [string_agg(b.x order_by(b.x ASC NULLS LAST))] }
-          LogicalProject { exprs: [b.z, b.x] }
-            LogicalScan { table: b, columns: [b.x, b.z] }
+        LogicalAgg { group_key: [a.z], aggs: [string_agg(b.x order_by(b.x ASC NULLS LAST))] }
+          LogicalJoin { type: LeftOuter, on: (a.z = b.z), output: [a.z, b.x] }
+            LogicalAgg { group_key: [a.z], aggs: [] }
+              LogicalScan { table: a, columns: [a.z] }
+            LogicalProject { exprs: [b.z, b.x] }
+              LogicalScan { table: b, columns: [b.x, b.z] }
 - sql: |
     create table a(x int, y int, z int);
     create table b(x int, y int, z int);
     select count(*) from a where a.y = (select count(distinct x) from b where b.z = a.z);
   optimized_logical_plan: |
     LogicalAgg { aggs: [count] }
-      LogicalJoin { type: Inner, on: (a.z = b.z) AND (a.y::Int64 = count(b.x) filter((flag = 0:Int64))), output: [] }
+      LogicalJoin { type: Inner, on: (a.z = a.z) AND (a.y::Int64 = count(b.x) filter((flag = 0:Int64))), output: [] }
         LogicalProject { exprs: [a.z, a.y::Int64] }
           LogicalScan { table: a, columns: [a.y, a.z] }
-        LogicalAgg { group_key: [b.z], aggs: [count(b.x) filter((flag = 0:Int64))] }
-          LogicalAgg { group_key: [b.z, b.x, flag], aggs: [] }
-            LogicalExpand { column_subsets: [[b.z, b.x]] }
-              LogicalProject { exprs: [b.z, b.x] }
-                LogicalScan { table: b, columns: [b.x, b.z] }
+        LogicalAgg { group_key: [a.z], aggs: [count(b.x) filter((flag = 0:Int64))] }
+          LogicalAgg { group_key: [a.z, b.x, flag], aggs: [] }
+            LogicalExpand { column_subsets: [[a.z, b.x]] }
+              LogicalJoin { type: LeftOuter, on: (a.z = b.z), output: [a.z, b.x] }
+                LogicalAgg { group_key: [a.z], aggs: [] }
+                  LogicalScan { table: a, columns: [a.z] }
+                LogicalProject { exprs: [b.z, b.x] }
+                  LogicalScan { table: b, columns: [b.x, b.z] }
 - sql: |
     create table a(x int, y int, z int);
     create table b(x int, y int, z int);
     select count(*) from a where a.y = (select count(x) filter(where x < 100) from b where b.z = a.z);
   optimized_logical_plan: |
     LogicalAgg { aggs: [count] }
-      LogicalJoin { type: Inner, on: (a.z = b.z) AND (a.y::Int64 = count(b.x) filter((b.x < 100:Int32))), output: [] }
+      LogicalJoin { type: Inner, on: (a.z = a.z) AND (a.y::Int64 = count(b.x) filter((b.x < 100:Int32))), output: [] }
         LogicalProject { exprs: [a.z, a.y::Int64] }
           LogicalScan { table: a, columns: [a.y, a.z] }
-        LogicalAgg { group_key: [b.z], aggs: [count(b.x) filter((b.x < 100:Int32))] }
-          LogicalProject { exprs: [b.z, b.x] }
-            LogicalScan { table: b, columns: [b.x, b.z] }
+        LogicalAgg { group_key: [a.z], aggs: [count(b.x) filter((b.x < 100:Int32))] }
+          LogicalJoin { type: LeftOuter, on: (a.z = b.z), output: [a.z, b.x] }
+            LogicalAgg { group_key: [a.z], aggs: [] }
+              LogicalScan { table: a, columns: [a.z] }
+            LogicalProject { exprs: [b.z, b.x] }
+              LogicalScan { table: b, columns: [b.x, b.z] }
 - sql: |
     create table t1(x int, y int);
     create table t2(x int, y int);

--- a/src/frontend/test_runner/tests/testdata/tpch.yaml
+++ b/src/frontend/test_runner/tests/testdata/tpch.yaml
@@ -211,20 +211,23 @@
     LogicalTopN { order: "[supplier.s_acctbal DESC, nation.n_name ASC, supplier.s_name ASC, part.p_partkey ASC]", limit: 100, offset: 0 }
       LogicalJoin { type: Inner, on: (nation.n_regionkey = region.r_regionkey), output: [supplier.s_acctbal, supplier.s_name, nation.n_name, part.p_partkey, part.p_mfgr, supplier.s_address, supplier.s_phone, supplier.s_comment] }
         LogicalJoin { type: Inner, on: (supplier.s_nationkey = nation.n_nationkey), output: [part.p_partkey, part.p_mfgr, supplier.s_name, supplier.s_address, supplier.s_phone, supplier.s_acctbal, supplier.s_comment, nation.n_name, nation.n_regionkey] }
-          LogicalJoin { type: Inner, on: (part.p_partkey = partsupp.ps_partkey) AND (partsupp.ps_supplycost = min(partsupp.ps_supplycost)), output: [part.p_partkey, part.p_mfgr, supplier.s_name, supplier.s_address, supplier.s_nationkey, supplier.s_phone, supplier.s_acctbal, supplier.s_comment] }
+          LogicalJoin { type: Inner, on: (part.p_partkey = part.p_partkey) AND (partsupp.ps_supplycost = min(partsupp.ps_supplycost)), output: [part.p_partkey, part.p_mfgr, supplier.s_name, supplier.s_address, supplier.s_nationkey, supplier.s_phone, supplier.s_acctbal, supplier.s_comment] }
             LogicalJoin { type: Inner, on: (supplier.s_suppkey = partsupp.ps_suppkey), output: [partsupp.ps_supplycost, part.p_partkey, part.p_mfgr, supplier.s_name, supplier.s_address, supplier.s_nationkey, supplier.s_phone, supplier.s_acctbal, supplier.s_comment] }
               LogicalJoin { type: Inner, on: (part.p_partkey = partsupp.ps_partkey), output: [partsupp.ps_suppkey, partsupp.ps_supplycost, part.p_partkey, part.p_mfgr] }
                 LogicalScan { table: partsupp, columns: [partsupp.ps_partkey, partsupp.ps_suppkey, partsupp.ps_supplycost] }
                 LogicalScan { table: part, output_columns: [part.p_partkey, part.p_mfgr], required_columns: [p_partkey, p_mfgr, p_type, p_size], predicate: (part.p_size = 4:Int32) AND Like(part.p_type, '%TIN':Varchar) }
               LogicalScan { table: supplier, columns: [supplier.s_suppkey, supplier.s_name, supplier.s_address, supplier.s_nationkey, supplier.s_phone, supplier.s_acctbal, supplier.s_comment] }
-            LogicalAgg { group_key: [partsupp.ps_partkey], aggs: [min(partsupp.ps_supplycost)] }
-              LogicalJoin { type: Inner, on: (nation.n_regionkey = region.r_regionkey), output: [partsupp.ps_partkey, partsupp.ps_supplycost] }
-                LogicalJoin { type: Inner, on: (supplier.s_nationkey = nation.n_nationkey), output: [partsupp.ps_partkey, partsupp.ps_supplycost, nation.n_regionkey] }
-                  LogicalJoin { type: Inner, on: (supplier.s_suppkey = partsupp.ps_suppkey), output: [partsupp.ps_partkey, partsupp.ps_supplycost, supplier.s_nationkey] }
-                    LogicalScan { table: partsupp, columns: [partsupp.ps_partkey, partsupp.ps_suppkey, partsupp.ps_supplycost] }
-                    LogicalScan { table: supplier, columns: [supplier.s_suppkey, supplier.s_nationkey] }
-                  LogicalScan { table: nation, columns: [nation.n_nationkey, nation.n_regionkey] }
-                LogicalScan { table: region, output_columns: [region.r_regionkey], required_columns: [r_regionkey, r_name], predicate: (region.r_name = 'AFRICA':Varchar) }
+            LogicalAgg { group_key: [part.p_partkey], aggs: [min(partsupp.ps_supplycost)] }
+              LogicalJoin { type: LeftOuter, on: (part.p_partkey = partsupp.ps_partkey), output: [part.p_partkey, partsupp.ps_supplycost] }
+                LogicalAgg { group_key: [part.p_partkey], aggs: [] }
+                  LogicalScan { table: part, columns: [part.p_partkey] }
+                LogicalJoin { type: Inner, on: (nation.n_regionkey = region.r_regionkey), output: [partsupp.ps_partkey, partsupp.ps_supplycost] }
+                  LogicalJoin { type: Inner, on: (supplier.s_nationkey = nation.n_nationkey), output: [partsupp.ps_partkey, partsupp.ps_supplycost, nation.n_regionkey] }
+                    LogicalJoin { type: Inner, on: (supplier.s_suppkey = partsupp.ps_suppkey), output: [partsupp.ps_partkey, partsupp.ps_supplycost, supplier.s_nationkey] }
+                      LogicalScan { table: partsupp, columns: [partsupp.ps_partkey, partsupp.ps_suppkey, partsupp.ps_supplycost] }
+                      LogicalScan { table: supplier, columns: [supplier.s_suppkey, supplier.s_nationkey] }
+                    LogicalScan { table: nation, columns: [nation.n_nationkey, nation.n_regionkey] }
+                  LogicalScan { table: region, output_columns: [region.r_regionkey], required_columns: [r_regionkey, r_name], predicate: (region.r_name = 'AFRICA':Varchar) }
           LogicalScan { table: nation, columns: [nation.n_nationkey, nation.n_name, nation.n_regionkey] }
         LogicalScan { table: region, output_columns: [region.r_regionkey], required_columns: [r_regionkey, r_name], predicate: (region.r_name = 'AFRICA':Varchar) }
   batch_plan: |
@@ -235,7 +238,7 @@
             BatchExchange { order: [], dist: HashShard(nation.n_regionkey) }
               BatchHashJoin { type: Inner, predicate: supplier.s_nationkey = nation.n_nationkey, output: [part.p_partkey, part.p_mfgr, supplier.s_name, supplier.s_address, supplier.s_phone, supplier.s_acctbal, supplier.s_comment, nation.n_name, nation.n_regionkey] }
                 BatchExchange { order: [], dist: HashShard(supplier.s_nationkey) }
-                  BatchHashJoin { type: Inner, predicate: part.p_partkey = partsupp.ps_partkey AND partsupp.ps_supplycost = min(partsupp.ps_supplycost), output: [part.p_partkey, part.p_mfgr, supplier.s_name, supplier.s_address, supplier.s_nationkey, supplier.s_phone, supplier.s_acctbal, supplier.s_comment] }
+                  BatchHashJoin { type: Inner, predicate: part.p_partkey = part.p_partkey AND partsupp.ps_supplycost = min(partsupp.ps_supplycost), output: [part.p_partkey, part.p_mfgr, supplier.s_name, supplier.s_address, supplier.s_nationkey, supplier.s_phone, supplier.s_acctbal, supplier.s_comment] }
                     BatchExchange { order: [], dist: HashShard(part.p_partkey) }
                       BatchHashJoin { type: Inner, predicate: partsupp.ps_suppkey = supplier.s_suppkey, output: [partsupp.ps_supplycost, part.p_partkey, part.p_mfgr, supplier.s_name, supplier.s_address, supplier.s_nationkey, supplier.s_phone, supplier.s_acctbal, supplier.s_comment] }
                         BatchExchange { order: [], dist: HashShard(partsupp.ps_suppkey) }
@@ -248,23 +251,27 @@
                                   BatchScan { table: part, columns: [part.p_partkey, part.p_mfgr, part.p_type, part.p_size], distribution: SomeShard }
                         BatchExchange { order: [], dist: HashShard(supplier.s_suppkey) }
                           BatchScan { table: supplier, columns: [supplier.s_suppkey, supplier.s_name, supplier.s_address, supplier.s_nationkey, supplier.s_phone, supplier.s_acctbal, supplier.s_comment], distribution: SomeShard }
-                    BatchHashAgg { group_key: [partsupp.ps_partkey], aggs: [min(partsupp.ps_supplycost)] }
-                      BatchExchange { order: [], dist: HashShard(partsupp.ps_partkey) }
-                        BatchHashJoin { type: Inner, predicate: nation.n_regionkey = region.r_regionkey, output: [partsupp.ps_partkey, partsupp.ps_supplycost] }
-                          BatchExchange { order: [], dist: HashShard(nation.n_regionkey) }
-                            BatchHashJoin { type: Inner, predicate: supplier.s_nationkey = nation.n_nationkey, output: [partsupp.ps_partkey, partsupp.ps_supplycost, nation.n_regionkey] }
-                              BatchExchange { order: [], dist: HashShard(supplier.s_nationkey) }
-                                BatchHashJoin { type: Inner, predicate: partsupp.ps_suppkey = supplier.s_suppkey, output: [partsupp.ps_partkey, partsupp.ps_supplycost, supplier.s_nationkey] }
-                                  BatchExchange { order: [], dist: HashShard(partsupp.ps_suppkey) }
-                                    BatchScan { table: partsupp, columns: [partsupp.ps_partkey, partsupp.ps_suppkey, partsupp.ps_supplycost], distribution: SomeShard }
-                                  BatchExchange { order: [], dist: HashShard(supplier.s_suppkey) }
-                                    BatchScan { table: supplier, columns: [supplier.s_suppkey, supplier.s_nationkey], distribution: SomeShard }
-                              BatchExchange { order: [], dist: HashShard(nation.n_nationkey) }
-                                BatchScan { table: nation, columns: [nation.n_nationkey, nation.n_regionkey], distribution: SomeShard }
-                          BatchExchange { order: [], dist: HashShard(region.r_regionkey) }
-                            BatchProject { exprs: [region.r_regionkey] }
-                              BatchFilter { predicate: (region.r_name = 'AFRICA':Varchar) }
-                                BatchScan { table: region, columns: [region.r_regionkey, region.r_name], distribution: SomeShard }
+                    BatchHashAgg { group_key: [part.p_partkey], aggs: [min(partsupp.ps_supplycost)] }
+                      BatchHashJoin { type: LeftOuter, predicate: part.p_partkey = partsupp.ps_partkey, output: [part.p_partkey, partsupp.ps_supplycost] }
+                        BatchHashAgg { group_key: [part.p_partkey], aggs: [] }
+                          BatchExchange { order: [], dist: HashShard(part.p_partkey) }
+                            BatchScan { table: part, columns: [part.p_partkey], distribution: SomeShard }
+                        BatchExchange { order: [], dist: HashShard(partsupp.ps_partkey) }
+                          BatchHashJoin { type: Inner, predicate: nation.n_regionkey = region.r_regionkey, output: [partsupp.ps_partkey, partsupp.ps_supplycost] }
+                            BatchExchange { order: [], dist: HashShard(nation.n_regionkey) }
+                              BatchHashJoin { type: Inner, predicate: supplier.s_nationkey = nation.n_nationkey, output: [partsupp.ps_partkey, partsupp.ps_supplycost, nation.n_regionkey] }
+                                BatchExchange { order: [], dist: HashShard(supplier.s_nationkey) }
+                                  BatchHashJoin { type: Inner, predicate: partsupp.ps_suppkey = supplier.s_suppkey, output: [partsupp.ps_partkey, partsupp.ps_supplycost, supplier.s_nationkey] }
+                                    BatchExchange { order: [], dist: HashShard(partsupp.ps_suppkey) }
+                                      BatchScan { table: partsupp, columns: [partsupp.ps_partkey, partsupp.ps_suppkey, partsupp.ps_supplycost], distribution: SomeShard }
+                                    BatchExchange { order: [], dist: HashShard(supplier.s_suppkey) }
+                                      BatchScan { table: supplier, columns: [supplier.s_suppkey, supplier.s_nationkey], distribution: SomeShard }
+                                BatchExchange { order: [], dist: HashShard(nation.n_nationkey) }
+                                  BatchScan { table: nation, columns: [nation.n_nationkey, nation.n_regionkey], distribution: SomeShard }
+                            BatchExchange { order: [], dist: HashShard(region.r_regionkey) }
+                              BatchProject { exprs: [region.r_regionkey] }
+                                BatchFilter { predicate: (region.r_name = 'AFRICA':Varchar) }
+                                  BatchScan { table: region, columns: [region.r_regionkey, region.r_name], distribution: SomeShard }
                 BatchExchange { order: [], dist: HashShard(nation.n_nationkey) }
                   BatchScan { table: nation, columns: [nation.n_nationkey, nation.n_name, nation.n_regionkey], distribution: SomeShard }
             BatchExchange { order: [], dist: HashShard(region.r_regionkey) }
@@ -272,14 +279,14 @@
                 BatchFilter { predicate: (region.r_name = 'AFRICA':Varchar) }
                   BatchScan { table: region, columns: [region.r_regionkey, region.r_name], distribution: SomeShard }
   stream_plan: |
-    StreamMaterialize { columns: [s_acctbal, s_name, n_name, p_partkey, p_mfgr, s_address, s_phone, s_comment, partsupp._row_id(hidden), part._row_id(hidden), supplier._row_id(hidden), partsupp.ps_partkey(hidden), nation._row_id(hidden), region._row_id(hidden)], pk_columns: [partsupp._row_id, part._row_id, supplier._row_id, partsupp.ps_partkey, nation._row_id, region._row_id], order_descs: [s_acctbal, n_name, s_name, p_partkey, partsupp._row_id, part._row_id, supplier._row_id, partsupp.ps_partkey, nation._row_id, region._row_id] }
+    StreamMaterialize { columns: [s_acctbal, s_name, n_name, p_partkey, p_mfgr, s_address, s_phone, s_comment, partsupp._row_id(hidden), part._row_id(hidden), supplier._row_id(hidden), part.p_partkey(hidden), nation._row_id(hidden), region._row_id(hidden)], pk_columns: [partsupp._row_id, part._row_id, supplier._row_id, part.p_partkey, nation._row_id, region._row_id], order_descs: [s_acctbal, n_name, s_name, p_partkey, partsupp._row_id, part._row_id, supplier._row_id, part.p_partkey, nation._row_id, region._row_id] }
       StreamTopN { order: "[supplier.s_acctbal DESC, nation.n_name ASC, supplier.s_name ASC, part.p_partkey ASC]", limit: 100, offset: 0 }
         StreamExchange { dist: Single }
-          StreamHashJoin { type: Inner, predicate: nation.n_regionkey = region.r_regionkey, output: [supplier.s_acctbal, supplier.s_name, nation.n_name, part.p_partkey, part.p_mfgr, supplier.s_address, supplier.s_phone, supplier.s_comment, partsupp._row_id, part._row_id, supplier._row_id, partsupp.ps_partkey, nation._row_id, region._row_id] }
+          StreamHashJoin { type: Inner, predicate: nation.n_regionkey = region.r_regionkey, output: [supplier.s_acctbal, supplier.s_name, nation.n_name, part.p_partkey, part.p_mfgr, supplier.s_address, supplier.s_phone, supplier.s_comment, partsupp._row_id, part._row_id, supplier._row_id, part.p_partkey, nation._row_id, region._row_id] }
             StreamExchange { dist: HashShard(nation.n_regionkey) }
-              StreamHashJoin { type: Inner, predicate: supplier.s_nationkey = nation.n_nationkey, output: [part.p_partkey, part.p_mfgr, supplier.s_name, supplier.s_address, supplier.s_phone, supplier.s_acctbal, supplier.s_comment, nation.n_name, nation.n_regionkey, partsupp._row_id, part._row_id, supplier._row_id, partsupp.ps_partkey, nation._row_id] }
+              StreamHashJoin { type: Inner, predicate: supplier.s_nationkey = nation.n_nationkey, output: [part.p_partkey, part.p_mfgr, supplier.s_name, supplier.s_address, supplier.s_phone, supplier.s_acctbal, supplier.s_comment, nation.n_name, nation.n_regionkey, partsupp._row_id, part._row_id, supplier._row_id, part.p_partkey, nation._row_id] }
                 StreamExchange { dist: HashShard(supplier.s_nationkey) }
-                  StreamHashJoin { type: Inner, predicate: part.p_partkey = partsupp.ps_partkey AND partsupp.ps_supplycost = min(partsupp.ps_supplycost), output: [part.p_partkey, part.p_mfgr, supplier.s_name, supplier.s_address, supplier.s_nationkey, supplier.s_phone, supplier.s_acctbal, supplier.s_comment, partsupp._row_id, part._row_id, supplier._row_id, partsupp.ps_partkey] }
+                  StreamHashJoin { type: Inner, predicate: part.p_partkey = part.p_partkey AND partsupp.ps_supplycost = min(min(partsupp.ps_supplycost)), output: [part.p_partkey, part.p_mfgr, supplier.s_name, supplier.s_address, supplier.s_nationkey, supplier.s_phone, supplier.s_acctbal, supplier.s_comment, partsupp._row_id, part._row_id, supplier._row_id, part.p_partkey] }
                     StreamExchange { dist: HashShard(part.p_partkey) }
                       StreamHashJoin { type: Inner, predicate: partsupp.ps_suppkey = supplier.s_suppkey, output: [partsupp.ps_supplycost, part.p_partkey, part.p_mfgr, supplier.s_name, supplier.s_address, supplier.s_nationkey, supplier.s_phone, supplier.s_acctbal, supplier.s_comment, partsupp._row_id, part._row_id, supplier._row_id] }
                         StreamExchange { dist: HashShard(partsupp.ps_suppkey) }
@@ -292,23 +299,31 @@
                                   StreamTableScan { table: part, columns: [part.p_partkey, part.p_mfgr, part._row_id, part.p_type, part.p_size], pk: [part._row_id], distribution: HashShard(part._row_id) }
                         StreamExchange { dist: HashShard(supplier.s_suppkey) }
                           StreamTableScan { table: supplier, columns: [supplier.s_suppkey, supplier.s_name, supplier.s_address, supplier.s_nationkey, supplier.s_phone, supplier.s_acctbal, supplier.s_comment, supplier._row_id], pk: [supplier._row_id], distribution: HashShard(supplier._row_id) }
-                    StreamHashAgg { group_key: [partsupp.ps_partkey], aggs: [count, min(partsupp.ps_supplycost)] }
-                      StreamExchange { dist: HashShard(partsupp.ps_partkey) }
-                        StreamHashJoin { type: Inner, predicate: nation.n_regionkey = region.r_regionkey, output: [partsupp.ps_partkey, partsupp.ps_supplycost, partsupp._row_id, supplier._row_id, nation._row_id, region._row_id] }
-                          StreamExchange { dist: HashShard(nation.n_regionkey) }
-                            StreamHashJoin { type: Inner, predicate: supplier.s_nationkey = nation.n_nationkey, output: [partsupp.ps_partkey, partsupp.ps_supplycost, nation.n_regionkey, partsupp._row_id, supplier._row_id, nation._row_id] }
-                              StreamExchange { dist: HashShard(supplier.s_nationkey) }
-                                StreamHashJoin { type: Inner, predicate: partsupp.ps_suppkey = supplier.s_suppkey, output: [partsupp.ps_partkey, partsupp.ps_supplycost, supplier.s_nationkey, partsupp._row_id, supplier._row_id] }
-                                  StreamExchange { dist: HashShard(partsupp.ps_suppkey) }
-                                    StreamTableScan { table: partsupp, columns: [partsupp.ps_partkey, partsupp.ps_suppkey, partsupp.ps_supplycost, partsupp._row_id], pk: [partsupp._row_id], distribution: HashShard(partsupp._row_id) }
-                                  StreamExchange { dist: HashShard(supplier.s_suppkey) }
-                                    StreamTableScan { table: supplier, columns: [supplier.s_suppkey, supplier.s_nationkey, supplier._row_id], pk: [supplier._row_id], distribution: HashShard(supplier._row_id) }
-                              StreamExchange { dist: HashShard(nation.n_nationkey) }
-                                StreamTableScan { table: nation, columns: [nation.n_nationkey, nation.n_regionkey, nation._row_id], pk: [nation._row_id], distribution: HashShard(nation._row_id) }
-                          StreamExchange { dist: HashShard(region.r_regionkey) }
-                            StreamProject { exprs: [region.r_regionkey, region._row_id] }
-                              StreamFilter { predicate: (region.r_name = 'AFRICA':Varchar) }
-                                StreamTableScan { table: region, columns: [region.r_regionkey, region._row_id, region.r_name], pk: [region._row_id], distribution: HashShard(region._row_id) }
+                    StreamHashAgg { group_key: [part.p_partkey], aggs: [sum(count), min(min(partsupp.ps_supplycost))] }
+                      StreamHashAgg { group_key: [part.p_partkey, Vnode(part.p_partkey)], aggs: [count, min(partsupp.ps_supplycost)] }
+                        StreamProject { exprs: [part.p_partkey, partsupp.ps_supplycost, partsupp._row_id, supplier._row_id, nation._row_id, region._row_id, Vnode(part.p_partkey)] }
+                          StreamHashJoin { type: LeftOuter, predicate: part.p_partkey = partsupp.ps_partkey, output: [part.p_partkey, partsupp.ps_supplycost, partsupp._row_id, supplier._row_id, nation._row_id, region._row_id] }
+                            StreamHashAgg { group_key: [part.p_partkey], aggs: [sum(count)] }
+                              StreamExchange { dist: HashShard(part.p_partkey) }
+                                StreamHashAgg { group_key: [part.p_partkey, Vnode(part._row_id)], aggs: [count] }
+                                  StreamProject { exprs: [part.p_partkey, part._row_id, Vnode(part._row_id)] }
+                                    StreamTableScan { table: part, columns: [part.p_partkey, part._row_id], pk: [part._row_id], distribution: HashShard(part._row_id) }
+                            StreamExchange { dist: HashShard(partsupp.ps_partkey) }
+                              StreamHashJoin { type: Inner, predicate: nation.n_regionkey = region.r_regionkey, output: [partsupp.ps_partkey, partsupp.ps_supplycost, partsupp._row_id, supplier._row_id, nation._row_id, region._row_id] }
+                                StreamExchange { dist: HashShard(nation.n_regionkey) }
+                                  StreamHashJoin { type: Inner, predicate: supplier.s_nationkey = nation.n_nationkey, output: [partsupp.ps_partkey, partsupp.ps_supplycost, nation.n_regionkey, partsupp._row_id, supplier._row_id, nation._row_id] }
+                                    StreamExchange { dist: HashShard(supplier.s_nationkey) }
+                                      StreamHashJoin { type: Inner, predicate: partsupp.ps_suppkey = supplier.s_suppkey, output: [partsupp.ps_partkey, partsupp.ps_supplycost, supplier.s_nationkey, partsupp._row_id, supplier._row_id] }
+                                        StreamExchange { dist: HashShard(partsupp.ps_suppkey) }
+                                          StreamTableScan { table: partsupp, columns: [partsupp.ps_partkey, partsupp.ps_suppkey, partsupp.ps_supplycost, partsupp._row_id], pk: [partsupp._row_id], distribution: HashShard(partsupp._row_id) }
+                                        StreamExchange { dist: HashShard(supplier.s_suppkey) }
+                                          StreamTableScan { table: supplier, columns: [supplier.s_suppkey, supplier.s_nationkey, supplier._row_id], pk: [supplier._row_id], distribution: HashShard(supplier._row_id) }
+                                    StreamExchange { dist: HashShard(nation.n_nationkey) }
+                                      StreamTableScan { table: nation, columns: [nation.n_nationkey, nation.n_regionkey, nation._row_id], pk: [nation._row_id], distribution: HashShard(nation._row_id) }
+                                StreamExchange { dist: HashShard(region.r_regionkey) }
+                                  StreamProject { exprs: [region.r_regionkey, region._row_id] }
+                                    StreamFilter { predicate: (region.r_name = 'AFRICA':Varchar) }
+                                      StreamTableScan { table: region, columns: [region.r_regionkey, region._row_id, region.r_name], pk: [region._row_id], distribution: HashShard(region._row_id) }
                 StreamExchange { dist: HashShard(nation.n_nationkey) }
                   StreamTableScan { table: nation, columns: [nation.n_nationkey, nation.n_name, nation.n_regionkey, nation._row_id], pk: [nation._row_id], distribution: HashShard(nation._row_id) }
             StreamExchange { dist: HashShard(region.r_regionkey) }
@@ -1758,13 +1773,16 @@
   optimized_logical_plan: |
     LogicalProject { exprs: [RoundDigit((sum(lineitem.l_extendedprice) / 7.0:Decimal), 16:Int32)] }
       LogicalAgg { aggs: [sum(lineitem.l_extendedprice)] }
-        LogicalJoin { type: Inner, on: (part.p_partkey = lineitem.l_partkey) AND (lineitem.l_quantity < (0.2:Decimal * (sum(lineitem.l_quantity) / count(lineitem.l_quantity)))), output: [lineitem.l_extendedprice] }
+        LogicalJoin { type: Inner, on: (part.p_partkey = part.p_partkey) AND (lineitem.l_quantity < (0.2:Decimal * (sum(lineitem.l_quantity) / count(lineitem.l_quantity)))), output: [lineitem.l_extendedprice] }
           LogicalJoin { type: Inner, on: (part.p_partkey = lineitem.l_partkey), output: [lineitem.l_quantity, lineitem.l_extendedprice, part.p_partkey] }
             LogicalScan { table: lineitem, columns: [lineitem.l_partkey, lineitem.l_quantity, lineitem.l_extendedprice] }
             LogicalScan { table: part, output_columns: [part.p_partkey], required_columns: [p_partkey, p_brand, p_container], predicate: (part.p_brand = 'Brand#13':Varchar) AND (part.p_container = 'JUMBO PKG':Varchar) }
-          LogicalProject { exprs: [lineitem.l_partkey, (0.2:Decimal * (sum(lineitem.l_quantity) / count(lineitem.l_quantity)))] }
-            LogicalAgg { group_key: [lineitem.l_partkey], aggs: [sum(lineitem.l_quantity), count(lineitem.l_quantity)] }
-              LogicalScan { table: lineitem, columns: [lineitem.l_partkey, lineitem.l_quantity] }
+          LogicalProject { exprs: [part.p_partkey, (0.2:Decimal * (sum(lineitem.l_quantity) / count(lineitem.l_quantity)))] }
+            LogicalAgg { group_key: [part.p_partkey], aggs: [sum(lineitem.l_quantity), count(lineitem.l_quantity)] }
+              LogicalJoin { type: LeftOuter, on: (part.p_partkey = lineitem.l_partkey), output: [part.p_partkey, lineitem.l_quantity] }
+                LogicalAgg { group_key: [part.p_partkey], aggs: [] }
+                  LogicalScan { table: part, columns: [part.p_partkey] }
+                LogicalScan { table: lineitem, columns: [lineitem.l_partkey, lineitem.l_quantity] }
   batch_plan: |
     BatchProject { exprs: [RoundDigit((sum(sum(lineitem.l_extendedprice)) / 7.0:Decimal), 16:Int32)] }
       BatchSimpleAgg { aggs: [sum(sum(lineitem.l_extendedprice))] }
@@ -1772,7 +1790,7 @@
           BatchSimpleAgg { aggs: [sum(lineitem.l_extendedprice)] }
             BatchProject { exprs: [lineitem.l_extendedprice] }
               BatchFilter { predicate: (lineitem.l_quantity < (0.2:Decimal * (sum(lineitem.l_quantity) / count(lineitem.l_quantity)))) }
-                BatchHashJoin { type: Inner, predicate: part.p_partkey = lineitem.l_partkey, output: all }
+                BatchHashJoin { type: Inner, predicate: part.p_partkey = part.p_partkey, output: all }
                   BatchExchange { order: [], dist: HashShard(part.p_partkey) }
                     BatchHashJoin { type: Inner, predicate: lineitem.l_partkey = part.p_partkey, output: [lineitem.l_quantity, lineitem.l_extendedprice, part.p_partkey] }
                       BatchExchange { order: [], dist: HashShard(lineitem.l_partkey) }
@@ -1781,19 +1799,23 @@
                         BatchProject { exprs: [part.p_partkey] }
                           BatchFilter { predicate: (part.p_brand = 'Brand#13':Varchar) AND (part.p_container = 'JUMBO PKG':Varchar) }
                             BatchScan { table: part, columns: [part.p_partkey, part.p_brand, part.p_container], distribution: SomeShard }
-                  BatchProject { exprs: [lineitem.l_partkey, (0.2:Decimal * (sum(lineitem.l_quantity) / count(lineitem.l_quantity)))] }
-                    BatchHashAgg { group_key: [lineitem.l_partkey], aggs: [sum(lineitem.l_quantity), count(lineitem.l_quantity)] }
-                      BatchExchange { order: [], dist: HashShard(lineitem.l_partkey) }
-                        BatchScan { table: lineitem, columns: [lineitem.l_partkey, lineitem.l_quantity], distribution: SomeShard }
+                  BatchProject { exprs: [part.p_partkey, (0.2:Decimal * (sum(lineitem.l_quantity) / count(lineitem.l_quantity)))] }
+                    BatchHashAgg { group_key: [part.p_partkey], aggs: [sum(lineitem.l_quantity), count(lineitem.l_quantity)] }
+                      BatchHashJoin { type: LeftOuter, predicate: part.p_partkey = lineitem.l_partkey, output: [part.p_partkey, lineitem.l_quantity] }
+                        BatchHashAgg { group_key: [part.p_partkey], aggs: [] }
+                          BatchExchange { order: [], dist: HashShard(part.p_partkey) }
+                            BatchScan { table: part, columns: [part.p_partkey], distribution: SomeShard }
+                        BatchExchange { order: [], dist: HashShard(lineitem.l_partkey) }
+                          BatchScan { table: lineitem, columns: [lineitem.l_partkey, lineitem.l_quantity], distribution: SomeShard }
   stream_plan: |
     StreamMaterialize { columns: [avg_yearly], pk_columns: [] }
       StreamProject { exprs: [RoundDigit((sum(sum(lineitem.l_extendedprice)) / 7.0:Decimal), 16:Int32)] }
         StreamGlobalSimpleAgg { aggs: [sum(count), sum(sum(lineitem.l_extendedprice))] }
           StreamExchange { dist: Single }
             StreamStatelessLocalSimpleAgg { aggs: [count, sum(lineitem.l_extendedprice)] }
-              StreamProject { exprs: [lineitem.l_extendedprice, lineitem._row_id, part._row_id, lineitem.l_partkey] }
+              StreamProject { exprs: [lineitem.l_extendedprice, lineitem._row_id, part._row_id, part.p_partkey] }
                 StreamFilter { predicate: (lineitem.l_quantity < (0.2:Decimal * (sum(sum(lineitem.l_quantity)) / sum(count(lineitem.l_quantity))))) }
-                  StreamHashJoin { type: Inner, predicate: part.p_partkey = lineitem.l_partkey, output: all }
+                  StreamHashJoin { type: Inner, predicate: part.p_partkey = part.p_partkey, output: all }
                     StreamExchange { dist: HashShard(part.p_partkey) }
                       StreamHashJoin { type: Inner, predicate: lineitem.l_partkey = part.p_partkey, output: [lineitem.l_quantity, lineitem.l_extendedprice, part.p_partkey, lineitem._row_id, part._row_id] }
                         StreamExchange { dist: HashShard(lineitem.l_partkey) }
@@ -1802,12 +1824,18 @@
                           StreamProject { exprs: [part.p_partkey, part._row_id] }
                             StreamFilter { predicate: (part.p_brand = 'Brand#13':Varchar) AND (part.p_container = 'JUMBO PKG':Varchar) }
                               StreamTableScan { table: part, columns: [part.p_partkey, part._row_id, part.p_brand, part.p_container], pk: [part._row_id], distribution: HashShard(part._row_id) }
-                    StreamProject { exprs: [lineitem.l_partkey, (0.2:Decimal * (sum(sum(lineitem.l_quantity)) / sum(count(lineitem.l_quantity))))] }
-                      StreamHashAgg { group_key: [lineitem.l_partkey], aggs: [sum(count), sum(sum(lineitem.l_quantity)), sum(count(lineitem.l_quantity))] }
-                        StreamExchange { dist: HashShard(lineitem.l_partkey) }
-                          StreamHashAgg { group_key: [lineitem.l_partkey, Vnode(lineitem._row_id)], aggs: [count, sum(lineitem.l_quantity), count(lineitem.l_quantity)] }
-                            StreamProject { exprs: [lineitem.l_partkey, lineitem.l_quantity, lineitem._row_id, Vnode(lineitem._row_id)] }
-                              StreamTableScan { table: lineitem, columns: [lineitem.l_partkey, lineitem.l_quantity, lineitem._row_id], pk: [lineitem._row_id], distribution: HashShard(lineitem._row_id) }
+                    StreamProject { exprs: [part.p_partkey, (0.2:Decimal * (sum(sum(lineitem.l_quantity)) / sum(count(lineitem.l_quantity))))] }
+                      StreamHashAgg { group_key: [part.p_partkey], aggs: [sum(count), sum(sum(lineitem.l_quantity)), sum(count(lineitem.l_quantity))] }
+                        StreamHashAgg { group_key: [part.p_partkey, Vnode(part.p_partkey)], aggs: [count, sum(lineitem.l_quantity), count(lineitem.l_quantity)] }
+                          StreamProject { exprs: [part.p_partkey, lineitem.l_quantity, lineitem._row_id, Vnode(part.p_partkey)] }
+                            StreamHashJoin { type: LeftOuter, predicate: part.p_partkey = lineitem.l_partkey, output: [part.p_partkey, lineitem.l_quantity, lineitem._row_id] }
+                              StreamHashAgg { group_key: [part.p_partkey], aggs: [sum(count)] }
+                                StreamExchange { dist: HashShard(part.p_partkey) }
+                                  StreamHashAgg { group_key: [part.p_partkey, Vnode(part._row_id)], aggs: [count] }
+                                    StreamProject { exprs: [part.p_partkey, part._row_id, Vnode(part._row_id)] }
+                                      StreamTableScan { table: part, columns: [part.p_partkey, part._row_id], pk: [part._row_id], distribution: HashShard(part._row_id) }
+                              StreamExchange { dist: HashShard(lineitem.l_partkey) }
+                                StreamTableScan { table: lineitem, columns: [lineitem.l_partkey, lineitem.l_quantity, lineitem._row_id], pk: [lineitem._row_id], distribution: HashShard(lineitem._row_id) }
 - id: tpch_q18
   before:
   - create_tables
@@ -2068,13 +2096,16 @@
       LogicalJoin { type: Inner, on: (supplier.s_nationkey = nation.n_nationkey), output: [supplier.s_suppkey, supplier.s_name, supplier.s_address] }
         LogicalScan { table: supplier, columns: [supplier.s_suppkey, supplier.s_name, supplier.s_address, supplier.s_nationkey] }
         LogicalScan { table: nation, output_columns: [nation.n_nationkey], required_columns: [n_nationkey, n_name], predicate: (nation.n_name = 'KENYA':Varchar) }
-      LogicalJoin { type: Inner, on: (partsupp.ps_partkey = lineitem.l_partkey) AND (partsupp.ps_suppkey = lineitem.l_suppkey) AND (partsupp.ps_availqty > (0.5:Decimal * sum(lineitem.l_quantity))), output: [partsupp.ps_suppkey] }
+      LogicalJoin { type: Inner, on: (partsupp.ps_partkey = partsupp.ps_partkey) AND (partsupp.ps_suppkey = partsupp.ps_suppkey) AND (partsupp.ps_availqty > (0.5:Decimal * sum(lineitem.l_quantity))), output: [partsupp.ps_suppkey] }
         LogicalJoin { type: LeftSemi, on: (partsupp.ps_partkey = part.p_partkey), output: all }
           LogicalScan { table: partsupp, columns: [partsupp.ps_partkey, partsupp.ps_suppkey, partsupp.ps_availqty] }
           LogicalScan { table: part, output_columns: [part.p_partkey], required_columns: [p_partkey, p_name], predicate: Like(part.p_name, 'forest%':Varchar) }
-        LogicalProject { exprs: [lineitem.l_partkey, lineitem.l_suppkey, (0.5:Decimal * sum(lineitem.l_quantity))] }
-          LogicalAgg { group_key: [lineitem.l_partkey, lineitem.l_suppkey], aggs: [sum(lineitem.l_quantity)] }
-            LogicalScan { table: lineitem, output_columns: [lineitem.l_partkey, lineitem.l_suppkey, lineitem.l_quantity], required_columns: [l_partkey, l_suppkey, l_quantity, l_shipdate], predicate: (lineitem.l_shipdate >= '1994-01-01':Varchar::Date) AND (lineitem.l_shipdate < ('1994-01-01':Varchar::Date + '1 year 00:00:00':Interval)) }
+        LogicalProject { exprs: [partsupp.ps_partkey, partsupp.ps_suppkey, (0.5:Decimal * sum(lineitem.l_quantity))] }
+          LogicalAgg { group_key: [partsupp.ps_partkey, partsupp.ps_suppkey], aggs: [sum(lineitem.l_quantity)] }
+            LogicalJoin { type: LeftOuter, on: (partsupp.ps_partkey = lineitem.l_partkey) AND (partsupp.ps_suppkey = lineitem.l_suppkey), output: [partsupp.ps_partkey, partsupp.ps_suppkey, lineitem.l_quantity] }
+              LogicalAgg { group_key: [partsupp.ps_partkey, partsupp.ps_suppkey], aggs: [] }
+                LogicalScan { table: partsupp, columns: [partsupp.ps_partkey, partsupp.ps_suppkey] }
+              LogicalScan { table: lineitem, output_columns: [lineitem.l_partkey, lineitem.l_suppkey, lineitem.l_quantity], required_columns: [l_partkey, l_suppkey, l_quantity, l_shipdate], predicate: (lineitem.l_shipdate >= '1994-01-01':Varchar::Date) AND (lineitem.l_shipdate < ('1994-01-01':Varchar::Date + '1 year 00:00:00':Interval)) }
   batch_plan: |
     BatchExchange { order: [supplier.s_name ASC], dist: Single }
       BatchSort { order: [supplier.s_name ASC] }
@@ -2090,7 +2121,7 @@
           BatchExchange { order: [], dist: HashShard(partsupp.ps_suppkey) }
             BatchProject { exprs: [partsupp.ps_suppkey] }
               BatchFilter { predicate: (partsupp.ps_availqty > (0.5:Decimal * sum(lineitem.l_quantity))) }
-                BatchHashJoin { type: Inner, predicate: partsupp.ps_partkey = lineitem.l_partkey AND partsupp.ps_suppkey = lineitem.l_suppkey, output: all }
+                BatchHashJoin { type: Inner, predicate: partsupp.ps_partkey = partsupp.ps_partkey AND partsupp.ps_suppkey = partsupp.ps_suppkey, output: all }
                   BatchExchange { order: [], dist: HashShard(partsupp.ps_partkey, partsupp.ps_suppkey) }
                     BatchHashJoin { type: LeftSemi, predicate: partsupp.ps_partkey = part.p_partkey, output: all }
                       BatchExchange { order: [], dist: HashShard(partsupp.ps_partkey) }
@@ -2099,12 +2130,16 @@
                         BatchProject { exprs: [part.p_partkey] }
                           BatchFilter { predicate: Like(part.p_name, 'forest%':Varchar) }
                             BatchScan { table: part, columns: [part.p_partkey, part.p_name], distribution: SomeShard }
-                  BatchProject { exprs: [lineitem.l_partkey, lineitem.l_suppkey, (0.5:Decimal * sum(lineitem.l_quantity))] }
-                    BatchHashAgg { group_key: [lineitem.l_partkey, lineitem.l_suppkey], aggs: [sum(lineitem.l_quantity)] }
-                      BatchExchange { order: [], dist: HashShard(lineitem.l_partkey, lineitem.l_suppkey) }
-                        BatchProject { exprs: [lineitem.l_partkey, lineitem.l_suppkey, lineitem.l_quantity] }
-                          BatchFilter { predicate: (lineitem.l_shipdate >= '1994-01-01':Varchar::Date) AND (lineitem.l_shipdate < ('1994-01-01':Varchar::Date + '1 year 00:00:00':Interval)) }
-                            BatchScan { table: lineitem, columns: [lineitem.l_partkey, lineitem.l_suppkey, lineitem.l_quantity, lineitem.l_shipdate], distribution: SomeShard }
+                  BatchProject { exprs: [partsupp.ps_partkey, partsupp.ps_suppkey, (0.5:Decimal * sum(lineitem.l_quantity))] }
+                    BatchHashAgg { group_key: [partsupp.ps_partkey, partsupp.ps_suppkey], aggs: [sum(lineitem.l_quantity)] }
+                      BatchHashJoin { type: LeftOuter, predicate: partsupp.ps_partkey = lineitem.l_partkey AND partsupp.ps_suppkey = lineitem.l_suppkey, output: [partsupp.ps_partkey, partsupp.ps_suppkey, lineitem.l_quantity] }
+                        BatchHashAgg { group_key: [partsupp.ps_partkey, partsupp.ps_suppkey], aggs: [] }
+                          BatchExchange { order: [], dist: HashShard(partsupp.ps_partkey, partsupp.ps_suppkey) }
+                            BatchScan { table: partsupp, columns: [partsupp.ps_partkey, partsupp.ps_suppkey], distribution: SomeShard }
+                        BatchExchange { order: [], dist: HashShard(lineitem.l_partkey, lineitem.l_suppkey) }
+                          BatchProject { exprs: [lineitem.l_partkey, lineitem.l_suppkey, lineitem.l_quantity] }
+                            BatchFilter { predicate: (lineitem.l_shipdate >= '1994-01-01':Varchar::Date) AND (lineitem.l_shipdate < ('1994-01-01':Varchar::Date + '1 year 00:00:00':Interval)) }
+                              BatchScan { table: lineitem, columns: [lineitem.l_partkey, lineitem.l_suppkey, lineitem.l_quantity, lineitem.l_shipdate], distribution: SomeShard }
   stream_plan: |
     StreamMaterialize { columns: [s_name, s_address, supplier._row_id(hidden), nation._row_id(hidden)], pk_columns: [supplier._row_id, nation._row_id], order_descs: [s_name, supplier._row_id, nation._row_id] }
       StreamExchange { dist: HashShard(supplier._row_id, nation._row_id) }
@@ -2118,9 +2153,9 @@
                   StreamFilter { predicate: (nation.n_name = 'KENYA':Varchar) }
                     StreamTableScan { table: nation, columns: [nation.n_nationkey, nation._row_id, nation.n_name], pk: [nation._row_id], distribution: HashShard(nation._row_id) }
           StreamExchange { dist: HashShard(partsupp.ps_suppkey) }
-            StreamProject { exprs: [partsupp.ps_suppkey, partsupp._row_id, lineitem.l_partkey, lineitem.l_suppkey] }
+            StreamProject { exprs: [partsupp.ps_suppkey, partsupp._row_id, partsupp.ps_partkey, partsupp.ps_suppkey] }
               StreamFilter { predicate: (partsupp.ps_availqty > (0.5:Decimal * sum(sum(lineitem.l_quantity)))) }
-                StreamHashJoin { type: Inner, predicate: partsupp.ps_partkey = lineitem.l_partkey AND partsupp.ps_suppkey = lineitem.l_suppkey, output: all }
+                StreamHashJoin { type: Inner, predicate: partsupp.ps_partkey = partsupp.ps_partkey AND partsupp.ps_suppkey = partsupp.ps_suppkey, output: all }
                   StreamExchange { dist: HashShard(partsupp.ps_partkey, partsupp.ps_suppkey) }
                     StreamHashJoin { type: LeftSemi, predicate: partsupp.ps_partkey = part.p_partkey, output: all }
                       StreamExchange { dist: HashShard(partsupp.ps_partkey) }
@@ -2129,14 +2164,20 @@
                         StreamProject { exprs: [part.p_partkey, part._row_id] }
                           StreamFilter { predicate: Like(part.p_name, 'forest%':Varchar) }
                             StreamTableScan { table: part, columns: [part.p_partkey, part._row_id, part.p_name], pk: [part._row_id], distribution: HashShard(part._row_id) }
-                  StreamProject { exprs: [lineitem.l_partkey, lineitem.l_suppkey, (0.5:Decimal * sum(sum(lineitem.l_quantity)))] }
-                    StreamHashAgg { group_key: [lineitem.l_partkey, lineitem.l_suppkey], aggs: [sum(count), sum(sum(lineitem.l_quantity))] }
-                      StreamExchange { dist: HashShard(lineitem.l_partkey, lineitem.l_suppkey) }
-                        StreamHashAgg { group_key: [lineitem.l_partkey, lineitem.l_suppkey, Vnode(lineitem._row_id)], aggs: [count, sum(lineitem.l_quantity)] }
-                          StreamProject { exprs: [lineitem.l_partkey, lineitem.l_suppkey, lineitem.l_quantity, lineitem._row_id, Vnode(lineitem._row_id)] }
-                            StreamProject { exprs: [lineitem.l_partkey, lineitem.l_suppkey, lineitem.l_quantity, lineitem._row_id] }
-                              StreamFilter { predicate: (lineitem.l_shipdate >= '1994-01-01':Varchar::Date) AND (lineitem.l_shipdate < ('1994-01-01':Varchar::Date + '1 year 00:00:00':Interval)) }
-                                StreamTableScan { table: lineitem, columns: [lineitem.l_partkey, lineitem.l_suppkey, lineitem.l_quantity, lineitem._row_id, lineitem.l_shipdate], pk: [lineitem._row_id], distribution: HashShard(lineitem._row_id) }
+                  StreamProject { exprs: [partsupp.ps_partkey, partsupp.ps_suppkey, (0.5:Decimal * sum(sum(lineitem.l_quantity)))] }
+                    StreamHashAgg { group_key: [partsupp.ps_partkey, partsupp.ps_suppkey], aggs: [sum(count), sum(sum(lineitem.l_quantity))] }
+                      StreamHashAgg { group_key: [partsupp.ps_partkey, partsupp.ps_suppkey, Vnode(partsupp.ps_partkey, partsupp.ps_suppkey)], aggs: [count, sum(lineitem.l_quantity)] }
+                        StreamProject { exprs: [partsupp.ps_partkey, partsupp.ps_suppkey, lineitem.l_quantity, lineitem._row_id, Vnode(partsupp.ps_partkey, partsupp.ps_suppkey)] }
+                          StreamHashJoin { type: LeftOuter, predicate: partsupp.ps_partkey = lineitem.l_partkey AND partsupp.ps_suppkey = lineitem.l_suppkey, output: [partsupp.ps_partkey, partsupp.ps_suppkey, lineitem.l_quantity, lineitem._row_id] }
+                            StreamHashAgg { group_key: [partsupp.ps_partkey, partsupp.ps_suppkey], aggs: [sum(count)] }
+                              StreamExchange { dist: HashShard(partsupp.ps_partkey, partsupp.ps_suppkey) }
+                                StreamHashAgg { group_key: [partsupp.ps_partkey, partsupp.ps_suppkey, Vnode(partsupp._row_id)], aggs: [count] }
+                                  StreamProject { exprs: [partsupp.ps_partkey, partsupp.ps_suppkey, partsupp._row_id, Vnode(partsupp._row_id)] }
+                                    StreamTableScan { table: partsupp, columns: [partsupp.ps_partkey, partsupp.ps_suppkey, partsupp._row_id], pk: [partsupp._row_id], distribution: HashShard(partsupp._row_id) }
+                            StreamExchange { dist: HashShard(lineitem.l_partkey, lineitem.l_suppkey) }
+                              StreamProject { exprs: [lineitem.l_partkey, lineitem.l_suppkey, lineitem.l_quantity, lineitem._row_id] }
+                                StreamFilter { predicate: (lineitem.l_shipdate >= '1994-01-01':Varchar::Date) AND (lineitem.l_shipdate < ('1994-01-01':Varchar::Date + '1 year 00:00:00':Interval)) }
+                                  StreamTableScan { table: lineitem, columns: [lineitem.l_partkey, lineitem.l_suppkey, lineitem.l_quantity, lineitem._row_id, lineitem.l_shipdate], pk: [lineitem._row_id], distribution: HashShard(lineitem._row_id) }
 - id: tpch_q21
   before:
   - create_tables


### PR DESCRIPTION
I hereby agree to the terms of the [Singularity Data, Inc. Contributor License Agreement](https://gist.github.com/skyzh/0663682a70b0edde7ae991492f2314cb#file-s9y_cla).

## What's changed and what's your intention?

***PLEASE DO NOT LEAVE THIS EMPTY !!!***

Please explain **IN DETAIL** what the changes are in this PR and why they are needed:

- Summarize your change (**mandatory**)
We used to treat scalar agg and group agg the same when push Apply down. However this isn't true when it comes to count(*).
This pr fix this bug.
- Describe any limitations of the current code (optional)
If we run TranslateApply multiple times, then Apply's left will be rewritten multiple times, but the logic of rewriting Apply's left can only be applied once. We currently rely `rewrite()` on returning None to remind us that left doesn't need to be rewritten, but returning None actually means left can't be rewritten now, which is an error! So we need a way to prevent us from rewriting left more than once. Maybe we can add a flag to LogicalApply but this is not that elegant........ Please take a look @chenzl25 
## Checklist

- [x] I have written necessary rustdoc comments
- [x] I have added necessary unit tests and integration tests
- [x] All checks passed in `./risedev check` (or alias, `./risedev c`).

## Refer to a related PR or issue link (optional)
related #4355 