### PR TITLE
feat(sqlsmith): generate explicit type castings

### DIFF
--- a/src/frontend/src/expr/mod.rs
+++ b/src/frontend/src/expr/mod.rs
@@ -48,8 +48,8 @@ pub type ExprType = risingwave_pb::expr::expr_node::Type;
 pub use expr_rewriter::ExprRewriter;
 pub use expr_visitor::ExprVisitor;
 pub use type_inference::{
-    agg_func_sigs, align_types, cast_map_array, cast_ok, func_sigs, infer_type, least_restrictive,
-    AggFuncSig, CastContext, DataTypeName, FuncSign,
+    agg_func_sigs, align_types, cast_map_array, cast_ok, cast_sigs, func_sigs, infer_type,
+    least_restrictive, AggFuncSig, CastContext, CastSig, DataTypeName, FuncSign,
 };
 pub use utils::*;
 

--- a/src/frontend/src/expr/type_inference/mod.rs
+++ b/src/frontend/src/expr/type_inference/mod.rs
@@ -21,7 +21,8 @@ mod cast;
 mod func;
 pub use agg::{agg_func_sigs, AggFuncSig};
 pub use cast::{
-    align_types, cast_map_array, cast_ok, cast_ok_base, least_restrictive, CastContext,
+    align_types, cast_map_array, cast_ok, cast_ok_base, cast_sigs, least_restrictive, CastContext,
+    CastSig,
 };
 pub use func::{func_sigs, infer_type, FuncSign};
 /// `DataTypeName` is designed for type derivation here. In other scenarios,

--- a/src/frontend/src/expr/type_inference/mod.rs
+++ b/src/frontend/src/expr/type_inference/mod.rs
@@ -15,6 +15,7 @@
 //! This type inference is just to infer the return type of function calls, and make sure the
 //! functionCall expressions have same input type requirement and return type definition as backend.
 use risingwave_common::types::DataType;
+use risingwave_sqlparser::ast::DataType as AstDataType;
 
 mod agg;
 mod cast;
@@ -93,6 +94,29 @@ impl From<&DataType> for DataTypeName {
 impl From<DataType> for DataTypeName {
     fn from(ty: DataType) -> Self {
         (&ty).into()
+    }
+}
+
+impl From<DataTypeName> for AstDataType {
+    fn from(type_name: DataTypeName) -> Self {
+        match type_name {
+            DataTypeName::Boolean => AstDataType::Boolean,
+            DataTypeName::Int16 => AstDataType::SmallInt(None),
+            DataTypeName::Int32 => AstDataType::Int(None),
+            DataTypeName::Int64 => AstDataType::BigInt(None),
+            DataTypeName::Decimal => AstDataType::Decimal(None, None),
+            DataTypeName::Float32 => AstDataType::Real,
+            DataTypeName::Float64 => AstDataType::Double,
+            DataTypeName::Varchar => AstDataType::Varchar,
+            DataTypeName::Date => AstDataType::Date,
+            DataTypeName::Timestamp => AstDataType::Timestamp(false),
+            DataTypeName::Timestampz => AstDataType::Timestamp(true),
+            DataTypeName::Time => AstDataType::Time(false),
+            DataTypeName::Interval => AstDataType::Interval,
+            DataTypeName::Struct | DataTypeName::List => {
+                panic!("Functions returning struct or list can not be inferred. Please use `FunctionCall::new_unchecked`.")
+            }
+        }
     }
 }
 

--- a/src/frontend/src/expr/type_inference/mod.rs
+++ b/src/frontend/src/expr/type_inference/mod.rs
@@ -15,7 +15,6 @@
 //! This type inference is just to infer the return type of function calls, and make sure the
 //! functionCall expressions have same input type requirement and return type definition as backend.
 use risingwave_common::types::DataType;
-use risingwave_sqlparser::ast::DataType as AstDataType;
 
 mod agg;
 mod cast;
@@ -94,29 +93,6 @@ impl From<&DataType> for DataTypeName {
 impl From<DataType> for DataTypeName {
     fn from(ty: DataType) -> Self {
         (&ty).into()
-    }
-}
-
-impl From<DataTypeName> for AstDataType {
-    fn from(type_name: DataTypeName) -> Self {
-        match type_name {
-            DataTypeName::Boolean => AstDataType::Boolean,
-            DataTypeName::Int16 => AstDataType::SmallInt(None),
-            DataTypeName::Int32 => AstDataType::Int(None),
-            DataTypeName::Int64 => AstDataType::BigInt(None),
-            DataTypeName::Decimal => AstDataType::Decimal(None, None),
-            DataTypeName::Float32 => AstDataType::Real,
-            DataTypeName::Float64 => AstDataType::Double,
-            DataTypeName::Varchar => AstDataType::Varchar,
-            DataTypeName::Date => AstDataType::Date,
-            DataTypeName::Timestamp => AstDataType::Timestamp(false),
-            DataTypeName::Timestampz => AstDataType::Timestamp(true),
-            DataTypeName::Time => AstDataType::Time(false),
-            DataTypeName::Interval => AstDataType::Interval,
-            DataTypeName::Struct | DataTypeName::List => {
-                panic!("Functions returning struct or list can not be inferred. Please use `FunctionCall::new_unchecked`.")
-            }
-        }
     }
 }
 

--- a/src/tests/sqlsmith/README.md
+++ b/src/tests/sqlsmith/README.md
@@ -29,6 +29,7 @@ Additionally, in some cases where you may want to debug whether we have defined 
 you can try:
 
 ```sh
+cargo build
 ./target/debug/sqlsmith print-function-table > ft.txt
 ```
 

--- a/src/tests/sqlsmith/src/expr.rs
+++ b/src/tests/sqlsmith/src/expr.rs
@@ -386,5 +386,27 @@ pub fn print_function_table() -> String {
         })
         .join("\n");
 
-    func_str + "\n" + &agg_func_str
+    let cast_str = cast_sigs()
+        .map(|sig| {
+            format!(
+                "{:?} CAST {:?} -> {:?}",
+                sig.context, sig.to_type, sig.from_type,
+            )
+        })
+        .sorted()
+        .join("\n");
+
+    format!(
+        "
+==== FUNCTION SIGNATURES
+{}
+
+==== AGGREGATE FUNCTION SIGNATURES
+{}
+
+==== CAST SIGNATURES
+{}
+",
+        func_str, agg_func_str, cast_str
+    )
 }

