### PR TITLE
refactor(stream): extract `iter_state_table` function

### DIFF
--- a/src/storage/src/table/state_table.rs
+++ b/src/storage/src/table/state_table.rs
@@ -226,6 +226,8 @@ impl<S: StateStore, RS: RowSerde> StateTableBase<S, RS> {
 
 pub type RowStream<'a, S: StateStore, RS: RowSerde> =
     impl Stream<Item = StorageResult<Cow<'a, Row>>>;
+pub type RowBasedRowStream<'a, S> = RowStream<'a, S, RowBasedSerde>;
+
 struct StateTableRowIter<'a, M, C> {
     mem_table_iter: M,
     storage_table_iter: C,

--- a/src/stream/src/executor/managed_state/aggregation/extreme.rs
+++ b/src/stream/src/executor/managed_state/aggregation/extreme.rs
@@ -30,6 +30,7 @@ use smallvec::SmallVec;
 
 use crate::executor::aggregation::{AggArgs, AggCall};
 use crate::executor::error::StreamExecutorResult;
+use crate::executor::managed_state::iter_state_table;
 use crate::executor::PkDataTypes;
 
 pub type ManagedMinState<S, A> = GenericExtremeState<S, A, { variants::EXTREME_MIN }>;
@@ -305,11 +306,8 @@ where
             // To future developers: please make **SURE** you have taken `EXTREME_TYPE` into
             // account. EXTREME_MIN and EXTREME_MAX will significantly impact the
             // following logic.
-            let all_data_iter = if let Some(group_key) = self.group_key.as_ref() {
-                state_table.iter_with_pk_prefix(group_key, epoch).await?
-            } else {
-                state_table.iter(epoch).await?
-            };
+            let all_data_iter =
+                iter_state_table(state_table, epoch, self.group_key.as_ref()).await?;
             pin_mut!(all_data_iter);
 
             for _ in 0..self.top_n_count.unwrap_or(usize::MAX) {

--- a/src/stream/src/executor/managed_state/mod.rs
+++ b/src/stream/src/executor/managed_state/mod.rs
@@ -16,3 +16,21 @@ pub mod aggregation;
 pub mod dynamic_filter;
 pub mod join;
 pub mod top_n;
+
+use risingwave_common::array::Row;
+use risingwave_storage::table::state_table::{RowBasedRowStream, RowBasedStateTable};
+use risingwave_storage::StateStore;
+
+use crate::executor::StreamExecutorResult;
+
+pub async fn iter_state_table<'a, S: StateStore>(
+    state_table: &'a RowBasedStateTable<S>,
+    epoch: u64,
+    prefix: Option<&'a Row>,
+) -> StreamExecutorResult<RowBasedRowStream<'a, S>> {
+    Ok(if let Some(group_key) = prefix {
+        state_table.iter_with_pk_prefix(group_key, epoch).await?
+    } else {
+        state_table.iter(epoch).await?
+    })
+}


### PR DESCRIPTION
Signed-off-by: Richard Chien <stdrc@outlook.com>

I hereby agree to the terms of the [Singularity Data, Inc. Contributor License Agreement](https://gist.github.com/skyzh/0663682a70b0edde7ae991492f2314cb#file-s9y_cla).

## What's changed and what's your intention?

This PR extracts the creation of iterator on state table with/without pk prefix as a function, to improve code reuse.

This is part of the refactoring of managed agg state.

## Checklist

- [x] I have written necessary rustdoc comments
- [x] I have added necessary unit tests and integration tests
- [x] All checks passed in `./risedev check` (or alias, `./risedev c`)