### PR TITLE
fix(binder): remove usage of `is_correlated`

### DIFF
--- a/src/frontend/src/binder/query.rs
+++ b/src/frontend/src/binder/query.rs
@@ -45,14 +45,6 @@ impl BoundQuery {
         self.schema().data_types()
     }
 
-    pub fn is_correlated(&self) -> bool {
-        self.body.is_correlated()
-            || self
-                .extra_order_exprs
-                .iter()
-                .any(|e| e.has_correlated_input_ref_by_depth())
-    }
-
     pub fn collect_correlated_indices_by_depth_and_assign_id(
         &mut self,
         correlated_id: CorrelatedId,

--- a/src/frontend/src/binder/relation/mod.rs
+++ b/src/frontend/src/binder/relation/mod.rs
@@ -68,18 +68,6 @@ impl Relation {
         }
     }
 
-    pub fn is_correlated(&self) -> bool {
-        match self {
-            Relation::Subquery(subquery) => subquery.query.is_correlated(),
-            Relation::Join(join) => {
-                join.cond.has_correlated_input_ref_by_depth()
-                    || join.left.is_correlated()
-                    || join.right.is_correlated()
-            }
-            _ => false,
-        }
-    }
-
     pub fn collect_correlated_indices_by_depth_and_assign_id(
         &mut self,
         correlated_id: CorrelatedId,

--- a/src/frontend/src/binder/select.rs
+++ b/src/frontend/src/binder/select.rs
@@ -44,18 +44,6 @@ impl BoundSelect {
         &self.schema
     }
 
-    pub fn is_correlated(&self) -> bool {
-        self.select_items
-            .iter()
-            .chain(self.group_by.iter())
-            .chain(self.where_clause.iter())
-            .any(|expr| expr.has_correlated_input_ref_by_depth())
-            || match self.from.as_ref() {
-                Some(relation) => relation.is_correlated(),
-                None => false,
-            }
-    }
-
     pub fn collect_correlated_indices_by_depth_and_assign_id(
         &mut self,
         correlated_id: CorrelatedId,

--- a/src/frontend/src/binder/set_expr.rs
+++ b/src/frontend/src/binder/set_expr.rs
@@ -37,13 +37,6 @@ impl BoundSetExpr {
         }
     }
 
-    pub fn is_correlated(&self) -> bool {
-        match self {
-            BoundSetExpr::Select(s) => s.is_correlated(),
-            BoundSetExpr::Values(_) => false,
-        }
-    }
-
     pub fn collect_correlated_indices_by_depth_and_assign_id(
         &mut self,
         correlated_id: CorrelatedId,

--- a/src/frontend/src/expr/mod.rs
+++ b/src/frontend/src/expr/mod.rs
@@ -222,7 +222,7 @@ impl ExprImpl {
 
         impl ExprVisitor<()> for Has {
             fn visit_correlated_input_ref(&mut self, correlated_input_ref: &CorrelatedInputRef) {
-                if correlated_input_ref.depth() == self.depth {
+                if correlated_input_ref.depth() >= self.depth {
                     self.has = true;
                 }
             }

--- a/src/frontend/src/expr/subquery.rs
+++ b/src/frontend/src/expr/subquery.rs
@@ -46,10 +46,6 @@ impl Subquery {
         Self { query, kind }
     }
 
-    pub fn is_correlated(&self) -> bool {
-        self.query.is_correlated()
-    }
-
     pub fn collect_correlated_indices_by_depth_and_assign_id(
         &mut self,
         correlated_id: CorrelatedId,

--- a/src/frontend/src/optimizer/plan_node/logical_agg.rs
+++ b/src/frontend/src/optimizer/plan_node/logical_agg.rs
@@ -853,12 +853,6 @@ impl ExprRewriter for LogicalAggBuilder {
     }
 
     fn rewrite_subquery(&mut self, subquery: crate::expr::Subquery) -> ExprImpl {
-        if subquery.is_correlated() {
-            self.error = Some(ErrorCode::NotImplemented(
-                "correlated subquery in HAVING or SELECT with agg".into(),
-                2275.into(),
-            ));
-        }
         subquery.into()
     }
 }

--- a/src/frontend/test_runner/tests/testdata/subquery_expr_correlated.yaml
+++ b/src/frontend/test_runner/tests/testdata/subquery_expr_correlated.yaml
@@ -273,52 +273,6 @@
         LogicalProject { exprs: [t3.y, t3.y] }
           LogicalScan { table: t3, columns: [t3.y] }
 - sql: |
-    /* correlated agg column in SELECT */
-    create table t (v1 int, v2 int);
-    select min(v1), (select max(v2)) from t;
-  planner_error: 'Feature is not yet implemented: correlated subquery in HAVING or
-    SELECT with agg, Tracking issue: https://github.com/singularity-data/risingwave/issues/2275'
-- sql: |
-    /* correlated group column in SELECT */
-    create table t (v1 int, v2 int);
-    select min(v1), (select v2) from t group by v2;
-  planner_error: 'Feature is not yet implemented: correlated subquery in HAVING or
-    SELECT with agg, Tracking issue: https://github.com/singularity-data/risingwave/issues/2275'
-- sql: |
-    /* correlated non-group column in SELECT */
-    create table t (v1 int, v2 int);
-    select min(v1), (select v2) from t;
-  planner_error: 'Feature is not yet implemented: correlated subquery in HAVING or
-    SELECT with agg, Tracking issue: https://github.com/singularity-data/risingwave/issues/2275'
-- sql: |
-    /* correlated agg column in HAVING */
-    create table t (v1 int, v2 int);
-    select 1 from t having min(v1) > (select max(v2));
-  planner_error: 'Feature is not yet implemented: correlated subquery in HAVING or
-    SELECT with agg, Tracking issue: https://github.com/singularity-data/risingwave/issues/2275'
-- sql: |
-    /* correlated group column in HAVING */
-    create table t (v1 int, v2 int);
-    select 1 from t group by v2 having min(v1) > (select v2);
-  planner_error: 'Feature is not yet implemented: correlated subquery in HAVING or
-    SELECT with agg, Tracking issue: https://github.com/singularity-data/risingwave/issues/2275'
-- sql: |
-    /* correlated non-group column in HAVING */
-    create table t (v1 int, v2 int);
-    select 1 from t having min(v1) > (select v2);
-  planner_error: 'Feature is not yet implemented: correlated subquery in HAVING or
-    SELECT with agg, Tracking issue: https://github.com/singularity-data/risingwave/issues/2275'
-- sql: |
-    /* correlated agg column belongs to outer query */
-    create table t (v1 int, v2 int);
-    create table t2 (v3 int, v4 int);
-    select
-      min(v1),
-      (select max(v2) + v3 from t2)  -- access to v3 is ok
-    from t;
-  planner_error: 'Feature is not yet implemented: correlated subquery in HAVING or
-    SELECT with agg, Tracking issue: https://github.com/singularity-data/risingwave/issues/2275'
-- sql: |
     create table t1(x int, y int);
     create table t2(x int, y int);
     select t2.x, (select x from t1 where t1.y = t2.y) from t2 where x > 100 order by t2.x limit 100;


### PR DESCRIPTION
I hereby agree to the terms of the [Singularity Data, Inc. Contributor License Agreement](https://gist.github.com/skyzh/0663682a70b0edde7ae991492f2314cb#file-s9y_cla).

## What's changed and what's your intention?

This PR is not meant to be merged. It just removes `is_correlated` so that we are clear how it is used currently. As the code change and passing tests indicated, the only usage is to reject certain correlated subqueries that we do not support yet (#2275 #4579). It has no usage in the happy path. Based on this observation, I am going to propose a semantic change / bug fix of these APIs (PR with explanation to come).

## Checklist

- [x] I have written necessary rustdoc comments
- [x] I have added necessary unit tests and integration tests
- [x] All checks passed in `./risedev check` (or alias, `./risedev c`)

## Refer to a related PR or issue link (optional)
