### PR TITLE
fix: cargo run playground

### DIFF
--- a/src/risedevtool/src/task/compute_node_service.rs
+++ b/src/risedevtool/src/task/compute_node_service.rs
@@ -47,8 +47,6 @@ impl ComputeNodeService {
         config: &ComputeNodeConfig,
         hummock_in_memory_strategy: HummockInMemoryStrategy,
     ) -> Result<()> {
-        let prefix_data = env::var("PREFIX_DATA")?;
-
         cmd.arg("--host")
             .arg(format!("{}:{}", config.listen_address, config.port))
             .arg("--prometheus-listener-addr")
@@ -62,6 +60,7 @@ impl ComputeNodeService {
             .arg("1");
 
         if config.enable_tiered_cache {
+            let prefix_data = env::var("PREFIX_DATA")?;
             cmd.arg("--file-cache-dir").arg(
                 PathBuf::from(prefix_data)
                     .join("filecache")


### PR DESCRIPTION
I hereby agree to the terms of the [Singularity Data, Inc. Contributor License Agreement](https://gist.github.com/skyzh/0663682a70b0edde7ae991492f2314cb#file-s9y_cla).

## What's changed and what's your intention?

After this PR, 

```sh
RW_NODE=playground cargo run --bin risingwave -- playground
```

can work.

## Checklist

N/A

## Documentation

N/A

## Refer to a related PR or issue link (optional)

None