### PR TITLE
fix(test): fix or ignore several unit tests on madsim

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4633,7 +4633,6 @@ dependencies = [
  "memcomparable",
  "more-asserts",
  "num-traits",
- "num_cpus",
  "parking_lot",
  "paste",
  "postgres-types",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6285,6 +6285,29 @@ dependencies = [
 ]
 
 [[package]]
+name = "tokio-postgres"
+version = "0.7.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "19c88a47a23c5d2dc9ecd28fb38fba5fc7e5ddc1fe64488ec145076b0c71c8ae"
+dependencies = [
+ "async-trait",
+ "byteorder",
+ "bytes",
+ "fallible-iterator",
+ "futures",
+ "log",
+ "parking_lot",
+ "percent-encoding",
+ "phf",
+ "pin-project-lite",
+ "postgres-protocol",
+ "postgres-types",
+ "socket2",
+ "tokio",
+ "tokio-util",
+]
+
+[[package]]
 name = "tokio-retry"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3702,9 +3702,9 @@ dependencies = [
  "bytes",
  "madsim",
  "madsim-tokio",
+ "madsim-tokio-postgres",
  "regex",
  "thiserror",
- "tokio-postgres",
  "tracing",
  "workspace-hack",
 ]
@@ -5281,12 +5281,12 @@ dependencies = [
  "log",
  "madsim",
  "madsim-tokio",
+ "madsim-tokio-postgres",
  "paste",
  "rand 0.8.5",
  "risingwave_expr",
  "risingwave_frontend",
  "risingwave_sqlparser",
- "tokio-postgres",
  "workspace-hack",
 ]
 
@@ -6282,29 +6282,6 @@ checksum = "f7d995660bd2b7f8c1568414c1126076c13fbb725c40112dc0120b78eb9b717b"
 dependencies = [
  "native-tls",
  "tokio",
-]
-
-[[package]]
-name = "tokio-postgres"
-version = "0.7.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "19c88a47a23c5d2dc9ecd28fb38fba5fc7e5ddc1fe64488ec145076b0c71c8ae"
-dependencies = [
- "async-trait",
- "byteorder",
- "bytes",
- "fallible-iterator",
- "futures",
- "log",
- "parking_lot",
- "percent-encoding",
- "phf",
- "pin-project-lite",
- "postgres-protocol",
- "postgres-types",
- "socket2",
- "tokio",
- "tokio-util",
 ]
 
 [[package]]

--- a/e2e_test/batch/aggregate/timestamp.slt.part
+++ b/e2e_test/batch/aggregate/timestamp.slt.part
@@ -15,7 +15,7 @@ insert into t1 values
     (7, 1, '2022-01-01 10:52:00'),
     (8, 3, '2022-01-01 11:02:00');
 
-query IT
+query IT rowsort
 select sum(v), created_at from t1 group by created_at;
 ----
 3 2022-01-01 11:02:00

--- a/src/batch/src/execution/local_exchange.rs
+++ b/src/batch/src/execution/local_exchange.rs
@@ -130,7 +130,7 @@ mod tests {
         }
     }
 
