### PR TITLE
feat(optimizer): support non-covering index selection

### DIFF
--- a/e2e_test/batch/basic/index.slt.part
+++ b/e2e_test/batch/basic/index.slt.part
@@ -8,18 +8,29 @@ statement ok
 create index idx1 on t1(v1) include(v2);
 
 statement ok
+create index idx2 on t1(v2);
+
+statement ok
 insert into t1 values(1, 2),(3,4),(5,6);
 
 statement ok
 explain select v1,v2 from t1 where v1 = 1;
 
-query III
+query II
 select v1,v2 from t1 where v1 = 1;
 ----
 1 2
 
+query II
+select v1,v2 from t1 where v2 = 4;
+----
+3 4
+
 statement ok
 drop index idx1;
+
+statement ok
+drop index idx2;
 
 statement ok
 drop table t1;

--- a/src/frontend/src/handler/mod.rs
+++ b/src/frontend/src/handler/mod.rs
@@ -48,7 +48,7 @@ pub mod privilege;
 pub mod query;
 mod show;
 pub mod util;
-mod variable;
+pub mod variable;
 
 pub async fn handle(
     session: Arc<SessionImpl>,

--- a/src/frontend/src/handler/variable.rs
+++ b/src/frontend/src/handler/variable.rs
@@ -20,7 +20,7 @@ use risingwave_sqlparser::ast::{Ident, SetVariableValue};
 
 use crate::session::OptimizerContext;
 
-pub(super) fn handle_set(
+pub fn handle_set(
     context: OptimizerContext,
     name: Ident,
     value: Vec<SetVariableValue>,

--- a/src/frontend/src/optimizer/rule/index_selection.rs
+++ b/src/frontend/src/optimizer/rule/index_selection.rs
@@ -129,11 +129,11 @@ impl Rule for IndexSelectionRule {
     }
 }
 
-struct Rewriter {
+struct IndexPredicateRewriter {
     p2s_mapping: HashMap<usize, usize>,
     offset: usize,
 }
-impl ExprRewriter for Rewriter {
+impl ExprRewriter for IndexPredicateRewriter {
     fn rewrite_input_ref(&mut self, input_ref: InputRef) -> ExprImpl {
         // transform primary predicate to index predicate if it can
         if self.p2s_mapping.contains_key(&input_ref.index) {
@@ -160,7 +160,7 @@ impl IndexSelectionRule {
         //                index_scan   primary_table_scan
         let predicate = logical_scan.predicate().clone();
         let offset = index.index_item.len();
-        let mut rewriter = Rewriter {
+        let mut rewriter = IndexPredicateRewriter {
             p2s_mapping,
             offset,
         };

--- a/src/frontend/src/optimizer/rule/index_selection.rs
+++ b/src/frontend/src/optimizer/rule/index_selection.rs
@@ -267,8 +267,7 @@ impl<'a> TableScanIoEstimator<'a> {
                             .map(|x| &table_desc.columns[x.column_idx]),
                     )
                     .map(|x| TableScanIoEstimator::estimate_data_type_size(&x.data_type))
-                    .reduce(|x, y| x + y)
-                    .unwrap(),
+                    .sum::<usize>(),
         }
     }
 

--- a/src/frontend/test_runner/src/lib.rs
+++ b/src/frontend/test_runner/src/lib.rs
@@ -25,7 +25,7 @@ use anyhow::{anyhow, Result};
 pub use resolve_id::*;
 use risingwave_frontend::handler::util::handle_with_properties;
 use risingwave_frontend::handler::{
-    create_index, create_mv, create_source, create_table, drop_table,
+    create_index, create_mv, create_source, create_table, drop_table, variable,
 };
 use risingwave_frontend::session::{OptimizerContext, OptimizerContextRef, SessionImpl};
 use risingwave_frontend::test_utils::{create_proto_file, LocalFrontend};
@@ -313,6 +313,13 @@ impl TestCase {
                 }
                 Statement::Drop(drop_statement) => {
                     drop_table::handle_drop_table(context, drop_statement.object_name).await?;
+                }
+                Statement::SetVariable {
+                    local: _,
+                    variable,
+                    value,
+                } => {
+                    variable::handle_set(context, variable, value).unwrap();
                 }
                 _ => return Err(anyhow!("Unsupported statement type")),
             }

--- a/src/frontend/test_runner/tests/testdata/index_selection.yaml
+++ b/src/frontend/test_runner/tests/testdata/index_selection.yaml
@@ -119,3 +119,51 @@
   batch_plan: |
     BatchExchange { order: [], dist: Single }
       BatchScan { table: idx2, columns: [idx2.a, idx2.b, idx2.c], scan_ranges: [idx2.b = Decimal(Normalized(2))], distribution: SomeShard }
+- sql: |
+    set rw_batch_enable_lookup_join=true;
+    set query_mode=local;
+    create table t1 (a int, b numeric, c bigint);
+    create index idx1 on t1(a);
+    create index idx2 on t1(b, a);
+    create index idx3 on t1(c);
+    select * from t1 where c = 1 and a < 10;
+  batch_local_plan: |
+    BatchLookupJoin { type: Inner, predicate: idx3.t1._row_id = t1._row_id AND (t1.a < 10:Int32), output: [t1.a, t1.b, t1.c] }
+      BatchExchange { order: [], dist: Single }
+        BatchScan { table: idx3, columns: [idx3.t1._row_id], scan_ranges: [idx3.c = Int64(1)], distribution: SomeShard }
+- sql: |
+    set rw_batch_enable_lookup_join=true;
+    set query_mode=local;
+    create table t1 (a int, b numeric, c bigint);
+    create index idx1 on t1(a);
+    create index idx2 on t1(b, a);
+    create index idx3 on t1(c);
+    select * from t1 where a = 1;
+  batch_local_plan: |
+    BatchLookupJoin { type: Inner, predicate: idx1.t1._row_id = t1._row_id, output: [t1.a, t1.b, t1.c] }
+      BatchExchange { order: [], dist: Single }
+        BatchScan { table: idx1, columns: [idx1.t1._row_id], scan_ranges: [idx1.a = Int32(1)], distribution: SomeShard }
+- sql: |
+    set rw_batch_enable_lookup_join=true;
+    set query_mode=local;
+    create table t1 (a int, b numeric, c bigint);
+    create index idx1 on t1(a);
+    create index idx2 on t1(b, a);
+    create index idx3 on t1(c);
+    select * from t1 where a = 1 and b = 2;
+  batch_local_plan: |
+    BatchLookupJoin { type: Inner, predicate: idx2.t1._row_id = t1._row_id, output: [t1.a, t1.b, t1.c] }
+      BatchExchange { order: [], dist: Single }
+        BatchScan { table: idx2, columns: [idx2.t1._row_id], scan_ranges: [idx2.b = Decimal(Normalized(2)), idx2.a = Int32(1)], distribution: SomeShard }
+- sql: |
+    set rw_batch_enable_lookup_join=true;
+    set query_mode=local;
+    create table t1 (a int, b numeric, c bigint);
+    create index idx1 on t1(a);
+    create index idx2 on t1(b, a);
+    create index idx3 on t1(c);
+    select * from t1 where b = 2;
+  batch_local_plan: |
+    BatchLookupJoin { type: Inner, predicate: idx2.t1._row_id = t1._row_id, output: [t1.a, t1.b, t1.c] }
+      BatchExchange { order: [], dist: Single }
+        BatchScan { table: idx2, columns: [idx2.t1._row_id], scan_ranges: [idx2.b = Decimal(Normalized(2))], distribution: SomeShard }


### PR DESCRIPTION
I hereby agree to the terms of the [Singularity Data, Inc. Contributor License Agreement](https://gist.github.com/skyzh/0663682a70b0edde7ae991492f2314cb#file-s9y_cla).

## What's changed and what's your intention?

- support non-covering index selection
- index lookup is logically equivalent to a logical join with an index scan as its left input and a primary table scan as its right input.
- index lookup cost is equal to the index cost of the index scan multiplying a constant value which simply is 3 currently.

## Checklist

- [x] I have written necessary rustdoc comments
- [x] I have added necessary unit tests and integration tests
- [x] All checks passed in `./risedev check` (or alias, `./risedev c`)

## Refer to a related PR or issue link (optional)
#4339
