### PR TITLE
fix: stack unwind when profiling

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,11 +1,11 @@
 [target.x86_64-unknown-linux-gnu]
 rustflags = [
-    "-C", "link-arg=-fuse-ld=lld", "--cfg", "tokio_unstable"
+    "-Clink-arg=-fuse-ld=lld", "-Clink-arg=-Wl,--no-rosegment", "--cfg", "tokio_unstable"
 ]
 
 [target.aarch64-unknown-linux-gnu]
 rustflags = [
-    "-C", "link-arg=-fuse-ld=lld", "--cfg", "tokio_unstable"
+    "-Clink-arg=-fuse-ld=lld", "-Clink-arg=-Wl,--no-rosegment", "--cfg", "tokio_unstable"
 ]
 
 [build]


### PR DESCRIPTION
I hereby agree to the terms of the [Singularity Data, Inc. Contributor License Agreement](https://gist.github.com/skyzh/0663682a70b0edde7ae991492f2314cb#file-s9y_cla).

## What's changed and what's your intention?

Previously the stack cannot be shown correctly when profiling. This is caused by [a bug in `lld `](https://bugs.chromium.org/p/chromium/issues/detail?id=919499#c16) which we used to link on Linux platform. The stack unwind is broken so flamegraph looks weird.

After adding flag `-Wl,--no-rosegment` to `lld`, everything works.

<img width="1505" alt="image" src="https://user-images.githubusercontent.com/10192522/183885079-1d851408-fc29-436a-b583-90e97ba311b1.png">

By the way, the [cargo-flamegraph](https://github.com/flamegraph-rs/flamegraph) project works well for me. It helps you to run `perf` and then generate flame graph in one command.

## Checklist

N/A

## Documentation

N/A

## Refer to a related PR or issue link (optional)

None