### PR TITLE
fix(sqlsmith): disable single value

### DIFF
--- a/src/expr/src/expr/agg.rs
+++ b/src/expr/src/expr/agg.rs
@@ -26,11 +26,11 @@ pub enum AggKind {
     Count,
     Avg,
     StringAgg,
-    /// This is an internal Agg operation.
-    /// It was introduced by our legacy java frontend to report
-    /// an error for a scalar subquery which may return more than one row.
-    /// FIXME: This is currently unused by our codebase.
-    /// Tracked: <https://github.com/singularity-data/risingwave/issues/4866>
+    // This is an internal Agg operation.
+    // It was introduced by our legacy java frontend to handle
+    // scalar subqueries which may return more than one row.
+    // FIXME: This is currently unused by our codebase.
+    // Tracked: <https://github.com/singularity-data/risingwave/issues/4866>
     SingleValue,
     ApproxCountDistinct,
     ArrayAgg,

--- a/src/expr/src/expr/agg.rs
+++ b/src/expr/src/expr/agg.rs
@@ -26,6 +26,11 @@ pub enum AggKind {
     Count,
     Avg,
     StringAgg,
+    /// This is an internal Agg operation.
+    /// It was introduced by our legacy java frontend to report
+    /// an error for a scalar subquery which may return more than one row.
+    /// **This is currently unused by our codebase.**
+    /// Tracked: <https://github.com/singularity-data/risingwave/issues/1335>
     SingleValue,
     ApproxCountDistinct,
     ArrayAgg,

--- a/src/expr/src/expr/agg.rs
+++ b/src/expr/src/expr/agg.rs
@@ -29,8 +29,8 @@ pub enum AggKind {
     /// This is an internal Agg operation.
     /// It was introduced by our legacy java frontend to report
     /// an error for a scalar subquery which may return more than one row.
-    /// **This is currently unused by our codebase.**
-    /// Tracked: <https://github.com/singularity-data/risingwave/issues/1335>
+    /// FIXME: This is currently unused by our codebase.
+    /// Tracked: <https://github.com/singularity-data/risingwave/issues/4866>
     SingleValue,
     ApproxCountDistinct,
     ArrayAgg,

--- a/src/tests/sqlsmith/src/expr.rs
+++ b/src/tests/sqlsmith/src/expr.rs
@@ -300,7 +300,11 @@ impl<'a, R: Rng> SqlGenerator<'a, R> {
                 if distinct {
                     None
                 } else {
-                    Some(Expr::Function(make_agg_func("approx_count_distinct", exprs, false)))
+                    Some(Expr::Function(make_agg_func(
+                        "approx_count_distinct",
+                        exprs,
+                        false,
+                    )))
                 }
             }
             // TODO(yuchao): `array_agg` support is still WIP, see #4657.

--- a/src/tests/sqlsmith/src/expr.rs
+++ b/src/tests/sqlsmith/src/expr.rs
@@ -285,6 +285,7 @@ impl<'a, R: Rng> SqlGenerator<'a, R> {
             .unwrap_or_else(|| self.gen_simple_scalar(ret))
     }
 
+    /// Generates aggregate expressions. For internal / unsupported aggregators, we return `None`.
     fn make_agg_expr(&mut self, func: AggKind, exprs: &[Expr], distinct: bool) -> Option<Expr> {
         use AggKind as A;
 

--- a/src/tests/sqlsmith/src/expr.rs
+++ b/src/tests/sqlsmith/src/expr.rs
@@ -282,28 +282,29 @@ impl<'a, R: Rng> SqlGenerator<'a, R> {
 
         let distinct = self.flip_coin() && self.is_distinct_allowed;
         self.make_agg_expr(func.func, &exprs, distinct)
+            .unwrap_or_else(|| self.gen_simple_scalar(ret))
     }
 
-    fn make_agg_expr(&mut self, func: AggKind, exprs: &[Expr], distinct: bool) -> Expr {
+    fn make_agg_expr(&mut self, func: AggKind, exprs: &[Expr], distinct: bool) -> Option<Expr> {
         use AggKind as A;
 
         match func {
-            A::Sum => Expr::Function(make_agg_func("sum", exprs, distinct)),
-            A::Min => Expr::Function(make_agg_func("min", exprs, distinct)),
-            A::Max => Expr::Function(make_agg_func("max", exprs, distinct)),
-            A::Count => Expr::Function(make_agg_func("count", exprs, distinct)),
-            A::Avg => Expr::Function(make_agg_func("avg", exprs, distinct)),
-            A::StringAgg => Expr::Function(make_agg_func("string_agg", exprs, distinct)),
-            A::SingleValue => Expr::Function(make_agg_func("single_value", exprs, false)),
+            A::Sum => Some(Expr::Function(make_agg_func("sum", exprs, distinct))),
+            A::Min => Some(Expr::Function(make_agg_func("min", exprs, distinct))),
+            A::Max => Some(Expr::Function(make_agg_func("max", exprs, distinct))),
+            A::Count => Some(Expr::Function(make_agg_func("count", exprs, distinct))),
+            A::Avg => Some(Expr::Function(make_agg_func("avg", exprs, distinct))),
+            A::StringAgg => Some(Expr::Function(make_agg_func("string_agg", exprs, distinct))),
+            A::SingleValue => None,
             A::ApproxCountDistinct => {
                 if distinct {
-                    self.gen_simple_scalar(DataTypeName::Int64)
+                    None
                 } else {
-                    Expr::Function(make_agg_func("approx_count_distinct", exprs, false))
+                    Some(Expr::Function(make_agg_func("approx_count_distinct", exprs, false)))
                 }
             }
             // TODO(yuchao): `array_agg` support is still WIP, see #4657.
-            A::ArrayAgg => self.gen_simple_scalar(DataTypeName::List),
+            A::ArrayAgg => None,
         }
     }
 }


### PR DESCRIPTION
I hereby agree to the terms of the [Singularity Data, Inc. Contributor License Agreement](https://gist.github.com/skyzh/0663682a70b0edde7ae991492f2314cb#file-s9y_cla).

## What's changed and what's your intention?

- Disable single value in sqlsmith. I think this approach is better, since single value is meant for internal use.
- Added some comments providing more clarity on single-value.
- [See previous discussion on single value ](https://risingwave-labs.slack.com/archives/C03G9HMLEBC/p1653378232953079).
- I don't think we necessarily want / need to support `single_value(timestamp)` as a feature. 
  It is unused, hence disabling it on sqlsmith should close #4864 .

## Checklist

- [x] I have written necessary rustdoc comments
~~- [ ] I have added necessary unit tests and integration tests~~
~~- [ ] All checks passed in `./risedev check` (or alias, `./risedev c`)~~

## Refer to a related PR or issue link (optional)

Related to: #1335, #4866, #4864