-    #[tokio::test(flavor = "multi_thread")]
+    #[tokio::test]
     async fn test_exchange_client() {
         let rpc_called = Arc::new(AtomicBool::new(false));
         let server_run = Arc::new(AtomicBool::new(false));

--- a/src/common/Cargo.toml
+++ b/src/common/Cargo.toml
@@ -27,7 +27,6 @@ madsim = "=0.2.0-alpha.6"
 memcomparable = { path = "../utils/memcomparable" }
 more-asserts = "0.3"
 num-traits = "0.2"
-num_cpus = "1.13.1"
 parking_lot = "0.12"
 paste = "1"
 postgres-types = { version = "0.2", features = ["derive","with-chrono-0_4"] }

--- a/src/common/src/config.rs
+++ b/src/common/src/config.rs
@@ -295,7 +295,7 @@ mod default {
     }
 
     pub fn worker_node_parallelism() -> usize {
-        num_cpus::get()
+        std::thread::available_parallelism().unwrap().get()
     }
 
     pub fn compactor_memory_limit_mb() -> usize {

--- a/src/connector/src/source/filesystem/file_common.rs
+++ b/src/connector/src/source/filesystem/file_common.rs
@@ -349,7 +349,7 @@ mod test {
         MockFileSystemConf("/mock/path".to_string(), 1, 5, 10000)
     }
 
-    #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
+    #[tokio::test]
     async fn test_mock_file_system() {
         let file_system = MockFileSystem::new(default_filesystem_conf());
         let files_change_before = file_system.list_files().await;
@@ -370,7 +370,7 @@ mod test {
         tokio::task::yield_now().await;
     }
 
-    #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
+    #[tokio::test]
     async fn test_push_entries_change() {
         let file_system = MockFileSystem::new(default_filesystem_conf());
         let directory = DummyDirectory::new(file_system.clone());

--- a/src/connector/src/source/filesystem/s3/s3_dir.rs
+++ b/src/connector/src/source/filesystem/s3/s3_dir.rs
@@ -546,7 +546,7 @@ pub(crate) mod test {
         println!("list_curr_entries = {:?}", curr_entries);
     }
 
-    #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
+    #[tokio::test]
     #[ignore]
     async fn test_s3_directory_entries_change() {
         let shared_config = new_share_config(TEST_REGION_NAME.to_string(), AwsCredential::Default)

--- a/src/connector/src/source/pulsar/admin/client.rs
+++ b/src/connector/src/source/pulsar/admin/client.rs
@@ -106,7 +106,6 @@ pub struct PartitionedTopicMetadata {
 }
 
 #[cfg(test)]
-#[cfg(not(madsim))] // MockServer is not supported in simulation.
 mod test {
     use wiremock::{Mock, MockServer, ResponseTemplate};
 
@@ -131,6 +130,7 @@ mod test {
     }
 
     #[tokio::test]
+    #[cfg_attr(madsim, ignore)] // MockServer is not supported in simulation.
     async fn test_get_topic_metadata() {
         let server = mock_server(
             "/admin/v2/persistent/public/default/t2/partitions",

--- a/src/connector/src/source/pulsar/admin/client.rs
+++ b/src/connector/src/source/pulsar/admin/client.rs
@@ -106,6 +106,7 @@ pub struct PartitionedTopicMetadata {
 }
 
 #[cfg(test)]
+#[cfg(not(madsim))] // MockServer is not supported in simulation.
 mod test {
     use wiremock::{Mock, MockServer, ResponseTemplate};
 

--- a/src/connector/src/source/pulsar/enumerator/client.rs
+++ b/src/connector/src/source/pulsar/enumerator/client.rs
@@ -111,7 +111,6 @@ impl SplitEnumerator for PulsarSplitEnumerator {
 }
 
 #[cfg(test)]
-#[cfg(not(madsim))] // MockServer is not supported in simulation.
 mod test {
     use wiremock::{Mock, MockServer, ResponseTemplate};
 
@@ -140,6 +139,7 @@ mod test {
     }
 
     #[tokio::test]
+    #[cfg_attr(madsim, ignore)] // MockServer is not supported in simulation.
     async fn test_list_splits_on_no_existing_pulsar() {
         let prop = PulsarProperties {
             topic: "t".to_string(),
@@ -153,6 +153,7 @@ mod test {
     }
 
     #[tokio::test]
+    #[cfg_attr(madsim, ignore)] // MockServer is not supported in simulation.
     async fn test_list_on_no_existing_topic() {
         let server = empty_mock_server().await;
 
@@ -168,6 +169,7 @@ mod test {
     }
 
     #[tokio::test]
+    #[cfg_attr(madsim, ignore)] // MockServer is not supported in simulation.
     async fn test_list_splits_with_partitioned_topic() {
         let server = mock_server(
             "/admin/v2/persistent/public/default/t/partitions",
@@ -194,6 +196,7 @@ mod test {
     }
 
     #[tokio::test]
+    #[cfg_attr(madsim, ignore)] // MockServer is not supported in simulation.
     async fn test_list_splits_with_non_partitioned_topic() {
         let server = mock_server(
             "/admin/v2/persistent/public/default/t/partitions",

--- a/src/connector/src/source/pulsar/enumerator/client.rs
+++ b/src/connector/src/source/pulsar/enumerator/client.rs
@@ -111,6 +111,7 @@ impl SplitEnumerator for PulsarSplitEnumerator {
 }
 
 #[cfg(test)]
+#[cfg(not(madsim))] // MockServer is not supported in simulation.
 mod test {
     use wiremock::{Mock, MockServer, ResponseTemplate};
 

--- a/src/meta/src/hummock/metrics_utils.rs
+++ b/src/meta/src/hummock/metrics_utils.rs
@@ -89,16 +89,14 @@ pub fn trigger_sst_stat(
         .with_label_values(&[&level_label])
         .set(sst_num as i64);
 
-    use std::sync::atomic::AtomicU64;
-
-    static TIME_AFTER_LAST_OBSERVATION: AtomicU64 = AtomicU64::new(0);
-    let previous_time = TIME_AFTER_LAST_OBSERVATION.load(Ordering::Relaxed);
+    let previous_time = metrics.time_after_last_observation.load(Ordering::Relaxed);
     let current_time = SystemTime::now()
         .duration_since(UNIX_EPOCH)
         .unwrap()
         .as_secs();
     if current_time - previous_time > 600
-        && TIME_AFTER_LAST_OBSERVATION
+        && metrics
+            .time_after_last_observation
             .compare_exchange(
                 previous_time,
                 current_time,

--- a/src/meta/src/rpc/metrics.rs
+++ b/src/meta/src/rpc/metrics.rs
@@ -12,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use std::sync::atomic::AtomicU64;
+
 use prometheus::{
     exponential_buckets, histogram_opts, register_histogram_vec_with_registry,
     register_histogram_with_registry, register_int_gauge_vec_with_registry,
@@ -55,6 +57,8 @@ pub struct MetaMetrics {
 
     /// Latency for hummock manager to really process a request after acquire the lock
     pub hummock_manager_real_process_time: HistogramVec,
+
+    pub time_after_last_observation: AtomicU64,
 }
 
 impl MetaMetrics {
@@ -177,6 +181,7 @@ impl MetaMetrics {
             version_size,
             hummock_manager_lock_time,
             hummock_manager_real_process_time,
+            time_after_last_observation: AtomicU64::new(0),
         }
     }
 

--- a/src/meta/src/rpc/server.rs
+++ b/src/meta/src/rpc/server.rs
@@ -539,7 +539,7 @@ mod tests {
 
     use super::*;
 
-    #[tokio::test(flavor = "multi_thread")]
+    #[tokio::test]
     async fn test_leader_lease() {
         let info = AddressInfo {
             addr: "node1".to_string(),

--- a/src/meta/src/stream/stream_manager.rs
+++ b/src/meta/src/stream/stream_manager.rs
@@ -983,7 +983,7 @@ mod tests {
             .collect_vec()
     }
 
-    #[tokio::test(flavor = "multi_thread")]
+    #[tokio::test]
     async fn test_create_materialized_view() -> MetaResult<()> {
         let services = MockServices::start("127.0.0.1", 12333).await?;
 

--- a/src/meta/src/stream/test_fragmenter.rs
+++ b/src/meta/src/stream/test_fragmenter.rs
@@ -344,8 +344,6 @@ fn make_stream_graph() -> StreamFragmentGraph {
 }
 
 // TODO: enable this test with madsim
-// NOTE: frontend is not yet available with madsim
-#[cfg(not(madsim))]
 #[tokio::test]
 async fn test_fragmenter() -> MetaResult<()> {
     let env = MetaSrvEnv::for_test().await;

--- a/src/object_store/src/object/disk.rs
+++ b/src/object_store/src/object/disk.rs
@@ -330,6 +330,7 @@ impl ObjectStore for DiskObjectStore {
 }
 
 #[cfg(test)]
+#[cfg(not(madsim))] // TODO: remove this when madsim supports fs
 mod tests {
     use std::fs::OpenOptions;
     use std::io::Read;

--- a/src/object_store/src/object/disk.rs
+++ b/src/object_store/src/object/disk.rs
@@ -330,7 +330,6 @@ impl ObjectStore for DiskObjectStore {
 }
 
 #[cfg(test)]
-#[cfg(not(madsim))] // TODO: remove this when madsim supports fs
 mod tests {
     use std::fs::OpenOptions;
     use std::io::Read;
@@ -360,6 +359,7 @@ mod tests {
     }
 
     #[tokio::test]
+    #[cfg_attr(madsim, ignore)] // TODO: remove this when madsim supports fs
     async fn test_simple_upload() {
         let test_dir = TempDir::new().unwrap();
         let test_root_path = test_dir.path().to_str().unwrap();
@@ -378,6 +378,7 @@ mod tests {
     }
 
     #[tokio::test]
+    #[cfg_attr(madsim, ignore)] // TODO: remove this when madsim supports fs
     async fn test_multi_level_dir_upload() {
         let test_dir = TempDir::new().unwrap();
         let test_root_path = test_dir.path().to_str().unwrap();
@@ -396,6 +397,7 @@ mod tests {
     }
 
     #[tokio::test]
+    #[cfg_attr(madsim, ignore)] // TODO: remove this when madsim supports fs
     async fn test_read_all() {
         let test_dir = TempDir::new().unwrap();
         let test_root_path = test_dir.path().to_str().unwrap();
@@ -412,6 +414,7 @@ mod tests {
     }
 
     #[tokio::test]
+    #[cfg_attr(madsim, ignore)] // TODO: remove this when madsim supports fs
     async fn test_read_partial() {
         let test_dir = TempDir::new().unwrap();
         let test_root_path = test_dir.path().to_str().unwrap();
@@ -437,6 +440,7 @@ mod tests {
     }
 
     #[tokio::test]
+    #[cfg_attr(madsim, ignore)] // TODO: remove this when madsim supports fs
     async fn test_read_multi_block() {
         let test_dir = TempDir::new().unwrap();
         let test_root_path = test_dir.path().to_str().unwrap();
@@ -469,6 +473,7 @@ mod tests {
     }
 
     #[tokio::test]
+    #[cfg_attr(madsim, ignore)] // TODO: remove this when madsim supports fs
     async fn test_delete() {
         let test_dir = TempDir::new().unwrap();
         let test_root_path = test_dir.path().to_str().unwrap();
@@ -486,6 +491,7 @@ mod tests {
     }
 
     #[tokio::test]
+    #[cfg_attr(madsim, ignore)] // TODO: remove this when madsim supports fs
     async fn test_read_not_exists() {
         let test_dir = TempDir::new().unwrap();
         let test_root_path = test_dir.path().to_str().unwrap();
@@ -495,6 +501,7 @@ mod tests {
     }
 
     #[tokio::test]
+    #[cfg_attr(madsim, ignore)] // TODO: remove this when madsim supports fs
     async fn test_read_out_of_range() {
         let test_dir = TempDir::new().unwrap();
         let test_root_path = test_dir.path().to_str().unwrap();
@@ -557,6 +564,7 @@ mod tests {
     }
 
     #[tokio::test]
+    #[cfg_attr(madsim, ignore)] // TODO: remove this when madsim supports fs
     async fn test_list() {
         let test_dir = TempDir::new().unwrap();
         let test_root_path = test_dir.path().to_str().unwrap();

--- a/src/source/src/table_v2.rs
+++ b/src/source/src/table_v2.rs
@@ -78,16 +78,6 @@ impl TableSourceV2 {
 
         Ok(notifier_rx)
     }
-
-    /// Write stream chunk into table using `write_chunk`, and then block until a reader consumes
-    /// the chunk.
-    ///
-    /// Returns the cardinality of this chunk.
-    pub async fn blocking_write_chunk(&self, chunk: StreamChunk) -> Result<usize> {
-        let rx = self.write_chunk(chunk)?;
-        let written_cardinality = rx.await.unwrap();
-        Ok(written_cardinality)
-    }
 }
 
 // TODO: Currently batch read directly calls api from `ScannableTable` instead of using
@@ -198,9 +188,7 @@ mod tests {
                     vec![column_nonnull!(I64Array, [$i])],
                     None,
                 );
-                tokio::spawn(async move {
-                    source.blocking_write_chunk(chunk).await.unwrap();
-                })
+                source.write_chunk(chunk).unwrap();
             }};
         }
 

--- a/src/storage/hummock_sdk/src/filter_key_extractor.rs
+++ b/src/storage/hummock_sdk/src/filter_key_extractor.rs
@@ -614,7 +614,7 @@ mod tests {
         }
     }
 
-    #[tokio::test(flavor = "multi_thread")]
+    #[tokio::test]
     async fn test_filter_key_extractor_manager() {
         let filter_key_extractor_manager = Arc::new(FilterKeyExtractorManager::default());
         let filter_key_extractor_manager_ref = filter_key_extractor_manager.clone();

--- a/src/stream/src/executor/merge.rs
+++ b/src/stream/src/executor/merge.rs
@@ -525,7 +525,7 @@ mod tests {
         }
     }
 
-    #[tokio::test(flavor = "multi_thread")]
+    #[tokio::test]
     async fn test_stream_exchange_client() {
         let rpc_called = Arc::new(AtomicBool::new(false));
         let server_run = Arc::new(AtomicBool::new(false));

--- a/src/tests/sqlsmith/Cargo.toml
+++ b/src/tests/sqlsmith/Cargo.toml
@@ -20,7 +20,7 @@ risingwave_expr = { path = "../../expr" }
 risingwave_frontend = { path = "../../frontend" }
 risingwave_sqlparser = { path = "../../sqlparser" }
 tokio = { version = "=0.2.0-alpha.6", package = "madsim-tokio" }
-tokio-postgres = "0.7"
+tokio-postgres = { version = "=0.2.0-alpha.6", package = "madsim-tokio-postgres" }
 workspace-hack = { version = "0.1", path = "../../workspace-hack" }
 
 [[bin]]

--- a/src/utils/pgwire/Cargo.toml
+++ b/src/utils/pgwire/Cargo.toml
@@ -16,4 +16,4 @@ tracing = { version = "0.1" }
 workspace-hack = { version = "0.1", path = "../../workspace-hack" }
 
 [dev-dependencies]
-tokio-postgres = "0.7"
+tokio-postgres = { version = "=0.2.0-alpha.6", package = "madsim-tokio-postgres" }

--- a/src/utils/pgwire/src/pg_server.rs
+++ b/src/utils/pgwire/src/pg_server.rs
@@ -192,6 +192,8 @@ mod tests {
     async fn test_psql_extended_mode_explicit_simple() {
         let session_mgr = Arc::new(MockSessionManager {});
         tokio::spawn(async move { pg_serve("127.0.0.1:10000", session_mgr).await });
+        // wait for server to start
+        tokio::time::sleep(std::time::Duration::from_millis(10)).await;
 
         // Connect to the database.
         let (mut client, connection) = tokio_postgres::connect("host=localhost port=10000", NoTls)

--- a/src/workspace-hack/Cargo.toml
+++ b/src/workspace-hack/Cargo.toml
@@ -46,7 +46,7 @@ libc = { version = "0.2", features = ["extra_traits", "std"] }
 libz-sys = { version = "1", features = ["libc", "stock-zlib"] }
 lock_api = { version = "0.4", default-features = false, features = ["arc_lock"] }
 log = { version = "0.4", default-features = false, features = ["release_max_level_info", "std"] }
-madsim-tokio = { version = "0.2.0-alpha.6", default-features = false, features = ["fs", "macros", "process", "rt", "rt-multi-thread", "signal", "sync", "time", "tracing"] }
+madsim-tokio = { version = "0.2.0-alpha.6", default-features = false, features = ["fs", "io-util", "macros", "net", "process", "rt", "rt-multi-thread", "signal", "sync", "time", "tracing"] }
 memchr = { version = "2", features = ["std", "use_std"] }
 minimal-lexical = { version = "0.2", default-features = false, features = ["std"] }
 nix = { version = "0.24", features = ["acct", "aio", "dir", "env", "event", "feature", "fs", "hostname", "inotify", "ioctl", "kmod", "memoffset", "mman", "mount", "mqueue", "net", "personality", "poll", "process", "pthread", "ptrace", "quota", "reboot", "resource", "sched", "signal", "socket", "term", "time", "ucontext", "uio", "user", "zerocopy"] }
@@ -117,7 +117,7 @@ libc = { version = "0.2", features = ["extra_traits", "std"] }
 libz-sys = { version = "1", features = ["libc", "stock-zlib"] }
 lock_api = { version = "0.4", default-features = false, features = ["arc_lock"] }
 log = { version = "0.4", default-features = false, features = ["release_max_level_info", "std"] }
-madsim-tokio = { version = "0.2.0-alpha.6", default-features = false, features = ["fs", "macros", "process", "rt", "rt-multi-thread", "signal", "sync", "time", "tracing"] }
+madsim-tokio = { version = "0.2.0-alpha.6", default-features = false, features = ["fs", "io-util", "macros", "net", "process", "rt", "rt-multi-thread", "signal", "sync", "time", "tracing"] }
 memchr = { version = "2", features = ["std", "use_std"] }
 minimal-lexical = { version = "0.2", default-features = false, features = ["std"] }
 nix = { version = "0.24", features = ["acct", "aio", "dir", "env", "event", "feature", "fs", "hostname", "inotify", "ioctl", "kmod", "memoffset", "mman", "mount", "mqueue", "net", "personality", "poll", "process", "pthread", "ptrace", "quota", "reboot", "resource", "sched", "signal", "socket", "term", "time", "ucontext", "uio", "user", "zerocopy"] }


### PR DESCRIPTION
I hereby agree to the terms of the [Singularity Data, Inc. Contributor License Agreement](https://gist.github.com/skyzh/0663682a70b0edde7ae991492f2314cb#file-s9y_cla).

## What's changed and what's your intention?

This PR fixes several unit tests in simulation:
- switch all multi-thread tokio runtime to default current-thread runtime
- `risingwave_common cache::tests::test_future_cancel`: yield instead of spin loop. @Little-Wallace 
- `risingwave_connector`: ignore all tests using MockServer since it's not supported on madsim. @shanicky 
- `risingwave_object_store`: ignore all tests in disk object store since madsim does not support fs yet. @wenym1 
- `risingwave_stream executor::source::source_executor::tests::test_table_dropped`: write chunk on current task instead of spawn a new one to avoid panic after table dropped @BugenZhao 
- `risingwave_stream executor::source::source_executor::tests::test_split_change_mutation`: allow different chunk output order @tabVersion 
- `risingwave_meta`: move static `TIME_AFTER_LAST_OBSERVATION` to a field in `MetaMetrics`. In the simulation, we'll run a test multiple times with different system times, which leads to a subtraction overflow panic. @soundOfDestiny 

## Checklist

- [x] I have written necessary rustdoc comments
- [x] I have added necessary unit tests and integration tests
- [x] All checks passed in `./risedev check` (or alias, `./risedev c`)

## Refer to a related PR or issue link (optional)
