### PR TITLE
feat(batch): abort task when failed

### DIFF
--- a/src/frontend/src/scheduler/distributed/stage.rs
+++ b/src/frontend/src/scheduler/distributed/stage.rs
@@ -212,14 +212,12 @@ impl StageExecution {
         }
 
         // Send message to tell Stage Runner stop.
-        let shutdown_tx = self
-            .shutdown_rx
-            .write()
-            .await
-            .take()
-            .expect("Only expect to stop once");
-        if shutdown_tx.send(StageMessage::Stop).is_err() {
-            // The stage runner handle has already closed. so do no-op.
+        if let Some(shutdown_tx) = self.shutdown_rx.write().await.take() {
+            // It's possible that the stage has not been scheduled, so the channel sender is
+            // None.
+            if shutdown_tx.send(StageMessage::Stop).is_err() {
+                // The stage runner handle has already closed. so do no-op.
+            }
         }
     }
 

--- a/src/frontend/src/scheduler/distributed/stage.rs
+++ b/src/frontend/src/scheduler/distributed/stage.rs
@@ -19,8 +19,8 @@ use std::sync::Arc;
 use anyhow::anyhow;
 use arc_swap::ArcSwap;
 use futures::{stream, StreamExt};
-use futures_async_stream::for_await;
 use itertools::Itertools;
