### PR TITLE
feat(sqlsmith): Enable gen_agg but workaround distinct agg

### DIFF
--- a/src/tests/sqlsmith/src/expr.rs
+++ b/src/tests/sqlsmith/src/expr.rs
@@ -98,9 +98,7 @@ impl<'a, R: Rng> SqlGenerator<'a, R> {
             assert!(!inside_agg);
         }
 
-        // TODO:  https://github.com/singularity-data/risingwave/issues/3989.
-        // let range = if can_agg & !inside_agg { 99 } else { 90 };
-        let range = 90;
+        let range = if can_agg & !inside_agg { 99 } else { 90 };
 
         match self.rng.gen_range(0..=range) {
             0..=80 => self.gen_func(typ, can_agg, inside_agg),
@@ -329,17 +327,19 @@ fn make_simple_func(func_name: &str, exprs: &[Expr]) -> Function {
 /// This is the function that generate aggregate function.
 /// DISTINCT , ORDER BY or FILTER is allowed in aggregation functions。
 /// Currently, distinct is allowed only, other and others rule is TODO: <https://github.com/singularity-data/risingwave/issues/3933>
-fn make_agg_func(func_name: &str, exprs: &[Expr], distinct: bool) -> Function {
+fn make_agg_func(func_name: &str, exprs: &[Expr], _distinct: bool) -> Function {
     let args = exprs
         .iter()
         .map(|e| FunctionArg::Unnamed(FunctionArgExpr::Expr(e.clone())))
         .collect();
 
+    // Distinct Aggregate shall be workaround until the following issue is resolved
+    // https://github.com/singularity-data/risingwave/issues/4220
     Function {
         name: ObjectName(vec![Ident::new(func_name)]),
         args,
         over: None,
-        distinct,
+        distinct: false,
         order_by: vec![],
         filter: None,
     }


### PR DESCRIPTION
I hereby agree to the terms of the [Singularity Data, Inc. Contributor License Agreement](https://gist.github.com/skyzh/0663682a70b0edde7ae991492f2314cb#file-s9y_cla).

## What's changed and what's your intention?

Enable gen_agg however disallow distinct agg first until the issue  https://github.com/singularity-data/risingwave/issues/4220 is resolved.
 
## Checklist
- [x] I have written necessary rustdoc comments
- [x] I have added necessary unit tests and integration tests
- [x] All checks passed in `./risedev check` (or alias, `./risedev c`)
