### PR TITLE
refactor(meta): use apply_version_delta to replace apply_compact_result

### DIFF
--- a/src/meta/src/hummock/compaction/mod.rs
+++ b/src/meta/src/hummock/compaction/mod.rs
@@ -26,14 +26,11 @@ use std::fmt::{Debug, Formatter};
 use std::sync::Arc;
 
 pub use base_level_compaction_picker::LevelCompactionPicker;
-use risingwave_hummock_sdk::compaction_group::hummock_version_ext::HummockVersionExt;
 use risingwave_hummock_sdk::prost_key_range::KeyRangeExt;
 use risingwave_hummock_sdk::{CompactionGroupId, HummockCompactionTaskId, HummockEpoch};
 use risingwave_pb::hummock::compaction_config::CompactionMode;
 use risingwave_pb::hummock::hummock_version::Levels;
-use risingwave_pb::hummock::{
-    CompactTask, CompactionConfig, HummockVersion, InputLevel, KeyRange, LevelType,
-};
+use risingwave_pb::hummock::{CompactTask, CompactionConfig, InputLevel, KeyRange, LevelType};
 
 use crate::hummock::compaction::level_selector::{DynamicLevelSelector, LevelSelector};
 use crate::hummock::compaction::overlap_strategy::{
@@ -249,36 +246,6 @@ impl CompactStatus {
             }
         }
         count
-    }
-
-    /// Applies the compact task result and get a new hummock version.
-    pub fn apply_compact_result(
-        compact_task: &CompactTask,
-        based_hummock_version: HummockVersion,
-    ) -> HummockVersion {
-        let mut new_version = based_hummock_version;
-        new_version.safe_epoch = std::cmp::max(new_version.safe_epoch, compact_task.watermark);
-        let mut removed_table: HashSet<u64> = HashSet::default();
-        let mut removed_levels = vec![];
-        for input_level in &compact_task.input_ssts {
-            for table in &input_level.table_infos {
-                removed_table.insert(table.id);
-            }
-            removed_levels.push(input_level.level_idx);
-        }
-
-        removed_levels.sort();
-        removed_levels.dedup();
-        new_version.apply_compact_ssts(
-            compact_task.compaction_group_id,
-            &removed_levels,
-            &removed_table,
-            compact_task.target_level,
-            compact_task.target_sub_level_id,
-            compact_task.sorted_output_ssts.clone(),
-        );
-
-        new_version
     }
 
     pub fn compaction_group_id(&self) -> CompactionGroupId {

--- a/src/meta/src/hummock/manager/mod.rs
+++ b/src/meta/src/hummock/manager/mod.rs
@@ -651,11 +651,12 @@ where
                 compaction_group_id,
             );
 
-            tracing::trace!(
-                "TrivialMove for compaction group {}: pick up {} tables in level {} to compact.  cost time: {:?}",
+            tracing::info!(
+                "TrivialMove for compaction group {}: pick up {} tables in level {} to compact to target_level {}  cost time: {:?}",
                 compaction_group_id,
                 compact_task.input_ssts[0].table_infos.len(),
                 compact_task.input_ssts[0].level_idx,
+                compact_task.target_level,
                 start_time.elapsed()
             );
         } else {


### PR DESCRIPTION
I hereby agree to the terms of the [Singularity Data, Inc. Contributor License Agreement](https://gist.github.com/skyzh/0663682a70b0edde7ae991492f2314cb#file-s9y_cla).

## What's changed and what's your intention?

 use apply_version_delta to replace apply_compact_result in order to avoid using `compact_task` to apply vesrion again after generating `version_delta` with `compact_task`

Please explain **IN DETAIL** what the changes are in this PR and why they are needed:

- use `apply_version_delta` for `current_version`
- remove the calculation of `new_version_id`, `new_version_id` is only calculated in `apply_version_delta`
- remove unused function

## Checklist

- [x] I have written necessary rustdoc comments
~- [ ] I have added necessary unit tests and integration tests~
- [x] All checks passed in `./risedev check` (or alias, `./risedev c`)

## Refer to a related PR or issue link (optional)
- https://github.com/singularity-data/risingwave/pull/4890