### PR TITLE
chore: bump madsim to support coarse clock

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2664,9 +2664,9 @@ dependencies = [
 
 [[package]]
 name = "madsim"
-version = "0.2.3"
+version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f26e34ff2d7e2d3c0e7403ef85848ed3667f9c89fc50321d62d480c03388f8cf"
+checksum = "2fbcfa3e52808d948f10928c17a720efd3324942b1059cef77cc88077ea639f9"
 dependencies = [
  "ahash",
  "async-channel",

--- a/src/tests/simulation/Cargo.toml
+++ b/src/tests/simulation/Cargo.toml
@@ -9,7 +9,7 @@ async-trait = "0.1"
 clap = "3"
 futures = { version = "0.3", default-features = false, features = ["alloc"] }
 glob = "0.3"
-madsim = "0.2.3"
+madsim = "0.2.4"
 rand = "0.8"
 risingwave_compactor = { path = "../../storage/compactor" }
 risingwave_compute = { path = "../../compute" }


### PR DESCRIPTION
Signed-off-by: Bugen Zhao <i@bugenzhao.com>

I hereby agree to the terms of the [Singularity Data, Inc. Contributor License Agreement](https://gist.github.com/skyzh/0663682a70b0edde7ae991492f2314cb#file-s9y_cla).

## What's changed and what's your intention?

Thanks to @wangrunji0408's hard work, the madsim v0.2.4 supports simulating coarse clock, which is necessary for those systems without `tsc` support (mainly seen on virtual machines).

```
❯ cat /sys/devices/system/clocksource/clocksource0/available_clocksource
kvm-clock hpet acpi_pm 
```

## Checklist

- [x] I have written necessary rustdoc comments
- [x] I have added necessary unit tests and integration tests
- [x] All checks passed in `./risedev check` (or alias, `./risedev c`)
