### PR TITLE
fix(optimizer): fix logical scan distribution key

### DIFF
--- a/src/frontend/src/optimizer/plan_node/logical_scan.rs
+++ b/src/frontend/src/optimizer/plan_node/logical_scan.rs
@@ -224,13 +224,13 @@ impl LogicalScan {
 
     /// The mapped distribution key of the scan operator.
     ///
-    /// The column indices in it is the position in the `required_col_idx`, instead of the position
+    /// The column indices in it is the position in the `output_col_idx`, instead of the position
     /// in all the columns of the table (which is the table's distribution key).
     ///
-    /// Return `None` if the table's distribution key are not all in the `required_col_idx`.
+    /// Return `None` if the table's distribution key are not all in the `output_col_idx`.
     pub fn distribution_key(&self) -> Option<Vec<usize>> {
         let tb_idx_to_op_idx = self
-            .required_col_idx
+            .output_col_idx
             .iter()
             .enumerate()
             .map(|(op_idx, tb_idx)| (*tb_idx, op_idx))


### PR DESCRIPTION
I hereby agree to the terms of the [Singularity Data, Inc. Contributor License Agreement](https://gist.github.com/skyzh/0663682a70b0edde7ae991492f2314cb#file-s9y_cla).

## What's changed and what's your intention?

- fix logical scan distribution_key using `output_col_idx` instead of `required_col_idx`.

## Checklist

- [x] I have written necessary rustdoc comments
- [x] I have added necessary unit tests and integration tests
- [x] All checks passed in `./risedev check` (or alias, `./risedev c`)
