### PR TITLE
fix(storage): remove timeout when get compaction group id

### DIFF
--- a/src/storage/src/hummock/error.rs
+++ b/src/storage/src/hummock/error.rs
@@ -50,9 +50,11 @@ enum HummockErrorInner {
     CompactionExecutor(String),
     #[error("TieredCache error {0}.")]
     TieredCache(String),
-    #[error("Other error {0}.")]
-    SstIdTrackerError(String),
     #[error("SstIdTracker error {0}.")]
+    SstIdTrackerError(String),
+    #[error("CompactionGroup error {0}.")]
+    CompactionGroupError(String),
+    #[error("Other error {0}.")]
     Other(String),
 }
 
@@ -119,6 +121,10 @@ impl HummockError {
 
     pub fn sst_id_tracker_error(error: impl ToString) -> HummockError {
         HummockErrorInner::SstIdTrackerError(error.to_string()).into()
+    }
+
+    pub fn compaction_group_error(error: impl ToString) -> HummockError {
+        HummockErrorInner::CompactionGroupError(error.to_string()).into()
     }
 
     pub fn tiered_cache(error: impl ToString) -> HummockError {

--- a/src/storage/src/hummock/mod.rs
+++ b/src/storage/src/hummock/mod.rs
@@ -16,7 +16,6 @@
 
 use std::fmt;
 use std::sync::Arc;
-use std::time::Duration;
 
 use bytes::Bytes;
 use risingwave_common::config::StorageConfig;
@@ -207,19 +206,9 @@ impl HummockStorage {
     }
 
     async fn get_compaction_group_id(&self, table_id: TableId) -> HummockResult<CompactionGroupId> {
-        match tokio::time::timeout(
-            Duration::from_secs(10),
-            self.compaction_group_client
-                .get_compaction_group_id(table_id.table_id),
-        )
-        .await
-        {
-            Err(_) => Err(HummockError::other(format!(
-                "get_compaction_group_id {} timeout",
-                table_id
-            ))),
-            Ok(resp) => resp,
-        }
+        self.compaction_group_client
+            .get_compaction_group_id(table_id.table_id)
+            .await
     }
 
     pub fn sstable_id_manager(&self) -> &SstableIdManagerRef {


### PR DESCRIPTION
I hereby agree to the terms of the [Singularity Data, Inc. Contributor License Agreement](https://gist.github.com/skyzh/0663682a70b0edde7ae991492f2314cb#file-s9y_cla).

## What's changed and what's your intention?

As titled. See https://github.com/singularity-data/risingwave/issues/4427 for detail.

## Checklist

- [x] I have written necessary rustdoc comments
- [x] All checks passed in `./risedev check` (or alias, `./risedev c`)

## Documentation

If your pull request contains user-facing changes, please specify the types of the changes, and create a release note. Otherwise, please feel free to remove this section.

### Types of user-facing changes

Please keep the types that apply to your changes, and remove those that do not apply.

* Installation and deployment 
* Connector (sources & sinks)
* SQL commands, functions, and operators
* RisingWave cluster configuration changes
* Other (please specify in the release note below)

### Release note

Please create a release note for your changes. In the release note, focus on the impact on users, and mention the environment or conditions where the impact may occur.

## Refer to a related PR or issue link (optional)
fix https://github.com/singularity-data/risingwave/issues/4427
