### PR TITLE
feat(runtime): replace tokio-tracing with minitrace

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1598,7 +1598,7 @@ dependencies = [
  "crossterm_winapi",
  "libc",
  "mio",
- "parking_lot",
+ "parking_lot 0.12.1",
  "signal-hook",
  "signal-hook-mio",
  "winapi",
@@ -1764,7 +1764,7 @@ dependencies = [
  "cfg-if",
  "hashbrown 0.12.3",
  "lock_api",
- "parking_lot_core",
+ "parking_lot_core 0.9.3",
 ]
 
 [[package]]
@@ -3025,7 +3025,7 @@ dependencies = [
  "futures",
  "log",
  "madsim-tokio",
- "parking_lot",
+ "parking_lot 0.12.1",
  "percent-encoding",
  "phf",
  "pin-project-lite",
@@ -3164,6 +3164,34 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
 
 [[package]]
+name = "minitrace"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8a07fdf302cc0591c97eb45939550ddaddd9962e400c20b319aa16c244cb1f16"
+dependencies = [
+ "crossbeam",
+ "futures",
+ "minitrace-macro",
+ "minstant",
+ "once_cell",
+ "parking_lot 0.11.2",
+ "pin-project",
+ "retain_mut",
+]
+
+[[package]]
+name = "minitrace-macro"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4132dfe6097f4a90c0bbb34be0687c38d14303dd2e74f8442ae80e9bc5a34c47"
+dependencies = [
+ "proc-macro-error",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "miniz_oxide"
 version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3209,7 +3237,7 @@ dependencies = [
  "futures-util",
  "num_cpus",
  "once_cell",
- "parking_lot",
+ "parking_lot 0.12.1",
  "quanta",
  "scheduled-thread-pool",
  "skeptic",
@@ -3625,12 +3653,37 @@ checksum = "427c3892f9e783d91cc128285287e70a59e206ca452770ece88a76f7a3eddd72"
 
 [[package]]
 name = "parking_lot"
+version = "0.11.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7d17b78036a60663b797adeaee46f5c9dfebb86948d1255007a1d6be0271ff99"
+dependencies = [
+ "instant",
+ "lock_api",
+ "parking_lot_core 0.8.5",
+]
+
+[[package]]
+name = "parking_lot"
 version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3742b2c103b9f06bc9fff0a37ff4912935851bee6d36f3c02bcc755bcfec228f"
 dependencies = [
  "lock_api",
- "parking_lot_core",
+ "parking_lot_core 0.9.3",
+]
+
+[[package]]
+name = "parking_lot_core"
+version = "0.8.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d76e8e1493bcac0d2766c42737f34458f1c8c50c0d23bcb24ea953affb273216"
+dependencies = [
+ "cfg-if",
+ "instant",
+ "libc",
+ "redox_syscall",
+ "smallvec",
+ "winapi",
 ]
 
 [[package]]
@@ -3908,7 +3961,7 @@ dependencies = [
  "log",
  "nix",
  "once_cell",
- "parking_lot",
+ "parking_lot 0.12.1",
  "smallvec",
  "symbolic-demangle",
  "tempfile",
@@ -4015,7 +4068,7 @@ dependencies = [
  "lazy_static",
  "libc",
  "memchr",
- "parking_lot",
+ "parking_lot 0.12.1",
  "procfs",
  "protobuf",
  "thiserror",
@@ -4523,8 +4576,9 @@ dependencies = [
  "madsim-tokio",
  "madsim-tonic",
  "memcomparable",
+ "minitrace",
  "num-traits",
- "parking_lot",
+ "parking_lot 0.12.1",
  "paste",
  "prometheus",
  "prost 0.11.0",
@@ -4574,7 +4628,7 @@ dependencies = [
  "madsim-tokio",
  "moka",
  "nix",
- "parking_lot",
+ "parking_lot 0.12.1",
  "prometheus",
  "rand 0.8.5",
  "risingwave_common",
@@ -4659,7 +4713,7 @@ dependencies = [
  "memcomparable",
  "more-asserts",
  "num-traits",
- "parking_lot",
+ "parking_lot 0.12.1",
  "paste",
  "pin-project",
  "postgres-types",
@@ -4710,7 +4764,7 @@ dependencies = [
  "clap 3.2.15",
  "madsim-tokio",
  "madsim-tonic",
- "parking_lot",
+ "parking_lot 0.12.1",
  "prometheus",
  "risingwave_common",
  "risingwave_common_service",
@@ -4753,7 +4807,7 @@ dependencies = [
  "maplit",
  "memcomparable",
  "num-traits",
- "parking_lot",
+ "parking_lot 0.12.1",
  "paste",
  "prometheus",
  "prost 0.11.0",
@@ -4860,7 +4914,7 @@ dependencies = [
  "comfy-table",
  "futures",
  "madsim-tokio",
- "parking_lot",
+ "parking_lot 0.12.1",
  "risingwave_common",
  "risingwave_frontend",
  "risingwave_hummock_sdk",
@@ -4938,7 +4992,7 @@ dependencies = [
  "md5",
  "num-integer",
  "num-traits",
- "parking_lot",
+ "parking_lot 0.12.1",
  "paste",
  "pgwire",
  "prost 0.11.0",
@@ -4993,7 +5047,7 @@ dependencies = [
  "madsim-tokio",
  "num-derive",
  "num-traits",
- "parking_lot",
+ "parking_lot 0.12.1",
  "prost 0.11.0",
  "risingwave_common",
  "risingwave_pb",
@@ -5009,7 +5063,7 @@ dependencies = [
  "futures",
  "itertools",
  "madsim-tokio",
- "parking_lot",
+ "parking_lot 0.12.1",
  "rand 0.8.5",
  "risingwave_common",
  "risingwave_hummock_sdk",
@@ -5051,7 +5105,7 @@ dependencies = [
  "memcomparable",
  "num-integer",
  "num-traits",
- "parking_lot",
+ "parking_lot 0.12.1",
  "paste",
  "prometheus",
  "prost 0.11.0",
@@ -5172,7 +5226,7 @@ dependencies = [
  "madsim-tokio",
  "opentelemetry",
  "opentelemetry-jaeger",
- "parking_lot",
+ "parking_lot 0.12.1",
  "pprof",
  "thrift",
  "tokio-stream",
@@ -5226,7 +5280,7 @@ dependencies = [
  "maplit",
  "memcomparable",
  "num-traits",
- "parking_lot",
+ "parking_lot 0.12.1",
  "paste",
  "prometheus",
  "prost 0.11.0",
@@ -5343,7 +5397,7 @@ dependencies = [
  "nix",
  "num-integer",
  "num-traits",
- "parking_lot",
+ "parking_lot 0.12.1",
  "paste",
  "prometheus",
  "prost 0.11.0",
@@ -5401,9 +5455,10 @@ dependencies = [
  "madsim-tonic",
  "maplit",
  "memcomparable",
+ "minitrace",
  "minstant",
  "num-traits",
- "parking_lot",
+ "parking_lot 0.12.1",
  "paste",
  "pin-project",
  "prometheus",
@@ -5538,7 +5593,7 @@ version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "977a7519bff143a44f842fd07e80ad1329295bd71686457f18e496736f4bf9bf"
 dependencies = [
- "parking_lot",
+ "parking_lot 0.12.1",
 ]
 
 [[package]]
@@ -6314,7 +6369,7 @@ dependencies = [
  "fallible-iterator",
  "futures",
  "log",
- "parking_lot",
+ "parking_lot 0.12.1",
  "percent-encoding",
  "phf",
  "pin-project-lite",
@@ -6596,7 +6651,7 @@ dependencies = [
  "ansi_term",
  "matchers",
  "once_cell",
- "parking_lot",
+ "parking_lot 0.12.1",
  "regex",
  "sharded-slab",
  "smallvec",
@@ -7040,8 +7095,8 @@ dependencies = [
  "nom 7.1.1",
  "num-integer",
  "num-traits",
- "parking_lot",
- "parking_lot_core",
+ "parking_lot 0.12.1",
+ "parking_lot_core 0.9.3",
  "petgraph",
  "postgres-types",
  "prometheus",

--- a/src/batch/Cargo.toml
+++ b/src/batch/Cargo.toml
@@ -21,6 +21,7 @@ itertools = "0.10"
 lazy_static = "1"
 log = "0.4"
 memcomparable = { path = "../utils/memcomparable" }
+minitrace = "0.4"
 num-traits = "0.2"
 parking_lot = { version = "0.12", features = ["arc_lock"] }
 paste = "1"

--- a/src/stream/Cargo.toml
+++ b/src/stream/Cargo.toml
@@ -27,6 +27,7 @@ lazy_static = "1"
 log = "0.4"
 maplit = "1.0.2"
 memcomparable = { path = "../utils/memcomparable" }
+minitrace = "0.4"
 minstant = "0.1"
 num-traits = "0.2"
 parking_lot = "0.12"

--- a/src/stream/src/executor/actor.rs
+++ b/src/stream/src/executor/actor.rs
@@ -18,10 +18,10 @@ use std::time::Instant;
 
 use async_stack_trace::{SpanValue, StackTrace};
 use futures::pin_mut;
+use minitrace::prelude::*;
 use parking_lot::Mutex;
 use risingwave_common::error::Result;
 use tokio_stream::StreamExt;
-use tracing_futures::Instrument;
 
 use super::monitor::StreamingMetrics;
 use super::{Message, StreamConsumer};
@@ -132,14 +132,14 @@ where
 
     pub async fn run(self) -> Result<()> {
         let span_name = format!("actor_poll_{:03}", self.id);
-        let mut span = tracing::trace_span!(
-            "actor_poll",
-            otel.name = span_name.as_str(),
-            // For the upstream trace pipe, its output is our input.
-            actor_id = self.id,
-            next = "Outbound",
-            epoch = -1
-        );
+        let mut span = {
+            let mut span = Span::enter_with_local_parent("actor_poll");
+            span.add_property(|| ("otel.name", span_name.to_string()));
+            span.add_property(|| ("next", self.id.to_string()));
+            span.add_property(|| ("next", "Outbound".to_string()));
+            span.add_property(|| ("epoch", (-1).to_string()));
+            span
+        };
 
         let actor_id_string = self.id.to_string();
         let operator_id_string = {
@@ -159,7 +159,7 @@ where
         // Drive the streaming task with an infinite loop
         while let Some(barrier) = stream
             .next()
-            .instrument(span)
+            .in_span(span)
             .stack_trace(last_epoch.map_or(SpanValue::Slice("Epoch <initial>"), |e| {
                 format!("Epoch {}", e.curr).into()
             }))
@@ -206,27 +206,14 @@ where
             }
 
             // Tracing related work
-            let span_parent = barrier.span;
-            if !span_parent.is_none() {
-                span = tracing::trace_span!(
-                    parent: span_parent,
-                    "actor_poll",
-                    otel.name = span_name.as_str(),
-                    // For the upstream trace pipe, its output is our input.
-                    actor_id = self.id,
-                    next = "Outbound",
-                    epoch = barrier.epoch.curr,
-                );
-            } else {
-                span = tracing::trace_span!(
-                    "actor_poll",
-                    otel.name = span_name.as_str(),
-                    // For the upstream trace pipe, its output is our input.
-                    actor_id = self.id,
-                    next = "Outbound",
-                    epoch = barrier.epoch.curr,
-                );
-            }
+            span = {
+                let mut span = Span::enter_with_local_parent("actor_poll");
+                span.add_property(|| ("otel.name", span_name.to_string()));
+                span.add_property(|| ("next", self.id.to_string()));
+                span.add_property(|| ("next", "Outbound".to_string()));
+                span.add_property(|| ("epoch", barrier.epoch.curr.to_string()));
+                span
+            };
         }
 
         tracing::error!(actor_id = self.id, "actor exit without stop barrier");

--- a/src/stream/src/executor/debug/trace.rs
+++ b/src/stream/src/executor/debug/trace.rs
@@ -17,8 +17,8 @@ use std::sync::Arc;
 use async_stack_trace::{SpanValue, StackTrace};
 use futures::{pin_mut, StreamExt};
 use futures_async_stream::try_stream;
+use minitrace::prelude::*;
 use tracing::event;
-use tracing_futures::Instrument;
 
 use crate::executor::error::StreamExecutorError;
 use crate::executor::monitor::StreamingMetrics;
@@ -45,17 +45,16 @@ pub async fn trace(
     let executor_id_string = executor_id.to_string();
 
     let span = || {
-        tracing::trace_span!(
-            "next",
-            otel.name = span_name.as_str(),
-            next = info.identity.as_str(), // For the upstream trace pipe, its output is our input.
-            input_pos = input_pos,
-        )
+        let mut span = Span::enter_with_local_parent("next");
+        span.add_property(|| ("otel.name", span_name.to_string()));
+        span.add_property(|| ("next", info.identity.to_string()));
+        span.add_property(|| ("input_pos", input_pos.to_string()));
+        span
     };
 
     pin_mut!(input);
 
-    while let Some(message) = input.next().instrument(span()).await.transpose()? {
+    while let Some(message) = input.next().in_span(span()).await.transpose()? {
         if let Message::Chunk(chunk) = &message {
             if chunk.cardinality() > 0 {
                 if ENABLE_EXECUTOR_ROW_COUNT {

--- a/src/stream/src/task/stream_manager.rs
+++ b/src/stream/src/task/stream_manager.rs
@@ -289,7 +289,6 @@ impl LocalStreamManager {
         let barrier = &Barrier {
             epoch,
             mutation: Some(Arc::new(Mutation::Stop(actor_ids_to_collect.clone()))),
-            span: tracing::Span::none(),
         };
 
         self.send_barrier(barrier, actor_ids_to_send, actor_ids_to_collect)?;


### PR DESCRIPTION
Signed-off-by: Alex Chi <iskyzh@gmail.com>

I hereby agree to the terms of the [Singularity Data, Inc. Contributor License Agreement](https://gist.github.com/skyzh/0663682a70b0edde7ae991492f2314cb#file-s9y_cla).

## What's changed and what's your intention?

This is the first PR in series to enable minitrace and find slow requests using minitrace. We replace all tokio tracing spans with minitrace. As currently we don't specify a root span, all those spans are no-op and won't do any actual work.

## Checklist

- [x] I have written necessary rustdoc comments
- [x] I have added necessary unit tests and integration tests
- [x] All checks passed in `./risedev check` (or alias, `./risedev c`)

## Documentation

If your pull request contains user-facing changes, please specify the types of the changes, and create a release note. Otherwise, please feel free to remove this section.

### Types of user-facing changes

Please keep the types that apply to your changes, and remove those that do not apply.

* Installation and deployment 
* Connector (sources & sinks)
* SQL commands, functions, and operators
* RisingWave cluster configuration changes
* Other (please specify in the release note below)

### Release note

Please create a release note for your changes. In the release note, focus on the impact on users, and mention the environment or conditions where the impact may occur.

## Refer to a related PR or issue link (optional)

Part of https://github.com/singularity-data/risingwave/issues/4120