### PR TITLE
fix(metrics): fix iterator metrics data report duplication and lost

### DIFF
--- a/src/storage/benches/bench_compactor.rs
+++ b/src/storage/benches/bench_compactor.rs
@@ -259,7 +259,7 @@ fn bench_merge_iterator_compactor(c: &mut Criterion) {
                     read_options.clone(),
                 )),
             ];
-            let iter = MultiSstIterator::new(sub_iters, stats.clone());
+            let iter = MultiSstIterator::for_compactor(sub_iters, stats.clone());
             let sstable_store = Arc::new(CompactorSstableStore::new(
                 sstable_store1,
                 MemoryLimiter::unlimit(),
@@ -278,7 +278,7 @@ fn bench_merge_iterator_compactor(c: &mut Criterion) {
                 ConcatSstableIterator::new(level1.clone(), KeyRange::inf(), sstable_store.clone()),
                 ConcatSstableIterator::new(level2.clone(), KeyRange::inf(), sstable_store.clone()),
             ];
-            let iter = UnorderedMergeIteratorInner::new(sub_iters, stats.clone());
+            let iter = UnorderedMergeIteratorInner::for_compactor(sub_iters, stats.clone());
             let sstable_store1 = sstable_store.clone();
             async move { compact(iter, sstable_store1).await }
         });

--- a/src/storage/benches/bench_merge_iter.rs
+++ b/src/storage/benches/bench_merge_iter.rs
@@ -13,7 +13,6 @@
 // limitations under the License.
 
 use std::cell::RefCell;
-use std::sync::Arc;
 
 use bytes::Bytes;
 use criterion::{criterion_group, criterion_main, BenchmarkId, Criterion};
@@ -27,7 +26,6 @@ use risingwave_storage::hummock::shared_buffer::shared_buffer_batch::{
     SharedBufferBatch, SharedBufferBatchIterator,
 };
 use risingwave_storage::hummock::value::HummockValue;
