### PR TITLE
refactor(stream,agg): add `StateTableColumnMapping` to convert column indices

### DIFF
--- a/src/stream/src/common/column_mapping.rs
+++ b/src/stream/src/common/column_mapping.rs
@@ -46,7 +46,7 @@ impl StateTableColumnMapping {
     }
 
     /// Return the number of columns in the mapping.
-    pub fn size(&self) -> usize {
+    pub fn len(&self) -> usize {
         self.upstream_columns.len()
     }
 
@@ -73,7 +73,7 @@ mod tests {
         assert_eq!(mapping.upstream_to_state_table(0), Some(2));
         assert_eq!(mapping.upstream_to_state_table(1), Some(3));
         assert_eq!(mapping.upstream_to_state_table(4), None);
-        assert_eq!(mapping.size(), 4);
+        assert_eq!(mapping.len(), 4);
         assert_eq!(mapping.upstream_columns(), &[2, 3, 0, 1]);
     }
 }

--- a/src/stream/src/common/column_mapping.rs
+++ b/src/stream/src/common/column_mapping.rs
@@ -1,0 +1,79 @@
+// Copyright 2022 Singularity Data
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::collections::HashMap;
+
+pub struct StateTableColumnMapping {
+    /// index: state table column index, value: upstream column index
+    upstream_columns: Vec<usize>,
+    /// key: upstream column index, value: state table column index
+    mapping: HashMap<usize, usize>,
+}
+
+impl StateTableColumnMapping {
+    /// Creates a new column mapping with the upstream columns included in state table.
+    pub fn new(upstream_columns: Vec<usize>) -> Self {
+        let mapping = upstream_columns
+            .iter()
+            .enumerate()
+            .map(|(i, col_idx)| (*col_idx, i))
+            .collect();
+        Self {
+            upstream_columns,
+            mapping,
+        }
+    }
+
+    /// Convert state table column index to upstream chunk column index.
+    pub fn state_table_to_upstream(&self, idx: usize) -> Option<usize> {
+        self.upstream_columns.get(idx).copied()
+    }
+
+    /// Convert upstream chunk column index to state table column index.
+    pub fn upstream_to_state_table(&self, idx: usize) -> Option<usize> {
+        self.mapping.get(&idx).copied()
+    }
+
+    /// Return the number of columns in the mapping.
+    pub fn size(&self) -> usize {
+        self.upstream_columns.len()
+    }
+
+    /// Return slice of all upstream columns.
+    pub fn upstream_columns(&self) -> &[usize] {
+        &self.upstream_columns
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_column_mapping() {
+        let mapping = StateTableColumnMapping::new(vec![2, 3, 0, 1]);
+        assert_eq!(mapping.state_table_to_upstream(0), Some(2));
+        assert_eq!(mapping.state_table_to_upstream(1), Some(3));
+        assert_eq!(mapping.state_table_to_upstream(2), Some(0));
+        assert_eq!(mapping.state_table_to_upstream(3), Some(1));
+        assert_eq!(mapping.state_table_to_upstream(4), None);
+        assert_eq!(mapping.upstream_to_state_table(2), Some(0));
+        assert_eq!(mapping.upstream_to_state_table(3), Some(1));
+        assert_eq!(mapping.upstream_to_state_table(0), Some(2));
+        assert_eq!(mapping.upstream_to_state_table(1), Some(3));
+        assert_eq!(mapping.upstream_to_state_table(4), None);
+        assert_eq!(mapping.size(), 4);
+        assert_eq!(mapping.upstream_columns(), &[2, 3, 0, 1]);
+    }
+}

--- a/src/stream/src/common/column_mapping.rs
+++ b/src/stream/src/common/column_mapping.rs
@@ -46,6 +46,7 @@ impl StateTableColumnMapping {
     }
 
     /// Return the number of columns in the mapping.
+    #[expect(clippy::len_without_is_empty)]
     pub fn len(&self) -> usize {
         self.upstream_columns.len()
     }

--- a/src/stream/src/common/mod.rs
+++ b/src/stream/src/common/mod.rs
@@ -14,3 +14,6 @@
 
 mod builder;
 pub use builder::*;
+
+mod column_mapping;
+pub use column_mapping::*;

--- a/src/stream/src/executor/aggregation/mod.rs
+++ b/src/stream/src/executor/aggregation/mod.rs
@@ -40,6 +40,7 @@ pub use row_count::*;
 use static_assertions::const_assert_eq;
 
 use super::PkIndices;
+use crate::common::StateTableColumnMapping;
 use crate::executor::aggregation::approx_count_distinct::StreamingApproxCountDistinct;
 use crate::executor::aggregation::single_value::StreamingSingleValueAgg;
 use crate::executor::error::{StreamExecutorError, StreamExecutorResult};
@@ -358,7 +359,7 @@ pub async fn generate_managed_agg_state<S: StateStore>(
     epoch: u64,
     key_hash_code: Option<HashCode>,
     state_tables: &[RowBasedStateTable<S>],
-    state_table_col_mappings: &[Vec<usize>],
+    state_table_col_mappings: &[Arc<StateTableColumnMapping>],
 ) -> StreamExecutorResult<AggState<S>> {
     let mut managed_states = vec![];
 

--- a/src/stream/src/executor/hash_agg.rs
+++ b/src/stream/src/executor/hash_agg.rs
@@ -36,6 +36,7 @@ use super::{
     expect_first_barrier, pk_input_arrays, Executor, PkDataTypes, PkIndicesRef,
     StreamExecutorResult,
 };
+use crate::common::StateTableColumnMapping;
 use crate::executor::aggregation::{
     agg_input_arrays, generate_agg_schema, generate_managed_agg_state, AggCall, AggState,
 };
@@ -83,8 +84,11 @@ struct HashAggExecutorExtra<S: StateStore> {
     /// all of the aggregation functions in this executor should depend on same group of keys
     key_indices: Vec<usize>,
 
+    /// Relational state tables for each aggregation calls.
     state_tables: Vec<RowBasedStateTable<S>>,
-    state_table_col_mappings: Vec<Vec<usize>>,
+
+    /// State table column mappings for each aggregation calls,
+    state_table_col_mappings: Vec<Arc<StateTableColumnMapping>>,
 }
 
 impl<K: HashKey, S: StateStore> Executor for HashAggExecutor<K, S> {
@@ -134,7 +138,11 @@ impl<K: HashKey, S: StateStore> HashAggExecutor<K, S> {
                 agg_calls,
                 key_indices,
                 state_tables,
-                state_table_col_mappings,
+                state_table_col_mappings: state_table_col_mappings
+                    .into_iter()
+                    .map(StateTableColumnMapping::new)
+                    .map(Arc::new)
+                    .collect(),
             },
             _phantom: PhantomData,
         })

--- a/src/stream/src/executor/managed_state/aggregation/mod.rs
+++ b/src/stream/src/executor/managed_state/aggregation/mod.rs
@@ -14,6 +14,8 @@
 
 //! Aggregators with state store support
 
+use std::sync::Arc;
+
 pub use extreme::*;
 use risingwave_common::array::stream_chunk::Ops;
 use risingwave_common::array::{ArrayImpl, Row};
@@ -25,6 +27,7 @@ use risingwave_storage::table::state_table::RowBasedStateTable;
 use risingwave_storage::StateStore;
 pub use value::*;
 
+use crate::common::StateTableColumnMapping;
 use crate::executor::aggregation::AggCall;
 use crate::executor::error::StreamExecutorResult;
 use crate::executor::managed_state::aggregation::string_agg::ManagedStringAggState;
@@ -119,7 +122,7 @@ impl<S: StateStore> ManagedStateImpl<S> {
         key_hash_code: Option<HashCode>,
         pk: Option<&Row>,
         state_table: &RowBasedStateTable<S>,
-        state_table_col_indices: Vec<usize>,
+        state_table_col_mapping: Arc<StateTableColumnMapping>,
     ) -> StreamExecutorResult<Self> {
         match agg_call.kind {
             AggKind::Max | AggKind::Min => {
@@ -149,8 +152,8 @@ impl<S: StateStore> ManagedStateImpl<S> {
                 agg_call,
                 pk,
                 pk_indices,
-                state_table_col_indices,
-            )?))),
+                state_table_col_mapping,
+            )))),
             // TODO: for append-only lists, we can create `ManagedValueState` instead of
             // `ManagedExtremeState`.
             AggKind::Avg | AggKind::Count | AggKind::Sum | AggKind::ApproxCountDistinct => {

--- a/src/stream/src/executor/managed_state/aggregation/string_agg.rs
+++ b/src/stream/src/executor/managed_state/aggregation/string_agg.rs
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use std::collections::{BTreeSet, HashMap};
+use std::collections::BTreeSet;
 use std::marker::PhantomData;
 use std::sync::Arc;
 
@@ -29,13 +29,14 @@ use risingwave_storage::table::state_table::RowBasedStateTable;
 use risingwave_storage::StateStore;
 
 use super::ManagedTableState;
+use crate::common::StateTableColumnMapping;
 use crate::executor::aggregation::AggCall;
 use crate::executor::error::StreamExecutorResult;
 use crate::executor::PkIndices;
 
 #[derive(Debug)]
 struct Cache {
-    synced: bool, // `false` means not synced from state table (cold start)
+    synced: bool, // `false` means not synced with state table (cold start)
     order_pairs: Arc<Vec<OrderPair>>, // order requirements used to sort cached rows
     rows: BTreeSet<DescOrderedRow>,
 }
@@ -59,15 +60,15 @@ impl Cache {
 
     fn insert(&mut self, row: Row) {
         if self.synced {
-            let orderable_row = DescOrderedRow::new(row, None, self.order_pairs.clone());
-            self.rows.insert(orderable_row);
+            let ordered_row = DescOrderedRow::new(row, None, self.order_pairs.clone());
+            self.rows.insert(ordered_row);
         }
     }
 
     fn remove(&mut self, row: Row) {
         if self.synced {
-            let orderable_row = DescOrderedRow::new(row, None, self.order_pairs.clone());
-            self.rows.remove(&orderable_row);
+            let ordered_row = DescOrderedRow::new(row, None, self.order_pairs.clone());
+            self.rows.remove(&ordered_row);
         }
     }
 }
@@ -79,8 +80,8 @@ pub struct ManagedStringAggState<S: StateStore> {
     /// None for simple agg, Some for group key of hash agg.
     group_key: Option<Row>,
 
-    /// Contains the column indices in upstream schema that are selected into state table.
-    state_table_col_indices: Vec<usize>,
+    /// Contains the column mapping between upstream schema and state table.
+    state_table_col_mapping: Arc<StateTableColumnMapping>,
 
     /// The column to aggregate in state table.
     state_table_agg_col_idx: usize,
@@ -97,50 +98,44 @@ impl<S: StateStore> ManagedStringAggState<S> {
         agg_call: AggCall,
         group_key: Option<&Row>,
         pk_indices: PkIndices,
-        state_table_col_indices: Vec<usize>,
-    ) -> StreamExecutorResult<Self> {
-        // construct a hashmap from the selected columns in the state table
-        let col_mapping: HashMap<usize, usize> = state_table_col_indices
-            .iter()
-            .enumerate()
-            .map(|(i, col_idx)| (*col_idx, i))
-            .collect();
+        col_mapping: Arc<StateTableColumnMapping>,
+    ) -> Self {
         // map agg column to state table column index
-        let state_table_agg_col_idx = *col_mapping
-            .get(&agg_call.args.val_indices()[0])
+        let state_table_agg_col_idx = col_mapping
+            .upstream_to_state_table(agg_call.args.val_indices()[0])
             .expect("the column to be aggregate must appear in the state table");
-        let state_table_delim_col_idx = *col_mapping
-            .get(&agg_call.args.val_indices()[1])
+        let state_table_delim_col_idx = col_mapping
+            .upstream_to_state_table(agg_call.args.val_indices()[1])
             .expect("the column as delimiter must appear in the state table");
         // map order by columns to state table column indices
-        let order_pair = agg_call
+        let order_pairs = agg_call
             .order_pairs
             .iter()
             .map(|o| {
                 OrderPair::new(
-                    *col_mapping
-                        .get(&o.column_idx)
+                    col_mapping
+                        .upstream_to_state_table(o.column_idx)
                         .expect("the column to be order by must appear in the state table"),
                     o.order_type,
                 )
             })
             .chain(pk_indices.iter().map(|idx| {
                 OrderPair::new(
-                    *col_mapping
-                        .get(idx)
+                    col_mapping
+                        .upstream_to_state_table(*idx)
                         .expect("the pk columns must appear in the state table"),
                     OrderType::Ascending,
                 )
             }))
             .collect();
-        Ok(Self {
+        Self {
             _phantom_data: PhantomData,
             group_key: group_key.cloned(),
-            state_table_col_indices,
+            state_table_col_mapping: col_mapping,
             state_table_agg_col_idx,
             state_table_delim_col_idx,
-            cache: Cache::new(order_pair),
-        })
+            cache: Cache::new(order_pairs),
+        }
     }
 }
 
@@ -163,7 +158,8 @@ impl<S: StateStore> ManagedTableState<S> for ManagedStringAggState<S> {
             }
 
             let state_row = Row::new(
-                self.state_table_col_indices
+                self.state_table_col_mapping
+                    .upstream_columns()
                     .iter()
                     .map(|col_idx| chunk_cols[*col_idx].datum_at(i))
                     .collect(),
@@ -249,6 +245,8 @@ impl<S: StateStore> ManagedTableState<S> for ManagedStringAggState<S> {
 
 #[cfg(test)]
 mod tests {
+    use std::sync::Arc;
+
     use risingwave_common::array::{Row, StreamChunk, StreamChunkTestExt};
     use risingwave_common::catalog::{ColumnDesc, ColumnId, TableId};
     use risingwave_common::types::{DataType, ScalarImpl};
@@ -258,6 +256,7 @@ mod tests {
     use risingwave_storage::table::state_table::RowBasedStateTable;
 
     use super::ManagedStringAggState;
+    use crate::common::StateTableColumnMapping;
     use crate::executor::aggregation::{AggArgs, AggCall};
     use crate::executor::managed_state::aggregation::ManagedTableState;
     use crate::executor::StreamExecutorResult;
@@ -285,7 +284,7 @@ mod tests {
             ColumnDesc::unnamed(ColumnId::new(1), DataType::Varchar), // a
             ColumnDesc::unnamed(ColumnId::new(2), DataType::Varchar), // _delim
         ];
-        let state_table_col_indices = vec![4, 0, 1];
+        let state_table_col_mapping = Arc::new(StateTableColumnMapping::new(vec![4, 0, 1]));
         let mut state_table = RowBasedStateTable::new_without_distribution(
             MemoryStateStore::new(),
             table_id,
@@ -295,7 +294,7 @@ mod tests {
         );
 
         let mut agg_state =
-            ManagedStringAggState::new(agg_call, None, input_pk_indices, state_table_col_indices)?;
+            ManagedStringAggState::new(agg_call, None, input_pk_indices, state_table_col_mapping);
 
         let mut epoch = 0;
 
@@ -362,7 +361,7 @@ mod tests {
             ColumnDesc::unnamed(ColumnId::new(2), DataType::Int64), // _row_id
             ColumnDesc::unnamed(ColumnId::new(3), DataType::Varchar), // _delim
         ];
-        let state_table_col_indices = vec![2, 0, 4, 1];
+        let state_table_col_mapping = Arc::new(StateTableColumnMapping::new(vec![2, 0, 4, 1]));
         let mut state_table = RowBasedStateTable::new_without_distribution(
             MemoryStateStore::new(),
             table_id,
@@ -376,7 +375,7 @@ mod tests {
         );
 
         let mut agg_state =
-            ManagedStringAggState::new(agg_call, None, input_pk_indices, state_table_col_indices)?;
+            ManagedStringAggState::new(agg_call, None, input_pk_indices, state_table_col_mapping);
 
         let mut epoch = 0;
 
@@ -473,7 +472,7 @@ mod tests {
             ColumnDesc::unnamed(ColumnId::new(3), DataType::Varchar), // a
             ColumnDesc::unnamed(ColumnId::new(4), DataType::Varchar), // _delim
         ];
-        let state_table_col_indices = vec![3, 2, 4, 0, 1];
+        let state_table_col_mapping = Arc::new(StateTableColumnMapping::new(vec![3, 2, 4, 0, 1]));
         let mut state_table = RowBasedStateTable::new_without_distribution(
             MemoryStateStore::new(),
             table_id,
@@ -490,8 +489,8 @@ mod tests {
             agg_call,
             Some(&Row::new(vec![Some(8.into())])),
             input_pk_indices,
-            state_table_col_indices,
-        )?;
+            state_table_col_mapping,
+        );
 
         let mut epoch = 0;
 


### PR DESCRIPTION
I hereby agree to the terms of the [Singularity Data, Inc. Contributor License Agreement](https://gist.github.com/skyzh/0663682a70b0edde7ae991492f2314cb#file-s9y_cla).

## What's changed and what's your intention?

This PR adds a new `StateTableColumnMapping` to convert column indices between state table and input chunk. It's intended to be used in managed agg states to find columns they're interested in from state table and construct state table rows from input chunks.

This is part of the refactoring of managed agg states.

## Checklist

- [x] I have written necessary rustdoc comments
- [x] I have added necessary unit tests and integration tests
- [x] All checks passed in `./risedev check` (or alias, `./risedev c`)

## Refer to a related PR or issue link (optional)

#4185