### PR TITLE
feat(sqlsmith): support generating `string_agg` calls

### DIFF
--- a/src/frontend/src/expr/agg_call.rs
+++ b/src/frontend/src/expr/agg_call.rs
@@ -135,8 +135,7 @@ impl AggCall {
             (AggKind::Count | AggKind::ApproxCountDistinct, _) => DataType::Int64,
 
             // StringAgg
-            (AggKind::StringAgg, [DataType::Varchar, DataType::Varchar]) => DataType::Varchar,
-            (AggKind::StringAgg, _) => return invalid(),
+            (AggKind::StringAgg, _) => DataType::Varchar,
 
             (AggKind::ArrayAgg, [input]) => DataType::List {
                 datatype: Box::new(input.clone()),

--- a/src/frontend/src/expr/agg_call.rs
+++ b/src/frontend/src/expr/agg_call.rs
@@ -135,7 +135,8 @@ impl AggCall {
             (AggKind::Count | AggKind::ApproxCountDistinct, _) => DataType::Int64,
 
             // StringAgg
-            (AggKind::StringAgg, _) => DataType::Varchar,
+            (AggKind::StringAgg, [DataType::Varchar, DataType::Varchar]) => DataType::Varchar,
+            (AggKind::StringAgg, _) => return invalid(),
 
             (AggKind::ArrayAgg, [input]) => DataType::List {
                 datatype: Box::new(input.clone()),

--- a/src/frontend/src/expr/type_inference/agg.rs
+++ b/src/frontend/src/expr/type_inference/agg.rs
@@ -75,7 +75,6 @@ fn build_type_derive_map() -> AggFuncSigMap {
         A::Max,
         A::Count,
         A::Avg,
-        A::StringAgg,
         A::SingleValue,
         A::ApproxCountDistinct,
     ] {
@@ -86,6 +85,12 @@ fn build_type_derive_map() -> AggFuncSigMap {
             }
         }
     }
+    // Handle special case for `string_agg`, for it accepts two input arguments.
+    map.insert(
+        AggKind::StringAgg,
+        vec![DataTypeName::Varchar, DataTypeName::Varchar],
+        DataTypeName::Varchar,
+    );
     map
 }
 

--- a/src/tests/sqlsmith/src/expr.rs
+++ b/src/tests/sqlsmith/src/expr.rs
@@ -274,35 +274,32 @@ impl<'a, R: Rng> SqlGenerator<'a, R> {
         let can_agg = true;
         // show then the expression inside this function is in aggregate function
         let inside_agg = true;
-        let expr: Vec<Expr> = func
+        let exprs: Vec<Expr> = func
             .inputs_type
             .iter()
             .map(|t| self.gen_expr(*t, can_agg, inside_agg))
             .collect();
-        assert!(expr.len() == 1);
 
         let distinct = self.flip_coin() && self.is_distinct_allowed;
-        self.make_agg_expr(func.func, expr[0].clone(), distinct)
+        self.make_agg_expr(func.func, &exprs, distinct)
     }
 
-    fn make_agg_expr(&mut self, func: AggKind, expr: Expr, distinct: bool) -> Expr {
+    fn make_agg_expr(&mut self, func: AggKind, exprs: &[Expr], distinct: bool) -> Expr {
         use AggKind as A;
 
         match func {
-            A::Sum => Expr::Function(make_agg_func("sum", &[expr], distinct)),
-            A::Min => Expr::Function(make_agg_func("min", &[expr], distinct)),
-            A::Max => Expr::Function(make_agg_func("max", &[expr], distinct)),
-            A::Count => Expr::Function(make_agg_func("count", &[expr], distinct)),
-            A::Avg => Expr::Function(make_agg_func("avg", &[expr], distinct)),
-            // TODO: Tracked by: <https://github.com/singularity-data/risingwave/issues/3115>
-            // A::StringAgg => Expr::Function(make_agg_func("string_agg", &[expr], distinct)),
-            A::StringAgg => self.gen_simple_scalar(DataTypeName::Varchar),
-            A::SingleValue => Expr::Function(make_agg_func("single_value", &[expr], false)),
+            A::Sum => Expr::Function(make_agg_func("sum", exprs, distinct)),
+            A::Min => Expr::Function(make_agg_func("min", exprs, distinct)),
+            A::Max => Expr::Function(make_agg_func("max", exprs, distinct)),
+            A::Count => Expr::Function(make_agg_func("count", exprs, distinct)),
+            A::Avg => Expr::Function(make_agg_func("avg", exprs, distinct)),
+            A::StringAgg => Expr::Function(make_agg_func("string_agg", exprs, distinct)),
+            A::SingleValue => Expr::Function(make_agg_func("single_value", exprs, false)),
             A::ApproxCountDistinct => {
                 if distinct {
                     self.gen_simple_scalar(DataTypeName::Int64)
                 } else {
-                    Expr::Function(make_agg_func("approx_count_distinct", &[expr], false))
+                    Expr::Function(make_agg_func("approx_count_distinct", exprs, false))
                 }
             }
             // TODO(yuchao): `array_agg` support is still WIP, see #4657.


### PR DESCRIPTION
I hereby agree to the terms of the [Singularity Data, Inc. Contributor License Agreement](https://gist.github.com/skyzh/0663682a70b0edde7ae991492f2314cb#file-s9y_cla).

## What's changed and what's your intention?

Add support to generate `string_agg` calls in `SqlGenerator::gen_agg`, since `string_agg` is already fully supported in RW.

## Checklist

- [x] I have written necessary rustdoc comments
- [x] I have added necessary unit tests and integration tests
- [x] All checks passed in `./risedev check` (or alias, `./risedev c`)