### PR TITLE
fix(optimizer): fix logical scan clone with predicate

### DIFF
--- a/src/frontend/src/optimizer/plan_node/logical_scan.rs
+++ b/src/frontend/src/optimizer/plan_node/logical_scan.rs
@@ -334,7 +334,7 @@ impl LogicalScan {
         Self::new(
             self.table_name.clone(),
             self.is_sys_table,
-            self.required_col_idx.clone(),
+            self.output_col_idx.clone(),
             self.table_desc.clone(),
             self.indexes.clone(),
             self.base.ctx.clone(),


### PR DESCRIPTION
I hereby agree to the terms of the [Singularity Data, Inc. Contributor License Agreement](https://gist.github.com/skyzh/0663682a70b0edde7ae991492f2314cb#file-s9y_cla).

## What's changed and what's your intention?

- LogicalScan clone should use `output_col_idx` instead of `required_col_idx` to preserve its output schema.

## Checklist

- [x] I have written necessary rustdoc comments
- [x] I have added necessary unit tests and integration tests
- [x] All checks passed in `./risedev check` (or alias, `./risedev c`)
