### PR TITLE
feat(expr): support casting temporal types to string

### DIFF
--- a/e2e_test/batch/types/cast.slt.part
+++ b/e2e_test/batch/types/cast.slt.part
@@ -64,6 +64,31 @@ values(1.23::float::varchar);
 1.23
 
 query T
+values('nan'::real::varchar);
+----
+NaN
+
+query T
+values('inf'::real::varchar);
+----
+Infinity
+
+query T
+values('-inf'::real::varchar);
+----
+-Infinity
+
+query T
+values(round(-0.1::real)::varchar);
+----
+-0
+
+query T
+values(round(-0.1)::varchar);
+----
+0
+
+query T
 values(1.233333333333333321123123123::decimal::varchar);
 ----
 1.233333333333333321123123123
@@ -102,3 +127,28 @@ query T
 values(interval '-50 h'::time);
 ----
 22:00:00
+
+query T
+values('12:34:56'::time::varchar);
+----
+12:34:56
+
+query T
+values(interval '-3 day'::varchar);
+----
+-3 days 00:00:00
+
+query T
+values('2020-01-01'::date::varchar);
+----
+2020-01-01
+
+query T
+values('2020-01-01 12:34:56'::timestamp::varchar);
+----
+2020-01-01 12:34:56
+
+query T
+values('2020-01-02 12:34:56 -11:00'::timestamp with time zone::varchar);
+----
+2020-01-02T23:34:56+00:00

--- a/src/common/src/types/ordered_float.rs
+++ b/src/common/src/types/ordered_float.rs
@@ -196,6 +196,16 @@ impl<T: Float> Hash for OrderedFloat<T> {
 impl<T: Float + fmt::Display> fmt::Display for OrderedFloat<T> {
     #[inline]
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        let v = self.0;
+        if v.is_nan() {
+            return write!(f, "NaN");
+        }
+        if v.is_infinite() {
+            if v.is_sign_negative() {
+                write!(f, "-")?
+            }
+            return write!(f, "Infinity");
+        }
         self.0.fmt(f)
     }
 }

--- a/src/expr/src/expr/expr_unary.rs
+++ b/src/expr/src/expr/expr_unary.rs
@@ -92,6 +92,10 @@ macro_rules! gen_cast {
             { float32, varchar, general_to_string },
             { float64, varchar, general_to_string },
             { decimal, varchar, general_to_string },
+            { time, varchar, general_to_string },
+            { interval, varchar, general_to_string },
+            { date, varchar, general_to_string },
+            { timestamp, varchar, general_to_string },
 
             { boolean, int32, general_cast },
             { int32, boolean, int32_to_bool },

--- a/src/expr/src/expr/expr_unary.rs
+++ b/src/expr/src/expr/expr_unary.rs
@@ -96,6 +96,7 @@ macro_rules! gen_cast {
             { interval, varchar, general_to_string },
             { date, varchar, general_to_string },
             { timestamp, varchar, general_to_string },
+            { timestampz, varchar, timestampz_to_utc_string },
 
             { boolean, int32, general_cast },
             { int32, boolean, int32_to_bool },

--- a/src/expr/src/vector_op/cast.rs
+++ b/src/expr/src/vector_op/cast.rs
@@ -15,7 +15,7 @@
 use std::any::type_name;
 use std::str::FromStr;
 
-use chrono::{DateTime, NaiveDate, NaiveDateTime, NaiveTime};
+use chrono::{DateTime, NaiveDate, NaiveDateTime, NaiveTime, TimeZone, Utc};
 use num_traits::ToPrimitive;
 use risingwave_common::types::{
     Decimal, IntervalUnit, NaiveDateTimeWrapper, NaiveDateWrapper, NaiveTimeWrapper, OrderedF32,
@@ -74,6 +74,13 @@ pub fn str_to_timestampz(elem: &str) -> Result<i64> {
     DateTime::parse_from_str(elem, "%Y-%m-%d %H:%M:%S %:z")
         .map(|ret| ret.timestamp_nanos() / 1000)
         .map_err(|_| ExprError::Parse(PARSE_ERROR_STR_TO_TIMESTAMP))
+}
+
+#[inline(always)]
+pub fn timestampz_to_utc_string(elem: i64) -> Result<String> {
+    // Just a meaningful representation as placeholder. The real implementation depends on TimeZone
+    // from session. See #3552.
+    Ok(Utc.timestamp_nanos(elem * 1000).to_rfc3339())
 }
 
 #[inline(always)]

--- a/src/frontend/src/handler/util.rs
+++ b/src/frontend/src/handler/util.rs
@@ -16,7 +16,6 @@ use std::collections::HashMap;
 
 use bytes::Bytes;
 use itertools::Itertools;
-use num_traits::Float;
 use pgwire::pg_field_descriptor::{PgFieldDescriptor, TypeOid};
 use pgwire::types::Row;
 use risingwave_common::array::DataChunk;
@@ -35,27 +34,10 @@ fn pg_value_format(d: ScalarRefImpl, format: bool) -> Bytes {
     if !format {
         match d {
             ScalarRefImpl::Bool(b) => if b { "t" } else { "f" }.into(),
-            ScalarRefImpl::Float32(v) => pg_float_format(v).into(),
-            ScalarRefImpl::Float64(v) => pg_float_format(v).into(),
             _ => d.to_string().into(),
         }
     } else {
         d.binary_serialize()
-    }
-}
-
-fn pg_float_format<T: Float + ToString>(v: T) -> String {
-    if v.is_infinite() {
-        if v.is_sign_positive() {
-            "Infinity"
-        } else {
-            "-Infinity"
-        }
-        .to_string()
-    } else if v.is_nan() {
-        "NaN".to_string()
-    } else {
-        v.to_string()
     }
 }
 


### PR DESCRIPTION
I hereby agree to the terms of the [Singularity Data, Inc. Contributor License Agreement](https://gist.github.com/skyzh/0663682a70b0edde7ae991492f2314cb#file-s9y_cla).

## What's changed and what's your intention?

* Fixes float to string casting of `Infinity`. (It used to be `inf`)
* Support casting to string from `time`/`interval`/`date`/`timestamp`.
* Placeholder implementation for casting `timestamp with time zone` to string. Its final implementation depends on `TimeZone` from session (#3552).

## Checklist

- [x] I have written necessary rustdoc comments
- [x] I have added necessary unit tests and integration tests
- [x] All checks passed in `./risedev check` (or alias, `./risedev c`)

## Refer to a related PR or issue link (optional)

#1632