### PR TITLE
fix(compactor): fix drop mv stuck

### DIFF
--- a/src/meta/src/manager/catalog/mod.rs
+++ b/src/meta/src/manager/catalog/mod.rs
@@ -347,7 +347,7 @@ where
             }
             core.add_table(table);
             let version = self
-                .broadcast_info_op(Operation::Add, Info::Table(table.to_owned()))
+                .notify_frontend(Operation::Add, Info::Table(table.to_owned()))
                 .await;
 
             Ok(version)
@@ -416,7 +416,7 @@ where
                     }
                     for table in tables_to_drop {
                         database_core.drop_table(&table);
-                        self.broadcast_info_op(Operation::Delete, Info::Table(table))
+                        self.notify_frontend(Operation::Delete, Info::Table(table))
                             .await;
                     }
                     database_core.drop_table(&table);
@@ -425,7 +425,7 @@ where
                     }
 
                     let version = self
-                        .broadcast_info_op(Operation::Delete, Info::Table(table.to_owned()))
+                        .notify_frontend(Operation::Delete, Info::Table(table.to_owned()))
                         .await;
 
                     Ok(version)
@@ -500,7 +500,7 @@ where
                         }
                         for table in tables_to_drop {
                             database_core.drop_table(&table);
-                            self.broadcast_info_op(Operation::Delete, Info::Table(table))
+                            self.notify_frontend(Operation::Delete, Info::Table(table))
                                 .await;
                         }
                         for &dependent_relation_id in &table.dependent_relations {
@@ -510,7 +510,7 @@ where
                             .await;
 
                         let version = self
-                            .broadcast_info_op(Operation::Delete, Info::Table(table.to_owned()))
+                            .notify_frontend(Operation::Delete, Info::Table(table.to_owned()))
                             .await;
 
                         Ok(version)
@@ -547,7 +547,7 @@ where
             core.add_source(source);
 
             let version = self
-                .broadcast_info_op(Operation::Add, Info::Source(source.to_owned()))
+                .notify_frontend(Operation::Add, Info::Source(source.to_owned()))
                 .await;
 
             Ok(version)
@@ -596,7 +596,7 @@ where
                             .await;
                     }
                     let version = self
-                        .broadcast_info_op(Operation::Delete, Info::Source(source))
+                        .notify_frontend(Operation::Delete, Info::Source(source))
                         .await;
 
                     Ok(version)
@@ -662,12 +662,12 @@ where
                 self.notify_frontend(Operation::Add, Info::Table(table.to_owned()))
                     .await;
             }
-            self.broadcast_info_op(Operation::Add, Info::Table(mview.to_owned()))
+            self.notify_frontend(Operation::Add, Info::Table(mview.to_owned()))
                 .await;
 
             // Currently frontend uses source's version
             let version = self
-                .broadcast_info_op(Operation::Add, Info::Source(source.to_owned()))
+                .notify_frontend(Operation::Add, Info::Source(source.to_owned()))
                 .await;
             Ok(version)
         } else {
@@ -830,13 +830,13 @@ where
             for internal_table in internal_tables {
                 core.add_table(&internal_table);
 
-                self.broadcast_info_op(Operation::Add, Info::Table(internal_table.to_owned()))
+                self.notify_frontend(Operation::Add, Info::Table(internal_table.to_owned()))
                     .await;
             }
             core.add_table(table);
             core.add_index(index);
 
-            self.broadcast_info_op(Operation::Add, Info::Table(table.to_owned()))
+            self.notify_frontend(Operation::Add, Info::Table(table.to_owned()))
                 .await;
 
             let version = self
@@ -960,13 +960,6 @@ where
         self.env
             .notification_manager()
             .notify_frontend(operation, info)
-            .await
-    }
-
-    async fn broadcast_info_op(&self, operation: Operation, info: Info) -> NotificationVersion {
-        self.env
-            .notification_manager()
-            .notify_all_node(operation, info)
             .await
     }
 }

--- a/src/meta/src/stream/stream_manager.rs
+++ b/src/meta/src/stream/stream_manager.rs
@@ -836,6 +836,10 @@ where
         self.processing_table.lock().await
     }
 
