### PR TITLE
fix(binder): fix panic when index on non composite type

### DIFF
--- a/e2e_test/batch/aggregate/aggregate2/test.slt.part
+++ b/e2e_test/batch/aggregate/aggregate2/test.slt.part
@@ -1,0 +1,11 @@
+# Copied from https://github.com/duckdb/duckdb (MIT licensed).
+# Copyright 2018-2022 Stichting DuckDB Foundation
+
+statement ok
+SET RW_IMPLICIT_FLUSH TO true;
+
+statement ok
+create table t(v1 int);
+
+statement ok
+select * from t where v1[1]=1;

--- a/e2e_test/batch/basic/array_access.slt.part
+++ b/e2e_test/batch/basic/array_access.slt.part
@@ -23,3 +23,10 @@ NULL
 
 statement error
 select (ARRAY['foo', 'bar'])[];
+
+# array access is not possible for non-composite types
+statement error
+select (1::INT)[1];
+
+statement error
+select ('a'::VARCHAR)[1];

--- a/src/frontend/src/binder/expr/value.rs
+++ b/src/frontend/src/binder/expr/value.rs
@@ -127,7 +127,7 @@ impl Binder {
                 "array index applied to type {}, which is not a composite type",
                 data_type
             ))
-            .into())
+            .into()),
         }
     }
 

--- a/src/frontend/src/binder/expr/value.rs
+++ b/src/frontend/src/binder/expr/value.rs
@@ -123,7 +123,11 @@ impl Binder {
                     FunctionCall::new_unchecked(ExprType::ArrayAccess, indexs, *return_type).into();
                 Ok(expr)
             }
-            _ => panic!("Should be a List"),
+            data_type => Err(ErrorCode::BindError(format!(
+                "array index applied to type {}, which is not a composite type",
+                data_type
+            ))
+            .into())
         }
     }
 


### PR DESCRIPTION
I hereby agree to the terms of the [Singularity Data, Inc. Contributor License Agreement](https://gist.github.com/skyzh/0663682a70b0edde7ae991492f2314cb#file-s9y_cla).

## What's changed and what's your intention?

Replace panic with BindError.

Please explain **IN DETAIL** what the changes are in this PR and why they are needed:

Previously `select * from t where v1[1]=1;` resulted in a panic, now in a BindError.

## Checklist

- [x] All checks passed in `./risedev check` (or alias, `./risedev c`)
- [x]  I have added necessary unit tests and integration tests

## Refer to a related PR or issue link (optional)
closes #4755