### PR TITLE
refactor: simplify the task status and stage state

### DIFF
--- a/proto/task_service.proto
+++ b/proto/task_service.proto
@@ -18,16 +18,13 @@ message TaskId {
 
 message TaskInfo {
   enum TaskStatus {
+    // Note: Requirement of proto3: first enum must be 0.
     UNSPECIFIED = 0;
-    NOT_FOUND = 1;
     PENDING = 2;
     RUNNING = 3;
-    FAILING = 4;
-    CANCELLING = 5;
     FINISHED = 6;
     FAILED = 7;
     ABORTED = 8;
-    ABORTING = 9;
   }
   batch_plan.TaskId task_id = 1;
   TaskStatus task_status = 2;

--- a/risedev.yml
+++ b/risedev.yml
@@ -21,14 +21,13 @@ risedev:
       unsafe-disable-recovery: true
     - use: compute-node
     - use: frontend
-    - use: prometheus
-    - use: grafana
 
     # If you want to enable compactor, uncomment the following line, and enable either minio or aws-s3 as well.
     # - use: compactor
 
     # If you want to enable metrics, uncomment those two lines.
-
+    # - use: prometheus
+    # - use: grafana
 
     # If you want to enable tracing, uncomment the following line.
     # - use: jaeger

--- a/risedev.yml
+++ b/risedev.yml
@@ -21,13 +21,14 @@ risedev:
       unsafe-disable-recovery: true
     - use: compute-node
     - use: frontend
+    - use: prometheus
+    - use: grafana
 
     # If you want to enable compactor, uncomment the following line, and enable either minio or aws-s3 as well.
     # - use: compactor
 
     # If you want to enable metrics, uncomment those two lines.
-    # - use: prometheus
-    # - use: grafana
+
 
     # If you want to enable tracing, uncomment the following line.
     # - use: jaeger

--- a/src/batch/src/task/task_execution.rs
+++ b/src/batch/src/task/task_execution.rs
@@ -62,14 +62,6 @@ impl Debug for TaskOutputId {
     }
 }
 
-pub(crate) enum TaskState {
-    Pending,
-    Running,
-    Blocking,
-    Finished,
-    Failed,
-}
-
 impl From<&ProstTaskId> for TaskId {
     fn from(prost: &ProstTaskId) -> Self {
         TaskId {
@@ -386,7 +378,7 @@ impl<C: BatchTaskContext> BatchTaskExecution<C> {
 
     pub fn abort_task(&self) {
         if let Some(sender) = self.shutdown_tx.lock().take() {
-            self.change_state(TaskStatus::Aborting);
+            // No need to set state to be Aborted here cuz it will be set by shutdown receiver.
             // Stop task execution.
             if sender.send(0).is_err() {
                 warn!("The task has already died before this request, so the abort did no-op")

--- a/src/frontend/src/scheduler/distributed/query.rs
+++ b/src/frontend/src/scheduler/distributed/query.rs
@@ -20,9 +20,8 @@ use anyhow::anyhow;
 use risingwave_common::bail;
 use risingwave_pb::batch_plan::{TaskId as TaskIdProst, TaskOutputId as TaskOutputIdProst};
 use risingwave_rpc_client::ComputeClientPoolRef;
-use tokio::sync::mpsc::{channel, Receiver, Sender};
+use tokio::sync::mpsc::{channel, Receiver};
 use tokio::sync::{oneshot, RwLock};
-use tokio::task::JoinHandle;
 use tracing::{debug, error, info, warn};
 
 use super::{QueryResultFetcher, StageEvent};
@@ -36,9 +35,6 @@ use crate::scheduler::{HummockSnapshotManagerRef, SchedulerError, SchedulerResul
 /// Message sent to a `QueryRunner` to control its execution.
 #[derive(Debug)]
 pub enum QueryMessage {
-    /// Commands to stop execution..
-    Stop,
-
     /// Events passed running execution.
     Stage(StageEvent),
 }
@@ -49,19 +45,11 @@ enum QueryState {
     /// In this state, some data structures for starting executions are created to avoid holding
     /// them `QueryExecution`
     Pending {
-        /// We create this runner before start execution to avoid hold unuseful fields in
-        /// `QueryExecution`
-        runner: QueryRunner,
-
-        /// Receiver of root stage info.
-        root_stage_receiver: oneshot::Receiver<SchedulerResult<QueryResultFetcher>>,
+        msg_receiver: Receiver<QueryMessage>,
     },
 
     /// Running
-    Running {
-        _msg_sender: Sender<QueryMessage>,
-        _task_handle: JoinHandle<SchedulerResult<()>>,
-    },
+    Running,
 
     /// Failed
     Failed,
@@ -73,7 +61,12 @@ enum QueryState {
 pub struct QueryExecution {
     query: Arc<Query>,
     state: Arc<RwLock<QueryState>>,
-    _stage_executions: Arc<HashMap<StageId, Arc<StageExecution>>>,
+
+    /// These fields are just used for passing to Query Runner.
+    epoch: u64,
+    stage_executions: Arc<HashMap<StageId, Arc<StageExecution>>>,
+    hummock_snapshot_manager: HummockSnapshotManagerRef,
+    compute_client_pool: ComputeClientPoolRef,
 }
 
 struct QueryRunner {
@@ -82,8 +75,6 @@ struct QueryRunner {
     scheduled_stages_count: usize,
     /// Query messages receiver. For example, stage state change events, query commands.
     msg_receiver: Receiver<QueryMessage>,
-    // Sender of above message receiver. We need to keep it so that we can pass it to stages.
-    msg_sender: Sender<QueryMessage>,
 
     /// Will be set to `None` after all stage scheduled.
     root_stage_sender: Option<oneshot::Sender<SchedulerResult<QueryResultFetcher>>>,
@@ -129,30 +120,17 @@ impl QueryExecution {
             Arc::new(stage_executions)
         };
 
-        let (root_stage_sender, root_stage_receiver) =
-            oneshot::channel::<SchedulerResult<QueryResultFetcher>>();
-
-        let runner = QueryRunner {
-            query: query.clone(),
-            stage_executions: stage_executions.clone(),
-            msg_receiver: receiver,
-            root_stage_sender: Some(root_stage_sender),
-            msg_sender: sender,
-            scheduled_stages_count: 0,
-            epoch,
-            hummock_snapshot_manager,
-            compute_client_pool,
-        };
-
         let state = QueryState::Pending {
-            runner,
-            root_stage_receiver,
+            msg_receiver: receiver,
         };
 
         Self {
             query,
             state: Arc::new(RwLock::new(state)),
-            _stage_executions: stage_executions,
+            stage_executions,
+            epoch,
+            compute_client_pool,
+            hummock_snapshot_manager,
         }
     }
 
@@ -162,12 +140,24 @@ impl QueryExecution {
         let cur_state = mem::replace(&mut *state, QueryState::Failed);
 
         match cur_state {
-            QueryState::Pending {
-                runner,
-                root_stage_receiver,
-            } => {
-                let msg_sender = runner.msg_sender.clone();
-                let task_handle = tokio::spawn(async move {
+            QueryState::Pending { msg_receiver } => {
+                *state = QueryState::Running;
+
+                let (root_stage_sender, root_stage_receiver) =
+                    oneshot::channel::<SchedulerResult<QueryResultFetcher>>();
+
+                let runner = QueryRunner {
+                    query: self.query.clone(),
+                    stage_executions: self.stage_executions.clone(),
+                    msg_receiver,
+                    root_stage_sender: Some(root_stage_sender),
+                    scheduled_stages_count: 0,
+                    epoch: self.epoch,
+                    hummock_snapshot_manager: self.hummock_snapshot_manager.clone(),
+                    compute_client_pool: self.compute_client_pool.clone(),
+                };
+
+                tokio::spawn(async move {
                     let query_id = runner.query.query_id.clone();
                     runner.run().await.map_err(|e| {
                         error!("Query {:?} failed, reason: {:?}", query_id, e);
@@ -184,11 +174,6 @@ impl QueryExecution {
                     root_stage,
                     self.query.query_id
                 );
-
-                *state = QueryState::Running {
-                    _msg_sender: msg_sender,
-                    _task_handle: task_handle,
-                };
 
                 Ok(root_stage)
             }
@@ -395,9 +380,7 @@ mod tests {
             ))),
             compute_client_pool,
         );
-        let err = query_execution.start().await;
-        println!("err: {:?}", err);
-        // assert!(query_execution.start().await.is_err());
+        assert!(query_execution.start().await.is_err());
     }
 
     async fn create_query() -> Query {

--- a/src/frontend/src/scheduler/distributed/stage.rs
+++ b/src/frontend/src/scheduler/distributed/stage.rs
@@ -178,6 +178,9 @@ impl StageExecution {
                 let mut holder = self.shutdown_rx.write().await;
                 *holder = Some(sender);
 
+                // Change state before spawn runner.
+                *s = StageState::Started;
+
                 spawn(async move {
                     if let Err(e) = runner.run(receiver).await {
                         error!("Stage failed: {:?}", e);
@@ -187,8 +190,6 @@ impl StageExecution {
                     }
                 });
 
-                // TODO: Should change state before spawn task.
-                *s = StageState::Started;
                 Ok(())
             }
             _ => {
@@ -393,19 +394,21 @@ impl StageRunner {
                                     break;
                                 }
 
-                                TaskStatusProst::Finished => {
-                                    // no-op
+                                TaskStatusProst::Finished | TaskStatusProst::Aborted => {
+                                    // if Finished, no-op
+                                    // if Aborted, still no-op cuz it means there must already have failed schedule.
                                 }
 
                                 status => {
+                                    // The remain possible variant is Pending, but now it won't be pushed from CN.
                                     unimplemented!("Unexpected task status {:?}", status);
                                 }
                             }
                          } else {
-                        // After processing all stream status, we must have sent signal (Either Scheduled or
-                        // Failed) to Query Runner. If this is not true, query runner will stuck cuz it do not receive any signals.
-                        assert!(sent_signal_to_next);
-                        break;
+                            // After processing all stream status, we must have sent signal (Either Scheduled or
+                            // Failed) to Query Runner. If this is not true, query runner will stuck cuz it do not receive any signals.
+                            assert!(sent_signal_to_next);
+                            break;
                     }
                 }
             }


### PR DESCRIPTION
I hereby agree to the terms of the [Singularity Data, Inc. Contributor License Agreement](https://gist.github.com/skyzh/0663682a70b0edde7ae991492f2314cb#file-s9y_cla).

## What's changed and what's your intention?
* Cut down some unused status in task_service.proto.
* Simplify `StateState` and `QueryState`, tries to move join_handle, sender etc out from it. 
* 

## Checklist

- [x] I have written necessary rustdoc comments
- [x] I have added necessary unit tests and integration tests
- [x] All checks passed in `./risedev check` (or alias, `./risedev c`)

## Documentation

If your pull request contains user-facing changes, please specify the types of the changes, and create a release note. Otherwise, please feel free to remove this section.

### Types of user-facing changes

Please keep the types that apply to your changes, and remove those that do not apply.

* Installation and deployment 
* Connector (sources & sinks)
* SQL commands, functions, and operators
* RisingWave cluster configuration changes
* Other (please specify in the release note below)

### Release note

Please create a release note for your changes. In the release note, focus on the impact on users, and mention the environment or conditions where the impact may occur.

## Refer to a related PR or issue link (optional)
