### PR TITLE
feat(Meta): Add is_sync to support some features

### DIFF
--- a/proto/stream_service.proto
+++ b/proto/stream_service.proto
@@ -66,6 +66,7 @@ message InjectBarrierRequest {
   stream_plan.Barrier barrier = 2;
   repeated uint32 actor_ids_to_send = 3;
   repeated uint32 actor_ids_to_collect = 4;
+  bool is_sync = 5;
 }
 
 message InjectBarrierResponse {
@@ -91,6 +92,7 @@ message BarrierCompleteResponse {
     hummock.SstableInfo sst = 2;
   }
   repeated GroupedSstableInfo synced_sstables = 4;
+  bool is_sync = 5;
 }
 
 // Before starting streaming, the leader node broadcast the actor-host table to needed workers.

--- a/src/compute/src/rpc/service/stream_service.rs
+++ b/src/compute/src/rpc/service/stream_service.rs
@@ -155,7 +155,7 @@ impl StreamService for StreamServiceImpl {
         let collect_result = self.mgr.collect_barrier(req.prev_epoch).await;
         // Must finish syncing data written in the epoch before respond back to ensure persistency
         // of the state.
-        let synced_sstables = self.mgr.sync_epoch(req.prev_epoch).await;
+        let (synced_sstables, is_sync) = self.mgr.sync_epoch(req.prev_epoch).await;
 
         Ok(Response::new(BarrierCompleteResponse {
             request_id: req.request_id,
@@ -168,6 +168,7 @@ impl StreamService for StreamServiceImpl {
                     sst: Some(sst),
                 })
                 .collect_vec(),
+            is_sync,
         }))
     }
 


### PR DESCRIPTION
I hereby agree to the terms of the [Singularity Data, Inc. Contributor License Agreement](https://gist.github.com/skyzh/0663682a70b0edde7ae991492f2314cb#file-s9y_cla).

## What's changed and what's your intention?

***PLEASE DO NOT LEAVE THIS EMPTY !!!***

We will add `is_sync` to differentiate between barrier and checkpoint.  But this is only a temporary version, We only add `is_sync` to support some features. 
Because we will support uploading data of the different epochs, so we will not sync all `checkpoints`. If this checkpoint is not synced, we will not finish create_mv of finish flush.

- Summarize your change (**mandatory**)
- How does this PR work? Need a brief introduction for the changed logic (optional)
- Describe clearly one logical change and avoid lazy messages (optional)
- Describe any limitations of the current code (optional)

## Checklist

- [ ] I have written necessary rustdoc comments
- [ ] I have added necessary unit tests and integration tests
- [ ] All checks passed in `./risedev check` (or alias, `./risedev c`)

## Documentation

If your pull request contains user-facing changes, please specify the types of the changes, and create a release note. Otherwise, please feel free to remove this section.

### Types of user-facing changes

Please keep the types that apply to your changes, and remove those that do not apply.

* Installation and deployment 
* Connector (sources & sinks)
* SQL commands, functions, and operators
* RisingWave cluster configuration changes
* Other (please specify in the release note below)

### Release note

Please create a release note for your changes. In the release note, focus on the impact on users, and mention the environment or conditions where the impact may occur.

## Refer to a related PR or issue link (optional)
https://github.com/singularity-data/risingwave/issues/4290