### PR TITLE
fix(planner): Pullup predicates in `LogicalScan` into `BatchLookupJoin` 

### DIFF
--- a/e2e_test/batch/basic/local/lookup_join.slt.part
+++ b/e2e_test/batch/basic/local/lookup_join.slt.part
@@ -24,12 +24,21 @@ select * from t1 left join t3 on t1.v1 = t3.v1 order by t1.v1, t1.v2;
 3 3 NULL NULL
 5 5 NULL NULL
 
+query IIII
+select * from t1 left join t3 on t1.v1 = t3.v1 where t1.v1 > 1 order by t1.v1, t1.v2;
+----
+3 3 NULL NULL
+5 5 NULL NULL
 
 query IIII
 select * from t1 join t3 on t1.v1 = t3.v1 order by t1.v1, t1.v2;
 ----
 1 1 1 2
 1 4 1 2
+
+query IIII
+select * from t1 join t3 on t1.v1 = t3.v1 where t1.v1 > 1 order by t1.v1, t1.v2;
+----
 
 statement error
 select * from t1 right join t3 on t1.v1 = t3.v1;

--- a/src/frontend/src/optimizer/plan_node/eq_join_predicate.rs
+++ b/src/frontend/src/optimizer/plan_node/eq_join_predicate.rs
@@ -122,6 +122,11 @@ impl EqJoinPredicate {
         &self.other_cond
     }
 
+    /// Get a mutable reference to the join predicate's other cond.
+    pub fn other_cond_mut(&mut self) -> &mut Condition {
+        &mut self.other_cond
+    }
+
     /// Get a reference to the join predicate's eq keys.
     pub fn eq_keys(&self) -> &[(InputRef, InputRef)] {
         self.eq_keys.as_ref()

--- a/src/frontend/src/optimizer/plan_node/logical_join.rs
+++ b/src/frontend/src/optimizer/plan_node/logical_join.rs
@@ -474,7 +474,7 @@ impl LogicalJoin {
     fn convert_to_lookup_join(
         &self,
         logical_join: LogicalJoin,
-        predicate: EqJoinPredicate,
+        mut predicate: EqJoinPredicate,
     ) -> Option<PlanRef> {
         if self.right.as_ref().node_type() != PlanNodeType::LogicalScan {
             log::warn!(
@@ -508,6 +508,12 @@ impl LogicalJoin {
                 return None;
             }
         }
+
+        let new_other = predicate
+            .other_cond()
+            .clone()
+            .and(logical_scan.predicate().clone());
+        *predicate.other_cond_mut() = new_other;
 
         Some(BatchLookupJoin::new(logical_join, predicate, table_desc, output_column_ids).into())
     }

--- a/src/frontend/src/optimizer/plan_node/logical_scan.rs
+++ b/src/frontend/src/optimizer/plan_node/logical_scan.rs
@@ -211,6 +211,11 @@ impl LogicalScan {
         &self.indexes
     }
 
+    /// Get the logical scan's filter predicate
+    pub fn predicate(&self) -> &Condition {
+        &self.predicate
+    }
+
     /// The mapped distribution key of the scan operator.
     ///
     /// The column indices in it is the position in the `required_col_idx`, instead of the position

--- a/src/frontend/test_runner/tests/testdata/join.yaml
+++ b/src/frontend/test_runner/tests/testdata/join.yaml
@@ -505,3 +505,20 @@
                 StreamTableScan { table: a, columns: [a.x, a._row_id], pk: [a._row_id], distribution: HashShard(a._row_id) }
               StreamExchange { dist: HashShard(b.x) }
                 StreamTableScan { table: b, columns: [b.x, b._row_id], pk: [b._row_id], distribution: HashShard(b._row_id) }
+- sql: |
+    /* Use lookup join with predicate */
+    create table t1 (v1 int, v2 int);
+    create table t2 (v1 int, v2 int);
+    create materialized view t3 as select v1, count(v2) as v2 from t2 group by v1;
+    select * from t1 join t3 where t1.v2 = t3.v1 and t3.v1 > 1;
+  optimized_logical_plan: |
+    LogicalJoin { type: Inner, on: (t1.v2 = t3.v1), output: all }
+      LogicalScan { table: t1, columns: [t1.v1, t1.v2] }
+      LogicalScan { table: t3, output_columns: [t3.v1, t3.v2], required_columns: [v1, v2], predicate: (t3.v1 > 1:Int32) }
+  batch_local_plan: |
+    BatchLookupJoin { type: Inner, predicate: t1.v2 = t3.v1 AND (t1.v1 > 1:Int32), output: all }
+      BatchExchange { order: [], dist: Single }
+        BatchScan { table: t1, columns: [t1.v1, t1.v2], distribution: SomeShard }
+  with_config_map:
+    QUERY_MODE: local
+    RW_BATCH_ENABLE_LOOKUP_JOIN: 'true'


### PR DESCRIPTION
I hereby agree to the terms of the [Singularity Data, Inc. Contributor License Agreement](https://gist.github.com/skyzh/0663682a70b0edde7ae991492f2314cb#file-s9y_cla).

## What's changed and what's your intention?
Pullup predicates in `LogicalScan` into `BatchLookupJoin` 

## Checklist

- [x] I have written necessary rustdoc comments
- [x] I have added necessary unit tests and integration tests
- [x] All checks passed in `./risedev check` (or alias, `./risedev c`)


## Refer to a related PR or issue link (optional)
Fixes: https://github.com/singularity-data/risingwave/issues/4042