### PR TITLE
fix(binder): allow `Clone` for `expr::Subquery` as part of CTE

### DIFF
--- a/src/frontend/src/expr/subquery.rs
+++ b/src/frontend/src/expr/subquery.rs
@@ -20,7 +20,7 @@ use super::{Expr, ExprImpl, ExprType};
 use crate::binder::BoundQuery;
 use crate::expr::CorrelatedId;
 
-#[derive(Debug, PartialEq, Eq)]
+#[derive(Clone, Debug, PartialEq, Eq)]
 pub enum SubqueryKind {
     /// Returns a scalar value (single column single row).
     Scalar,
@@ -35,6 +35,7 @@ pub enum SubqueryKind {
 }
 
 /// Subquery expression.
+#[derive(Clone)]
 pub struct Subquery {
     pub query: BoundQuery,
     pub kind: SubqueryKind,
@@ -59,12 +60,6 @@ impl Subquery {
         correlated_indices.sort();
         correlated_indices.dedup();
         correlated_indices
-    }
-}
-
-impl Clone for Subquery {
-    fn clone(&self) -> Self {
-        unreachable!("Subquery {:?} has not been unnested", self)
     }
 }
 

--- a/src/frontend/test_runner/tests/testdata/common_table_expressions.yaml
+++ b/src/frontend/test_runner/tests/testdata/common_table_expressions.yaml
@@ -39,3 +39,15 @@
   stream_plan: |
     StreamMaterialize { columns: [v1, t1._row_id(hidden)], pk_columns: [t1._row_id] }
       StreamTableScan { table: t1, columns: [t1.v1, t1._row_id], pk: [t1._row_id], distribution: HashShard(t1._row_id) }
+- sql: |
+    create table t1 (x int);
+    with with_0 as (select * from t1 group by x having EXISTS(select 0.1)) select * from with_0;
+  logical_plan: |
+    LogicalProject { exprs: [t1.x] }
+      LogicalProject { exprs: [t1.x] }
+        LogicalJoin { type: LeftSemi, on: true, output: all }
+          LogicalAgg { group_key: [t1.x], aggs: [] }
+            LogicalProject { exprs: [t1.x] }
+              LogicalScan { table: t1, columns: [t1._row_id, t1.x] }
+          LogicalProject { exprs: [0.1:Decimal] }
+            LogicalValues { rows: [[]], schema: Schema { fields: [] } }


### PR DESCRIPTION
I hereby agree to the terms of the [Singularity Data, Inc. Contributor License Agreement](https://gist.github.com/skyzh/0663682a70b0edde7ae991492f2314cb#file-s9y_cla).

## What's changed and what's your intention?

`Clone` of `expr::Subquery` was purposed banned as `BoundQuery` was not `Clone` at that time and `ExprImpl`s are only cloned after decorrelation. However, since support of CTE in #2741, we do need to clone `BoundQuery` (including `expr::Subquery`) before decorrelation.

## Checklist

- [x] I have written necessary rustdoc comments
- [x] I have added necessary unit tests and integration tests
- [x] All checks passed in `./risedev check` (or alias, `./risedev c`)

## Refer to a related PR or issue link (optional)

Fixes #4404