+    // For creating and destroying, compactor and compute must maintain the Catalog for compaction
+    // that it can build the prefix_bloom_filter by Catalog until last barrier through the whole
+    // graph. we notify the `Add` before `Barrier Command` and notify the `Delete` after `Barrier
+    // Command` in StreamManager
     async fn notify_compute_and_compactor(&self, operation: Operation, info: Info) {
         self.notification_manager
             .notify_compute(operation, info.clone())

--- a/src/meta/src/stream/stream_manager.rs
+++ b/src/meta/src/stream/stream_manager.rs
@@ -657,20 +657,23 @@ where
                 };
 
                 processing_table_guard.insert(*table_id, table_catalog.clone());
-                self.notify_state_ful_node(Operation::Add, Info::Table(table_catalog.clone()))
-                    .await;
+                self.notify_compute_and_compactor(
+                    Operation::Add,
+                    Info::Table(table_catalog.clone()),
+                )
+                .await;
             }
 
             match relation {
                 Relation::Table(mview) => {
                     processing_table_guard.insert(mview.id, mview.clone());
-                    self.notify_state_ful_node(Operation::Add, Info::Table(mview.clone()))
+                    self.notify_compute_and_compactor(Operation::Add, Info::Table(mview.clone()))
                         .await;
                 }
 
                 Relation::Index(_, mview) => {
                     processing_table_guard.insert(mview.id, mview.clone());
-                    self.notify_state_ful_node(Operation::Add, Info::Table(mview.clone()))
+                    self.notify_compute_and_compactor(Operation::Add, Info::Table(mview.clone()))
                         .await;
                 }
 
@@ -685,7 +688,7 @@ where
                         ..Default::default()
                     },
                 );
-                self.notify_state_ful_node(Operation::Add, Info::Source(source.clone()))
+                self.notify_compute_and_compactor(Operation::Add, Info::Source(source.clone()))
                     .await;
             }
         }
@@ -817,7 +820,7 @@ where
             processing_table_guard.remove(&table_id);
 
             if notify {
-                self.notify_state_ful_node(
+                self.notify_compute_and_compactor(
                     Operation::Delete,
                     Info::Table(Table {
                         id: table_id,
@@ -833,7 +836,7 @@ where
         self.processing_table.lock().await
     }
 
-    async fn notify_state_ful_node(&self, operation: Operation, info: Info) {
+    async fn notify_compute_and_compactor(&self, operation: Operation, info: Info) {
         self.notification_manager
             .notify_compute(operation, info.clone())
             .await;


### PR DESCRIPTION
I hereby agree to the terms of the [Singularity Data, Inc. Contributor License Agreement](https://gist.github.com/skyzh/0663682a70b0edde7ae991492f2314cb#file-s9y_cla).

## What's changed and what's your intention?

Due to the misunderstanding of the process at the beginning , the previous PR introduced `broadcast_info_op`. It will notify all nodes (`frontend`, `compute`, `compactor`) after creating and destorying the mview. 

For creating and destorying, `compactor` and `compute` must maintain the `Catalog` for compaction that it can build the `prefix_bloom_filter` by `Catalog` until last `barrier`  through the whole graph. 
In short, we need to ensure that before the `Barrier Command`, `compactor` and `compute` must maintain the `Catalog` , otherwise it will stuck.

Why did we remove broadcast in `catalog.rs` ?
It is no longer needed in the current design，we notify the  `Add` before `Barrier Command`  and notify the `Delete` after `Barrier Command` in `StreamManager`

Please explain **IN DETAIL** what the changes are in this PR and why they are needed:

- fix drop stuck and remove broadcast_info_op
- rename function

## Checklist

- ~[ ] I have written necessary rustdoc comments~
- ~[ ] I have added necessary unit tests and integration tests~
- [x] All checks passed in `./risedev check` (or alias, `./risedev c`)

## Refer to a related PR or issue link (optional)
- https://github.com/singularity-data/risingwave/issues/4790