### PR TITLE
refactor(expr): support string-to-interval casting

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5262,7 +5262,6 @@ dependencies = [
  "itertools",
  "log",
  "matches",
- "risingwave_common",
  "serde",
  "serde_json",
  "workspace-hack",

--- a/e2e_test/batch/types/interval.slt.part
+++ b/e2e_test/batch/types/interval.slt.part
@@ -34,6 +34,16 @@ SELECT interval '6 second';
 00:00:06
 
 query T
+SELECT '6'::interval;
+----
+00:00:06
+
+query T
+SELECT concat(5, 'minute')::interval;
+----
+00:05:00
+
+query T
 SELECT interval '1' month = interval '30' day;
 ----
 t

--- a/src/common/src/types/interval.rs
+++ b/src/common/src/types/interval.rs
@@ -272,7 +272,7 @@ impl IntervalUnit {
 }
 
 impl Serialize for IntervalUnit {
-    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
     where
         S: serde::Serializer,
     {
@@ -287,7 +287,7 @@ impl Serialize for IntervalUnit {
 }
 
 impl<'de> Deserialize<'de> for IntervalUnit {
-    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
     where
         D: serde::Deserializer<'de>,
     {

--- a/src/common/src/types/interval.rs
+++ b/src/common/src/types/interval.rs
@@ -26,6 +26,7 @@ use risingwave_pb::data::IntervalUnit as IntervalUnitProto;
 use smallvec::SmallVec;
 
 use super::*;
+use crate::error::{ErrorCode, Result, RwError};
 
 /// Every interval can be represented by a `IntervalUnit`.
 /// Note that the difference between Interval and Instant.
@@ -443,6 +444,155 @@ impl Display for IntervalUnit {
         }
         v.push(format_time);
         Display::fmt(&v.join(" "), f)
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub enum DateTimeField {
+    Year,
+    Month,
+    Day,
+    Hour,
+    Minute,
+    Second,
+}
+
+impl FromStr for DateTimeField {
+    type Err = RwError;
+
+    fn from_str(s: &str) -> Result<Self> {
+        match s.to_lowercase().as_str() {
+            "years" | "year" | "yrs" | "yr" | "y" => Ok(Self::Year),
+            "days" | "day" | "d" => Ok(Self::Day),
+            "hours" | "hour" | "hrs" | "hr" | "h" => Ok(Self::Hour),
+            "minutes" | "minute" | "mins" | "min" | "m" => Ok(Self::Minute),
+            "months" | "month" | "mons" | "mon" => Ok(Self::Month),
+            "seconds" | "second" | "secs" | "sec" | "s" => Ok(Self::Second),
+            _ => Err(ErrorCode::InvalidInputSyntax(format!("unknown unit {}", s)).into()),
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+enum TimeStrToken {
+    Num(i64),
+    TimeUnit(DateTimeField),
+}
+
+fn parse_interval(s: &str) -> Result<Vec<TimeStrToken>> {
+    let s = s.trim();
+    let mut tokens = Vec::new();
+    let mut num_buf = "".to_string();
+    let mut char_buf = "".to_string();
+    for (i, c) in s.chars().enumerate() {
+        match c {
+            '-' => {
+                num_buf.push(c);
+            }
+            c if c.is_ascii_digit() => {
+                convert_unit(&mut char_buf, &mut tokens)?;
+                num_buf.push(c);
+            }
+            c if c.is_ascii_alphabetic() => {
+                convert_digit(&mut num_buf, &mut tokens)?;
+                char_buf.push(c);
+            }
+            chr if chr.is_ascii_whitespace() => {
+                convert_unit(&mut char_buf, &mut tokens)?;
+                convert_digit(&mut num_buf, &mut tokens)?;
+            }
+            _ => {
+                return Err(ErrorCode::InvalidInputSyntax(format!(
+                    "Invalid character at offset {} in {}: {:?}. Only support digit or alphabetic now",
+                    i, s, c
+                )).into());
+            }
+        }
+    }
+    convert_digit(&mut num_buf, &mut tokens)?;
+    convert_unit(&mut char_buf, &mut tokens)?;
+
+    Ok(tokens)
+}
+
+fn convert_digit(c: &mut String, t: &mut Vec<TimeStrToken>) -> Result<()> {
+    if !c.is_empty() {
+        match c.parse::<i64>() {
+            Ok(num) => {
+                t.push(TimeStrToken::Num(num));
+            }
+            Err(_) => {
+                return Err(
+                    ErrorCode::InvalidInputSyntax(format!("Invalid interval: {}", c)).into(),
+                );
+            }
+        }
+        c.clear();
+    }
+    Ok(())
+}
+
+fn convert_unit(c: &mut String, t: &mut Vec<TimeStrToken>) -> Result<()> {
+    if !c.is_empty() {
+        t.push(TimeStrToken::TimeUnit(c.parse()?));
+        c.clear();
+    }
+    Ok(())
+}
+
+impl IntervalUnit {
+    pub fn parse_with_fields(s: &str, leading_field: Option<DateTimeField>) -> Result<Self> {
+        // > INTERVAL '1' means 1 second.
+        // https://www.postgresql.org/docs/current/datatype-datetime.html#DATATYPE-INTERVAL-INPUT
+        let unit = leading_field.unwrap_or(DateTimeField::Second);
+        use DateTimeField::*;
+        let tokens = parse_interval(s)?;
+        // Todo: support more syntax
+        if tokens.len() > 2 {
+            return Err(ErrorCode::InvalidInputSyntax(format!("Invalid interval {}.", &s)).into());
+        }
+        let num = match tokens.get(0) {
+            Some(TimeStrToken::Num(num)) => *num,
+            _ => {
+                return Err(
+                    ErrorCode::InvalidInputSyntax(format!("Invalid interval {}.", &s)).into(),
+                );
+            }
+        };
+        let interval_unit = match tokens.get(1) {
+            Some(TimeStrToken::TimeUnit(unit)) => unit,
+            _ => &unit,
+        };
+
+        (|| match interval_unit {
+            Year => {
+                let months = num.checked_mul(12)?;
+                Some(IntervalUnit::from_month(months as i32))
+            }
+            Month => Some(IntervalUnit::from_month(num as i32)),
+            Day => Some(IntervalUnit::from_days(num as i32)),
+            Hour => {
+                let ms = num.checked_mul(3600 * 1000)?;
+                Some(IntervalUnit::from_millis(ms))
+            }
+            Minute => {
+                let ms = num.checked_mul(60 * 1000)?;
+                Some(IntervalUnit::from_millis(ms))
+            }
+            Second => {
+                let ms = num.checked_mul(1000)?;
+                Some(IntervalUnit::from_millis(ms))
+            }
+        })()
+        .ok_or_else(|| ErrorCode::InvalidInputSyntax(format!("Invalid interval {}.", s)).into())
+    }
+}
+
+impl FromStr for IntervalUnit {
+    type Err = RwError;
+
+    fn from_str(s: &str) -> Result<Self> {
+        Self::parse_with_fields(s, None)
     }
 }
 

--- a/src/expr/src/expr/expr_unary.rs
+++ b/src/expr/src/expr/expr_unary.rs
@@ -75,6 +75,7 @@ macro_rules! gen_cast {
 
             { varchar, date, str_to_date },
             { varchar, time, str_to_time },
+            { varchar, interval, str_parse },
             { varchar, timestamp, str_to_timestamp },
             { varchar, timestampz, str_to_timestampz },
             { varchar, int16, str_parse },

--- a/src/frontend/src/binder/expr/value.rs
+++ b/src/frontend/src/binder/expr/value.rs
@@ -13,10 +13,10 @@
 // limitations under the License.
 
 use itertools::Itertools;
-use risingwave_common::error::{ErrorCode, Result, RwError};
-use risingwave_common::types::{DataType, Decimal, IntervalUnit, ScalarImpl};
+use risingwave_common::error::{ErrorCode, Result};
+use risingwave_common::types::{DataType, DateTimeField, Decimal, IntervalUnit, ScalarImpl};
 use risingwave_expr::vector_op::cast::str_parse;
-use risingwave_sqlparser::ast::{DateTimeField, Expr, Value};
+use risingwave_sqlparser::ast::{DateTimeField as AstDateTimeField, Expr, Value};
 
 use crate::binder::Binder;
 use crate::expr::{align_types, Expr as _, ExprImpl, ExprType, FunctionCall, Literal};
@@ -66,61 +66,25 @@ impl Binder {
     fn bind_interval(
         &mut self,
         s: String,
-        leading_field: Option<DateTimeField>,
+        leading_field: Option<AstDateTimeField>,
     ) -> Result<Literal> {
-        // > INTERVAL '1' means 1 second.
-        // https://www.postgresql.org/docs/current/datatype-datetime.html#DATATYPE-INTERVAL-INPUT
-        let unit = leading_field.unwrap_or(DateTimeField::Second);
-        use DateTimeField::*;
-        let tokens = parse_interval(&s)?;
-        // Todo: support more syntax
-        if tokens.len() > 2 {
-            return Err(ErrorCode::InvalidInputSyntax(format!("Invalid interval {}.", &s)).into());
-        }
-        let num = match tokens.get(0) {
-            Some(TimeStrToken::Num(num)) => *num,
-            _ => {
-                return Err(
-                    ErrorCode::InvalidInputSyntax(format!("Invalid interval {}.", &s)).into(),
-                );
-            }
-        };
-        let interval_unit = match tokens.get(1) {
-            Some(TimeStrToken::TimeUnit(unit)) => unit,
-            _ => &unit,
-        };
-
-        let interval = (|| match interval_unit {
-            Year => {
-                let months = num.checked_mul(12)?;
-                Some(IntervalUnit::from_month(months as i32))
-            }
-            Month => Some(IntervalUnit::from_month(num as i32)),
-            Day => Some(IntervalUnit::from_days(num as i32)),
-            Hour => {
-                let ms = num.checked_mul(3600 * 1000)?;
-                Some(IntervalUnit::from_millis(ms))
-            }
-            Minute => {
-                let ms = num.checked_mul(60 * 1000)?;
-                Some(IntervalUnit::from_millis(ms))
-            }
-            Second => {
-                let ms = num.checked_mul(1000)?;
-                Some(IntervalUnit::from_millis(ms))
-            }
-        })()
-        .ok_or_else(|| {
-            RwError::from(ErrorCode::InvalidInputSyntax(format!(
-                "Invalid interval {}.",
-                s
-            )))
-        })?;
-
+        let interval =
+            IntervalUnit::parse_with_fields(&s, leading_field.map(Self::bind_date_time_field))?;
         let datum = Some(ScalarImpl::Interval(interval));
         let literal = Literal::new(datum, DataType::Interval);
 
         Ok(literal)
+    }
+
+    fn bind_date_time_field(field: AstDateTimeField) -> DateTimeField {
+        match field {
+            AstDateTimeField::Year => DateTimeField::Year,
+            AstDateTimeField::Month => DateTimeField::Month,
+            AstDateTimeField::Day => DateTimeField::Day,
+            AstDateTimeField::Hour => DateTimeField::Hour,
+            AstDateTimeField::Minute => DateTimeField::Minute,
+            AstDateTimeField::Second => DateTimeField::Second,
+        }
     }
 
     /// `ARRAY[...]` is represented as an function call at the binder stage.
@@ -173,73 +137,6 @@ impl Binder {
         let expr: ExprImpl = FunctionCall::new_unchecked(ExprType::Row, exprs, data_type).into();
         Ok(expr)
     }
-}
-
-#[derive(Debug, Clone, PartialEq, Eq, Hash)]
-pub enum TimeStrToken {
-    Num(i64),
-    TimeUnit(DateTimeField),
-}
-
-fn convert_digit(c: &mut String, t: &mut Vec<TimeStrToken>) -> Result<()> {
-    if !c.is_empty() {
-        match c.parse::<i64>() {
-            Ok(num) => {
-                t.push(TimeStrToken::Num(num));
-            }
-            Err(_) => {
-                return Err(
-                    ErrorCode::InvalidInputSyntax(format!("Invalid interval: {}", c)).into(),
-                );
-            }
-        }
-        c.clear();
-    }
-    Ok(())
-}
-
-fn convert_unit(c: &mut String, t: &mut Vec<TimeStrToken>) -> Result<()> {
-    if !c.is_empty() {
-        t.push(TimeStrToken::TimeUnit(c.parse()?));
-        c.clear();
-    }
-    Ok(())
-}
-
-pub fn parse_interval(s: &str) -> Result<Vec<TimeStrToken>> {
-    let s = s.trim();
-    let mut tokens = Vec::new();
-    let mut num_buf = "".to_string();
-    let mut char_buf = "".to_string();
-    for (i, c) in s.chars().enumerate() {
-        match c {
-            '-' => {
-                num_buf.push(c);
-            }
-            c if c.is_ascii_digit() => {
-                convert_unit(&mut char_buf, &mut tokens)?;
-                num_buf.push(c);
-            }
-            c if c.is_ascii_alphabetic() => {
-                convert_digit(&mut num_buf, &mut tokens)?;
-                char_buf.push(c);
-            }
-            chr if chr.is_ascii_whitespace() => {
-                convert_unit(&mut char_buf, &mut tokens)?;
-                convert_digit(&mut num_buf, &mut tokens)?;
-            }
-            _ => {
-                return Err(ErrorCode::InvalidInputSyntax(format!(
-                    "Invalid character at offset {} in {}: {:?}. Only support digit or alphabetic now",
-                    i, s, c
-                )).into());
-            }
-        }
-    }
-    convert_digit(&mut num_buf, &mut tokens)?;
-    convert_unit(&mut char_buf, &mut tokens)?;
-
-    Ok(tokens)
 }
 
 #[cfg(test)]

--- a/src/frontend/src/binder/expr/value.rs
+++ b/src/frontend/src/binder/expr/value.rs
@@ -77,6 +77,8 @@ impl Binder {
     }
 
     fn bind_date_time_field(field: AstDateTimeField) -> DateTimeField {
+        // This is a binder function rather than `impl From<AstDateTimeField> for DateTimeField`,
+        // so that the `sqlparser` crate and the `common` crate are kept independent.
         match field {
             AstDateTimeField::Year => DateTimeField::Year,
             AstDateTimeField::Month => DateTimeField::Month,

--- a/src/sqlparser/Cargo.toml
+++ b/src/sqlparser/Cargo.toml
@@ -20,7 +20,6 @@ json_example = ["serde_json", "serde"]
 [dependencies]
 itertools = "0.10"
 log = "0.4"
-risingwave_common = { path = "../common" }
 serde = { version = "1.0", features = ["derive"], optional = true }
 # serde_json is only used in examples/cli, but we have to put it outside
 # of dev-dependencies because of

--- a/src/sqlparser/src/ast/value.rs
+++ b/src/sqlparser/src/ast/value.rs
@@ -13,9 +13,7 @@
 #[cfg(not(feature = "std"))]
 use alloc::string::String;
 use core::fmt;
-use core::str::FromStr;
 
-use risingwave_common::error::{ErrorCode, RwError};
 #[cfg(feature = "serde")]
 use serde::{Deserialize, Serialize};
 
@@ -133,22 +131,6 @@ impl fmt::Display for DateTimeField {
             DateTimeField::Minute => "MINUTE",
             DateTimeField::Second => "SECOND",
         })
-    }
-}
-
-impl FromStr for DateTimeField {
-    type Err = RwError;
-
-    fn from_str(s: &str) -> Result<Self, Self::Err> {
-        match s.to_lowercase().as_str() {
-            "years" | "year" | "yrs" | "yr" | "y" => Ok(Self::Year),
-            "days" | "day" | "d" => Ok(Self::Day),
-            "hours" | "hour" | "hrs" | "hr" | "h" => Ok(Self::Hour),
-            "minutes" | "minute" | "mins" | "min" | "m" => Ok(Self::Minute),
-            "months" | "month" | "mons" | "mon" => Ok(Self::Month),
-            "seconds" | "second" | "secs" | "sec" | "s" => Ok(Self::Second),
-            _ => Err(ErrorCode::InvalidInputSyntax(format!("unknown unit {}", s)).into()),
-        }
     }
 }
 


### PR DESCRIPTION
I hereby agree to the terms of the [Singularity Data, Inc. Contributor License Agreement](https://gist.github.com/skyzh/0663682a70b0edde7ae991492f2314cb#file-s9y_cla).

## What's changed and what's your intention?

We used to parse interval in binder, and only support the first 2 queries but not the last one:
```
select interval '3' day;
select interval '3 day';
select '3 day'::interval;
```
This PR extracts the parsing logic (#3037) from `bind_interval` to `common::types::IntervalUnit`, and reuses it for casting expr.

Note that the parsing logic is moved unchanged. Its enhancement deserves a standalone PR.

This also decouples the crates `sqlparser` and `common`. Neither is dependent on the other.

## Checklist

- [x] I have written necessary rustdoc comments
- [x] I have added necessary unit tests and integration tests
- [x] All checks passed in `./risedev check` (or alias, `./risedev c`)

## Refer to a related PR or issue link (optional)

#1632