-use risingwave_storage::monitor::StateStoreMetrics;
 use tokio::sync::mpsc;
 
 fn gen_interleave_shared_buffer_batch_iter(
@@ -109,7 +107,6 @@ fn run_iter<I: HummockIterator<Direction = Forward>>(iter_ref: &RefCell<I>, tota
 fn criterion_benchmark(c: &mut Criterion) {
     let merge_iter = RefCell::new(UnorderedMergeIteratorInner::new(
         gen_interleave_shared_buffer_batch_iter(10000, 100),
-        Arc::new(StateStoreMetrics::unused()),
     ));
     c.bench_with_input(
         BenchmarkId::new("bench-merge-iter", "unordered"),
@@ -123,7 +120,6 @@ fn criterion_benchmark(c: &mut Criterion) {
 
     let ordered_merge_iter = RefCell::new(OrderedMergeIteratorInner::new(
         gen_interleave_shared_buffer_batch_iter(10000, 100),
-        Arc::new(StateStoreMetrics::unused()),
     ));
 
     c.bench_with_input(
@@ -138,7 +134,6 @@ fn criterion_benchmark(c: &mut Criterion) {
 
     let merge_iter = RefCell::new(UnorderedMergeIteratorInner::new(
         gen_interleave_shared_buffer_batch_enum_iter(10000, 100),
-        Arc::new(StateStoreMetrics::unused()),
     ));
     c.bench_with_input(
         BenchmarkId::new("bench-enum-merge-iter", "unordered"),
@@ -152,7 +147,6 @@ fn criterion_benchmark(c: &mut Criterion) {
 
     let ordered_merge_iter = RefCell::new(OrderedMergeIteratorInner::new(
         gen_interleave_shared_buffer_batch_enum_iter(10000, 100),
-        Arc::new(StateStoreMetrics::unused()),
     ));
 
     c.bench_with_input(

--- a/src/storage/src/hummock/compactor/compactor_runner.rs
+++ b/src/storage/src/hummock/compactor/compactor_runner.rs
@@ -114,7 +114,7 @@ impl CompactorRunner {
                 }
             }
         }
-        Ok(UnorderedMergeIteratorInner::new(
+        Ok(UnorderedMergeIteratorInner::for_compactor(
             table_iters,
             self.compactor.context.stats.clone(),
         ))

--- a/src/storage/src/hummock/iterator/backward_merge.rs
+++ b/src/storage/src/hummock/iterator/backward_merge.rs
@@ -14,7 +14,6 @@
 
 #[cfg(test)]
 mod test {
-    use std::sync::Arc;
 
     use crate::hummock::iterator::test_utils::{
         default_builder_opt_for_test, gen_iterator_test_sstable_base, iterator_test_key_of,
@@ -23,7 +22,6 @@ mod test {
     use crate::hummock::iterator::{HummockIterator, UnorderedMergeIteratorInner};
     use crate::hummock::test_utils::create_small_table_cache;
     use crate::hummock::BackwardSstableIterator;
-    use crate::monitor::StateStoreMetrics;
 
     #[tokio::test]
     async fn test_backward_merge_basic() {
@@ -68,7 +66,7 @@ mod test {
             ),
         ];
 
-        let mut mi = UnorderedMergeIteratorInner::new(iters, Arc::new(StateStoreMetrics::unused()));
+        let mut mi = UnorderedMergeIteratorInner::new(iters);
         let mut i = 3 * TEST_KEYS_COUNT;
         mi.rewind().await.unwrap();
         while mi.is_valid() {
@@ -131,7 +129,7 @@ mod test {
             ),
         ];
 
-        let mut mi = UnorderedMergeIteratorInner::new(iters, Arc::new(StateStoreMetrics::unused()));
+        let mut mi = UnorderedMergeIteratorInner::new(iters);
 
         // right edge case
         mi.seek(iterator_test_key_of(0).as_slice()).await.unwrap();
@@ -204,7 +202,7 @@ mod test {
             ),
         ];
 
-        let mut mi = UnorderedMergeIteratorInner::new(iters, Arc::new(StateStoreMetrics::unused()));
+        let mut mi = UnorderedMergeIteratorInner::new(iters);
 
         mi.rewind().await.unwrap();
         let mut count = 0;

--- a/src/storage/src/hummock/iterator/backward_user.rs
+++ b/src/storage/src/hummock/iterator/backward_user.rs
@@ -26,7 +26,7 @@ use crate::hummock::iterator::{
 use crate::hummock::local_version::PinnedVersion;
 use crate::hummock::value::HummockValue;
 use crate::hummock::{BackwardSstableIterator, HummockResult};
-use crate::monitor::StateStoreMetrics;
+use crate::monitor::{StateStoreMetrics, StoreLocalStatistic};
 
 /// [`BackwardUserIterator`] can be used by user directly.
 pub struct BackwardUserIterator {
@@ -270,6 +270,10 @@ impl BackwardUserIterator {
         let has_enough_input = self.iterator.is_valid() || !self.last_delete;
         has_enough_input && (!self.out_of_range)
     }
+
+    pub fn collect_local_statistic(&self, stats: &mut StoreLocalStatistic) {
+        self.iterator.collect_local_statistic(stats);
+    }
 }
 
 impl DirectedUserIteratorBuilder for BackwardUserIterator {
@@ -280,13 +284,13 @@ impl DirectedUserIteratorBuilder for BackwardUserIterator {
         iterator_iter: impl IntoIterator<
             Item = UserIteratorPayloadType<Backward, BackwardSstableIterator>,
         >,
-        stats: Arc<StateStoreMetrics>,
+        _stats: Arc<StateStoreMetrics>,
         key_range: (Bound<Vec<u8>>, Bound<Vec<u8>>),
         read_epoch: u64,
         min_epoch: u64,
         version: Option<Arc<PinnedVersion>>,
     ) -> DirectedUserIterator {
-        let iterator = UnorderedMergeIteratorInner::new(iterator_iter, stats);
+        let iterator = UnorderedMergeIteratorInner::new(iterator_iter);
         DirectedUserIterator::Backward(BackwardUserIterator::with_epoch(
             iterator, key_range, read_epoch, min_epoch, version,
         ))
@@ -299,7 +303,6 @@ mod tests {
     use std::cmp::Reverse;
     use std::collections::BTreeMap;
     use std::ops::Bound::*;
-    use std::sync::Arc;
 
     use rand::distributions::Alphanumeric;
     use rand::{thread_rng, Rng};
@@ -317,7 +320,6 @@ mod tests {
     use crate::hummock::test_utils::{create_small_table_cache, gen_test_sstable};
     use crate::hummock::value::HummockValue;
     use crate::hummock::{BackwardSstableIterator, SstableStoreRef};
-    use crate::monitor::StateStoreMetrics;
 
     #[tokio::test]
     async fn test_backward_user_basic() {
@@ -363,8 +365,7 @@ mod tests {
             HummockIteratorUnion::Fourth(BackwardSstableIterator::new(handle0, sstable_store)),
         ];
 
-        let mi =
-            UnorderedMergeIteratorInner::new(backward_iters, Arc::new(StateStoreMetrics::unused()));
+        let mi = UnorderedMergeIteratorInner::new(backward_iters);
         let mut ui = BackwardUserIterator::new(mi, (Unbounded, Unbounded));
         let mut i = 3 * TEST_KEYS_COUNT;
         ui.rewind().await.unwrap();
@@ -425,8 +426,7 @@ mod tests {
             HummockIteratorUnion::Fourth(BackwardSstableIterator::new(handle2, sstable_store)),
         ];
 
-        let bmi =
-            UnorderedMergeIteratorInner::new(backward_iters, Arc::new(StateStoreMetrics::unused()));
+        let bmi = UnorderedMergeIteratorInner::new(backward_iters);
         let mut bui = BackwardUserIterator::new(bmi, (Unbounded, Unbounded));
 
         // right edge case
@@ -507,8 +507,7 @@ mod tests {
                 sstable_store,
             )),
         ];
-        let bmi =
-            UnorderedMergeIteratorInner::new(backward_iters, Arc::new(StateStoreMetrics::unused()));
+        let bmi = UnorderedMergeIteratorInner::new(backward_iters);
         let mut bui = BackwardUserIterator::new(bmi, (Unbounded, Unbounded));
 
         bui.rewind().await.unwrap();
@@ -556,8 +555,7 @@ mod tests {
             handle,
             sstable_store,
         ))];
-        let bmi =
-            UnorderedMergeIteratorInner::new(backward_iters, Arc::new(StateStoreMetrics::unused()));
+        let bmi = UnorderedMergeIteratorInner::new(backward_iters);
 
         let begin_key = Included(user_key(iterator_test_key_of_epoch(2, 0).as_slice()).to_vec());
         let end_key = Included(user_key(iterator_test_key_of_epoch(7, 0).as_slice()).to_vec());
@@ -639,8 +637,7 @@ mod tests {
             handle,
             sstable_store,
         ))];
-        let bmi =
-            UnorderedMergeIteratorInner::new(backward_iters, Arc::new(StateStoreMetrics::unused()));
+        let bmi = UnorderedMergeIteratorInner::new(backward_iters);
 
         let begin_key = Excluded(user_key(iterator_test_key_of_epoch(2, 0).as_slice()).to_vec());
         let end_key = Included(user_key(iterator_test_key_of_epoch(7, 0).as_slice()).to_vec());
@@ -722,8 +719,7 @@ mod tests {
             cache.insert(sstable.id, sstable.id, 1, Box::new(sstable)),
             sstable_store,
         ))];
-        let bmi =
-            UnorderedMergeIteratorInner::new(backward_iters, Arc::new(StateStoreMetrics::unused()));
+        let bmi = UnorderedMergeIteratorInner::new(backward_iters);
         let end_key = Included(user_key(iterator_test_key_of_epoch(7, 0).as_slice()).to_vec());
 
         let mut bui = BackwardUserIterator::new(bmi, (Unbounded, end_key));
@@ -805,8 +801,7 @@ mod tests {
             handle,
             sstable_store,
         ))];
-        let bmi =
-            UnorderedMergeIteratorInner::new(backward_iters, Arc::new(StateStoreMetrics::unused()));
+        let bmi = UnorderedMergeIteratorInner::new(backward_iters);
         let begin_key = Included(user_key(iterator_test_key_of_epoch(2, 0).as_slice()).to_vec());
 
         let mut bui = BackwardUserIterator::new(bmi, (begin_key, Unbounded));
@@ -900,8 +895,7 @@ mod tests {
             handle,
             sstable_store,
         ))];
-        let bmi =
-            UnorderedMergeIteratorInner::new(backward_iters, Arc::new(StateStoreMetrics::unused()));
+        let bmi = UnorderedMergeIteratorInner::new(backward_iters);
         let mut bui = BackwardUserIterator::new(bmi, (start_bound, end_bound));
         let num_puts: usize = truth
             .iter()
@@ -1151,8 +1145,7 @@ mod tests {
         ))];
 
         let min_epoch = (TEST_KEYS_COUNT / 5) as u64;
-        let mi =
-            UnorderedMergeIteratorInner::new(backward_iters, Arc::new(StateStoreMetrics::unused()));
+        let mi = UnorderedMergeIteratorInner::new(backward_iters);
         let mut ui =
             BackwardUserIterator::with_epoch(mi, (Unbounded, Unbounded), u64::MAX, min_epoch, None);
         ui.rewind().await.unwrap();

--- a/src/storage/src/hummock/iterator/concat_inner.rs
+++ b/src/storage/src/hummock/iterator/concat_inner.rs
@@ -161,6 +161,9 @@ impl<TI: SstableIteratorType> HummockIterator for ConcatIteratorInner<TI> {
     }
 
     fn collect_local_statistic(&self, stats: &mut StoreLocalStatistic) {
-        stats.add(&self.stats)
+        stats.add(&self.stats);
+        if let Some(iter) = &self.sstable_iter {
+            iter.collect_local_statistic(stats);
+        }
     }
 }

--- a/src/storage/src/hummock/iterator/forward_merge.rs
+++ b/src/storage/src/hummock/iterator/forward_merge.rs
@@ -30,7 +30,6 @@ mod test {
     };
     use crate::hummock::test_utils::{create_small_table_cache, gen_test_sstable};
     use crate::hummock::value::HummockValue;
-    use crate::monitor::StateStoreMetrics;
 
     #[tokio::test]
     async fn test_merge_basic() {
@@ -40,7 +39,6 @@ mod test {
             OrderedMergeIteratorInner<SstableIterator>,
         > = HummockIteratorUnion::First(UnorderedMergeIteratorInner::new(
             gen_merge_iterator_interleave_test_sstable_iters(TEST_KEYS_COUNT, 3).await,
-            Arc::new(StateStoreMetrics::unused()),
         ));
         let mut ordered_iter: HummockIteratorUnion<
             Forward,
@@ -48,7 +46,6 @@ mod test {
             OrderedMergeIteratorInner<SstableIterator>,
         > = HummockIteratorUnion::Second(OrderedMergeIteratorInner::new(
             gen_merge_iterator_interleave_test_sstable_iters(TEST_KEYS_COUNT, 3).await,
-            Arc::new(StateStoreMetrics::unused()),
         ));
 
         // Test both ordered and unordered iterators
@@ -83,7 +80,6 @@ mod test {
             OrderedMergeIteratorInner<SstableIterator>,
         > = HummockIteratorUnion::First(UnorderedMergeIteratorInner::new(
             gen_merge_iterator_interleave_test_sstable_iters(TEST_KEYS_COUNT, 3).await,
-            Arc::new(StateStoreMetrics::unused()),
         ));
         let mut ordered_iter: HummockIteratorUnion<
             Forward,
@@ -91,7 +87,6 @@ mod test {
             OrderedMergeIteratorInner<SstableIterator>,
         > = HummockIteratorUnion::Second(OrderedMergeIteratorInner::new(
             gen_merge_iterator_interleave_test_sstable_iters(TEST_KEYS_COUNT, 3).await,
-            Arc::new(StateStoreMetrics::unused()),
         ));
 
         // Test both ordered and unordered iterators
@@ -170,40 +165,34 @@ mod test {
             Forward,
             UnorderedMergeIteratorInner<SstableIterator>,
             OrderedMergeIteratorInner<SstableIterator>,
-        > = HummockIteratorUnion::First(UnorderedMergeIteratorInner::new(
-            vec![
-                SstableIterator::create(
-                    cache.insert(table0.id, table0.id, 1, table0),
-                    sstable_store.clone(),
-                    read_options.clone(),
-                ),
-                SstableIterator::create(
-                    cache.insert(table1.id, table1.id, 1, table1),
-                    sstable_store.clone(),
-                    read_options.clone(),
-                ),
-            ],
-            Arc::new(StateStoreMetrics::unused()),
-        ));
+        > = HummockIteratorUnion::First(UnorderedMergeIteratorInner::new(vec![
+            SstableIterator::create(
+                cache.insert(table0.id, table0.id, 1, table0),
+                sstable_store.clone(),
+                read_options.clone(),
+            ),
+            SstableIterator::create(
+                cache.insert(table1.id, table1.id, 1, table1),
+                sstable_store.clone(),
+                read_options.clone(),
+            ),
+        ]));
         let mut ordered_iter: HummockIteratorUnion<
             Forward,
             UnorderedMergeIteratorInner<SstableIterator>,
             OrderedMergeIteratorInner<SstableIterator>,
-        > = HummockIteratorUnion::Second(OrderedMergeIteratorInner::new(
-            vec![
-                SstableIterator::create(
-                    cache.lookup(0, &0).unwrap(),
-                    sstable_store.clone(),
-                    read_options.clone(),
-                ),
-                SstableIterator::create(
-                    cache.lookup(1, &1).unwrap(),
-                    sstable_store.clone(),
-                    read_options.clone(),
-                ),
-            ],
-            Arc::new(StateStoreMetrics::unused()),
-        ));
+        > = HummockIteratorUnion::Second(OrderedMergeIteratorInner::new(vec![
+            SstableIterator::create(
+                cache.lookup(0, &0).unwrap(),
+                sstable_store.clone(),
+                read_options.clone(),
+            ),
+            SstableIterator::create(
+                cache.lookup(1, &1).unwrap(),
+                sstable_store.clone(),
+                read_options.clone(),
+            ),
+        ]));
 
         // Test both ordered and unordered iterators
         let test_iters = vec![&mut unordered_iter, &mut ordered_iter];
@@ -278,41 +267,38 @@ mod test {
         );
         let cache = create_small_table_cache();
 
-        let mut iter = OrderedMergeIteratorInner::new(
-            vec![
-                SstableIterator::create(
-                    cache.insert(
-                        non_overlapped_sstable.id,
-                        non_overlapped_sstable.id,
-                        1,
-                        non_overlapped_sstable,
-                    ),
-                    sstable_store.clone(),
-                    read_options.clone(),
+        let mut iter = OrderedMergeIteratorInner::new(vec![
+            SstableIterator::create(
+                cache.insert(
+                    non_overlapped_sstable.id,
+                    non_overlapped_sstable.id,
+                    1,
+                    non_overlapped_sstable,
                 ),
-                SstableIterator::create(
-                    cache.insert(
-                        overlapped_new_sstable.id,
-                        overlapped_new_sstable.id,
-                        1,
-                        overlapped_new_sstable,
-                    ),
-                    sstable_store.clone(),
-                    read_options.clone(),
+                sstable_store.clone(),
+                read_options.clone(),
+            ),
+            SstableIterator::create(
+                cache.insert(
+                    overlapped_new_sstable.id,
+                    overlapped_new_sstable.id,
+                    1,
+                    overlapped_new_sstable,
                 ),
-                SstableIterator::create(
-                    cache.insert(
-                        overlapped_old_sstable.id,
-                        overlapped_old_sstable.id,
-                        1,
-                        overlapped_old_sstable,
-                    ),
-                    sstable_store.clone(),
-                    read_options.clone(),
+                sstable_store.clone(),
+                read_options.clone(),
+            ),
+            SstableIterator::create(
+                cache.insert(
+                    overlapped_old_sstable.id,
+                    overlapped_old_sstable.id,
+                    1,
+                    overlapped_old_sstable,
                 ),
-            ],
-            Arc::new(StateStoreMetrics::unused()),
-        );
+                sstable_store.clone(),
+                read_options.clone(),
+            ),
+        ]);
 
         iter.rewind().await.unwrap();
 

--- a/src/storage/src/hummock/iterator/mod.rs
+++ b/src/storage/src/hummock/iterator/mod.rs
@@ -121,7 +121,7 @@ pub trait HummockIterator: Send + Sync + 'static {
     fn seek<'a>(&'a mut self, key: &'a [u8]) -> Self::SeekFuture<'a>;
 
     /// take local statistic info from iterator to report metrics.
-    fn collect_local_statistic(&self, _stats: &mut StoreLocalStatistic) {}
+    fn collect_local_statistic(&self, _stats: &mut StoreLocalStatistic);
 }
 
 /// This is a placeholder trait used in `HummockIteratorUnion`
@@ -159,6 +159,8 @@ impl<D: HummockIteratorDirection> HummockIterator for PhantomHummockIterator<D> 
     fn seek<'a>(&'a mut self, _key: &'a [u8]) -> Self::SeekFuture<'a> {
         async { unreachable!() }
     }
+
+    fn collect_local_statistic(&self, _stats: &mut StoreLocalStatistic) {}
 }
 
 /// The `HummockIteratorUnion` acts like a wrapper over multiple types of `HummockIterator`, so that
@@ -259,6 +261,15 @@ impl<
             }
         }
     }
+
+    fn collect_local_statistic(&self, stats: &mut StoreLocalStatistic) {
+        match self {
+            First(iter) => iter.collect_local_statistic(stats),
+            Second(iter) => iter.collect_local_statistic(stats),
+            Third(iter) => iter.collect_local_statistic(stats),
+            Fourth(iter) => iter.collect_local_statistic(stats),
+        }
+    }
 }
 
 impl<I: HummockIterator> HummockIterator for Box<I> {
@@ -290,6 +301,10 @@ impl<I: HummockIterator> HummockIterator for Box<I> {
 
     fn seek<'a>(&'a mut self, key: &'a [u8]) -> Self::SeekFuture<'a> {
         (*self).deref_mut().seek(key)
+    }
+
+    fn collect_local_statistic(&self, stats: &mut StoreLocalStatistic) {
+        (*self).deref().collect_local_statistic(stats);
     }
 }
 

--- a/src/storage/src/hummock/shared_buffer/mod.rs
+++ b/src/storage/src/hummock/shared_buffer/mod.rs
@@ -124,7 +124,7 @@ pub type SharedBufferIteratorType<
 pub(crate) async fn build_ordered_merge_iter<T: HummockIteratorType>(
     uncommitted_data: &OrderSortedUncommittedData,
     sstable_store: Arc<SstableStore>,
-    stats: Arc<StateStoreMetrics>,
+    _stats: Arc<StateStoreMetrics>,
     local_stats: &mut StoreLocalStatistic,
     read_options: Arc<SstableIteratorReadOptions>,
 ) -> HummockResult<SharedBufferIteratorType<T::Direction, T::SstableIteratorType>> {
@@ -156,11 +156,11 @@ pub(crate) async fn build_ordered_merge_iter<T: HummockIteratorType>(
             ordered_iters.push(HummockIteratorUnion::First(data_iters.pop().unwrap()));
         } else {
             ordered_iters.push(HummockIteratorUnion::Second(
-                UnorderedMergeIteratorInner::new(data_iters, stats.clone()),
+                UnorderedMergeIteratorInner::new(data_iters),
             ));
         }
     }
-    Ok(OrderedMergeIteratorInner::new(ordered_iters, stats.clone()))
+    Ok(OrderedMergeIteratorInner::new(ordered_iters))
 }
 
 #[derive(Debug, Clone)]

--- a/src/storage/src/hummock/shared_buffer/shared_buffer_batch.rs
+++ b/src/storage/src/hummock/shared_buffer/shared_buffer_batch.rs
@@ -303,6 +303,8 @@ impl<D: HummockIteratorDirection> HummockIterator for SharedBufferBatchIterator<
             Ok(())
         }
     }
+
+    fn collect_local_statistic(&self, _stats: &mut crate::monitor::StoreLocalStatistic) {}
 }
 
 #[cfg(test)]

--- a/src/storage/src/storage_failpoints/test_iterator.rs
+++ b/src/storage/src/storage_failpoints/test_iterator.rs
@@ -28,7 +28,7 @@ use crate::hummock::iterator::{
 use crate::hummock::sstable::SstableIteratorReadOptions;
 use crate::hummock::test_utils::default_builder_opt_for_test;
 use crate::hummock::{BackwardSstableIterator, SstableIterator};
-use crate::monitor::{StateStoreMetrics, StoreLocalStatistic};
+use crate::monitor::StoreLocalStatistic;
 
 #[tokio::test]
 #[cfg(feature = "failpoints")]
@@ -172,23 +172,20 @@ async fn test_failpoints_merge_invalid_key() {
     )
     .await;
     let tables = vec![table0, table1];
-    let mut mi = UnorderedMergeIteratorInner::new(
-        {
-            let mut iters = vec![];
-            for table in &tables {
-                iters.push(SstableIterator::new(
-                    sstable_store
-                        .sstable(table.id, &mut StoreLocalStatistic::default())
-                        .await
-                        .unwrap(),
-                    sstable_store.clone(),
-                    Arc::new(SstableIteratorReadOptions::default()),
-                ));
-            }
-            iters
-        },
-        Arc::new(StateStoreMetrics::unused()),
-    );
+    let mut mi = UnorderedMergeIteratorInner::new({
+        let mut iters = vec![];
+        for table in &tables {
+            iters.push(SstableIterator::new(
+                sstable_store
+                    .sstable(table.id, &mut StoreLocalStatistic::default())
+                    .await
+                    .unwrap(),
+                sstable_store.clone(),
+                Arc::new(SstableIteratorReadOptions::default()),
+            ));
+        }
+        iters
+    });
     mi.rewind().await.unwrap();
     let mut count = 0;
     fail::cfg(mem_read_err, "return").unwrap();
@@ -227,22 +224,19 @@ async fn test_failpoints_backward_merge_invalid_key() {
     )
     .await;
     let tables = vec![table0, table1];
-    let mut mi = UnorderedMergeIteratorInner::new(
-        {
-            let mut iters = vec![];
-            for table in &tables {
-                iters.push(BackwardSstableIterator::new(
-                    sstable_store
-                        .sstable(table.id, &mut StoreLocalStatistic::default())
-                        .await
-                        .unwrap(),
-                    sstable_store.clone(),
-                ));
-            }
-            iters
-        },
-        Arc::new(StateStoreMetrics::unused()),
-    );
+    let mut mi = UnorderedMergeIteratorInner::new({
+        let mut iters = vec![];
+        for table in &tables {
+            iters.push(BackwardSstableIterator::new(
+                sstable_store
+                    .sstable(table.id, &mut StoreLocalStatistic::default())
+                    .await
+                    .unwrap(),
+                sstable_store.clone(),
+            ));
+        }
+        iters
+    });
     mi.rewind().await.unwrap();
     let mut count = 0;
     fail::cfg(mem_read_err, "return").unwrap();
@@ -294,7 +288,7 @@ async fn test_failpoints_user_read_err() {
         )),
     ];
 
-    let mi = UnorderedMergeIteratorInner::new(iters, Arc::new(StateStoreMetrics::unused()));
+    let mi = UnorderedMergeIteratorInner::new(iters);
     let mut ui = UserIterator::for_test(mi, (Unbounded, Unbounded));
     ui.rewind().await.unwrap();
 
@@ -354,7 +348,7 @@ async fn test_failpoints_backward_user_read_err() {
         )),
     ];
 