+use risingwave_common::util::addr::HostAddr;
 use risingwave_common::util::select_all;
 use risingwave_pb::batch_plan::plan_node::NodeBody;
 use risingwave_pb::batch_plan::{
@@ -28,12 +28,11 @@ use risingwave_pb::batch_plan::{
     TaskId as TaskIdProst, TaskOutputId,
 };
 use risingwave_pb::common::{HostAddress, WorkerNode};
-use risingwave_pb::task_service::TaskInfoResponse;
+use risingwave_pb::task_service::{AbortTaskRequest, TaskInfoResponse};
 use risingwave_rpc_client::ComputeClientPoolRef;
 use tokio::spawn;
-use tokio::sync::mpsc::{channel, Receiver, Sender};
-use tokio::sync::RwLock;
-use tokio::task::JoinHandle;
+use tokio::sync::mpsc::Sender;
+use tokio::sync::{oneshot, RwLock};
 use tonic::Streaming;
 use tracing::error;
 use uuid::Uuid;
@@ -53,14 +52,8 @@ const TASK_SCHEDULING_PARALLELISM: usize = 10;
 
 enum StageState {
     Pending,
-    Started {
-        sender: Sender<StageMessage>,
-        handle: JoinHandle<SchedulerResult<()>>,
-    },
-    Running {
-        _sender: Sender<StageMessage>,
-        _handle: JoinHandle<SchedulerResult<()>>,
-    },
+    Started,
+    Running,
     Completed,
     Failed,
 }
@@ -99,7 +92,7 @@ pub struct StageExecution {
     tasks: Arc<HashMap<TaskId, TaskStatusHolder>>,
     state: Arc<RwLock<StageState>>,
     msg_sender: Sender<QueryMessage>,
-
+    shutdown_rx: RwLock<Option<oneshot::Sender<StageMessage>>>,
     /// Children stage executions.
     ///
     /// We use `Vec` here since children's size is usually small.
@@ -113,7 +106,6 @@ struct StageRunner {
     stage: QueryStageRef,
     worker_node_manager: WorkerNodeManagerRef,
     tasks: Arc<HashMap<TaskId, TaskStatusHolder>>,
-    _receiver: Receiver<StageMessage>,
     // Send message to `QueryRunner` to notify stage state change.
     msg_sender: Sender<QueryMessage>,
     children: Vec<Arc<StageExecution>>,
@@ -156,6 +148,7 @@ impl StageExecution {
             worker_node_manager,
             tasks: Arc::new(tasks),
             state: Arc::new(RwLock::new(Pending)),
+            shutdown_rx: RwLock::new(None),
             msg_sender,
             children,
             compute_client_pool,
@@ -167,20 +160,25 @@ impl StageExecution {
         let mut s = self.state.write().await;
         match &*s {
             &StageState::Pending => {
-                let (sender, receiver) = channel(100);
                 let runner = StageRunner {
                     epoch: self.epoch,
                     stage: self.stage.clone(),
                     worker_node_manager: self.worker_node_manager.clone(),
                     tasks: self.tasks.clone(),
-                    _receiver: receiver,
                     msg_sender: self.msg_sender.clone(),
                     children: self.children.clone(),
                     state: self.state.clone(),
                     compute_client_pool: self.compute_client_pool.clone(),
                 };
-                let handle = spawn(async move {
-                    if let Err(e) = runner.run().await {
+
+                // The channel used for shutdown signal messaging.
+                let (sender, receiver) = oneshot::channel();
+                // Fill the shutdown sender.
+                let mut holder = self.shutdown_rx.write().await;
+                *holder = Some(sender);
+
+                spawn(async move {
+                    if let Err(e) = runner.run(receiver).await {
                         error!("Stage failed: {:?}", e);
                         Err(e)
                     } else {
@@ -189,7 +187,7 @@ impl StageExecution {
                 });
 
                 // TODO: Should change state before spawn task.
-                *s = StageState::Started { sender, handle };
+                *s = StageState::Started;
                 Ok(())
             }
             _ => {
@@ -205,9 +203,24 @@ impl StageExecution {
         }
     }
 
-    #[expect(clippy::unused_async)]
-    pub async fn stop(&self) -> SchedulerResult<()> {
-        todo!()
+    pub async fn stop(&self) {
+        // Set state to failed.
+        {
+            let mut state = self.state.write().await;
+            // FIXME: Be careful for state jump back.
+            *state = StageState::Failed
+        }
+
+        // Send message to tell Stage Runner stop.
+        let shutdown_tx = self
+            .shutdown_rx
+            .write()
+            .await
+            .take()
+            .expect("Only expect to stop once");
+        if shutdown_tx.send(StageMessage::Stop).is_err() {
+            // The stage runner handle has already closed. so do no-op.
+        }
     }
 
     pub async fn is_scheduled(&self) -> bool {
@@ -249,8 +262,8 @@ impl StageExecution {
 }
 
 impl StageRunner {
-    async fn run(self) -> SchedulerResult<()> {
-        if let Err(e) = self.schedule_tasks().await {
+    async fn run(mut self, shutdown_tx: oneshot::Receiver<StageMessage>) -> SchedulerResult<()> {
+        if let Err(e) = self.schedule_tasks(shutdown_tx).await {
             error!(
                 "Stage {:?}-{:?} failed to schedule tasks, error: {:?}",
                 self.stage.query_id, self.stage.id, e
@@ -281,7 +294,10 @@ impl StageRunner {
 
     /// Schedule all tasks to CN and wait process all status messages from RPC. Note that when all
     /// task is created, it should tell `QueryRunner` to schedule next.
-    async fn schedule_tasks(&self) -> SchedulerResult<()> {
+    async fn schedule_tasks(
+        &mut self,
+        shutdown_tx: oneshot::Receiver<StageMessage>,
+    ) -> SchedulerResult<()> {
         let mut futures = vec![];
 
         if let Some(table_scan_info) = self.stage.table_scan_info.as_ref() && let Some(vnode_bitmaps) = table_scan_info.partitions.as_ref() {
@@ -327,38 +343,62 @@ impl StageRunner {
         }
 
         // Merge different task streams into a single stream.
-        let all_streams = select_all(buffered_streams);
+        let mut all_streams = select_all(buffered_streams);
 
         // Process the stream until finished.
         let mut running_task_cnt = 0;
         let mut sent_signal_to_next = false;
-        #[for_await]
-        for status_res in all_streams {
-            // The status can be Running, Finished, Failed etc. This stream contains status from
-            // different tasks.
-            let status = status_res.map_err(|e| RpcError(e.into()))?;
-            use risingwave_pb::task_service::task_info::TaskStatus as TaskStatusProst;
-            if TaskStatusProst::from_i32(status.task_info.as_ref().unwrap().task_status)
-                == Some(TaskStatusProst::Running)
-            {
-                running_task_cnt += 1;
-                // The task running count should always less or equal than the registered tasks
-                // number.
-                assert!(running_task_cnt <= self.tasks.keys().len());
-                // All tasks in this stage have been scheduled. Notify query runner to schedule next
-                // stage.
-                if running_task_cnt == self.tasks.keys().len() {
-                    self.notify_schedule_next_stage().await?;
-                    sent_signal_to_next = true;
+        let mut shutdown_tx = shutdown_tx;
+        // This loop will stops once receive a stop message, otherwise keep processing status
+        // message.
+        loop {
+            tokio::select! {
+                    biased;
+                    _ = &mut shutdown_tx => {
+                    // Received shutdown signal from query runner, should send abort RPC to all CNs.
+                    // change state to aborted. Note that the task cancel can only happen after schedule all these tasks to CN.
+                    // This can be an optimization for future: How to stop before schedule tasks.
+                    self.abort_all_running_tasks().await?;
+                    break;
                 }
+                status_res = all_streams.next() => {
+                        if let Some(stauts_res_inner) = status_res {
+                            // The status can be Running, Finished, Failed etc. This stream contains status from
+                            // different tasks.
+                            let status = stauts_res_inner.map_err(|e| RpcError(e.into()))?;
+                            use risingwave_pb::task_service::task_info::TaskStatus as TaskStatusProst;
+                            if TaskStatusProst::from_i32(status.task_info.as_ref().unwrap().task_status)
+                                == Some(TaskStatusProst::Running)
+                            {
+                                running_task_cnt += 1;
+                                // The task running count should always less or equal than the registered tasks
+                                // number.
+                                assert!(running_task_cnt <= self.tasks.keys().len());
+                                // All tasks in this stage have been scheduled. Notify query runner to schedule next
+                                // stage.
+                                if running_task_cnt == self.tasks.keys().len() {
+                                    self.notify_schedule_next_stage().await?;
+                                    sent_signal_to_next = true;
+                                }
+                            }
 
-                // TODO: handle task failure.
+                            // If receive task failure, report to query runner and also cancel
+                            if TaskStatusProst::from_i32(status.task_info.as_ref().unwrap().task_status) == Some(TaskStatusProst::Failed) {
+                                let task_execution_err = SchedulerError::TaskExecutionError;
+                                self.send_event(QueryMessage::Stage(StageEvent::Failed {id: self.stage.id, reason: task_execution_err})).await?;
+                                // Abort all tasks and break.
+                                self.abort_all_running_tasks().await?;
+                                break;
+                        }
+                         } else {
+                        // After processing all stream status, we must have sent signal (Either Scheduled or
+                        // Failed) to Query Runner. If this is not true, query runner will stuck cuz it do not receive any signals.
+                        assert!(sent_signal_to_next);
+                        break;
+                    }
+                }
             }
         }
-
-        // After processing all stream status, we must have sent signal (Either Scheduled or
-        // Failed) to Query Runner.
-        assert!(sent_signal_to_next);
         Ok(())
     }
 
@@ -369,17 +409,53 @@ impl StageRunner {
             // Changing state
             let mut s = self.state.write().await;
             match mem::replace(&mut *s, StageState::Failed) {
-                StageState::Started { sender, handle } => {
-                    *s = StageState::Running {
-                        _sender: sender,
-                        _handle: handle,
-                    };
+                StageState::Started => {
+                    *s = StageState::Running;
                 }
                 _ => unreachable!(),
             }
         }
         self.send_event(QueryMessage::Stage(StageEvent::Scheduled(self.stage.id)))
             .await
+    }
+
+    /// Abort all registered tasks. Note that here we do not care which part of tasks has already
+    /// failed or completed, cuz the abort task will not fail if the task has already die.
+    /// See PR (#4560).
+    async fn abort_all_running_tasks(&self) -> SchedulerResult<()> {
+        for (task, task_status) in self.tasks.iter() {
+            // 1. Collect task info and client.
+            let loc = &task_status.get_status().location;
+            let addr = loc.as_ref().expect("Get address should not fail");
+            let client = self
+                .compute_client_pool
+                .get_by_addr(HostAddr::from(addr))
+                .await
+                .map_err(|e| anyhow!(e))?;
+
+            // 2. Send RPC to each compute node for each task asynchronously.
+            let query_id = self.stage.query_id.id.clone();
+            let stage_id = self.stage.id;
+            let task_id = *task;
+            tokio::spawn(async move {
+                if let Err(e) = client
+                    .abort(AbortTaskRequest {
+                        task_id: Some(risingwave_pb::batch_plan::TaskId {
+                            query_id: query_id.clone(),
+                            stage_id,
+                            task_id,
+                        }),
+                    })
+                    .await
+                {
+                    error!(
+                        "Abort task failed, task_id: {}, stage_id: {}, query_id: {}, reason: {}",
+                        task_id, stage_id, query_id, e
+                    );
+                };
+            });
+        }
+        Ok(())
     }
 
     async fn schedule_task(

--- a/src/frontend/src/scheduler/error.rs
+++ b/src/frontend/src/scheduler/error.rs
@@ -32,6 +32,9 @@ pub enum SchedulerError {
     #[error("Empty workers found")]
     EmptyWorkerNodes,
 
+    #[error("Task fail")]
+    TaskExecutionError,
+
     #[error(transparent)]
     Internal(#[from] anyhow::Error),
 }

--- a/src/rpc_client/src/compute_client.rs
+++ b/src/rpc_client/src/compute_client.rs
@@ -22,8 +22,8 @@ use risingwave_pb::batch_plan::{PlanFragment, TaskId, TaskOutputId};
 use risingwave_pb::task_service::exchange_service_client::ExchangeServiceClient;
 use risingwave_pb::task_service::task_service_client::TaskServiceClient;
 use risingwave_pb::task_service::{
-    CreateTaskRequest, ExecuteRequest, GetDataRequest, GetDataResponse, GetStreamRequest,
-    GetStreamResponse, TaskInfoResponse,
+    AbortTaskRequest, AbortTaskResponse, CreateTaskRequest, ExecuteRequest, GetDataRequest,
+    GetDataResponse, GetStreamRequest, GetStreamResponse, TaskInfoResponse,
 };
 use tonic::transport::{Channel, Endpoint};
 use tonic::Streaming;
@@ -117,6 +117,15 @@ impl ComputeClient {
 
     pub async fn execute(&self, req: ExecuteRequest) -> Result<Streaming<GetDataResponse>> {
         Ok(self.task_client.to_owned().execute(req).await?.into_inner())
+    }
+
+    pub async fn abort(&self, req: AbortTaskRequest) -> Result<AbortTaskResponse> {
+        Ok(self
+            .task_client
+            .to_owned()
+            .abort_task(req)
+            .await?
+            .into_inner())
     }
 }
 


### PR DESCRIPTION
I hereby agree to the terms of the [Singularity Data, Inc. Contributor License Agreement](https://gist.github.com/skyzh/0663682a70b0edde7ae991492f2314cb#file-s9y_cla).

## What's changed and what's your intention?

* Add a shutdown channel to control task abort
* The test in basic.slt.part `values(CAST('abc' AS BOOLEAN))` is a test case we can observe. It shows that it is indeed being called `abort_task`

## Checklist

- [x] I have written necessary rustdoc comments
- [x] I have added necessary unit tests and integration tests
- [x] All checks passed in `./risedev check` (or alias, `./risedev c`)

## Documentation

If your pull request contains user-facing changes, please specify the types of the changes, and create a release note. Otherwise, please feel free to remove this section.

### Types of user-facing changes

Please keep the types that apply to your changes, and remove those that do not apply.

* Installation and deployment 
* Connector (sources & sinks)
* SQL commands, functions, and operators
* RisingWave cluster configuration changes
* Other (please specify in the release note below)

### Release note

Please create a release note for your changes. In the release note, focus on the impact on users, and mention the environment or conditions where the impact may occur.

## Refer to a related PR or issue link (optional)
