### PR TITLE
refactor(sink): rename sink properties

### DIFF
--- a/e2e_test/batch/explain.slt
+++ b/e2e_test/batch/explain.slt
@@ -5,7 +5,7 @@ statement ok
 explain create index i on t(v);
 
 statement ok
-explain create sink sink_t from t with ( sink_type = 'kafka' )
+explain create sink sink_t from t with ( connector = 'kafka' )
 
 statement ok
 drop table t;

--- a/e2e_test/ddl/table.slt
+++ b/e2e_test/ddl/table.slt
@@ -32,7 +32,7 @@ statement ok
 explain select v2 from ddl_t;
 
 statement ok
-explain create sink sink_t from ddl_t with ( sink_type = 'kafka' );
+explain create sink sink_t from ddl_t with ( connector = 'kafka' );
 
 # Create a mview with duplicated name.
 statement error

--- a/e2e_test/source/basic_test.slt
+++ b/e2e_test/source/basic_test.slt
@@ -35,7 +35,7 @@ statement ok
 select * from s6;
 
 statement ok
-create sink si from s5 with ( kafka.brokers = '127.0.0.1:29092', kafka.topic = 'sink_target', sink.type = 'append_only', sink_type = 'kafka' )
+create sink si from s5 with ( kafka.brokers = '127.0.0.1:29092', kafka.topic = 'sink_target', format = 'append_only', format = 'kafka' )
 
 statement ok
 create materialized source s7 (v1 int, v2 varchar) with ( connector = 'kafka', kafka.topic = 'sink_target', kafka.brokers = '127.0.0.1:29092', kafka.scan.startup.mode='earliest'  ) row format json

--- a/e2e_test/source/basic_test.slt
+++ b/e2e_test/source/basic_test.slt
@@ -35,7 +35,7 @@ statement ok
 select * from s6;
 
 statement ok
-create sink si from s5 with ( kafka.brokers = '127.0.0.1:29092', kafka.topic = 'sink_target', format = 'append_only', format = 'kafka' )
+create sink si from s5 with ( kafka.brokers = '127.0.0.1:29092', kafka.topic = 'sink_target', format = 'append_only', connector = 'kafka' )
 
 statement ok
 create materialized source s7 (v1 int, v2 varchar) with ( connector = 'kafka', kafka.topic = 'sink_target', kafka.brokers = '127.0.0.1:29092', kafka.scan.startup.mode='earliest'  ) row format json

--- a/src/connector/src/sink/mod.rs
+++ b/src/connector/src/sink/mod.rs
@@ -63,7 +63,7 @@ pub enum SinkState {
 
 impl SinkConfig {
     pub fn from_hashmap(properties: HashMap<String, String>) -> RwResult<Self> {
-        const SINK_TYPE_KEY: &str = "sink_type";
+        const SINK_TYPE_KEY: &str = "connector";
         let sink_type = properties.get(SINK_TYPE_KEY).ok_or_else(|| {
             RwError::from(ErrorCode::InvalidConfigValue {
                 config_entry: SINK_TYPE_KEY.to_string(),

--- a/src/frontend/src/handler/create_sink.rs
+++ b/src/frontend/src/handler/create_sink.rs
@@ -166,7 +166,7 @@ pub mod tests {
         frontend.run_sql(sql).await.unwrap();
 
         let sql = r#"CREATE SINK snk1 FROM mv1
-                    WITH (sink = 'mysql', mysql.endpoint = '127.0.0.1:3306', mysql.table =
+                    WITH (connector = 'mysql', mysql.endpoint = '127.0.0.1:3306', mysql.table =
                         '<table_name>', mysql.database = '<database_name>', mysql.user = '<user_name>',
                         mysql.password = '<password>');"#.to_string();
         frontend.run_sql(sql).await.unwrap();

--- a/src/frontend/src/handler/drop_sink.rs
+++ b/src/frontend/src/handler/drop_sink.rs
@@ -66,7 +66,7 @@ mod tests {
     async fn test_drop_sink_handler() {
         let sql_create_table = "create table t (v1 smallint);";
         let sql_create_mv = "create materialized view mv as select v1 from t;";
-        let sql_create_sink = "create sink snk from mv with(sink = 'mysql')";
+        let sql_create_sink = "create sink snk from mv with( connector = 'mysql')";
         let sql_drop_sink = "drop sink snk;";
         let frontend = LocalFrontend::new(Default::default()).await;
         frontend.run_sql(sql_create_table).await.unwrap();

--- a/src/sqlparser/tests/testdata/create.yaml
+++ b/src/sqlparser/tests/testdata/create.yaml
@@ -58,5 +58,5 @@
   error_msg: |
     sql parser error: Expected FROM, found: EOF
 
-- input: CREATE SINK IF NOT EXISTS snk FROM mv WITH (sink = 'mysql', mysql.endpoint = '127.0.0.1:3306', mysql.table = '<table_name>', mysql.database = '<database_name>', mysql.user = '<user_name>', mysql.password = '<password>')
-  formatted_sql: CREATE SINK IF NOT EXISTS snk FROM mv WITH (sink = 'mysql', mysql.endpoint = '127.0.0.1:3306', mysql.table = '<table_name>', mysql.database = '<database_name>', mysql.user = '<user_name>', mysql.password = '<password>')
+- input: CREATE SINK IF NOT EXISTS snk FROM mv WITH (connector = 'mysql', mysql.endpoint = '127.0.0.1:3306', mysql.table = '<table_name>', mysql.database = '<database_name>', mysql.user = '<user_name>', mysql.password = '<password>')
+  formatted_sql: CREATE SINK IF NOT EXISTS snk FROM mv WITH (connector = 'mysql', mysql.endpoint = '127.0.0.1:3306', mysql.table = '<table_name>', mysql.database = '<database_name>', mysql.user = '<user_name>', mysql.password = '<password>')


### PR DESCRIPTION
Signed-off-by: tabVersion <tabvision@bupt.icu>

I hereby agree to the terms of the [Singularity Data, Inc. Contributor License Agreement](https://gist.github.com/skyzh/0663682a70b0edde7ae991492f2314cb#file-s9y_cla).

## What's changed and what's your intention?

***PLEASE DO NOT LEAVE THIS EMPTY !!!***

Please explain **IN DETAIL** what the changes are in this PR and why they are needed:

as title, this pr rename sink usage in SQL. More info in release part 

- Summarize your change (**mandatory**)
- How does this PR work? Need a brief introduction for the changed logic (optional)
- Describe clearly one logical change and avoid lazy messages (optional)
- Describe any limitations of the current code (optional)

## Checklist

~~- [ ] I have written necessary rustdoc comments~~
- [x] I have added necessary unit tests and integration tests
- [x] All checks passed in `./risedev check` (or alias, `./risedev c`)

## Documentation

If your pull request contains user-facing changes, please specify the types of the changes, and create a release note. Otherwise, please feel free to remove this section.

### Types of user-facing changes

Please keep the types that apply to your changes, and remove those that do not apply.

* Connector (sources & sinks)

### Release note

Please create a release note for your changes. In the release note, focus on the impact on users, and mention the environment or conditions where the impact may occur.

rename properties in sink:

* sink.type => connector 
* sink_type => format

new example: 
```sql 
create sink si from s5 with ( kafka.brokers = '127.0.0.1:29092', kafka.topic = 'sink_target', format = 'append_only', connector = 'kafka' )
```

## Refer to a related PR or issue link (optional)

#4143 