### PR TITLE
feat: do not update downstream removed actors' merge node in case of cascading migration

### DIFF
--- a/src/meta/src/barrier/command.rs
+++ b/src/meta/src/barrier/command.rs
@@ -187,8 +187,8 @@ impl<S: MetaStore> CommandContext<S> {
 }
 
 impl<S> CommandContext<S>
-where
-    S: MetaStore,
+    where
+        S: MetaStore,
 {
     /// Generate a mutation for the given command.
     pub async fn to_mutation(&self) -> MetaResult<Option<Mutation>> {
@@ -239,7 +239,7 @@ where
                 let mut actor_dispatcher_update = HashMap::new();
                 for (_fragment_id, reschedule) in reschedules.iter() {
                     for &(upstream_fragment_id, dispatcher_id) in
-                        &reschedule.upstream_fragment_dispatcher_ids
+                    &reschedule.upstream_fragment_dispatcher_ids
                     {
                         // Find the actors of the upstream fragment.
                         let upstream_actor_ids = self
@@ -277,8 +277,16 @@ where
                             .get_running_actors_of_fragment(downstream_fragment_id)
                             .await?;
 
+                        let downstream_removed_actors: HashSet<_> = reschedules.get(&downstream_fragment_id).map(|downstream_reschedule| {
+                            downstream_reschedule.removed_actors.iter().copied().collect()
+                        }).unwrap_or_default();
+
                         // Record updates for all actors.
                         for actor_id in downstream_actor_ids {
+                            if downstream_removed_actors.contains(&actor_id) {
+                                continue
+                            }
+
                             actor_merge_update
                                 .try_insert(
                                     actor_id,


### PR DESCRIPTION
Signed-off-by: Peng Chen <peng@singularity-data.com>

I hereby agree to the terms of the [Singularity Data, Inc. Contributor License Agreement](https://gist.github.com/skyzh/0663682a70b0edde7ae991492f2314cb#file-s9y_cla).

## What's changed and what's your intention?

There are many cascading updates in the scaling scenario

When the upstream changes, the downstream actor will update its upstream by `merges` in `UpdateMutation` and wait for the new upstream barrier, but when the downstream actor is about to be deleted, the upstream actor does not forward the `Barrier` to it, so it will cause infinite waiting.

This PR skips the Merge Update of the deleted downstream actors

![未命名绘图](https://user-images.githubusercontent.com/1997790/186861911-aeca6ab1-4ff8-405c-b5a9-afee2e8d7a31.jpg)

As an example, the dashed node downstream in the diagram should not expect the upstream Barrier to forward through the red line

## Checklist

~- [ ] I have written necessary rustdoc comments~
~- [ ] I have added necessary unit tests and integration tests~
~- [ ] All checks passed in `./risedev check` (or alias, `./risedev c`)~

## Documentation

If your pull request contains user-facing changes, please specify the types of the changes, and create a release note. Otherwise, please feel free to remove this section.

### Types of user-facing changes

Please keep the types that apply to your changes, and remove those that do not apply.

* Installation and deployment 
* Connector (sources & sinks)
* SQL commands, functions, and operators
* RisingWave cluster configuration changes
* Other (please specify in the release note below)

### Release note

Please create a release note for your changes. In the release note, focus on the impact on users, and mention the environment or conditions where the impact may occur.

## Refer to a related PR or issue link (optional)
