### PR TITLE
chore(parser): remove todo for parsing nested negative expressions

### DIFF
--- a/e2e_test/batch/basic/func.slt.part
+++ b/e2e_test/batch/basic/func.slt.part
@@ -225,6 +225,11 @@ select pg_typeof('123');
 unknown
 
 query T
+select pg_typeof(-9223372036854775808);
+----
+bigint
+
+query T
 select pg_typeof(round(null));
 ----
 double precision

--- a/src/sqlparser/src/parser.rs
+++ b/src/sqlparser/src/parser.rs
@@ -436,8 +436,6 @@ impl Parser {
                     UnaryOperator::Minus
                 };
                 let mut sub_expr = self.parse_subexpr(Self::PLUS_MINUS_PREC)?;
-                // TODO: Deal with nested unary exp: -(-(-(1))) => -1
-                // Tracked by: <https://github.com/singularity-data/risingwave/issues/4344>
                 if let Expr::Value(Value::Number(ref mut s, _)) = sub_expr {
                     if tok == Token::Minus {
                         *s = format!("-{}", s);

--- a/src/sqlparser/src/parser.rs
+++ b/src/sqlparser/src/parser.rs
@@ -3419,4 +3419,15 @@ mod tests {
             parser.prev_token();
         });
     }
+
+    #[test]
+    fn test_parse_integer_min() {
+        let min_bigint = "-9223372036854775808";
+        run_parser_method(min_bigint, |parser| {
+            assert_eq!(
+                parser.parse_expr().unwrap(),
+                Expr::Value(Value::Number("-9223372036854775808".to_string(), false))
+            )
+        });
+    }
 }


### PR DESCRIPTION
I hereby agree to the terms of the [Singularity Data, Inc. Contributor License Agreement](https://gist.github.com/skyzh/0663682a70b0edde7ae991492f2314cb#file-s9y_cla).

## What's changed and what's your intention?

As per title. See discussion https://github.com/singularity-data/risingwave/pull/4729#discussion_r949988804.

## Checklist

~~- [ ] I have written necessary rustdoc comments~~
~~- [ ] I have added necessary unit tests and integration tests~~
~~- [ ] All checks passed in `./risedev check` (or alias, `./risedev c`)~~

## Refer to a related PR or issue link (optional)

#4344 