### PR TITLE
fix(planner): DynamicFilter's LHS should follow upstream distribution

### DIFF
--- a/src/frontend/src/optimizer/plan_node/logical_join.rs
+++ b/src/frontend/src/optimizer/plan_node/logical_join.rs
@@ -893,12 +893,7 @@ impl ToStream for LogicalJoin {
                 return Err(nested_loop_join_error);
             };
 
-            let left = self
-                .left()
-                .to_stream_with_dist_required(&RequiredDist::shard_by_key(
-                    self.left().schema().len(),
-                    &[left_ref_index],
-                ))?;
+            let left = self.left().to_stream()?;
 
             let right = self
                 .right()

--- a/src/frontend/test_runner/tests/testdata/tpch.yaml
+++ b/src/frontend/test_runner/tests/testdata/tpch.yaml
@@ -1272,41 +1272,39 @@
                           BatchScan { table: nation, columns: [nation.n_nationkey, nation.n_name], distribution: SomeShard }
   stream_plan: |
     StreamMaterialize { columns: [ps_partkey, value], pk_columns: [ps_partkey], order_descs: [value, ps_partkey] }
-      StreamExchange { dist: HashShard(partsupp.ps_partkey) }
-        StreamProject { exprs: [partsupp.ps_partkey, sum((partsupp.ps_supplycost * partsupp.ps_availqty))] }
-          StreamDynamicFilter { predicate: (sum((partsupp.ps_supplycost * partsupp.ps_availqty)) > (sum(sum((partsupp.ps_supplycost * partsupp.ps_availqty))) * 0.0001000000:Decimal)) }
-            StreamExchange { dist: HashShard(sum((partsupp.ps_supplycost * partsupp.ps_availqty))) }
-              StreamHashAgg { group_key: [partsupp.ps_partkey], aggs: [count, sum((partsupp.ps_supplycost * partsupp.ps_availqty)), sum((partsupp.ps_supplycost * partsupp.ps_availqty))] }
-                StreamExchange { dist: HashShard(partsupp.ps_partkey) }
-                  StreamProject { exprs: [partsupp.ps_partkey, (partsupp.ps_supplycost * partsupp.ps_availqty), partsupp._row_id, supplier._row_id, nation._row_id] }
-                    StreamHashJoin { type: Inner, predicate: supplier.s_nationkey = nation.n_nationkey, output: [partsupp.ps_partkey, partsupp.ps_availqty, partsupp.ps_supplycost, partsupp._row_id, supplier._row_id, nation._row_id] }
-                      StreamExchange { dist: HashShard(supplier.s_nationkey) }
-                        StreamHashJoin { type: Inner, predicate: partsupp.ps_suppkey = supplier.s_suppkey, output: [partsupp.ps_partkey, partsupp.ps_availqty, partsupp.ps_supplycost, supplier.s_nationkey, partsupp._row_id, supplier._row_id] }
-                          StreamExchange { dist: HashShard(partsupp.ps_suppkey) }
-                            StreamTableScan { table: partsupp, columns: [partsupp.ps_partkey, partsupp.ps_suppkey, partsupp.ps_availqty, partsupp.ps_supplycost, partsupp._row_id], pk: [partsupp._row_id], distribution: HashShard(partsupp._row_id) }
-                          StreamExchange { dist: HashShard(supplier.s_suppkey) }
-                            StreamTableScan { table: supplier, columns: [supplier.s_suppkey, supplier.s_nationkey, supplier._row_id], pk: [supplier._row_id], distribution: HashShard(supplier._row_id) }
-                      StreamExchange { dist: HashShard(nation.n_nationkey) }
-                        StreamProject { exprs: [nation.n_nationkey, nation._row_id] }
-                          StreamFilter { predicate: (nation.n_name = 'ARGENTINA':Varchar) }
-                            StreamTableScan { table: nation, columns: [nation.n_nationkey, nation._row_id, nation.n_name], pk: [nation._row_id], distribution: HashShard(nation._row_id) }
-            StreamExchange { dist: Broadcast }
-              StreamProject { exprs: [(sum(sum((partsupp.ps_supplycost * partsupp.ps_availqty))) * 0.0001000000:Decimal)] }
-                StreamGlobalSimpleAgg { aggs: [sum(count), sum(sum((partsupp.ps_supplycost * partsupp.ps_availqty)))] }
-                  StreamExchange { dist: Single }
-                    StreamStatelessLocalSimpleAgg { aggs: [count, sum((partsupp.ps_supplycost * partsupp.ps_availqty))] }
-                      StreamProject { exprs: [(partsupp.ps_supplycost * partsupp.ps_availqty), partsupp._row_id, supplier._row_id, nation._row_id] }
-                        StreamHashJoin { type: Inner, predicate: supplier.s_nationkey = nation.n_nationkey, output: [partsupp.ps_availqty, partsupp.ps_supplycost, partsupp._row_id, supplier._row_id, nation._row_id] }
-                          StreamExchange { dist: HashShard(supplier.s_nationkey) }
-                            StreamHashJoin { type: Inner, predicate: partsupp.ps_suppkey = supplier.s_suppkey, output: [partsupp.ps_availqty, partsupp.ps_supplycost, supplier.s_nationkey, partsupp._row_id, supplier._row_id] }
-                              StreamExchange { dist: HashShard(partsupp.ps_suppkey) }
-                                StreamTableScan { table: partsupp, columns: [partsupp.ps_suppkey, partsupp.ps_availqty, partsupp.ps_supplycost, partsupp._row_id], pk: [partsupp._row_id], distribution: HashShard(partsupp._row_id) }
-                              StreamExchange { dist: HashShard(supplier.s_suppkey) }
-                                StreamTableScan { table: supplier, columns: [supplier.s_suppkey, supplier.s_nationkey, supplier._row_id], pk: [supplier._row_id], distribution: HashShard(supplier._row_id) }
-                          StreamExchange { dist: HashShard(nation.n_nationkey) }
-                            StreamProject { exprs: [nation.n_nationkey, nation._row_id] }
-                              StreamFilter { predicate: (nation.n_name = 'ARGENTINA':Varchar) }
-                                StreamTableScan { table: nation, columns: [nation.n_nationkey, nation._row_id, nation.n_name], pk: [nation._row_id], distribution: HashShard(nation._row_id) }
+      StreamProject { exprs: [partsupp.ps_partkey, sum((partsupp.ps_supplycost * partsupp.ps_availqty))] }
+        StreamDynamicFilter { predicate: (sum((partsupp.ps_supplycost * partsupp.ps_availqty)) > (sum(sum((partsupp.ps_supplycost * partsupp.ps_availqty))) * 0.0001000000:Decimal)) }
+          StreamHashAgg { group_key: [partsupp.ps_partkey], aggs: [count, sum((partsupp.ps_supplycost * partsupp.ps_availqty)), sum((partsupp.ps_supplycost * partsupp.ps_availqty))] }
+            StreamExchange { dist: HashShard(partsupp.ps_partkey) }
+              StreamProject { exprs: [partsupp.ps_partkey, (partsupp.ps_supplycost * partsupp.ps_availqty), partsupp._row_id, supplier._row_id, nation._row_id] }
+                StreamHashJoin { type: Inner, predicate: supplier.s_nationkey = nation.n_nationkey, output: [partsupp.ps_partkey, partsupp.ps_availqty, partsupp.ps_supplycost, partsupp._row_id, supplier._row_id, nation._row_id] }
+                  StreamExchange { dist: HashShard(supplier.s_nationkey) }
+                    StreamHashJoin { type: Inner, predicate: partsupp.ps_suppkey = supplier.s_suppkey, output: [partsupp.ps_partkey, partsupp.ps_availqty, partsupp.ps_supplycost, supplier.s_nationkey, partsupp._row_id, supplier._row_id] }
+                      StreamExchange { dist: HashShard(partsupp.ps_suppkey) }
+                        StreamTableScan { table: partsupp, columns: [partsupp.ps_partkey, partsupp.ps_suppkey, partsupp.ps_availqty, partsupp.ps_supplycost, partsupp._row_id], pk: [partsupp._row_id], distribution: HashShard(partsupp._row_id) }
+                      StreamExchange { dist: HashShard(supplier.s_suppkey) }
+                        StreamTableScan { table: supplier, columns: [supplier.s_suppkey, supplier.s_nationkey, supplier._row_id], pk: [supplier._row_id], distribution: HashShard(supplier._row_id) }
+                  StreamExchange { dist: HashShard(nation.n_nationkey) }
+                    StreamProject { exprs: [nation.n_nationkey, nation._row_id] }
+                      StreamFilter { predicate: (nation.n_name = 'ARGENTINA':Varchar) }
+                        StreamTableScan { table: nation, columns: [nation.n_nationkey, nation._row_id, nation.n_name], pk: [nation._row_id], distribution: HashShard(nation._row_id) }
+          StreamExchange { dist: Broadcast }
+            StreamProject { exprs: [(sum(sum((partsupp.ps_supplycost * partsupp.ps_availqty))) * 0.0001000000:Decimal)] }
+              StreamGlobalSimpleAgg { aggs: [sum(count), sum(sum((partsupp.ps_supplycost * partsupp.ps_availqty)))] }
+                StreamExchange { dist: Single }
+                  StreamStatelessLocalSimpleAgg { aggs: [count, sum((partsupp.ps_supplycost * partsupp.ps_availqty))] }
+                    StreamProject { exprs: [(partsupp.ps_supplycost * partsupp.ps_availqty), partsupp._row_id, supplier._row_id, nation._row_id] }
+                      StreamHashJoin { type: Inner, predicate: supplier.s_nationkey = nation.n_nationkey, output: [partsupp.ps_availqty, partsupp.ps_supplycost, partsupp._row_id, supplier._row_id, nation._row_id] }
+                        StreamExchange { dist: HashShard(supplier.s_nationkey) }
+                          StreamHashJoin { type: Inner, predicate: partsupp.ps_suppkey = supplier.s_suppkey, output: [partsupp.ps_availqty, partsupp.ps_supplycost, supplier.s_nationkey, partsupp._row_id, supplier._row_id] }
+                            StreamExchange { dist: HashShard(partsupp.ps_suppkey) }
+                              StreamTableScan { table: partsupp, columns: [partsupp.ps_suppkey, partsupp.ps_availqty, partsupp.ps_supplycost, partsupp._row_id], pk: [partsupp._row_id], distribution: HashShard(partsupp._row_id) }
+                            StreamExchange { dist: HashShard(supplier.s_suppkey) }
+                              StreamTableScan { table: supplier, columns: [supplier.s_suppkey, supplier.s_nationkey, supplier._row_id], pk: [supplier._row_id], distribution: HashShard(supplier._row_id) }
+                        StreamExchange { dist: HashShard(nation.n_nationkey) }
+                          StreamProject { exprs: [nation.n_nationkey, nation._row_id] }
+                            StreamFilter { predicate: (nation.n_name = 'ARGENTINA':Varchar) }
+                              StreamTableScan { table: nation, columns: [nation.n_nationkey, nation._row_id, nation.n_name], pk: [nation._row_id], distribution: HashShard(nation._row_id) }
 - id: tpch_q12
   before:
   - create_tables
