### PR TITLE
fix(parser): fix parsing right angle brackets

### DIFF
--- a/e2e_test/streaming/struct_table.slt
+++ b/e2e_test/streaming/struct_table.slt
@@ -64,3 +64,21 @@ drop materialized view mv1;
 statement ok
 drop table st;
 
+# More tests to ensure `>>` in struct types can be parsed correctly
+statement ok
+create table t(v2 struct<v1 int, v2 struct<v1 int, v2 int>>, v1 int);
+
+statement ok
+drop table t;
+
+statement ok
+create table t(v2 struct<v1 int, v2 struct<v1 int, v2 struct <v1 int, v2 int>>>, v1 int);
+
+statement ok
+drop table t;
+
+statement ok
+create table t(v2 struct<v1 int, v2 struct<v1 int, v2 struct <v1 int, v2 int>>, v3 int>, v1 int);
+
+statement ok
+drop table t;

--- a/src/sqlparser/src/parser.rs
+++ b/src/sqlparser/src/parser.rs
@@ -2059,7 +2059,6 @@ impl Parser {
             } else {
                 return self.expected("struct field name", self.peek_token());
             }
-            let comma = self.consume_token(&Token::Comma);
             if self.angle_brackets_num == 0 {
                 break;
             } else if self.consume_token(&Token::Gt) {
@@ -2072,7 +2071,7 @@ impl Parser {
                 } else {
                     return parser_err!("too much '>'");
                 }
-            } else if !comma {
+            } else if !self.consume_token(&Token::Comma) {
                 return self.expected("',' or '>' after column definition", self.peek_token());
             }
         }


### PR DESCRIPTION
I hereby agree to the terms of the [Singularity Data, Inc. Contributor License Agreement](https://gist.github.com/skyzh/0663682a70b0edde7ae991492f2314cb#file-s9y_cla).

## What's changed and what's your intention?
fix https://github.com/singularity-data/risingwave/issues/4611

The problem is that when `parse_struct_data_type` handles `struct<v2 struct<v1 int, v2 int>>,` the comma is wrongly consumed by the outer call. It should return in the `self.angle_brackets_num == 0` branch without consuming the comma.


## Checklist

- [x] I have written necessary rustdoc comments
- [x] I have added necessary unit tests and integration tests
- [x] All checks passed in `./risedev check` (or alias, `./risedev c`)
