### PR TITLE
chore(risedev): unify clippy between risedev c and pre-unit-test.sh

### DIFF
--- a/Makefile.toml
+++ b/Makefile.toml
@@ -499,7 +499,7 @@ script = """
 #!@shell
 
 echo "Running $(tput setaf 4)cargo clippy$(tput sgr0) checks"
-cargo clippy --workspace --all-targets
+cargo clippy --all-targets --features failpoints --locked -- -D warnings
 echo "If cargo clippy check failed or generates warning, you may run $(tput setaf 4)cargo clippy --workspace --all-targets --fix$(tput sgr0) to fix it. Note that clippy fix requires manual review, as not all auto fixes are guaranteed to be reasonable."
 """
 


### PR DESCRIPTION
I hereby agree to the terms of the [Singularity Data, Inc. Contributor License Agreement](https://gist.github.com/skyzh/0663682a70b0edde7ae991492f2314cb#file-s9y_cla).

## What's changed and what's your intention?

as title, Occasionally, we use `risedev c` locally to check before we push new code to pull request , but it fail in CI through `pre-unit-test.sh`. if we unify them , we can figure out some problem locally ASAP, avoid to waste the cost of CI

Please explain **IN DETAIL** what the changes are in this PR and why they are needed:

- Makefile.toml for risedev c
- sqlsmith clippy

## Checklist

- ~[ ] I have written necessary rustdoc comments~
- ~[ ] I have added necessary unit tests and integration tests~
- [x] All checks passed in `./risedev check` (or alias, `./risedev c`)
