### PR TITLE
fix(optimizer): fix index scan output schema

### DIFF
--- a/src/frontend/src/optimizer/plan_node/logical_scan.rs
+++ b/src/frontend/src/optimizer/plan_node/logical_scan.rs
@@ -249,12 +249,11 @@ impl LogicalScan {
         index_table_desc: Rc<TableDesc>,
         primary_to_secondary_mapping: &HashMap<usize, usize>,
     ) -> LogicalScan {
-        let mut new_required_col_idx = Vec::with_capacity(self.required_col_idx.len());
-
-        // create index scan plan to match the output order of the current table scan
-        for &col_idx in &self.required_col_idx {
-            new_required_col_idx.push(*primary_to_secondary_mapping.get(&col_idx).unwrap());
-        }
+        let new_output_col_idx = self
+            .output_col_idx
+            .iter()
+            .map(|col_idx| *primary_to_secondary_mapping.get(col_idx).unwrap())
+            .collect_vec();
 
         struct Rewriter<'a> {
             primary_to_secondary_mapping: &'a HashMap<usize, usize>,
@@ -280,7 +279,7 @@ impl LogicalScan {
         Self::new(
             index_name.to_string(),
             false,
-            new_required_col_idx,
+            new_output_col_idx,
             index_table_desc,
             vec![],
             self.ctx(),


### PR DESCRIPTION
I hereby agree to the terms of the [Singularity Data, Inc. Contributor License Agreement](https://gist.github.com/skyzh/0663682a70b0edde7ae991492f2314cb#file-s9y_cla).

## What's changed and what's your intention?

***PLEASE DO NOT LEAVE THIS EMPTY !!!***

Please explain **IN DETAIL** what the changes are in this PR and why they are needed:

- Fix index scan output schema by using `output_col_idx` instead of `required_col_idx`.


## Checklist

- [x] I have written necessary rustdoc comments
- [x] I have added necessary unit tests and integration tests
- [x] All checks passed in `./risedev check` (or alias, `./risedev c`)

## Refer to a related PR or issue link (optional)
#4921