-    let mi = UnorderedMergeIteratorInner::new(iters, Arc::new(StateStoreMetrics::unused()));
+    let mi = UnorderedMergeIteratorInner::new(iters);
     let mut ui = BackwardUserIterator::new(mi, (Unbounded, Unbounded));
     ui.rewind().await.unwrap();
 


### PR DESCRIPTION
I hereby agree to the terms of the [Singularity Data, Inc. Contributor License Agreement](https://gist.github.com/skyzh/0663682a70b0edde7ae991492f2314cb#file-s9y_cla).

In #2709 we introduced local metrics for iterators and block cache, which, however, needs to be carefully reported by caller. Besides, it didn't check if the its data is reported or reported multiple times. And that leads to abnormal metrics:

e.g. 70k+ meta cache access but 0 data cache accesss
<img width="820" alt="image" src="https://user-images.githubusercontent.com/22407295/185359683-004e8ad1-bd25-416a-ac5b-f27c21d14405.png">

After investigation, both metrics lost and metrics reported multiple times problems exist by:

```rust
#[derive(Default)]
pub struct StoreLocalStatistic {
    // ... ...

    reported: AtomicBool,
    added: AtomicBool,
}

impl StoreLocalStatistic {
    pub fn add(&mut self, other: &StoreLocalStatistic) {
        // ... ...

        if other.added.fetch_or(true, Ordering::SeqCst) {
            panic!("double added");
        }
    }

    pub fn report(&self, metrics: &StateStoreMetrics) {
        // ... ...

        if self.reported.fetch_or(true, Ordering::SeqCst) {
            panic!("double reported");
        }
    }
}

impl Drop for StoreLocalStatistic {
    fn drop(&mut self) {
        if !self.reported.load(Ordering::SeqCst) && !self.added.load(Ordering::SeqCst) {
            panic!("local stats lost!");
        }
    }
}
```

And with the check (not included in this PR, because it will break unit tests), I fixed all related bugs. Now the metrics looks fine:

<img width="729" alt="image (3)" src="https://user-images.githubusercontent.com/22407295/185360039-f61acf76-53bb-4bda-9577-af8f81d84488.png">

## TODO (but not in this PR):
This PR is just a quick fix of #2709 , without the checking code, the local metrics still need to be carefully handled. I think we should refactor it later.

## Checklist

- [x] I have written necessary rustdoc comments
- [x] I have added necessary unit tests and integration tests
- [x] All checks passed in `./risedev check` (or alias, `./risedev c`)


## Refer to a related PR or issue link (optional)
fix #4706 