--- a/src/tests/sqlsmith/src/expr.rs
+++ b/src/tests/sqlsmith/src/expr.rs
@@ -63,6 +63,9 @@ fn init_cast_table() -> HashMap<DataTypeName, Vec<CastSig>> {
     let mut casts = HashMap::<DataTypeName, Vec<CastSig>>::new();
     cast_sigs()
         .filter(|cast| cast.context == CastContext::Explicit) // TODO: generate implicit casts.
+        .filter(|cast| {
+            cast.from_type != DataTypeName::Varchar || cast.to_type == DataTypeName::Varchar
+        })
         .for_each(|cast| casts.entry(cast.to_type).or_default().push(cast));
     casts
 }

--- a/src/tests/sqlsmith/src/utils.rs
+++ b/src/tests/sqlsmith/src/utils.rs
@@ -15,8 +15,9 @@
 use std::mem;
 
 use rand::Rng;
+use risingwave_frontend::expr::DataTypeName;
 use risingwave_sqlparser::ast::{
-    FunctionArg, FunctionArgExpr, TableAlias, TableFactor, TableWithJoins,
+    DataType, FunctionArg, FunctionArgExpr, TableAlias, TableFactor, TableWithJoins,
 };
 
 use crate::{Column, Expr, Ident, ObjectName, SqlGenerator, Table};
@@ -87,4 +88,24 @@ pub(crate) fn create_args(arg_exprs: Vec<Expr>) -> Vec<FunctionArg> {
 /// Create `FunctionArg` from an `Expr`.
 fn create_function_arg_from_expr(expr: Expr) -> FunctionArg {
     FunctionArg::Unnamed(FunctionArgExpr::Expr(expr))
+}
+
+/// Used to cast [`DataTypeName`] into [`DataType`] where possible.
+pub fn data_type_name_to_ast_data_type(type_name: DataTypeName) -> Option<DataType> {
+    match type_name {
+        DataTypeName::Boolean => Some(DataType::Boolean),
+        DataTypeName::Int16 => Some(DataType::SmallInt(None)),
+        DataTypeName::Int32 => Some(DataType::Int(None)),
+        DataTypeName::Int64 => Some(DataType::BigInt(None)),
+        DataTypeName::Decimal => Some(DataType::Decimal(None, None)),
+        DataTypeName::Float32 => Some(DataType::Real),
+        DataTypeName::Float64 => Some(DataType::Double),
+        DataTypeName::Varchar => Some(DataType::Varchar),
+        DataTypeName::Date => Some(DataType::Date),
+        DataTypeName::Timestamp => Some(DataType::Timestamp(false)),
+        DataTypeName::Timestampz => Some(DataType::Timestamp(true)),
+        DataTypeName::Time => Some(DataType::Time(false)),
+        DataTypeName::Interval => Some(DataType::Interval),
+        DataTypeName::Struct | DataTypeName::List => None,
+    }
 }


### PR DESCRIPTION
I hereby agree to the terms of the [Singularity Data, Inc. Contributor License Agreement](https://gist.github.com/skyzh/0663682a70b0edde7ae991492f2314cb#file-s9y_cla).

## What's changed and what's your intention?

- Summarize your change (**mandatory**)
  - Gen casts.
  - See [cast signatures](https://gist.github.com/kwannoel/5967f133ca79b37a17159497d84befd5)
- How does this PR work? Need a brief introduction for the changed logic (optional)
  - Provide cast sig map.
  - Filter out casts that often fail / can't easily generate cast expressions for.
- Describe any limitations of the current code (optional)
  - Avoids testing varchar casting, arbitrary string of characters may not be able to cast to datatypes.
  - To test implicit cast most straightforward way is probably INSERTs?
  - For assign cast it can be done under CONCAT perhaps.
  - TODO: Track these under refinements.
  - We also need to generate invalid casts, thinking of having a new sqlsmith mode for that. Done in separate PR.

## Checklist

- [x] I have written necessary rustdoc comments
- [x] I have added necessary unit tests and integration tests
- [x] All checks passed in `./risedev check` (or alias, `./risedev c`)

## Documentation

If your pull request contains user-facing changes, please specify the types of the changes, and create a release note. Otherwise, please feel free to remove this section.

### Types of user-facing changes

Please keep the types that apply to your changes, and remove those that do not apply.

* Installation and deployment 
* Connector (sources & sinks)
* SQL commands, functions, and operators
* RisingWave cluster configuration changes
* Other (please specify in the release note below)

### Release note

Please create a release note for your changes. In the release note, focus on the impact on users, and mention the environment or conditions where the impact may occur.

## Refer to a related PR or issue link (optional)

#3878
