### PR TITLE
refactor(frontend,meta): don't infer and create state tables for (stateless) local simple agg

### DIFF
--- a/src/frontend/src/optimizer/plan_node/stream_local_simple_agg.rs
+++ b/src/frontend/src/optimizer/plan_node/stream_local_simple_agg.rs
@@ -77,7 +77,6 @@ impl_plan_tree_node_for_unary! { StreamLocalSimpleAgg }
 impl ToStreamProst for StreamLocalSimpleAgg {
     fn to_stream_prost_body(&self) -> ProstStreamNode {
         use risingwave_pb::stream_plan::*;
-        let (internal_tables, column_mappings) = self.logical.infer_internal_table_catalog();
         ProstStreamNode::LocalSimpleAgg(SimpleAggNode {
             agg_calls: self
                 .agg_calls()
@@ -91,21 +90,8 @@ impl ToStreamProst for StreamLocalSimpleAgg {
                 .iter()
                 .map(|idx| *idx as u32)
                 .collect_vec(),
-            internal_tables: internal_tables
-                .into_iter()
-                .map(|table_catalog| {
-                    table_catalog.to_prost(
-                        SchemaId::placeholder() as u32,
-                        DatabaseId::placeholder() as u32,
-                    )
-                })
-                .collect_vec(),
-            column_mappings: column_mappings
-                .into_iter()
-                .map(|v| ColumnMapping {
-                    indices: v.iter().map(|x| *x as u32).collect(),
-                })
-                .collect(),
+            internal_tables: Vec::new(),
+            column_mappings: Vec::new(),
             is_append_only: self.input().append_only(),
         })
     }

--- a/src/frontend/src/optimizer/plan_node/stream_local_simple_agg.rs
+++ b/src/frontend/src/optimizer/plan_node/stream_local_simple_agg.rs
@@ -15,7 +15,6 @@
 use std::fmt;
 
 use itertools::Itertools;
-use risingwave_common::catalog::{DatabaseId, SchemaId};
 use risingwave_pb::stream_plan::stream_node::NodeBody as ProstStreamNode;
 
 use super::logical_agg::PlanAggCall;

--- a/src/frontend/src/stream_fragmenter/mod.rs
+++ b/src/frontend/src/stream_fragmenter/mod.rs
@@ -320,7 +320,7 @@ impl StreamFragmenter {
                 }
             }
 
-            NodeBody::GlobalSimpleAgg(node) | NodeBody::LocalSimpleAgg(node) => {
+            NodeBody::GlobalSimpleAgg(node) => {
                 for table in &mut node.internal_tables {
                     table.id = state.gen_table_id();
                 }

--- a/src/meta/src/stream/mod.rs
+++ b/src/meta/src/stream/mod.rs
@@ -51,7 +51,7 @@ pub fn record_table_vnode_mappings(
                 fragment.state_table_ids.push(table.id);
             }
         }
-        NodeBody::LocalSimpleAgg(node) | NodeBody::GlobalSimpleAgg(node) => {
+        NodeBody::GlobalSimpleAgg(node) => {
             for table in &node.internal_tables {
                 fragment.state_table_ids.push(table.id);
             }

--- a/src/meta/src/stream/stream_graph.rs
+++ b/src/meta/src/stream/stream_graph.rs
@@ -625,7 +625,7 @@ impl StreamGraphBuilder {
                         check_and_fill_internal_table(node.table_id_h, None);
                     }
 
-                    NodeBody::GlobalSimpleAgg(node) | NodeBody::LocalSimpleAgg(node) => {
+                    NodeBody::GlobalSimpleAgg(node) => {
                         assert_eq!(node.internal_tables.len(), node.agg_calls.len());
                         // In-place update the table id. Convert from local to global.
                         for table in &mut node.internal_tables {


### PR DESCRIPTION
I hereby agree to the terms of the [Singularity Data, Inc. Contributor License Agreement](https://gist.github.com/skyzh/0663682a70b0edde7ae991492f2314cb#file-s9y_cla).

## What's changed and what's your intention?

See the title. Fixes #4634.

## Checklist

- [x] I have written necessary rustdoc comments
- [x] I have added necessary unit tests and integration tests
- [x] All checks passed in `./risedev check` (or alias, `./risedev c`)

## Refer to a related PR or issue link (optional)

#4634