### PR TITLE
refactor: propose the API semantics of abort_task

### DIFF
--- a/proto/task_service.proto
+++ b/proto/task_service.proto
@@ -76,6 +76,7 @@ message ExecuteRequest {
 
 service TaskService {
   rpc CreateTask(CreateTaskRequest) returns (stream TaskInfoResponse);
+  // Abort an already-died (self execution-failure, previous aborted, completed) task will still succeed.
   rpc AbortTask(AbortTaskRequest) returns (AbortTaskResponse);
   rpc Execute(ExecuteRequest) returns (stream GetDataResponse);
 }

--- a/src/batch/src/rpc/service/task_service.rs
+++ b/src/batch/src/rpc/service/task_service.rs
@@ -90,16 +90,9 @@ impl TaskService for BatchServiceImpl {
         req: Request<AbortTaskRequest>,
     ) -> Result<Response<AbortTaskResponse>, Status> {
         let req = req.into_inner();
-        let res = self
-            .mgr
+        self.mgr
             .abort_task(req.get_task_id().expect("no task id found"));
-        match res {
-            Ok(_) => Ok(Response::new(AbortTaskResponse { status: None })),
-            Err(e) => {
-                error!("failed to abort task {}", e);
-                Err(e.into())
-            }
-        }
+        Ok(Response::new(AbortTaskResponse { status: None }))
     }
 
     #[cfg_attr(coverage, no_coverage)]

--- a/src/batch/src/task/task_execution.rs
+++ b/src/batch/src/task/task_execution.rs
@@ -383,26 +383,14 @@ impl<C: BatchTaskContext> BatchTaskExecution<C> {
         Ok(())
     }
 
-    pub fn abort_task(&self) -> Result<()> {
-        let sender = self.shutdown_tx.lock().take().ok_or_else(|| {
-            ErrorCode::InternalError(format!(
-                "Task{:?}'s shutdown channel does not exist. \
-                    Either the task has been aborted once, \
-                    or the channel has neven been initialized.",
-                self.task_id
-            ))
-        })?;
-        self.change_state(TaskStatus::Aborting);
-        // Stop task execution.
-        if let Err(e) = sender.send(0).map_err(|err| {
-            ErrorCode::InternalError(format!(
-                "Task{:?};s shutdown channel send error:{:?}",
-                self.task_id, err
-            ))
-        }) {
-            info!("the task has already been abort")
-        }
-        Ok(())
+    pub fn abort_task(&self) {
+        if let Some(sender) = self.shutdown_tx.lock().take() {
+            self.change_state(TaskStatus::Aborting);
+            // Stop task execution.
+            if sender.send(0).is_err() {
+                warn!("The task has already died before this request, so the abort did no-op")
+            }
+        };
     }
 
     pub fn get_task_output(&self, output_id: &ProstOutputId) -> Result<TaskOutput> {

--- a/src/batch/src/task/task_execution.rs
+++ b/src/batch/src/task/task_execution.rs
@@ -394,13 +394,15 @@ impl<C: BatchTaskContext> BatchTaskExecution<C> {
         })?;
         self.change_state(TaskStatus::Aborting);
         // Stop task execution.
-        sender.send(0).map_err(|err| {
+        if let Err(e) = sender.send(0).map_err(|err| {
             ErrorCode::InternalError(format!(
                 "Task{:?};s shutdown channel send error:{:?}",
                 self.task_id, err
             ))
-            .into()
-        })
+        }) {
+            info!("the task has already been abort")
+        }
+        Ok(())
     }
 
     pub fn get_task_output(&self, output_id: &ProstOutputId) -> Result<TaskOutput> {

--- a/src/batch/src/task/task_manager.rs
+++ b/src/batch/src/task/task_manager.rs
@@ -107,12 +107,14 @@ impl BatchManager {
             .get_task_output(output_id)
     }
 
-    pub fn abort_task(&self, sid: &ProstTaskId) -> Result<()> {
+    pub fn abort_task(&self, sid: &ProstTaskId) {
         let sid = TaskId::from(sid);
         match self.tasks.lock().get(&sid) {
             Some(task) => task.abort_task(),
-            None => Err(TaskNotFound.into()),
-        }
+            None => {
+                warn!("Task id not found for abort task")
+            }
+        };
     }
 
     pub fn remove_task(
@@ -301,7 +303,7 @@ mod tests {
             .fire_task(&task_id, plan.clone(), 0, context.clone())
             .await
             .unwrap();
-        manager.abort_task(&task_id).unwrap();
+        manager.abort_task(&task_id);
         let task_id = TaskId::from(&task_id);
         let res = manager.wait_until_task_aborted(&task_id).await;
         assert_eq!(res, Ok(()));


### PR DESCRIPTION
I hereby agree to the terms of the [Singularity Data, Inc. Contributor License Agreement](https://gist.github.com/skyzh/0663682a70b0edde7ae991492f2314cb#file-s9y_cla).

## What's changed and what's your intention?
Working on a draft PR of cancel task and I found that an important problem is how we define `abort_task()` API semantics. 
Now, `abort_task()` will succeed only if the task is cancelled by exact that request. Means if a task A has already stopped execution (may be because self-failure or complete) before that request, in this case abort_task still fail cuz it is not abort by exact that request.

I want to change that semantics of API to "**As long as the task is die, no matter in what ways, return success**".  This may means even if the task is died because of task execution failure, previous aborted, task_id not found (Already cleaned by task manager), `abort_task` will still returns success.  

There are serveral reasons to push me to do that:
1. Original way the Error message is useless. We can not handle **Abort Failure** in scheduler. 
2. When task A fails, we are only expect call abort_task RPC on B, C, D. This is because call abort_task on A will fail cuz it's already "die". But unfortuantely, B, C, D may also encounters execution failure and makes the flying `abort_task` fail. This is impossible to predict and makes the control flow really complex.

I found this problem worth seperate discussion so I pick it up from draft prs. The code is just for demo.


## Checklist

- [x] I have written necessary rustdoc comments
- [x] I have added necessary unit tests and integration tests
- [x] All checks passed in `./risedev check` (or alias, `./risedev c`)

## Documentation

If your pull request contains user-facing changes, please specify the types of the changes, and create a release note. Otherwise, please feel free to remove this section.

### Types of user-facing changes

Please keep the types that apply to your changes, and remove those that do not apply.

* Installation and deployment 
* Connector (sources & sinks)
* SQL commands, functions, and operators
* RisingWave cluster configuration changes
* Other (please specify in the release note below)

### Release note

Please create a release note for your changes. In the release note, focus on the impact on users, and mention the environment or conditions where the impact may occur.

## Refer to a related PR or issue link (optional)
