### PR TITLE
chore(risedev): avoid using ambiguous "playground" term with `risedev d`

### DIFF
--- a/Makefile.toml
+++ b/Makefile.toml
@@ -261,9 +261,9 @@ cp "src/risedevtool/run_command.sh" "${PREFIX_BIN}/run_command.sh"
 cp "src/risedevtool/welcome.sh" "${PREFIX_BIN}/welcome.sh"
 '''
 
-[tasks.pre-start-playground]
+[tasks.pre-start-dev]
 category = "RiseDev - Prepare"
-description = "Prepare playground by downloading necessary tools and build required components"
+description = "Prepare dev cluster by downloading necessary tools and build required components"
 dependencies = [
   "download-minio",
   "download-mcli",
@@ -336,10 +336,10 @@ alias = "dev"
 
 [tasks.dev]
 category = "RiseDev - Start"
-dependencies = ["pre-start-playground"]
-command = "target/${BUILD_MODE_DIR}/risedev-playground"
+dependencies = ["pre-start-dev"]
+command = "target/${BUILD_MODE_DIR}/risedev-dev"
 args = ["${@}"]
-description = "Start a full RisingWave dev cluster using risedev-playground"
+description = "Start a full RisingWave dev cluster using risedev-dev"
 
 [tasks.kafka]
 category = "RiseDev - Start"
@@ -559,10 +559,10 @@ echo If you still feel this is not enough, you may copy $(tput setaf 4)risedev$(
 
 [tasks.ci-start]
 category = "RiseDev - CI"
-dependencies = ["clean-data", "pre-start-playground"]
-command = "target/${BUILD_MODE_DIR}/risedev-playground"
+dependencies = ["clean-data", "pre-start-dev"]
+command = "target/${BUILD_MODE_DIR}/risedev-dev"
 args = ["${@}"]
-description = "Clean data and start a full RisingWave dev cluster using risedev-playground"
+description = "Clean data and start a full RisingWave dev cluster using risedev-dev"
 
 [tasks.ci-kill]
 category = "RiseDev - CI"

--- a/ci/scripts/build.sh
+++ b/ci/scripts/build.sh
@@ -44,8 +44,8 @@ ldd target/"$target"/risingwave
 
 echo "--- Upload artifacts"
 cp target/"$target"/risingwave ./risingwave-"$profile"
-cp target/"$target"/risedev-playground ./risedev-playground-"$profile"
+cp target/"$target"/risedev-dev ./risedev-dev-"$profile"
 cp target/"$target"/risingwave_regress_test ./risingwave_regress_test-"$profile"
 buildkite-agent artifact upload risingwave-"$profile"
-buildkite-agent artifact upload risedev-playground-"$profile"
+buildkite-agent artifact upload risedev-dev-"$profile"
 buildkite-agent artifact upload risingwave_regress_test-"$profile"

--- a/ci/scripts/e2e-source-test.sh
+++ b/ci/scripts/e2e-source-test.sh
@@ -8,19 +8,19 @@ source ci/scripts/common.env.sh
 echo "--- Download artifacts"
 mkdir -p target/debug
 buildkite-agent artifact download risingwave-dev target/debug/
-buildkite-agent artifact download risedev-playground-dev target/debug/
+buildkite-agent artifact download risedev-dev-dev target/debug/
 mv target/debug/risingwave-dev target/debug/risingwave
-mv target/debug/risedev-playground-dev target/debug/risedev-playground
+mv target/debug/risedev-dev-dev target/debug/risedev-dev
 
 echo "--- Adjust permission"
 chmod +x ./target/debug/risingwave
-chmod +x ./target/debug/risedev-playground
+chmod +x ./target/debug/risedev-dev
 
 echo "--- Generate RiseDev CI config"
 cp ci/risedev-components.ci.env risedev-components.user.env
 
-echo "--- Prepare RiseDev playground"
-cargo make pre-start-playground
+echo "--- Prepare RiseDev dev cluster"
+cargo make pre-start-dev
 cargo make link-all-in-one-binaries
 
 echo "--- e2e test w/ Rust frontend - source with kafka"

--- a/ci/scripts/e2e-test-parallel.sh
+++ b/ci/scripts/e2e-test-parallel.sh
@@ -24,19 +24,19 @@ shift $((OPTIND -1))
 echo "--- Download artifacts"
 mkdir -p target/debug
 buildkite-agent artifact download risingwave-"$profile" target/debug/
-buildkite-agent artifact download risedev-playground-"$profile" target/debug/
+buildkite-agent artifact download risedev-dev-"$profile" target/debug/
 mv target/debug/risingwave-"$profile" target/debug/risingwave
-mv target/debug/risedev-playground-"$profile" target/debug/risedev-playground
+mv target/debug/risedev-dev-"$profile" target/debug/risedev-dev
 
 echo "--- Adjust permission"
 chmod +x ./target/debug/risingwave
-chmod +x ./target/debug/risedev-playground
+chmod +x ./target/debug/risedev-dev
 
 echo "--- Generate RiseDev CI config"
 cp ci/risedev-components.ci.env risedev-components.user.env
 
-echo "--- Prepare RiseDev playground"
-cargo make pre-start-playground
+echo "--- Prepare RiseDev dev cluster"
+cargo make pre-start-dev
 cargo make link-all-in-one-binaries
 
 echo "--- e2e, ci-3cn-1fe, streaming"

--- a/ci/scripts/e2e-test.sh
+++ b/ci/scripts/e2e-test.sh
@@ -24,19 +24,19 @@ shift $((OPTIND -1))
 echo "--- Download artifacts"
 mkdir -p target/debug
 buildkite-agent artifact download risingwave-"$profile" target/debug/
-buildkite-agent artifact download risedev-playground-"$profile" target/debug/
+buildkite-agent artifact download risedev-dev-"$profile" target/debug/
 mv target/debug/risingwave-"$profile" target/debug/risingwave
-mv target/debug/risedev-playground-"$profile" target/debug/risedev-playground
+mv target/debug/risedev-dev-"$profile" target/debug/risedev-dev
 
 echo "--- Adjust permission"
 chmod +x ./target/debug/risingwave
-chmod +x ./target/debug/risedev-playground
+chmod +x ./target/debug/risedev-dev
 
 echo "--- Generate RiseDev CI config"
 cp ci/risedev-components.ci.env risedev-components.user.env
 
-echo "--- Prepare RiseDev playground"
-cargo make pre-start-playground
+echo "--- Prepare RiseDev dev cluster"
+cargo make pre-start-dev
 cargo make link-all-in-one-binaries
 
 echo "--- e2e, ci-3cn-1fe, streaming"

--- a/ci/scripts/regress-test.sh
+++ b/ci/scripts/regress-test.sh
@@ -8,22 +8,22 @@ source ci/scripts/common.env.sh
 echo "--- Download artifacts"
 mkdir -p target/debug
 buildkite-agent artifact download risingwave-dev target/debug/
-buildkite-agent artifact download risedev-playground-dev target/debug/
+buildkite-agent artifact download risedev-dev-dev target/debug/
 buildkite-agent artifact download risingwave_regress_test-dev target/debug/
 mv target/debug/risingwave-dev target/debug/risingwave
-mv target/debug/risedev-playground-dev target/debug/risedev-playground
+mv target/debug/risedev-dev-dev target/debug/risedev-dev
 mv target/debug/risingwave_regress_test-dev target/debug/risingwave_regress_test
 
 echo "--- Adjust permission"
 chmod +x ./target/debug/risingwave
-chmod +x ./target/debug/risedev-playground
+chmod +x ./target/debug/risedev-dev
 chmod +x ./target/debug/risingwave_regress_test
 
 echo "--- Generate RiseDev CI config"
 cp ci/risedev-components.ci.env risedev-components.user.env
 
-echo "--- Prepare RiseDev playground"
-cargo make pre-start-playground
+echo "--- Prepare RiseDev dev cluster"
+cargo make pre-start-dev
 cargo make link-all-in-one-binaries
 
 echo "--- Postgres regress test"

--- a/src/risedevtool/README.md
+++ b/src/risedevtool/README.md
@@ -44,7 +44,7 @@ And you will see:
 ✅ tmux: session risedev
 ✅ minio: api http://127.0.0.1:9301/, console http://127.0.0.1:9400/
 .. compute-node-5688: waiting for user-managed service online... (you should start it!)
-.. playground: starting 5 services for dev-compute-node...
+.. dev cluster: starting 5 services for dev-compute-node...
 ```
 
 Then, you need simply start compute-node by yourself -- either in command line by cargo run or use debuggers such as CLion to start this component.
@@ -69,7 +69,7 @@ risedev:
     - use: frontend
 ```
 
-The RiseDev playground will start these 5 services in sequence. The service type is set with `use`. `port: 5687` overrides the default config for compute-node.
+The RiseDev development cluster will start these 5 services in sequence. The service type is set with `use`. `port: 5687` overrides the default config for compute-node.
 If you don't want one service, or want them to start in different order, simply remove or switch them. For example, if we only need two compute nodes:
 
 ```yaml
@@ -280,6 +280,6 @@ risingwave.meta.node=127.0.0.1:5690
 
 ### RiseDev Service
 
-The RiseDev playground will read the config and start all the services in sequence. The tasks will be started in tmux. All commands run by playground can be found in `risedev.log` in `.risingwave/log`. After starting each service, it will check liveness and return code of the program, so as to ensure a service is running.
+The RiseDev development cluster will read the config and start all the services in sequence. The tasks will be started in tmux. All commands run by RiseDev can be found in `risedev.log` in `.risingwave/log`. After starting each service, it will check liveness and return code of the program, so as to ensure a service is running.
 
 These components conclude the internal implementation of RiseDev.

--- a/src/risedevtool/src/bin/risedev-compose.rs
+++ b/src/risedevtool/src/bin/risedev-compose.rs
@@ -156,7 +156,7 @@ fn main() -> Result<()> {
                 }
                 (c.address.clone(), c.compose(&compose_config)?)
             }
-            ServiceConfig::FrontendV2(c) => {
+            ServiceConfig::Frontend(c) => {
                 if opts.deploy {
                     let arg = format!("--frontend {} --frontend-port {}", c.address, c.port);
                     writeln!(

--- a/src/risedevtool/src/bin/risedev-dev.rs
+++ b/src/risedevtool/src/bin/risedev-dev.rs
@@ -357,7 +357,7 @@ fn main() -> Result<()> {
     // Always create a progress before calling `task_main`. Otherwise the progress bar won't be
     // shown.
     let p = manager.new_progress();
-    p.set_prefix("playground");
+    p.set_prefix("dev cluster");
     p.set_message(format!(
         "starting {} services for {}...",
         steps.len(),

--- a/src/risedevtool/src/bin/risedev-dev.rs
+++ b/src/risedevtool/src/bin/risedev-dev.rs
@@ -118,7 +118,7 @@ fn task_main(
             ServiceConfig::Prometheus(c) => Some((c.port, c.id.clone())),
             ServiceConfig::ComputeNode(c) => Some((c.port, c.id.clone())),
             ServiceConfig::MetaNode(c) => Some((c.port, c.id.clone())),
-            ServiceConfig::FrontendV2(c) => Some((c.port, c.id.clone())),
+            ServiceConfig::Frontend(c) => Some((c.port, c.id.clone())),
             ServiceConfig::Compactor(c) => Some((c.port, c.id.clone())),
             ServiceConfig::Grafana(c) => Some((c.port, c.id.clone())),
             ServiceConfig::Jaeger(c) => Some((c.dashboard_port, c.id.clone())),
@@ -203,7 +203,7 @@ fn task_main(
                     c.address, c.port, c.address, c.dashboard_port
                 ));
             }
-            ServiceConfig::FrontendV2(c) => {
+            ServiceConfig::Frontend(c) => {
                 let mut ctx =
                     ExecuteContext::new(&mut logger, manager.new_progress(), status_dir.clone());
                 let mut service = FrontendService::new(c.clone())?;

--- a/src/risedevtool/src/config.rs
+++ b/src/risedevtool/src/config.rs
@@ -113,7 +113,7 @@ impl ConfigExpander {
                 let result = match use_type.as_str() {
                     "minio" => ServiceConfig::Minio(serde_yaml::from_str(&out_str)?),
                     "etcd" => ServiceConfig::Etcd(serde_yaml::from_str(&out_str)?),
-                    "frontend" => ServiceConfig::FrontendV2(serde_yaml::from_str(&out_str)?),
+                    "frontend" => ServiceConfig::Frontend(serde_yaml::from_str(&out_str)?),
                     "compactor" => ServiceConfig::Compactor(serde_yaml::from_str(&out_str)?),
                     "compute-node" => ServiceConfig::ComputeNode(serde_yaml::from_str(&out_str)?),
                     "meta-node" => ServiceConfig::MetaNode(serde_yaml::from_str(&out_str)?),

--- a/src/risedevtool/src/service_config.rs
+++ b/src/risedevtool/src/service_config.rs
@@ -266,7 +266,7 @@ pub struct RedisConfig {
 pub enum ServiceConfig {
     ComputeNode(ComputeNodeConfig),
     MetaNode(MetaNodeConfig),
-    FrontendV2(FrontendConfig),
+    Frontend(FrontendConfig),
     Compactor(CompactorConfig),
     Minio(MinioConfig),
     Etcd(EtcdConfig),
@@ -285,7 +285,7 @@ impl ServiceConfig {
         match self {
             Self::ComputeNode(c) => &c.id,
             Self::MetaNode(c) => &c.id,
-            Self::FrontendV2(c) => &c.id,
+            Self::Frontend(c) => &c.id,
             Self::Compactor(c) => &c.id,
             Self::Minio(c) => &c.id,
             Self::Etcd(c) => &c.id,


### PR DESCRIPTION
I hereby agree to the terms of the [Singularity Data, Inc. Contributor License Agreement](https://gist.github.com/skyzh/0663682a70b0edde7ae991492f2314cb#file-s9y_cla).

## What's changed and what's your intention?

As title. This PR also fixes that the `risedev playground` ignores the config file.

## Checklist

- [x] I have written necessary rustdoc comments
- [x] I have added necessary unit tests and integration tests
- [x] All checks passed in `./risedev check` (or alias, `./risedev c`)

## Refer to a related PR or issue link (optional)