### PR TITLE
refactor(fragmenter): delete unneeded `self.` in fragmenter

### DIFF
--- a/src/frontend/src/stream_fragmenter/mod.rs
+++ b/src/frontend/src/stream_fragmenter/mod.rs
@@ -167,18 +167,17 @@ impl StreamFragmenter {
         stream_node: StreamNode,
     ) -> Result<()> {
         let stream_node = self.rewrite_stream_node(state, stream_node)?;
-        self.build_and_add_fragment(state, stream_node)?;
+        Self::build_and_add_fragment(state, stream_node)?;
         Ok(())
     }
 
     /// Use the given `stream_node` to create a fragment and add it to graph.
     fn build_and_add_fragment(
-        &self,
         state: &mut BuildFragmentGraphState,
         stream_node: StreamNode,
     ) -> Result<StreamFragment> {
         let mut fragment = state.new_stream_fragment();
-        let node = self.build_fragment(state, &mut fragment, stream_node)?;
+        let node = Self::build_fragment(state, &mut fragment, stream_node)?;
 
         assert!(fragment.node.is_none());
         fragment.node = Some(Box::new(node));
@@ -192,7 +191,6 @@ impl StreamFragmenter {
     /// tree, count how many table ids should be allocated in this fragment.
     // TODO: Should we store the concurrency in StreamFragment directly?
     fn build_fragment(
-        &self,
         state: &mut BuildFragmentGraphState,
         current_fragment: &mut StreamFragment,
         mut stream_node: StreamNode,
@@ -226,7 +224,11 @@ impl StreamFragmenter {
             if delta_index_join.get_join_type()? == JoinType::Inner
                 && delta_index_join.condition.is_none()
             {
-                return self.build_delta_join_without_arrange(state, current_fragment, stream_node);
+                return Self::build_delta_join_without_arrange(
+                    state,
+                    current_fragment,
+                    stream_node,
+                );
             } else {
                 panic!("only inner join without non-equal condition is supported for delta joins");
             }
@@ -249,7 +251,7 @@ impl StreamFragmenter {
 
                         assert_eq!(child_node.input.len(), 1);
                         let child_fragment =
-                            self.build_and_add_fragment(state, child_node.input.remove(0))?;
+                            Self::build_and_add_fragment(state, child_node.input.remove(0))?;
                         state.fragment_graph.add_edge(
                             child_fragment.fragment_id,
                             current_fragment.fragment_id,
@@ -269,7 +271,7 @@ impl StreamFragmenter {
                     }
 
                     // For other children, visit recursively.
-                    _ => self.build_fragment(state, current_fragment, child_node),
+                    _ => Self::build_fragment(state, current_fragment, child_node),
                 }
             })
             .try_collect()?;

--- a/src/frontend/src/stream_fragmenter/rewrite/delta_join.rs
+++ b/src/frontend/src/stream_fragmenter/rewrite/delta_join.rs
@@ -32,7 +32,6 @@ use crate::optimizer::plan_node::utils::TableCatalogBuilder;
 impl StreamFragmenter {
     /// All exchanges inside delta join is one-to-one exchange.
     fn build_exchange_for_delta_join(
-        &self,
         state: &mut BuildFragmentGraphState,
         upstream: &StreamNode,
     ) -> StreamNode {
@@ -57,7 +56,6 @@ impl StreamFragmenter {
     }
 
     fn build_lookup_for_delta_join(
-        &self,
         state: &mut BuildFragmentGraphState,
         (exchange_node_arrangement, exchange_node_stream): (&StreamNode, &StreamNode),
         (output_fields, output_pk_indices): (Vec<ProstField>, Vec<u32>),
@@ -78,7 +76,6 @@ impl StreamFragmenter {
     }
 
     fn build_delta_join_inner(
-        &self,
         state: &mut BuildFragmentGraphState,
         current_fragment: &mut StreamFragment,
         arrange_0_frag: StreamFragment,
@@ -94,10 +91,10 @@ impl StreamFragmenter {
 
         let arrange_0 = arrange_0_frag.node.as_ref().unwrap();
         let arrange_1 = arrange_1_frag.node.as_ref().unwrap();
-        let exchange_a0l0 = self.build_exchange_for_delta_join(state, arrange_0);
-        let exchange_a0l1 = self.build_exchange_for_delta_join(state, arrange_0);
-        let exchange_a1l0 = self.build_exchange_for_delta_join(state, arrange_1);
-        let exchange_a1l1 = self.build_exchange_for_delta_join(state, arrange_1);
+        let exchange_a0l0 = Self::build_exchange_for_delta_join(state, arrange_0);
+        let exchange_a0l1 = Self::build_exchange_for_delta_join(state, arrange_0);
+        let exchange_a1l0 = Self::build_exchange_for_delta_join(state, arrange_1);
+        let exchange_a1l1 = Self::build_exchange_for_delta_join(state, arrange_1);
 
         let i0_length = arrange_0.fields.len();
         let i1_length = arrange_1.fields.len();
@@ -113,7 +110,7 @@ impl StreamFragmenter {
                 .collect_vec()
         };
         // lookup left table by right stream
-        let lookup_0 = self.build_lookup_for_delta_join(
+        let lookup_0 = Self::build_lookup_for_delta_join(
             state,
             (&exchange_a1l0, &exchange_a0l0),
             (node.fields.clone(), node.pk_indices.clone()),
@@ -159,7 +156,7 @@ impl StreamFragmenter {
                 .collect_vec()
         };
         // lookup right table by left stream
-        let lookup_1 = self.build_lookup_for_delta_join(
+        let lookup_1 = Self::build_lookup_for_delta_join(
             state,
             (&exchange_a0l1, &exchange_a1l1),
             (node.fields.clone(), node.pk_indices.clone()),
@@ -195,8 +192,8 @@ impl StreamFragmenter {
             },
         );
 
-        let lookup_0_frag = self.build_and_add_fragment(state, lookup_0)?;
-        let lookup_1_frag = self.build_and_add_fragment(state, lookup_1)?;
+        let lookup_0_frag = Self::build_and_add_fragment(state, lookup_0)?;
+        let lookup_1_frag = Self::build_and_add_fragment(state, lookup_1)?;
 
         state.fragment_graph.add_edge(
             arrange_0_frag.fragment_id,
@@ -240,8 +237,8 @@ impl StreamFragmenter {
             },
         );
 
-        let exchange_l0m = self.build_exchange_for_delta_join(state, node);
-        let exchange_l1m = self.build_exchange_for_delta_join(state, node);
+        let exchange_l0m = Self::build_exchange_for_delta_join(state, node);
+        let exchange_l1m = Self::build_exchange_for_delta_join(state, node);
 
         let union = StreamNode {
             operator_id: state.gen_operator_id() as u64,
@@ -277,7 +274,6 @@ impl StreamFragmenter {
     }
 
     pub(in super::super) fn build_delta_join_without_arrange(
-        &self,
         state: &mut BuildFragmentGraphState,
         current_fragment: &mut StreamFragment,
         mut node: StreamNode,
@@ -308,10 +304,10 @@ impl StreamFragmenter {
         let arrange_0 = pass_through_exchange(arrange_0);
         let arrange_1 = pass_through_exchange(arrange_1);
 
-        let arrange_0_frag = self.build_and_add_fragment(state, arrange_0)?;
-        let arrange_1_frag = self.build_and_add_fragment(state, arrange_1)?;
+        let arrange_0_frag = Self::build_and_add_fragment(state, arrange_0)?;
+        let arrange_1_frag = Self::build_and_add_fragment(state, arrange_1)?;
 
-        let union = self.build_delta_join_inner(
+        let union = Self::build_delta_join_inner(
             state,
             current_fragment,
             arrange_0_frag,


### PR DESCRIPTION
I hereby agree to the terms of the [Singularity Data, Inc. Contributor License Agreement](https://gist.github.com/skyzh/0663682a70b0edde7ae991492f2314cb#file-s9y_cla).

## What's changed and what's your intention?

There is an empty struct called `StreamFragmenter` with many instance methods. I have made them static methods.

## Checklist

- [x] I have written necessary rustdoc comments
- [x] I have added necessary unit tests and integration tests
- [x] All checks passed in `./risedev check` (or alias, `./risedev c`)

## Refer to a related PR or issue link (optional)

This is a follow up after #4519 