### PR TITLE
fix: use SomeShard as the distribution of batch scan

### DIFF
--- a/e2e_test/batch/basic/join.slt.part
+++ b/e2e_test/batch/basic/join.slt.part
@@ -62,3 +62,21 @@ query I
 select count(*) from (values (1, 2), (3, 4)) as a, (values (9),(4),(1)) as b;
 ----
 6
+
+statement ok
+create table t(x int);
+
+statement ok
+create index i on t(x);
+
+statement ok
+insert into t values (1),(2),(3),(4),(5);
+
+query I rowsort
+Select * from t join i using(x)
+----
+1
+2
+3
+4
+5

--- a/e2e_test/batch/basic/join.slt.part
+++ b/e2e_test/batch/basic/join.slt.part
@@ -80,3 +80,9 @@ Select * from t join i using(x)
 3
 4
 5
+
+statement ok
+drop index i;
+
+statement ok
+drop table t;

--- a/src/frontend/src/optimizer/plan_node/logical_scan.rs
+++ b/src/frontend/src/optimizer/plan_node/logical_scan.rs
@@ -213,7 +213,7 @@ impl LogicalScan {
 
     /// The mapped distribution key of the scan operator.
     ///
-    /// The column indices in it is the position in the `required_col_idx`,instead of the position
+    /// The column indices in it is the position in the `required_col_idx`, instead of the position
     /// in all the columns of the table (which is the table's distribution key).
     ///
     /// Return `None` if the table's distribution key are not all in the `required_col_idx`.

--- a/src/frontend/test_runner/tests/testdata/basic_query.yaml
+++ b/src/frontend/test_runner/tests/testdata/basic_query.yaml
@@ -111,14 +111,14 @@
     delete from t;
   batch_plan: |
     BatchDelete { table: t }
-      BatchScan { table: t, columns: [t._row_id, t.v1, t.v2], distribution: HashShard(t._row_id) }
+      BatchScan { table: t, columns: [t._row_id, t.v1, t.v2], distribution: SomeShard }
 - sql: |
     create table t (v1 int, v2 int);
     delete from t where v1 = 1;
   batch_plan: |
     BatchDelete { table: t }
       BatchFilter { predicate: (t.v1 = 1:Int32) }
-        BatchScan { table: t, columns: [t._row_id, t.v1, t.v2], distribution: HashShard(t._row_id) }
+        BatchScan { table: t, columns: [t._row_id, t.v1, t.v2], distribution: SomeShard }
 - sql: |
     select * from generate_series('2'::INT,'10'::INT,'2'::INT);
   batch_plan: |

--- a/src/frontend/test_runner/tests/testdata/join.yaml
+++ b/src/frontend/test_runner/tests/testdata/join.yaml
@@ -189,15 +189,52 @@
       LogicalScan { table: t1, output_columns: [t1.v1, t1.v2], required_columns: [v1, v2], predicate: (t1.v1 > 100:Int32) }
       LogicalScan { table: t2, output_columns: [t2.v1, t2.v2], required_columns: [v1, v2], predicate: (t2.v1 < 1000:Int32) }
 - sql: |
-    /* Left & right has same distribution. There should be no exchange below hash join */
+    /* Left & right has same SomeShard distribution. There should still be exchanges below hash join */
     create table t(x int);
     create index i on t(x);
     select * from i join i as ii on i.x=ii.x;
   batch_plan: |
     BatchExchange { order: [], dist: Single }
       BatchHashJoin { type: Inner, predicate: i.x = i.x, output: all }
-        BatchScan { table: i, columns: [i.x], distribution: HashShard(i.x) }
-        BatchScan { table: i, columns: [i.x], distribution: HashShard(i.x) }
+        BatchExchange { order: [], dist: HashShard(i.x) }
+          BatchScan { table: i, columns: [i.x], distribution: SomeShard }
+        BatchExchange { order: [], dist: HashShard(i.x) }
+          BatchScan { table: i, columns: [i.x], distribution: SomeShard }
+- sql: |
+    /* Left & right has same SomeShard distribution. There should still be exchanges below hash join */
+    create table t(x int);
+    create index i on t(x);
+    select * from i join t on i.x=t.x;
+  batch_plan: |
+    BatchExchange { order: [], dist: Single }
+      BatchHashJoin { type: Inner, predicate: i.x = t.x, output: all }
+        BatchExchange { order: [], dist: HashShard(i.x) }
+          BatchScan { table: i, columns: [i.x], distribution: SomeShard }
+        BatchExchange { order: [], dist: HashShard(t.x) }
+          BatchScan { table: t, columns: [t.x], distribution: SomeShard }
+- sql: |
+    /* Left & right has same HashShard distribution. There should be no exchange below hash join */
+    create table t(x int);
+    create index i on t(x);
+    select * from
+      (select * from i join i as ii using (x)) t1
+    full join
+      (select * from i join i as ii using (x)) t2
+    using (x);
+  batch_plan: |
+    BatchExchange { order: [], dist: Single }
+      BatchProject { exprs: [Coalesce(i.x, i.x)] }
+        BatchHashJoin { type: FullOuter, predicate: i.x = i.x, output: all }
+          BatchHashJoin { type: Inner, predicate: i.x = i.x, output: [i.x] }
+            BatchExchange { order: [], dist: HashShard(i.x) }
+              BatchScan { table: i, columns: [i.x], distribution: SomeShard }
+            BatchExchange { order: [], dist: HashShard(i.x) }
+              BatchScan { table: i, columns: [i.x], distribution: SomeShard }
+          BatchHashJoin { type: Inner, predicate: i.x = i.x, output: [i.x] }
+            BatchExchange { order: [], dist: HashShard(i.x) }
+              BatchScan { table: i, columns: [i.x], distribution: SomeShard }
+            BatchExchange { order: [], dist: HashShard(i.x) }
+              BatchScan { table: i, columns: [i.x], distribution: SomeShard }
 - sql: |
     /* Use lookup join */
     create table t1 (v1 int, v2 int);

--- a/src/frontend/test_runner/tests/testdata/mv_on_mv.yaml
+++ b/src/frontend/test_runner/tests/testdata/mv_on_mv.yaml
@@ -29,7 +29,7 @@
     select v from mv; -- FIXME: there should not be a `Single` exchange here
   batch_plan: |
     BatchExchange { order: [], dist: Single }
-      BatchScan { table: mv, columns: [mv.v], distribution: HashShard() }
+      BatchScan { table: mv, columns: [mv.v], distribution: SomeShard }
 - id: single_fragment_mv_on_singleton_mv
   before:
   - create_singleton_mv

--- a/src/frontend/test_runner/tests/testdata/project_set.yaml
+++ b/src/frontend/test_runner/tests/testdata/project_set.yaml
@@ -24,7 +24,7 @@
     BatchProject { exprs: [Unnest($1)] }
       BatchExchange { order: [], dist: Single }
         BatchProjectSet { select_list: [Unnest($1)] }
-          BatchScan { table: t, columns: [t._row_id, t.x], distribution: HashShard(t._row_id) }
+          BatchScan { table: t, columns: [t._row_id, t.x], distribution: SomeShard }
   stream_plan: |
     StreamMaterialize { columns: [projected_row_id(hidden), unnest, t._row_id(hidden)], pk_columns: [t._row_id, projected_row_id] }
       StreamProjectSet { select_list: [Unnest($1), $0] }
@@ -37,7 +37,7 @@
     BatchProject { exprs: [Unnest($1), 1:Int32] }
       BatchExchange { order: [], dist: Single }
         BatchProjectSet { select_list: [Unnest($1), 1:Int32] }
-          BatchScan { table: t, columns: [t._row_id, t.x], distribution: HashShard(t._row_id) }
+          BatchScan { table: t, columns: [t._row_id, t.x], distribution: SomeShard }
 - sql: |
     /* multiple table functions */
     create table t(x int[]);
@@ -46,7 +46,7 @@
     BatchProject { exprs: [Unnest($1), Unnest(Array(1:Int32, 2:Int32))] }
       BatchExchange { order: [], dist: Single }
         BatchProjectSet { select_list: [Unnest($1), Unnest(Array(1:Int32, 2:Int32))] }
-          BatchScan { table: t, columns: [t._row_id, t.x], distribution: HashShard(t._row_id) }
+          BatchScan { table: t, columns: [t._row_id, t.x], distribution: SomeShard }
 - sql: |
     /* table functions as parameters of usual functions */
     create table t(x int);
@@ -55,7 +55,7 @@
     BatchExchange { order: [], dist: Single }
       BatchProject { exprs: [Neg(Generate($1, $1, $1))] }
         BatchProjectSet { select_list: [$0, $1, Generate($1, $1, $1)] }
-          BatchScan { table: t, columns: [t._row_id, t.x], distribution: HashShard(t._row_id) }
+          BatchScan { table: t, columns: [t._row_id, t.x], distribution: SomeShard }
 - sql: |
     /* table functions as parameters of usual functions */
     create table t(x int[]);
@@ -65,7 +65,7 @@
       BatchExchange { order: [], dist: Single }
         BatchProjectSet { select_list: [($3 * $4), Unnest($2)] }
           BatchProjectSet { select_list: [$0, $1, Unnest($1), Unnest($1)] }
-            BatchScan { table: t, columns: [t._row_id, t.x], distribution: HashShard(t._row_id) }
+            BatchScan { table: t, columns: [t._row_id, t.x], distribution: SomeShard }
   stream_plan: |
     StreamMaterialize { columns: [projected_row_id(hidden), a, b, t._row_id(hidden), projected_row_id#1(hidden)], pk_columns: [t._row_id, projected_row_id#1, projected_row_id] }
       StreamProjectSet { select_list: [($3 * $4), Unnest($2), $1, $0] }
@@ -80,4 +80,4 @@
       BatchExchange { order: [], dist: Single }
         BatchProjectSet { select_list: [Generate($3, 100:Int32, 1:Int32)] }
           BatchProjectSet { select_list: [$0, $1, Unnest($1)] }
-            BatchScan { table: t, columns: [t._row_id, t.x], distribution: HashShard(t._row_id) }
+            BatchScan { table: t, columns: [t._row_id, t.x], distribution: SomeShard }

--- a/src/frontend/test_runner/tests/testdata/range_scan.yaml
+++ b/src/frontend/test_runner/tests/testdata/range_scan.yaml
@@ -13,21 +13,21 @@
     SELECT * FROM orders_count_by_user WHERE user_id = 42
   batch_plan: |
     BatchExchange { order: [], dist: Single }
-      BatchScan { table: orders_count_by_user, columns: [orders_count_by_user.user_id, orders_count_by_user.date, orders_count_by_user.orders_count], scan_ranges: [orders_count_by_user.user_id = Int64(42)], distribution: HashShard(orders_count_by_user.user_id, orders_count_by_user.date) }
+      BatchScan { table: orders_count_by_user, columns: [orders_count_by_user.user_id, orders_count_by_user.date, orders_count_by_user.orders_count], scan_ranges: [orders_count_by_user.user_id = Int64(42)], distribution: SomeShard }
 - before:
   - create_table_and_mv
   sql: |
     SELECT * FROM orders_count_by_user WHERE user_id < 43
   batch_plan: |
     BatchExchange { order: [], dist: Single }
-      BatchScan { table: orders_count_by_user, columns: [orders_count_by_user.user_id, orders_count_by_user.date, orders_count_by_user.orders_count], scan_ranges: [orders_count_by_user.user_id < Int64(43)], distribution: HashShard(orders_count_by_user.user_id, orders_count_by_user.date) }
+      BatchScan { table: orders_count_by_user, columns: [orders_count_by_user.user_id, orders_count_by_user.date, orders_count_by_user.orders_count], scan_ranges: [orders_count_by_user.user_id < Int64(43)], distribution: SomeShard }
 - before:
   - create_table_and_mv
   sql: |
     SELECT * FROM orders_count_by_user WHERE user_id = 42 + 1
   batch_plan: |
     BatchExchange { order: [], dist: Single }
-      BatchScan { table: orders_count_by_user, columns: [orders_count_by_user.user_id, orders_count_by_user.date, orders_count_by_user.orders_count], scan_ranges: [orders_count_by_user.user_id = Int64(43)], distribution: HashShard(orders_count_by_user.user_id, orders_count_by_user.date) }
+      BatchScan { table: orders_count_by_user, columns: [orders_count_by_user.user_id, orders_count_by_user.date, orders_count_by_user.orders_count], scan_ranges: [orders_count_by_user.user_id = Int64(43)], distribution: SomeShard }
 - before:
   - create_table_and_mv
   sql: |
@@ -54,7 +54,7 @@
     SELECT * FROM orders_count_by_user WHERE user_id = '42'
   batch_plan: |
     BatchExchange { order: [], dist: Single }
-      BatchScan { table: orders_count_by_user, columns: [orders_count_by_user.user_id, orders_count_by_user.date, orders_count_by_user.orders_count], scan_ranges: [orders_count_by_user.user_id = Int64(42)], distribution: HashShard(orders_count_by_user.user_id, orders_count_by_user.date) }
+      BatchScan { table: orders_count_by_user, columns: [orders_count_by_user.user_id, orders_count_by_user.date, orders_count_by_user.orders_count], scan_ranges: [orders_count_by_user.user_id = Int64(42)], distribution: SomeShard }
 - before:
   - create_table_and_mv
   sql: |
@@ -68,7 +68,7 @@
   batch_plan: |
     BatchExchange { order: [], dist: Single }
       BatchFilter { predicate: IsNull(orders_count_by_user.user_id) }
-        BatchScan { table: orders_count_by_user, columns: [orders_count_by_user.user_id, orders_count_by_user.date, orders_count_by_user.orders_count], distribution: HashShard(orders_count_by_user.user_id, orders_count_by_user.date) }
+        BatchScan { table: orders_count_by_user, columns: [orders_count_by_user.user_id, orders_count_by_user.date, orders_count_by_user.orders_count], distribution: SomeShard }
 - before:
   - create_table_and_mv
   sql: |
@@ -81,7 +81,7 @@
     SELECT * FROM orders_count_by_user WHERE user_id = 42 AND date = 1111
   batch_plan: |
     BatchExchange { order: [], dist: Single }
-      BatchScan { table: orders_count_by_user, columns: [orders_count_by_user.user_id, orders_count_by_user.date, orders_count_by_user.orders_count], scan_ranges: [orders_count_by_user.user_id = Int64(42), orders_count_by_user.date = Int32(1111)], distribution: HashShard(orders_count_by_user.user_id, orders_count_by_user.date) }
+      BatchScan { table: orders_count_by_user, columns: [orders_count_by_user.user_id, orders_count_by_user.date, orders_count_by_user.orders_count], scan_ranges: [orders_count_by_user.user_id = Int64(42), orders_count_by_user.date = Int32(1111)], distribution: SomeShard }
 - before:
   - create_table_and_mv
   sql: |
@@ -89,7 +89,7 @@
   batch_plan: |
     BatchExchange { order: [], dist: Single }
       BatchFilter { predicate: (2:Int32 > 1:Int32) AND (orders_count_by_user.date = 1111:Int32) }
-        BatchScan { table: orders_count_by_user, columns: [orders_count_by_user.user_id, orders_count_by_user.date, orders_count_by_user.orders_count], scan_ranges: [orders_count_by_user.user_id > Int64(42)], distribution: HashShard(orders_count_by_user.user_id, orders_count_by_user.date) }
+        BatchScan { table: orders_count_by_user, columns: [orders_count_by_user.user_id, orders_count_by_user.date, orders_count_by_user.orders_count], scan_ranges: [orders_count_by_user.user_id > Int64(42)], distribution: SomeShard }
 - before:
   - create_table_and_mv
   sql: |
@@ -97,21 +97,21 @@
   batch_plan: |
     BatchExchange { order: [], dist: Single }
       BatchFilter { predicate: (5:Int32 < 6:Int32) }
-        BatchScan { table: orders_count_by_user, columns: [orders_count_by_user.user_id, orders_count_by_user.date, orders_count_by_user.orders_count], scan_ranges: [orders_count_by_user.user_id = Int64(42), orders_count_by_user.date > Int32(1111) AND orders_count_by_user.date <= Int32(6666)], distribution: HashShard(orders_count_by_user.user_id, orders_count_by_user.date) }
+        BatchScan { table: orders_count_by_user, columns: [orders_count_by_user.user_id, orders_count_by_user.date, orders_count_by_user.orders_count], scan_ranges: [orders_count_by_user.user_id = Int64(42), orders_count_by_user.date > Int32(1111) AND orders_count_by_user.date <= Int32(6666)], distribution: SomeShard }
 - before:
   - create_table_and_mv
   sql: |
     SELECT * FROM orders_count_by_user WHERE user_id in (42, 43)
   batch_plan: |
     BatchExchange { order: [], dist: Single }
-      BatchScan { table: orders_count_by_user, columns: [orders_count_by_user.user_id, orders_count_by_user.date, orders_count_by_user.orders_count], scan_ranges: [orders_count_by_user.user_id = Int64(42) OR orders_count_by_user.user_id = Int64(43)], distribution: HashShard(orders_count_by_user.user_id, orders_count_by_user.date) }
+      BatchScan { table: orders_count_by_user, columns: [orders_count_by_user.user_id, orders_count_by_user.date, orders_count_by_user.orders_count], scan_ranges: [orders_count_by_user.user_id = Int64(42) OR orders_count_by_user.user_id = Int64(43)], distribution: SomeShard }
 - before:
   - create_table_and_mv
   sql: |
     SELECT * FROM orders_count_by_user WHERE user_id in (42+1, 44-1)
   batch_plan: |
     BatchExchange { order: [], dist: Single }
-      BatchScan { table: orders_count_by_user, columns: [orders_count_by_user.user_id, orders_count_by_user.date, orders_count_by_user.orders_count], scan_ranges: [orders_count_by_user.user_id = Int64(43)], distribution: HashShard(orders_count_by_user.user_id, orders_count_by_user.date) }
+      BatchScan { table: orders_count_by_user, columns: [orders_count_by_user.user_id, orders_count_by_user.date, orders_count_by_user.orders_count], scan_ranges: [orders_count_by_user.user_id = Int64(43)], distribution: SomeShard }
 - before:
   - create_table_and_mv
   sql: |
@@ -120,14 +120,14 @@
   batch_plan: |
     BatchExchange { order: [], dist: Single }
       BatchFilter { predicate: In(orders_count_by_user.user_id::Decimal, 42.0:Decimal, 43.0:Decimal) }
-        BatchScan { table: orders_count_by_user, columns: [orders_count_by_user.user_id, orders_count_by_user.date, orders_count_by_user.orders_count], distribution: HashShard(orders_count_by_user.user_id, orders_count_by_user.date) }
+        BatchScan { table: orders_count_by_user, columns: [orders_count_by_user.user_id, orders_count_by_user.date, orders_count_by_user.orders_count], distribution: SomeShard }
 - before:
   - create_table_and_mv
   sql: |
     SELECT * FROM orders_count_by_user WHERE user_id in ('42', '43')
   batch_plan: |
     BatchExchange { order: [], dist: Single }
-      BatchScan { table: orders_count_by_user, columns: [orders_count_by_user.user_id, orders_count_by_user.date, orders_count_by_user.orders_count], scan_ranges: [orders_count_by_user.user_id = Int64(42) OR orders_count_by_user.user_id = Int64(43)], distribution: HashShard(orders_count_by_user.user_id, orders_count_by_user.date) }
+      BatchScan { table: orders_count_by_user, columns: [orders_count_by_user.user_id, orders_count_by_user.date, orders_count_by_user.orders_count], scan_ranges: [orders_count_by_user.user_id = Int64(42) OR orders_count_by_user.user_id = Int64(43)], distribution: SomeShard }
 - before:
   - create_table_and_mv
   sql: |
@@ -140,14 +140,14 @@
   batch_plan: |
     BatchExchange { order: [], dist: Single }
       BatchFilter { predicate: (orders_count_by_user.date = 6666:Int32) }
-        BatchScan { table: orders_count_by_user, columns: [orders_count_by_user.user_id, orders_count_by_user.date, orders_count_by_user.orders_count], scan_ranges: [orders_count_by_user.user_id = Int64(2147483648) OR orders_count_by_user.user_id = Int64(2147483649)], distribution: HashShard(orders_count_by_user.user_id, orders_count_by_user.date) }
+        BatchScan { table: orders_count_by_user, columns: [orders_count_by_user.user_id, orders_count_by_user.date, orders_count_by_user.orders_count], scan_ranges: [orders_count_by_user.user_id = Int64(2147483648) OR orders_count_by_user.user_id = Int64(2147483649)], distribution: SomeShard }
 - before:
   - create_table_and_mv
   sql: |
     SELECT * FROM orders_count_by_user WHERE user_id = 42 AND date in (2222, 3333)
   batch_plan: |
     BatchExchange { order: [], dist: Single }
-      BatchScan { table: orders_count_by_user, columns: [orders_count_by_user.user_id, orders_count_by_user.date, orders_count_by_user.orders_count], scan_ranges: [orders_count_by_user.user_id = Int64(42), orders_count_by_user.date = Int32(2222) OR orders_count_by_user.user_id = Int64(42), orders_count_by_user.date = Int32(3333)], distribution: HashShard(orders_count_by_user.user_id, orders_count_by_user.date) }
+      BatchScan { table: orders_count_by_user, columns: [orders_count_by_user.user_id, orders_count_by_user.date, orders_count_by_user.orders_count], scan_ranges: [orders_count_by_user.user_id = Int64(42), orders_count_by_user.date = Int32(2222) OR orders_count_by_user.user_id = Int64(42), orders_count_by_user.date = Int32(3333)], distribution: SomeShard }
 - before:
   - create_table_and_mv
   sql: |
@@ -155,7 +155,7 @@
     SELECT * FROM orders_count_by_user WHERE user_id = 42 AND date in (2222, 2222)
   batch_plan: |
     BatchExchange { order: [], dist: Single }
-      BatchScan { table: orders_count_by_user, columns: [orders_count_by_user.user_id, orders_count_by_user.date, orders_count_by_user.orders_count], scan_ranges: [orders_count_by_user.user_id = Int64(42), orders_count_by_user.date = Int32(2222)], distribution: HashShard(orders_count_by_user.user_id, orders_count_by_user.date) }
+      BatchScan { table: orders_count_by_user, columns: [orders_count_by_user.user_id, orders_count_by_user.date, orders_count_by_user.orders_count], scan_ranges: [orders_count_by_user.user_id = Int64(42), orders_count_by_user.date = Int32(2222)], distribution: SomeShard }
 - before:
   - create_table_and_mv
   sql: |
@@ -163,7 +163,7 @@
     SELECT * FROM orders_count_by_user WHERE user_id = 42 AND date in (2222, NULL)
   batch_plan: |
     BatchExchange { order: [], dist: Single }
-      BatchScan { table: orders_count_by_user, columns: [orders_count_by_user.user_id, orders_count_by_user.date, orders_count_by_user.orders_count], scan_ranges: [orders_count_by_user.user_id = Int64(42), orders_count_by_user.date = Int32(2222)], distribution: HashShard(orders_count_by_user.user_id, orders_count_by_user.date) }
+      BatchScan { table: orders_count_by_user, columns: [orders_count_by_user.user_id, orders_count_by_user.date, orders_count_by_user.orders_count], scan_ranges: [orders_count_by_user.user_id = Int64(42), orders_count_by_user.date = Int32(2222)], distribution: SomeShard }
 - before:
   - create_table_and_mv
   sql: |
@@ -178,7 +178,7 @@
     SELECT * FROM orders_count_by_user WHERE user_id = 42 AND date in (2222, 3333) AND date in (4444, 3333)
   batch_plan: |
     BatchExchange { order: [], dist: Single }
-      BatchScan { table: orders_count_by_user, columns: [orders_count_by_user.user_id, orders_count_by_user.date, orders_count_by_user.orders_count], scan_ranges: [orders_count_by_user.user_id = Int64(42), orders_count_by_user.date = Int32(3333)], distribution: HashShard(orders_count_by_user.user_id, orders_count_by_user.date) }
+      BatchScan { table: orders_count_by_user, columns: [orders_count_by_user.user_id, orders_count_by_user.date, orders_count_by_user.orders_count], scan_ranges: [orders_count_by_user.user_id = Int64(42), orders_count_by_user.date = Int32(3333)], distribution: SomeShard }
 - before:
   - create_table_and_mv
   sql: |
@@ -186,7 +186,7 @@
     SELECT * FROM orders_count_by_user WHERE user_id = 42 AND date in (2222, 3333) AND date = 3333
   batch_plan: |
     BatchExchange { order: [], dist: Single }
-      BatchScan { table: orders_count_by_user, columns: [orders_count_by_user.user_id, orders_count_by_user.date, orders_count_by_user.orders_count], scan_ranges: [orders_count_by_user.user_id = Int64(42), orders_count_by_user.date = Int32(3333)], distribution: HashShard(orders_count_by_user.user_id, orders_count_by_user.date) }
+      BatchScan { table: orders_count_by_user, columns: [orders_count_by_user.user_id, orders_count_by_user.date, orders_count_by_user.orders_count], scan_ranges: [orders_count_by_user.user_id = Int64(42), orders_count_by_user.date = Int32(3333)], distribution: SomeShard }
 - before:
   - create_table_and_mv
   sql: |
@@ -201,7 +201,7 @@
   batch_plan: |
     BatchExchange { order: [], dist: Single }
       BatchFilter { predicate: In(orders_count_by_user.date, 2222:Int32, 3333:Int32) }
-        BatchScan { table: orders_count_by_user, columns: [orders_count_by_user.user_id, orders_count_by_user.date, orders_count_by_user.orders_count], scan_ranges: [orders_count_by_user.user_id = Int64(2147483648) OR orders_count_by_user.user_id = Int64(2147483649)], distribution: HashShard(orders_count_by_user.user_id, orders_count_by_user.date) }
+        BatchScan { table: orders_count_by_user, columns: [orders_count_by_user.user_id, orders_count_by_user.date, orders_count_by_user.orders_count], scan_ranges: [orders_count_by_user.user_id = Int64(2147483648) OR orders_count_by_user.user_id = Int64(2147483649)], distribution: SomeShard }
 - id: create_table_and_mv_ordered
   sql: |
     CREATE TABLE orders (
@@ -219,21 +219,21 @@
   batch_plan: |
     BatchExchange { order: [], dist: Single }
       BatchFilter { predicate: (orders_count_by_user_ordered.user_id = 42:Int32) }
-        BatchScan { table: orders_count_by_user_ordered, columns: [orders_count_by_user_ordered.user_id, orders_count_by_user_ordered.date, orders_count_by_user_ordered.orders_count], distribution: HashShard(orders_count_by_user_ordered.user_id, orders_count_by_user_ordered.date) }
+        BatchScan { table: orders_count_by_user_ordered, columns: [orders_count_by_user_ordered.user_id, orders_count_by_user_ordered.date, orders_count_by_user_ordered.orders_count], distribution: SomeShard }
 - before:
   - create_table_and_mv_ordered
   sql: |
     SELECT * FROM orders_count_by_user_ordered WHERE user_id > 42 AND orders_count = 10
   batch_plan: |
     BatchExchange { order: [], dist: Single }
-      BatchScan { table: orders_count_by_user_ordered, columns: [orders_count_by_user_ordered.user_id, orders_count_by_user_ordered.date, orders_count_by_user_ordered.orders_count], scan_ranges: [orders_count_by_user_ordered.orders_count = Int64(10), orders_count_by_user_ordered.user_id > Int32(42)], distribution: HashShard(orders_count_by_user_ordered.user_id, orders_count_by_user_ordered.date) }
+      BatchScan { table: orders_count_by_user_ordered, columns: [orders_count_by_user_ordered.user_id, orders_count_by_user_ordered.date, orders_count_by_user_ordered.orders_count], scan_ranges: [orders_count_by_user_ordered.orders_count = Int64(10), orders_count_by_user_ordered.user_id > Int32(42)], distribution: SomeShard }
 - before:
   - create_table_and_mv_ordered
   sql: |
     SELECT * FROM orders_count_by_user_ordered WHERE orders_count = 10
   batch_plan: |
     BatchExchange { order: [], dist: Single }
-      BatchScan { table: orders_count_by_user_ordered, columns: [orders_count_by_user_ordered.user_id, orders_count_by_user_ordered.date, orders_count_by_user_ordered.orders_count], scan_ranges: [orders_count_by_user_ordered.orders_count = Int64(10)], distribution: HashShard(orders_count_by_user_ordered.user_id, orders_count_by_user_ordered.date) }
+      BatchScan { table: orders_count_by_user_ordered, columns: [orders_count_by_user_ordered.user_id, orders_count_by_user_ordered.date, orders_count_by_user_ordered.orders_count], scan_ranges: [orders_count_by_user_ordered.orders_count = Int64(10)], distribution: SomeShard }
 - id: create_small
   sql: |
     CREATE TABLE t(x smallint);
@@ -247,7 +247,7 @@
   batch_plan: |
     BatchExchange { order: [], dist: Single }
       BatchFilter { predicate: (mv.x = 60000:Int32) }
-        BatchScan { table: mv, columns: [mv.x], distribution: HashShard(mv.x) }
+        BatchScan { table: mv, columns: [mv.x], distribution: SomeShard }
 - before:
   - create_small
   sql: |
@@ -256,4 +256,4 @@
   batch_plan: |
     BatchExchange { order: [], dist: Single }
       BatchFilter { predicate: (mv.x < 60000:Int32) }
-        BatchScan { table: mv, columns: [mv.x], distribution: HashShard(mv.x) }
+        BatchScan { table: mv, columns: [mv.x], distribution: SomeShard }

--- a/src/frontend/test_runner/tests/testdata/update.yaml
+++ b/src/frontend/test_runner/tests/testdata/update.yaml
@@ -4,7 +4,7 @@
     update t set v1 = 0;
   batch_plan: |
     BatchUpdate { table: t, exprs: [$0, 0:Int32, $2] }
-      BatchScan { table: t, columns: [t._row_id, t.v1, t.v2], distribution: HashShard(t._row_id) }
+      BatchScan { table: t, columns: [t._row_id, t.v1, t.v2], distribution: SomeShard }
 - sql: |
     create table t (v1 int, v2 int);
     update t set v1 = true;
@@ -14,24 +14,24 @@
     update t set v1 = v2 + 1;
   batch_plan: |
     BatchUpdate { table: t, exprs: [$0, ($2 + 1:Int32), $2] }
-      BatchScan { table: t, columns: [t._row_id, t.v1, t.v2], distribution: HashShard(t._row_id) }
+      BatchScan { table: t, columns: [t._row_id, t.v1, t.v2], distribution: SomeShard }
 - sql: |
     create table t (v1 int, v2 real);
     update t set v1 = v2;
   batch_plan: |
     BatchUpdate { table: t, exprs: [$0, $2::Int32, $2] }
-      BatchScan { table: t, columns: [t._row_id, t.v1, t.v2], distribution: HashShard(t._row_id) }
+      BatchScan { table: t, columns: [t._row_id, t.v1, t.v2], distribution: SomeShard }
 - sql: |
     create table t (v1 int, v2 int);
     update t set v1 = v2 + 1 where v2 > 0;
   batch_plan: |
     BatchUpdate { table: t, exprs: [$0, ($2 + 1:Int32), $2] }
       BatchFilter { predicate: (t.v2 > 0:Int32) }
-        BatchScan { table: t, columns: [t._row_id, t.v1, t.v2], distribution: HashShard(t._row_id) }
+        BatchScan { table: t, columns: [t._row_id, t.v1, t.v2], distribution: SomeShard }
 - sql: |
     create table t (v1 int, v2 int);
     update t set (v1, v2) = (v2 + 1, v1 - 1) where v1 != v2;
   batch_plan: |
     BatchUpdate { table: t, exprs: [$0, ($2 + 1:Int32), ($1 - 1:Int32)] }
       BatchFilter { predicate: (t.v1 <> t.v2) }
-        BatchScan { table: t, columns: [t._row_id, t.v1, t.v2], distribution: HashShard(t._row_id) }
+        BatchScan { table: t, columns: [t._row_id, t.v1, t.v2], distribution: SomeShard }


### PR DESCRIPTION
I hereby agree to the terms of the [Singularity Data, Inc. Contributor License Agreement](https://gist.github.com/skyzh/0663682a70b0edde7ae991492f2314cb#file-s9y_cla).

## What's changed and what's your intention?
For other batch operators, `HashShard` is a simple hashing, i.e.,
`target_shard = hash(dist_key) % shard_num`

But MV is actually sharded by consistent hashing, i.e.,
`target_shard = vnode_mapping.map(hash(dist_key) % vnode_num)`

They are incompatible, so we just specify its distribution as `SomeShard` to force an exchange is inserted.

To reproduce the current wrong behavior:
```sql
create table t(x int);
create index i on t(x);
insert into t values (1),(2),(3),(4),(5);

explain select * from t join i using(x);
                      QUERY PLAN
-------------------------------------------------------
 BatchExchange { order: [], dist: Single }
   BatchHashJoin { type: Inner, predicate: t.x = i.x }
     BatchExchange { order: [], dist: HashShard(t.x) }
       BatchScan { table: t, columns: [x] }
     BatchScan { table: i, columns: [x] }
(5 rows)


select * from t join i using(x);
 x
---
 5
 3
(2 rows)

select * from t join i using(x);
 x
---
 4
(1 row)
```
---
Not fixed: Streaming MV on MV might have similar problem, because vnode mapping may change after scaling, so same ConsistentHashShard can also be different distribution. We may need to always insert exchange.

## Checklist

- [x] I have written necessary rustdoc comments
- [x] I have added necessary unit tests and integration tests
- [x] All checks passed in `./risedev check` (or alias, `./risedev c`)

