### PR TITLE
fix: allow create source with row format debezium_json

### DIFF
--- a/src/frontend/src/handler/create_source.rs
+++ b/src/frontend/src/handler/create_source.rs
@@ -115,7 +115,7 @@ pub async fn handle_create_source(
             row_id_index: 0,
             columns: bind_sql_columns(stmt.columns)?,
             pk_column_ids: vec![0],
-        }
+        },
     };
 
     let session = context.session_ctx.clone();

--- a/src/frontend/src/handler/create_source.rs
+++ b/src/frontend/src/handler/create_source.rs
@@ -108,6 +108,14 @@ pub async fn handle_create_source(
             columns: bind_sql_columns(stmt.columns)?,
             pk_column_ids: vec![0],
         },
+        SourceSchema::DebeziumJson => StreamSourceInfo {
+            properties: with_properties.clone(),
+            row_format: RowFormatType::DebeziumJson as i32,
+            row_schema_location: "".to_string(),
+            row_id_index: 0,
+            columns: bind_sql_columns(stmt.columns)?,
+            pk_column_ids: vec![0],
+        }
     };
 
     let session = context.session_ctx.clone();

--- a/src/sqlparser/src/ast/statement.rs
+++ b/src/sqlparser/src/ast/statement.rs
@@ -85,7 +85,7 @@ pub struct CreateSourceStatement {
 pub enum SourceSchema {
     Protobuf(ProtobufSchema),
     // Keyword::PROTOBUF ProtobufSchema
-    Json, // Keyword::JSON
+    Json,         // Keyword::JSON
     DebeziumJson, // Keyword::DEBEZIUM_JSON
 }
 

--- a/src/sqlparser/src/ast/statement.rs
+++ b/src/sqlparser/src/ast/statement.rs
@@ -86,6 +86,7 @@ pub enum SourceSchema {
     Protobuf(ProtobufSchema),
     // Keyword::PROTOBUF ProtobufSchema
     Json, // Keyword::JSON
+    DebeziumJson, // Keyword::DEBEZIUM_JSON
 }
 
 impl ParseTo for SourceSchema {
@@ -95,6 +96,8 @@ impl ParseTo for SourceSchema {
         } else if p.parse_keywords(&[Keyword::PROTOBUF]) {
             impl_parse_to!(protobuf_schema: ProtobufSchema, p);
             SourceSchema::Protobuf(protobuf_schema)
+        } else if p.parse_keywords(&[Keyword::DEBEZIUM_JSON]) {
+            SourceSchema::DebeziumJson
         } else {
             return Err(ParserError::ParserError(
                 "expected JSON | PROTOBUF after ROW FORMAT".to_string(),
@@ -109,6 +112,7 @@ impl fmt::Display for SourceSchema {
         match self {
             SourceSchema::Protobuf(protobuf_schema) => write!(f, "PROTOBUF {}", protobuf_schema),
             SourceSchema::Json => write!(f, "JSON"),
+            SourceSchema::DebeziumJson => write!(f, "DEBEZIUM JSON"),
         }
     }
 }

--- a/src/sqlparser/src/keywords.rs
+++ b/src/sqlparser/src/keywords.rs
@@ -168,6 +168,7 @@ define_keywords!(
     DATE,
     DAY,
     DEALLOCATE,
+    DEBEZIUM_JSON,
     DEC,
     DECIMAL,
     DECLARE,


### PR DESCRIPTION
Signed-off-by: tabVersion <tabvision@bupt.icu>

I hereby agree to the terms of the [Singularity Data, Inc. Contributor License Agreement](https://gist.github.com/skyzh/0663682a70b0edde7ae991492f2314cb#file-s9y_cla).

## What's changed and what's your intention?

***PLEASE DO NOT LEAVE THIS EMPTY !!!***

Please explain **IN DETAIL** what the changes are in this PR and why they are needed:

- Summarize your change (**mandatory**)
- How does this PR work? Need a brief introduction for the changed logic (optional)
- Describe clearly one logical change and avoid lazy messages (optional)
- Describe any limitations of the current code (optional)

## Checklist

- [x] I have written necessary rustdoc comments
- [x] I have added necessary unit tests and integration tests
- [x] All checks passed in `./risedev check` (or alias, `./risedev c`)

## Documentation

If your pull request contains user-facing changes, please specify the types of the changes, and create a release note. Otherwise, please feel free to remove this section.

cdc source row format change from `debezium json` to `debezium_json`. now we can use the following command to create a CDC source

```sql
create materialized source s (v1 int, v2 varchar, primary key (v1) ) with (kafka.brokers = '127.0.0.1:29092', kafka.topic = 'sink_target', connector = 'kafka', kafka.scan.startup.mode = 'earliest' ) row format debezium_json;
```

### Types of user-facing changes

Please keep the types that apply to your changes, and remove those that do not apply.

* SQL commands, functions, and operators

### Release note

Please create a release note for your changes. In the release note, focus on the impact on users, and mention the environment or conditions where the impact may occur.

## Refer to a related PR or issue link (optional)

close #4489 
functional tests is available in #4486 