### PR TITLE
feat: update row-id generator when vnode mapping changed

### DIFF
--- a/src/source/src/row_id.rs
+++ b/src/source/src/row_id.rs
@@ -32,7 +32,7 @@ pub struct RowIdGenerator {
     /// Last timestamp part of row id.
     last_duration_ms: i64,
     /// Current vnode id.
-    vnode_id: u32,
+    pub vnode_id: u32,
     /// Last sequence part of row id.
     sequence: u16,
 }

--- a/src/stream/src/executor/source/source_executor.rs
+++ b/src/stream/src/executor/source/source_executor.rs
@@ -313,7 +313,7 @@ impl<S: StateStore> SourceExecutor<S> {
                                 // Update row id generator if vnode mapping is changed.
                                 // Note that: since update barrier will only occurs between pause
                                 // and resume barrier, duplicated row id won't be generated.
-                                if let Some(vnode_bitmaps) = vnode_bitmaps.get(&self.actor_id) {
+                                if let Some(vnode_bitmaps) = vnode_bitmaps.get(&self.ctx.id) {
                                     let vnode_id =
                                         vnode_bitmaps.next_set_bit(0).unwrap_or(0) as u32;
                                     if self.row_id_generator.vnode_id != vnode_id {

--- a/src/stream/src/executor/source/source_executor.rs
+++ b/src/stream/src/executor/source/source_executor.rs
@@ -310,6 +310,8 @@ impl<S: StateStore> SourceExecutor<S> {
                             Mutation::Resume => stream.resume_source(),
                             Mutation::Update { vnode_bitmaps, .. } => {
                                 // Update row id generator if vnode mapping is changed.
+                                // Note that: since update barrier will only occurs between pause
+                                // and resume barrier, duplicated row id won't be generated.
                                 if let Some(vnode_bitmaps) = vnode_bitmaps.get(&self.actor_id) {
                                     let vnode_id =
                                         vnode_bitmaps.next_set_bit(0).unwrap_or(0) as u32;

--- a/src/stream/src/executor/source/source_executor.rs
+++ b/src/stream/src/executor/source/source_executor.rs
@@ -308,6 +308,19 @@ impl<S: StateStore> SourceExecutor<S> {
                             }
                             Mutation::Pause => stream.pause_source(),
                             Mutation::Resume => stream.resume_source(),
+                            Mutation::Update { vnode_bitmaps, .. } => {
+                                // Update row id generator if vnode mapping is changed.
+                                if let Some(vnode_bitmaps) = vnode_bitmaps.get(&self.actor_id) {
+                                    let vnode_id =
+                                        vnode_bitmaps.next_set_bit(0).unwrap_or(0) as u32;
+                                    if self.row_id_generator.vnode_id != vnode_id {
+                                        self.row_id_generator = RowIdGenerator::with_epoch(
+                                            vnode_id,
+                                            *UNIX_SINGULARITY_DATE_EPOCH,
+                                        );
+                                    }
+                                }
+                            }
                             _ => {}
                         }
                     }


### PR DESCRIPTION
I hereby agree to the terms of the [Singularity Data, Inc. Contributor License Agreement](https://gist.github.com/skyzh/0663682a70b0edde7ae991492f2314cb#file-s9y_cla).

## What's changed and what's your intention?

As title.

Please explain **IN DETAIL** what the changes are in this PR and why they are needed:

- Summarize your change (**mandatory**)
- How does this PR work? Need a brief introduction for the changed logic (optional)
- Describe clearly one logical change and avoid lazy messages (optional)
- Describe any limitations of the current code (optional)

## Checklist

- [x] I have written necessary rustdoc comments
- [x] I have added necessary unit tests and integration tests
- [x] All checks passed in `./risedev check` (or alias, `./risedev c`)

## Documentation

If your pull request contains user-facing changes, please specify the types of the changes, and create a release note. Otherwise, please feel free to remove this section.

### Types of user-facing changes

Please keep the types that apply to your changes, and remove those that do not apply.

* Installation and deployment 
* Connector (sources & sinks)
* SQL commands, functions, and operators
* RisingWave cluster configuration changes
* Other (please specify in the release note below)

### Release note

Please create a release note for your changes. In the release note, focus on the impact on users, and mention the environment or conditions where the impact may occur.

## Refer to a related PR or issue link (optional)
