### PR TITLE
feat(source): use `SourceError` instead of `RwError` in source connector

### DIFF
--- a/src/source/src/common.rs
+++ b/src/source/src/common.rs
@@ -17,17 +17,17 @@ use std::sync::Arc;
 use itertools::Itertools;
 use risingwave_common::array::column::Column;
 use risingwave_common::array::DataChunk;
-use risingwave_common::error::Result;
 use risingwave_common::types::Datum;
 use risingwave_common::util::chunk_coalesce::DEFAULT_CHUNK_BUFFER_SIZE;
 
 use crate::SourceColumnDesc;
+use crate::error::SourceResult;
 
 pub(crate) trait SourceChunkBuilder {
     fn build_columns(
         column_descs: &[SourceColumnDesc],
         rows: &[Vec<Datum>],
-    ) -> Result<Vec<Column>> {
+    ) -> SourceResult<Vec<Column>> {
         let mut builders: Vec<_> = column_descs
             .iter()
             .map(|k| k.data_type.create_array_builder(DEFAULT_CHUNK_BUFFER_SIZE))
@@ -46,7 +46,7 @@ pub(crate) trait SourceChunkBuilder {
             .map_err(Into::into)
     }
 
-    fn build_datachunk(column_desc: &[SourceColumnDesc], rows: &[Vec<Datum>]) -> Result<DataChunk> {
+    fn build_datachunk(column_desc: &[SourceColumnDesc], rows: &[Vec<Datum>]) -> SourceResult<DataChunk> {
         let columns = Self::build_columns(column_desc, rows)?;
         Ok(DataChunk::new(columns, rows.len()))
     }

--- a/src/source/src/connector_source.rs
+++ b/src/source/src/connector_source.rs
@@ -30,6 +30,7 @@ use tokio::sync::{mpsc, oneshot};
 use tokio::task::JoinHandle;
 
 use crate::common::SourceChunkBuilder;
+use crate::error::SourceResult;
 use crate::monitor::SourceMetrics;
 use crate::{SourceColumnDesc, SourceParserImpl, StreamChunkWithState, StreamSourceReader};
 
@@ -91,7 +92,7 @@ impl InnerConnectorSourceReader {
         columns: Vec<SourceColumnDesc>,
         metrics: Arc<SourceMetrics>,
         context: SourceContext,
-    ) -> Result<Self> {
+    ) -> SourceResult<Self> {
         tracing::debug!(
             "Spawning new connector source inner reader with config {:?}, split {:?}",
             prop,
@@ -113,8 +114,7 @@ impl InnerConnectorSourceReader {
                     .collect_vec(),
             ),
         )
-        .await
-        .to_rw_result()?;
+        .await?;
 
         Ok(InnerConnectorSourceReader {
             reader,
@@ -230,7 +230,7 @@ impl Drop for ConnectorSourceReader {
 }
 
 impl ConnectorSourceReader {
-    pub async fn add_split(&mut self, split: ConnectorState) -> Result<()> {
+    pub async fn add_split(&mut self, split: ConnectorState) -> SourceResult<()> {
         if let Some(append_splits) = split {
             for split in append_splits {
                 let split_id = split.id();

--- a/src/source/src/error.rs
+++ b/src/source/src/error.rs
@@ -1,0 +1,62 @@
+// Copyright 2022 Singularity Data
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::backtrace::Backtrace;
+use std::sync::Arc;
+
+pub type SourceResult<T> = std::result::Result<T, SourceError>;
+
+#[derive(thiserror::Error, Debug)]
+enum SourceErrorInner {
+    #[error("SourceReader error: {0}")]
+    SourceReaderError(String),
+    #[error(transparent)]
+    Internal(anyhow::Error),
+}
+
+impl From<SourceErrorInner> for SourceError {
+    fn from(inner: SourceErrorInner) -> Self {
+        Self {
+            inner: Arc::new(inner),
+            backtrace: Arc::new(Backtrace::capture()),
+        }
+    }
+}
+
+#[derive(thiserror::Error, Clone)]
+#[error("{inner}")]
+pub struct SourceError {
+    inner: Arc<SourceErrorInner>,
+    backtrace: Arc<Backtrace>,
+}
+
+impl std::fmt::Debug for SourceError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        use std::error::Error;
+
+        write!(f, "{}", self.inner)?;
+        writeln!(f)?;
+        if let Some(backtrace) = self.inner.backtrace() {
+            write!(f, "  backtrace of inner error:\n{}", backtrace)?;
+        } else {
+            write!(f, "  backtrace of `MetaError`:\n{}", self.backtrace)?;
+        }
+        Ok(())
+    }
+}
+impl From<anyhow::Error> for SourceError {
+    fn from(a: anyhow::Error) -> Self {
+        SourceErrorInner::Internal(a).into()
+    }
+}

--- a/src/source/src/lib.rs
+++ b/src/source/src/lib.rs
@@ -37,10 +37,10 @@ use std::fmt::Debug;
 
 use async_trait::async_trait;
 use enum_as_inner::EnumAsInner;
+use error::SourceResult;
 pub use manager::*;
 pub use parser::*;
 use risingwave_common::array::StreamChunk;
-use risingwave_common::error::Result;
 pub use table_v2::*;
 
 use crate::connector_source::{ConnectorSource, ConnectorSourceReader};
@@ -54,7 +54,7 @@ pub mod connector_source;
 pub mod monitor;
 pub mod row_id;
 mod table_v2;
-mod error;
+pub mod error;
 
 extern crate core;
 extern crate maplit;
@@ -82,7 +82,7 @@ pub enum SourceStreamReaderImpl {
 
 #[async_trait]
 impl StreamSourceReader for SourceStreamReaderImpl {
-    async fn next(&mut self) -> Result<StreamChunkWithState> {
+    async fn next(&mut self) -> SourceResult<StreamChunkWithState> {
         match self {
             SourceStreamReaderImpl::TableV2(t) => t.next().await,
             SourceStreamReaderImpl::Connector(c) => c.next().await,
@@ -103,5 +103,5 @@ pub struct StreamChunkWithState {
 pub trait StreamSourceReader: Send + Sync + 'static {
     /// `next` always returns a StreamChunk. If the queue is empty, it will
     /// block until new data coming
-    async fn next(&mut self) -> Result<StreamChunkWithState>;
+    async fn next(&mut self) -> SourceResult<StreamChunkWithState>;
 }

--- a/src/source/src/lib.rs
+++ b/src/source/src/lib.rs
@@ -30,6 +30,7 @@
 #![feature(generic_associated_types)]
 #![feature(binary_heap_drain_sorted)]
 #![feature(lint_reasons)]
+#![feature(backtrace)]
 
 use std::collections::HashMap;
 use std::fmt::Debug;
@@ -53,6 +54,7 @@ pub mod connector_source;
 pub mod monitor;
 pub mod row_id;
 mod table_v2;
+mod error;
 
 extern crate core;
 extern crate maplit;

--- a/src/source/src/table_v2.rs
+++ b/src/source/src/table_v2.rs
@@ -18,9 +18,9 @@ use async_trait::async_trait;
 use rand::prelude::SliceRandom;
 use risingwave_common::array::StreamChunk;
 use risingwave_common::catalog::{ColumnDesc, ColumnId};
-use risingwave_common::error::Result;
 use tokio::sync::{mpsc, oneshot};
 
+use crate::error::SourceResult;
 use crate::{StreamChunkWithState, StreamSourceReader};
 
 #[derive(Debug)]
@@ -63,7 +63,7 @@ impl TableSourceV2 {
     ///
     /// Returns an oneshot channel which will be notified when the chunk is taken by some reader,
     /// and the `usize` represents the cardinality of this chunk.
-    pub fn write_chunk(&self, chunk: StreamChunk) -> Result<oneshot::Receiver<usize>> {
+    pub fn write_chunk(&self, chunk: StreamChunk) -> SourceResult<oneshot::Receiver<usize>> {
         let tx = {
             let core = self.core.read().unwrap();
             core.changes_txs
@@ -100,7 +100,7 @@ pub struct TableV2StreamReader {
 
 #[async_trait]
 impl StreamSourceReader for TableV2StreamReader {
-    async fn next(&mut self) -> Result<StreamChunkWithState> {
+    async fn next(&mut self) -> SourceResult<StreamChunkWithState> {
         let (chunk, notifier) = self
             .rx
             .recv()
@@ -132,7 +132,7 @@ impl StreamSourceReader for TableV2StreamReader {
 impl TableSourceV2 {
     /// Create a new stream reader.
     #[expect(clippy::unused_async)]
-    pub async fn stream_reader(&self, column_ids: Vec<ColumnId>) -> Result<TableV2StreamReader> {
+    pub async fn stream_reader(&self, column_ids: Vec<ColumnId>) -> SourceResult<TableV2StreamReader> {
         let column_indices = column_ids
             .into_iter()
             .map(|id| {
@@ -176,7 +176,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn test_table_source_v2() -> Result<()> {
+    async fn test_table_source_v2() -> SourceResult<()> {
         let source = Arc::new(new_source());
         let mut reader = source.stream_reader(vec![ColumnId::from(0)]).await?;
 

--- a/src/stream/src/executor/error.rs
+++ b/src/stream/src/executor/error.rs
@@ -19,6 +19,7 @@ use risingwave_common::array::ArrayError;
 use risingwave_common::error::{BoxedError, Error, ErrorCode, RwError, TrackingIssue};
 use risingwave_expr::ExprError;
 use risingwave_rpc_client::error::RpcError;
+use risingwave_source::error::SourceError;
 use risingwave_storage::error::StorageError;
 
 use super::Barrier;
@@ -41,7 +42,7 @@ enum StreamExecutorErrorInner {
 
     // TODO: remove this
     #[error("Source error: {0}")]
-    SourceError(RwError),
+    SourceError(SourceError),
 
     // TODO: remove this
     #[error("Sink error: {0}")]
@@ -68,7 +69,7 @@ impl StreamExecutorError {
         StreamExecutorErrorInner::SerdeError(error.into()).into()
     }
 
-    pub fn source_error(error: impl Into<RwError>) -> Self {
+    pub fn source_error(error: impl Into<SourceError>) -> Self {
         StreamExecutorErrorInner::SourceError(error.into()).into()
     }
 


### PR DESCRIPTION
I hereby agree to the terms of the [Singularity Data, Inc. Contributor License Agreement](https://gist.github.com/skyzh/0663682a70b0edde7ae991492f2314cb#file-s9y_cla).

## What's changed and what's your intention?

As title

## Checklist

- [x] I have written necessary rustdoc comments
- [x] I have added necessary unit tests and integration tests
- [x] All checks passed in `./risedev check` (or alias, `./risedev c`)

## Refer to a related PR or issue link (optional)

Resolve #4105 