### PR TITLE
fix(meta): fix trigger_manual_compaction incorrect table_id

### DIFF
--- a/src/meta/src/rpc/service/hummock_service.rs
+++ b/src/meta/src/rpc/service/hummock_service.rs
@@ -16,7 +16,7 @@ use std::collections::HashSet;
 use std::sync::Arc;
 use std::time::Duration;
 
-use risingwave_common::catalog::TableId;
+use risingwave_common::catalog::{TableId, NON_RESERVED_PG_CATALOG_TABLE_ID};
 use risingwave_pb::hummock::hummock_manager_service_server::HummockManagerService;
 use risingwave_pb::hummock::*;
 use tonic::{Request, Response, Status};
@@ -261,15 +261,24 @@ where
         }
 
         // get internal_table_id by fragment_manager
-        let table_id = TableId::new(request.table_id);
-        if let Ok(table_frgament) = self
-            .fragment_manager
-            .select_table_fragments_by_table_id(&table_id)
-            .await
-        {
-            option.internal_table_id = HashSet::from_iter(table_frgament.internal_table_ids());
+        if request.table_id >= NON_RESERVED_PG_CATALOG_TABLE_ID as u32 {
+            // We need to make sure to use the correct table_id to filter sst
+            let table_id = TableId::new(request.table_id);
+            if let Ok(table_frgament) = self
+                .fragment_manager
+                .select_table_fragments_by_table_id(&table_id)
+                .await
+            {
+                option.internal_table_id = HashSet::from_iter(table_frgament.internal_table_ids());
+            }
+            option.internal_table_id.insert(request.table_id); // need to handle outter table_id
+                                                               // (mv)
         }
-        option.internal_table_id.insert(request.table_id); // need to handle outter table_id (mv)
+
+        assert!(option
+            .internal_table_id
+            .iter()
+            .all(|table_id| *table_id > (NON_RESERVED_PG_CATALOG_TABLE_ID as u32)),);
 
         tracing::info!(
             "Try trigger_manual_compaction compaction_group_id {} option {:?}",

--- a/src/meta/src/rpc/service/hummock_service.rs
+++ b/src/meta/src/rpc/service/hummock_service.rs
@@ -278,7 +278,7 @@ where
         assert!(option
             .internal_table_id
             .iter()
-            .all(|table_id| *table_id > (NON_RESERVED_PG_CATALOG_TABLE_ID as u32)),);
+            .all(|table_id| *table_id >= (NON_RESERVED_PG_CATALOG_TABLE_ID as u32)),);
 
         tracing::info!(
             "Try trigger_manual_compaction compaction_group_id {} option {:?}",


### PR DESCRIPTION
I hereby agree to the terms of the [Singularity Data, Inc. Contributor License Agreement](https://gist.github.com/skyzh/0663682a70b0edde7ae991492f2314cb#file-s9y_cla).

## What's changed and what's your intention?

as title

Please explain **IN DETAIL** what the changes are in this PR and why they are needed:

- prevent use incorrect table_id to filter sst
- add assert

## Checklist

- [x] I have written necessary rustdoc comments
- ~[ ] I have added necessary unit tests and integration tests~
- [x] All checks passed in `./risedev check` (or alias, `./risedev c`)