@@ -2374,25 +2372,22 @@
                           BatchFilter { predicate: (customer.c_acctbal > 0.00:Decimal) AND In(Substr(customer.c_phone, 1:Int32, 2:Int32), '30':Varchar, '24':Varchar, '31':Varchar, '38':Varchar, '25':Varchar, '34':Varchar, '37':Varchar) }
                             BatchScan { table: customer, columns: [customer.c_acctbal, customer.c_phone], distribution: SomeShard }
   stream_plan: |
-    StreamMaterialize { columns: [cntrycode, sum(count)(hidden), numcust, totacctbal], pk_columns: [cntrycode] }
-      StreamHashAgg { group_key: [Substr(customer.c_phone, 1:Int32, 2:Int32)], aggs: [sum(count), sum(count), sum(sum(customer.c_acctbal))] }
+    StreamMaterialize { columns: [cntrycode, count(hidden), numcust, totacctbal], pk_columns: [cntrycode] }
+      StreamHashAgg { group_key: [Substr(customer.c_phone, 1:Int32, 2:Int32)], aggs: [count, count, sum(customer.c_acctbal)] }
         StreamExchange { dist: HashShard(Substr(customer.c_phone, 1:Int32, 2:Int32)) }
-          StreamHashAgg { group_key: [Substr(customer.c_phone, 1:Int32, 2:Int32), Vnode(customer.c_acctbal)], aggs: [count, count, sum(customer.c_acctbal)] }
-            StreamProject { exprs: [Substr(customer.c_phone, 1:Int32, 2:Int32), customer.c_acctbal, customer._row_id, Vnode(customer.c_acctbal)] }
-              StreamProject { exprs: [Substr(customer.c_phone, 1:Int32, 2:Int32), customer.c_acctbal, customer._row_id] }
-                StreamDynamicFilter { predicate: (customer.c_acctbal > (sum(sum(customer.c_acctbal)) / sum(count(customer.c_acctbal)))) }
-                  StreamExchange { dist: HashShard(customer.c_acctbal) }
-                    StreamHashJoin { type: LeftAnti, predicate: customer.c_custkey = orders.o_custkey, output: [customer.c_phone, customer.c_acctbal, customer._row_id] }
-                      StreamExchange { dist: HashShard(customer.c_custkey) }
-                        StreamFilter { predicate: In(Substr(customer.c_phone, 1:Int32, 2:Int32), '30':Varchar, '24':Varchar, '31':Varchar, '38':Varchar, '25':Varchar, '34':Varchar, '37':Varchar) }
-                          StreamTableScan { table: customer, columns: [customer.c_custkey, customer.c_phone, customer.c_acctbal, customer._row_id], pk: [customer._row_id], distribution: HashShard(customer._row_id) }
-                      StreamExchange { dist: HashShard(orders.o_custkey) }
-                        StreamTableScan { table: orders, columns: [orders.o_custkey, orders._row_id], pk: [orders._row_id], distribution: HashShard(orders._row_id) }
-                  StreamExchange { dist: Broadcast }
-                    StreamProject { exprs: [(sum(sum(customer.c_acctbal)) / sum(count(customer.c_acctbal)))] }
-                      StreamGlobalSimpleAgg { aggs: [sum(count), sum(sum(customer.c_acctbal)), sum(count(customer.c_acctbal))] }
-                        StreamExchange { dist: Single }
-                          StreamStatelessLocalSimpleAgg { aggs: [count, sum(customer.c_acctbal), count(customer.c_acctbal)] }
-                            StreamProject { exprs: [customer.c_acctbal, customer._row_id] }
-                              StreamFilter { predicate: (customer.c_acctbal > 0.00:Decimal) AND In(Substr(customer.c_phone, 1:Int32, 2:Int32), '30':Varchar, '24':Varchar, '31':Varchar, '38':Varchar, '25':Varchar, '34':Varchar, '37':Varchar) }
-                                StreamTableScan { table: customer, columns: [customer.c_acctbal, customer._row_id, customer.c_phone], pk: [customer._row_id], distribution: HashShard(customer._row_id) }
+          StreamProject { exprs: [Substr(customer.c_phone, 1:Int32, 2:Int32), customer.c_acctbal, customer._row_id] }
+            StreamDynamicFilter { predicate: (customer.c_acctbal > (sum(sum(customer.c_acctbal)) / sum(count(customer.c_acctbal)))) }
+              StreamHashJoin { type: LeftAnti, predicate: customer.c_custkey = orders.o_custkey, output: [customer.c_phone, customer.c_acctbal, customer._row_id] }
+                StreamExchange { dist: HashShard(customer.c_custkey) }
+                  StreamFilter { predicate: In(Substr(customer.c_phone, 1:Int32, 2:Int32), '30':Varchar, '24':Varchar, '31':Varchar, '38':Varchar, '25':Varchar, '34':Varchar, '37':Varchar) }
+                    StreamTableScan { table: customer, columns: [customer.c_custkey, customer.c_phone, customer.c_acctbal, customer._row_id], pk: [customer._row_id], distribution: HashShard(customer._row_id) }
+                StreamExchange { dist: HashShard(orders.o_custkey) }
+                  StreamTableScan { table: orders, columns: [orders.o_custkey, orders._row_id], pk: [orders._row_id], distribution: HashShard(orders._row_id) }
+              StreamExchange { dist: Broadcast }
+                StreamProject { exprs: [(sum(sum(customer.c_acctbal)) / sum(count(customer.c_acctbal)))] }
+                  StreamGlobalSimpleAgg { aggs: [sum(count), sum(sum(customer.c_acctbal)), sum(count(customer.c_acctbal))] }
+                    StreamExchange { dist: Single }
+                      StreamStatelessLocalSimpleAgg { aggs: [count, sum(customer.c_acctbal), count(customer.c_acctbal)] }
+                        StreamProject { exprs: [customer.c_acctbal, customer._row_id] }
+                          StreamFilter { predicate: (customer.c_acctbal > 0.00:Decimal) AND In(Substr(customer.c_phone, 1:Int32, 2:Int32), '30':Varchar, '24':Varchar, '31':Varchar, '38':Varchar, '25':Varchar, '34':Varchar, '37':Varchar) }
+                            StreamTableScan { table: customer, columns: [customer.c_acctbal, customer._row_id, customer.c_phone], pk: [customer._row_id], distribution: HashShard(customer._row_id) }


### PR DESCRIPTION
I hereby agree to the terms of the [Singularity Data, Inc. Contributor License Agreement](https://gist.github.com/skyzh/0663682a70b0edde7ae991492f2314cb#file-s9y_cla).

## What's changed and what's your intention?
DynamicFilter's LHS should follow upstream distribution

## Checklist

- [x] I have written necessary rustdoc comments
- [x] I have added necessary unit tests and integration tests
- [x] All checks passed in `./risedev check` (or alias, `./risedev c`)

## Refer to a related PR or issue link (optional)
Fixes: https://github.com/singularity-data/risingwave/issues/4125