### PR TITLE
feat(risedev): add 'enable-disk-object-store' option for debug usage

### DIFF
--- a/risedev.yml
+++ b/risedev.yml
@@ -347,7 +347,6 @@ risedev:
     - use: compactor
     - use: redis
 
-
 compose:
   risingwave: "ghcr.io/singularity-data/risingwave:latest"
   prometheus: "prom/prometheus:latest"
@@ -429,6 +428,9 @@ template:
 
     # If `enable-tiered-cache` is true, hummock will use data directory as file cache.
     enable-tiered-cache: false
+
+    # If `enable-disk-object-store` is ture, hummock will use data directory as object store storage backend.
+    enable-disk-object-store: false
 
     # Minio instances used by this compute node
     provide-minio: "minio*"
@@ -556,6 +558,9 @@ template:
 
     # Id of this instance
     id: compactor-${port}
+
+    # If `enable-disk-object-store` is ture, hummock will use data directory as object store storage backend.
+    enable-disk-object-store: false
 
     # Minio instances used by this compute node
     provide-minio: "minio*"

--- a/src/risedevtool/src/risectl_env.rs
+++ b/src/risedevtool/src/risectl_env.rs
@@ -28,6 +28,7 @@ pub fn compute_risectl_env(services: &HashMap<String, ServiceConfig>) -> Result<
                 "risectl",
                 c.provide_minio.as_ref().unwrap(),
                 c.provide_aws_s3.as_ref().unwrap(),
+                None,
                 HummockInMemoryStrategy::Disallowed,
                 &mut cmd,
             )?;

--- a/src/risedevtool/src/service_config.rs
+++ b/src/risedevtool/src/service_config.rs
@@ -28,6 +28,7 @@ pub struct ComputeNodeConfig {
     pub listen_address: String,
     pub exporter_port: u16,
     pub enable_tiered_cache: bool,
+    pub enable_disk_object_store: bool,
 
     pub provide_minio: Option<Vec<MinioConfig>>,
     pub provide_meta_node: Option<Vec<MetaNodeConfig>>,
@@ -92,6 +93,7 @@ pub struct CompactorConfig {
     pub port: u16,
     pub listen_address: String,
     pub exporter_port: u16,
+    pub enable_disk_object_store: bool,
 
     pub provide_minio: Option<Vec<MinioConfig>>,
     pub provide_aws_s3: Option<Vec<AwsS3Config>>,

--- a/src/risedevtool/src/task/compute_node_service.rs
+++ b/src/risedevtool/src/task/compute_node_service.rs
@@ -63,8 +63,8 @@ impl ComputeNodeService {
 
         if config.enable_tiered_cache {
             cmd.arg("--file-cache-dir").arg(
-                PathBuf::from(prefix_data)
-                    .join("filecache")
+                PathBuf::from(&prefix_data)
+                    .join("file-cache")
                     .join(config.port.to_string()),
             );
         }
@@ -86,11 +86,23 @@ impl ComputeNodeService {
         let provide_minio = config.provide_minio.as_ref().unwrap();
         let provide_aws_s3 = config.provide_aws_s3.as_ref().unwrap();
         let provide_compute_node = config.provide_compute_node.as_ref().unwrap();
+        let disk_object_store = if config.enable_disk_object_store {
+            Some(
+                PathBuf::from(&prefix_data)
+                    .join("disk-object-store")
+                    .to_str()
+                    .unwrap()
+                    .to_string(),
+            )
+        } else {
+            None
+        };
 
         let is_shared_backend = add_storage_backend(
             &config.id,
             provide_minio,
             provide_aws_s3,
+            disk_object_store,
             hummock_in_memory_strategy,
             cmd,
         )?;


### PR DESCRIPTION
I hereby agree to the terms of the [Singularity Data, Inc. Contributor License Agreement](https://gist.github.com/skyzh/0663682a70b0edde7ae991492f2314cb#file-s9y_cla).

## What's changed and what's your intention?

Add `enable-disk-object-store` option for compute node and compactor node for debug usage.

For example, to enable disk object store on `ci-1cn-1fe` config, just set: 
```yaml
  ci-1cn-1fe:
    - use: minio
    - use: etcd
      unsafe-no-fsync: true
    - use: meta-node
      unsafe-disable-recovery: true
    - use: compute-node
      enable-tiered-cache: true
      enable-disk-object-store: true # new row
    - use: frontend
    - use: compactor
      enable-disk-object-store: true # new row
```

## Checklist

- [x] I have written necessary rustdoc comments
- [x] I have added necessary unit tests and integration tests
- [x] All checks passed in `./risedev check` (or alias, `./risedev c`)

## Refer to a related PR or issue link (optional)
#3921 