### PR TITLE
fix(compactor): fix version get for trivial_move

### DIFF
--- a/src/meta/src/hummock/manager/mod.rs
+++ b/src/meta/src/hummock/manager/mod.rs
@@ -605,6 +605,10 @@ where
             compact_status.report_compact_task(&compact_task);
             compact_task.sorted_output_ssts = compact_task.input_ssts[0].table_infos.clone();
             let mut versioning_guard = write_lock!(self, versioning).await;
+
+            // need to regain the newest version ynder the protection of a write lock, otherwise the
+            // old version may be used to overwrite the new one
+            let current_version = versioning_guard.current_version.clone();
             let new_version_id = current_version.id + 1;
             let versioning = versioning_guard.deref_mut();
             let mut hummock_version_deltas =
@@ -615,6 +619,9 @@ where
                 &compact_task,
                 true,
             );
+
+            // FIXME: refactor the implementation of `apply_compact_result` by using
+            // `hummock_version_deltas`
             let mut new_version =
                 CompactStatus::apply_compact_result(&compact_task, current_version);
             new_version.id = new_version_id;


### PR DESCRIPTION
I hereby agree to the terms of the [Singularity Data, Inc. Contributor License Agreement](https://gist.github.com/skyzh/0663682a70b0edde7ae991492f2314cb#file-s9y_cla).

## What's changed and what's your intention?

need to regain the newest version ynder the protection of a write lock, otherwise the old version may be used to overwrite the new one

Please explain **IN DETAIL** what the changes are in this PR and why they are needed:

- fix current_version

## Checklist

- ~[ ] I have written necessary rustdoc comments~
- ~[ ] I have added necessary unit tests and integration tests~
- [x] All checks passed in `./risedev check` (or alias, `./risedev c`)

## Refer to a related PR or issue link (optional)
