### PR TITLE
feat(ci): randomly pick from multiple frontends in parallel e2e

### DIFF
--- a/ci/build-ci-image.sh
+++ b/ci/build-ci-image.sh
@@ -14,7 +14,7 @@ export RUST_TOOLCHAIN=$(cat ../rust-toolchain)
 # !!! CHANGE THIS WHEN YOU WANT TO BUMP CI IMAGE !!! #
 #          AND ALSO docker-compose.yml               #
 ######################################################
-export BUILD_ENV_VERSION=v20220729
+export BUILD_ENV_VERSION=v20220822
 
 export BUILD_TAG="public.ecr.aws/x5u3w5h6/rw-build-env:${BUILD_ENV_VERSION}"
 

--- a/ci/docker-compose.yml
+++ b/ci/docker-compose.yml
@@ -15,12 +15,12 @@ services:
       retries: 5
 
   rw-build-env:
-    image: public.ecr.aws/x5u3w5h6/rw-build-env:v20220729
+    image: public.ecr.aws/x5u3w5h6/rw-build-env:v20220822
     volumes:
       - ..:/risingwave
 
   regress-test-env:
-    image: public.ecr.aws/x5u3w5h6/rw-build-env:v20220729
+    image: public.ecr.aws/x5u3w5h6/rw-build-env:v20220822
     depends_on:
       db:
         condition: service_healthy

--- a/ci/scripts/e2e-test-parallel.sh
+++ b/ci/scripts/e2e-test-parallel.sh
@@ -39,18 +39,20 @@ echo "--- Prepare RiseDev dev cluster"
 cargo make pre-start-dev
 cargo make link-all-in-one-binaries
 
-echo "--- e2e, ci-3cn-1fe, streaming"
-cargo make ci-start ci-3cn-1fe
+host_args="-h localhost -p 4565 -h localhost -p 4566 -h localhost -p 4567"
+
+echo "--- e2e, ci-3cn-3fe, streaming"
+cargo make ci-start ci-3cn-3fe
 # Please make sure the regression is expected before increasing the timeout.
-timeout 5m sqllogictest -p 4566 -d dev  './e2e_test/streaming/**/*.slt' -j 16 --junit "parallel-streaming-${profile}"
+timeout 5m sqllogictest ${host_args} -d dev  './e2e_test/streaming/**/*.slt' -j 16 --junit "parallel-streaming-${profile}"
 
 echo "--- Kill cluster"
 cargo make ci-kill
 
-echo "--- e2e, ci-3cn-1fe, batch distributed"
-cargo make ci-start ci-3cn-1fe
-timeout 2m sqllogictest -p 4566 -d dev  './e2e_test/ddl/**/*.slt' --junit "parallel-batch-ddl-${profile}"
-timeout 2m sqllogictest -p 4566 -d dev  './e2e_test/batch/**/*.slt' -j 16 --junit "parallel-batch-${profile}"
+echo "--- e2e, ci-3cn-3fe, batch distributed"
+cargo make ci-start ci-3cn-3fe
+timeout 2m sqllogictest ${host_args} -d dev  './e2e_test/ddl/**/*.slt' --junit "parallel-batch-ddl-${profile}"
+timeout 2m sqllogictest ${host_args} -d dev  './e2e_test/batch/**/*.slt' -j 16 --junit "parallel-batch-${profile}"
 
 echo "--- Kill cluster"
 cargo make ci-kill

--- a/risedev.yml
+++ b/risedev.yml
@@ -324,6 +324,32 @@ risedev:
     - use: frontend
     - use: compactor
 
+  ci-3cn-3fe:
+    - use: minio
+    - use: etcd
+      unsafe-no-fsync: true
+    - use: meta-node
+      unsafe-disable-recovery: true
+    - use: compute-node
+      port: 5687
+      exporter-port: 1222
+      enable-tiered-cache: true
+    - use: compute-node
+      port: 5688
+      exporter-port: 1223
+      enable-tiered-cache: true
+    - use: compute-node
+      port: 5689
+      exporter-port: 1224
+      enable-tiered-cache: true
+    - use: frontend
+      port: 4565
+    - use: frontend
+      port: 4566
+    - use: frontend
+      port: 4567
+    - use: compactor
+
   ci-kafka:
     - use: minio
     - use: etcd

--- a/src/risedevtool/README.md
+++ b/src/risedevtool/README.md
@@ -26,8 +26,9 @@ In root directory, simply run:
 The default scene contains a MinIO, compute-node, meta-node and a frontend. RiseDev will automatically download and configure those services for you.
 
 RiseDev also provides several other modes:
-- ci-3cn-1fe: 3 compute node + meta node + frontend + MinIO
-- ci-1cn-1fe: 1 compute node + meta node + frontend + MinIO
+- ci-3cn-1fe: 3 compute node + meta node + 1 frontend + MinIO
+- ci-3cn-3fe: 3 compute node + meta node + 3 frontend + MinIO
+- ci-1cn-1fe: 1 compute node + meta node + 1 frontend + MinIO
 - dev-compute-node: 1 compute-node (user managed) + MinIO + prometheus + meta + frontend
 
 #### Debug compute node


### PR DESCRIPTION
Signed-off-by: Bugen Zhao <i@bugenzhao.com>

I hereby agree to the terms of the [Singularity Data, Inc. Contributor License Agreement](https://gist.github.com/skyzh/0663682a70b0edde7ae991492f2314cb#file-s9y_cla).

## What's changed and what's your intention?

This PR adds a new profile of `ci-3cn-3fe` which starts 3 frontend nodes, and applies parallel e2e with it.

## Checklist

- [x] I have written necessary rustdoc comments
- [x] I have added necessary unit tests and integration tests
- [x] All checks passed in `./risedev check` (or alias, `./risedev c`)

## Refer to a related PR or issue link (optional)
- https://github.com/risinglightdb/sqllogictest-rs/pull/76