### PR TITLE
fix(worker-node-mgr): worker node manager should return error if no workers found

### DIFF
--- a/src/frontend/src/scheduler/error.rs
+++ b/src/frontend/src/scheduler/error.rs
@@ -29,6 +29,9 @@ pub enum SchedulerError {
     #[error("Feature is not yet implemented: {0}, {1}")]
     NotImplemented(String, TrackingIssue),
 
+    #[error("Empty workers found")]
+    EmptyWorkerNodes,
+
     #[error(transparent)]
     Internal(#[from] anyhow::Error),
 }


### PR DESCRIPTION
…orkers found

I hereby agree to the terms of the [Singularity Data, Inc. Contributor License Agreement](https://gist.github.com/skyzh/0663682a70b0edde7ae991492f2314cb#file-s9y_cla).

## What's changed and what's your intention?

I think we should return errors if 0 parallel units provides, cuz it will result in 0 worker nodes.
0 worker nodes means we do not schedule **any** task. 

If we do not do this, we need to add logic in caller side. But this is not necessary and duplicate and complex.

## Checklist

- [x] I have written necessary rustdoc comments
- [x] I have added necessary unit tests and integration tests
- [x] All checks passed in `./risedev check` (or alias, `./risedev c`)

## Documentation

If your pull request contains user-facing changes, please specify the types of the changes, and create a release note. Otherwise, please feel free to remove this section.

### Types of user-facing changes

Please keep the types that apply to your changes, and remove those that do not apply.

* Installation and deployment 
* Connector (sources & sinks)
* SQL commands, functions, and operators
* RisingWave cluster configuration changes
* Other (please specify in the release note below)

### Release note

Please create a release note for your changes. In the release note, focus on the impact on users, and mention the environment or conditions where the impact may occur.

## Refer to a related PR or issue link (optional)
