### PR TITLE
fix(handler): handle quoted names in `drop user`

### DIFF
--- a/e2e_test/ddl/user.slt
+++ b/e2e_test/ddl/user.slt
@@ -25,3 +25,28 @@ DROP USER ddl_user;
 # Drop it again with if exists.
 statement ok
 DROP USER IF EXISTS ddl_user;
+
+# Test quoting
+statement ok
+CREATE USER "n-m";
+
+statement ok
+DROP USER "n-m";
+
+statement ok
+CREATE USER "aBc";
+
+statement ok
+CREATE USER aBc;
+
+statement error
+CREATE USER Abc;
+
+statement ok
+DROP USER abc;
+
+statement error
+DROP USER aBc;
+
+statement ok
+DROP USER "aBc";

--- a/src/frontend/src/handler/drop_user.rs
+++ b/src/frontend/src/handler/drop_user.rs
@@ -16,6 +16,7 @@ use pgwire::pg_response::{PgResponse, StatementType};
 use risingwave_common::error::{ErrorCode, Result};
 use risingwave_sqlparser::ast::{DropMode, ObjectName};
 
+use crate::binder::Binder;
 use crate::catalog::CatalogError;
 use crate::session::OptimizerContext;
 
@@ -30,10 +31,11 @@ pub async fn handle_drop_user(
         return Err(ErrorCode::BindError("Drop user not support drop mode".to_string()).into());
     }
 
+    let user_name = Binder::resolve_user_name(user_name)?;
     let user_info_reader = session.env().user_info_reader();
     let user = user_info_reader
         .read_guard()
-        .get_user_by_name(&user_name.to_string())
+        .get_user_by_name(&user_name)
         .cloned();
     match user {
         Some(user) => {
@@ -47,7 +49,7 @@ pub async fn handle_drop_user(
                     format!("NOTICE: user {} does not exist, skipping", user_name),
                 ))
             } else {
-                Err(CatalogError::NotFound("user", user_name.to_string()).into())
+                Err(CatalogError::NotFound("user", user_name).into())
             };
         }
     }


### PR DESCRIPTION
I hereby agree to the terms of the [Singularity Data, Inc. Contributor License Agreement](https://gist.github.com/skyzh/0663682a70b0edde7ae991492f2314cb#file-s9y_cla).

## What's changed and what's your intention?

`ObjectName::to_string` is not meant to extract the user name. `create user` actually uses `Binder::resolve_user_name` to convert from `ObjectName` to `String`.

## Checklist

- [x] I have written necessary rustdoc comments
- [x] I have added necessary unit tests and integration tests
- [x] All checks passed in `./risedev check` (or alias, `./risedev c`)

## Refer to a related PR or issue link (optional)

Fixes #4623 