### PR TITLE
fix(frontend): make WITH optional for user create and alter

### DIFF
--- a/src/sqlparser/src/ast/statement.rs
+++ b/src/sqlparser/src/ast/statement.rs
@@ -396,47 +396,46 @@ pub struct UserOptions(pub Vec<UserOption>);
 impl ParseTo for UserOptions {
     fn parse_to(parser: &mut Parser) -> Result<Self, ParserError> {
         let mut options = vec![];
-        if parser.parse_keyword(Keyword::WITH) {
-            loop {
-                let token = parser.peek_token();
-                if token == Token::EOF || token == Token::SemiColon {
-                    break;
-                }
+        let _ = parser.parse_keyword(Keyword::WITH);
+        loop {
+            let token = parser.peek_token();
+            if token == Token::EOF || token == Token::SemiColon {
+                break;
+            }
 
-                if let Token::Word(ref w) = token {
-                    parser.next_token();
-                    let option = match w.keyword {
-                        Keyword::SUPERUSER => UserOption::SuperUser,
-                        Keyword::NOSUPERUSER => UserOption::NoSuperUser,
-                        Keyword::CREATEDB => UserOption::CreateDB,
-                        Keyword::NOCREATEDB => UserOption::NoCreateDB,
-                        Keyword::LOGIN => UserOption::Login,
-                        Keyword::NOLOGIN => UserOption::NoLogin,
-                        Keyword::PASSWORD => {
-                            if parser.parse_keyword(Keyword::NULL) {
-                                UserOption::Password(None)
-                            } else {
-                                UserOption::Password(Some(AstString::parse_to(parser)?))
-                            }
+            if let Token::Word(ref w) = token {
+                parser.next_token();
+                let option = match w.keyword {
+                    Keyword::SUPERUSER => UserOption::SuperUser,
+                    Keyword::NOSUPERUSER => UserOption::NoSuperUser,
+                    Keyword::CREATEDB => UserOption::CreateDB,
+                    Keyword::NOCREATEDB => UserOption::NoCreateDB,
+                    Keyword::LOGIN => UserOption::Login,
+                    Keyword::NOLOGIN => UserOption::NoLogin,
+                    Keyword::PASSWORD => {
+                        if parser.parse_keyword(Keyword::NULL) {
+                            UserOption::Password(None)
+                        } else {
+                            UserOption::Password(Some(AstString::parse_to(parser)?))
                         }
-                        Keyword::ENCRYPTED => {
-                            parser.expect_keyword(Keyword::PASSWORD)?;
-                            UserOption::EncryptedPassword(AstString::parse_to(parser)?)
-                        }
-                        _ => parser.expected(
-                            "SUPERUSER | NOSUPERUSER | CREATEDB | NOCREATEDB | LOGIN \
+                    }
+                    Keyword::ENCRYPTED => {
+                        parser.expect_keyword(Keyword::PASSWORD)?;
+                        UserOption::EncryptedPassword(AstString::parse_to(parser)?)
+                    }
+                    _ => parser.expected(
+                        "SUPERUSER | NOSUPERUSER | CREATEDB | NOCREATEDB | LOGIN \
                             | NOLOGIN | ENCRYPTED | PASSWORD | NULL",
-                            token,
-                        )?,
-                    };
-                    options.push(option);
-                } else {
-                    parser.expected(
-                        "SUPERUSER | NOSUPERUSER | CREATEDB | NOCREATEDB | LOGIN | NOLOGIN \
-                        | ENCRYPTED | PASSWORD | NULL",
                         token,
-                    )?
-                }
+                    )?,
+                };
+                options.push(option);
+            } else {
+                parser.expected(
+                    "SUPERUSER | NOSUPERUSER | CREATEDB | NOCREATEDB | LOGIN | NOLOGIN \
+                        | ENCRYPTED | PASSWORD | NULL",
+                    token,
+                )?
             }
         }
         Ok(Self(options))


### PR DESCRIPTION
I hereby agree to the terms of the [Singularity Data, Inc. Contributor License Agreement](https://gist.github.com/skyzh/0663682a70b0edde7ae991492f2314cb#file-s9y_cla).

## What's changed and what's your intention?

As title. Pointed out by @CharlieSYH , we should keep compatibility with PostgreSQL.
> 
> I tested this statement and it retuned an error "ERROR:  sql parser error: Expected end of statement, found: PASSWORD":
> `CREATE USER u1 PASSWORD 's1234';`
> But this works: `CREATE USER u1 WITH PASSWORD 's1234';`
>
> Seems that 'with' is not optional. Can you confirm on that?
>
> _Originally posted by @CharlieSYH in https://github.com/singularity-data/risingwave/issues/3074#issuecomment-1203882709_

## Checklist

- [x] I have written necessary rustdoc comments
- [x] I have added necessary unit tests and integration tests
- [x] All checks passed in `./risedev check` (or alias, `./risedev c`)

## Documentation

### Types of user-facing changes

Please keep the types that apply to your changes, and remove those that do not apply.

* SQL commands, functions, and operators

### Release note

Please create a release note for your changes. In the release note, focus on the impact on users, and mention the environment or conditions where the impact may occur.

## Refer to a related PR or issue link (optional)
